### PR TITLE
[Java] add basic type inference support

### DIFF
--- a/java/fury-core/src/main/java/io/fury/annotation/Ignore.java
+++ b/java/fury-core/src/main/java/io/fury/annotation/Ignore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Ignore fields just like transient. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Ignore {}

--- a/java/fury-core/src/main/java/io/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/io/fury/type/Descriptor.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.type;
+
+import static io.fury.util.Utils.checkArgument;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import io.fury.annotation.Ignore;
+import io.fury.annotation.Internal;
+import io.fury.collection.Tuple2;
+import io.fury.util.StringUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.WeakHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Build descriptors for a class.
+ *
+ * @see Ignore
+ */
+@SuppressWarnings("UnstableApiUsage")
+public class Descriptor {
+  private static Cache<Class<?>, Tuple2<SortedMap<Field, Descriptor>, SortedMap<Field, Descriptor>>>
+      descCache = CacheBuilder.newBuilder().weakKeys().softValues().concurrencyLevel(64).build();
+  private static final Map<Class<?>, AtomicBoolean> flags =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
+  @Internal
+  public static void clearDescriptorCache() {
+    descCache.cleanUp();
+    descCache = CacheBuilder.newBuilder().weakKeys().softValues().concurrencyLevel(64).build();
+  }
+
+  private TypeToken<?> typeToken;
+  private Class<?> type;
+  private final String name;
+  private final int modifier;
+  private final String declaringClass;
+  private final Field field;
+  private final Method readMethod;
+  private final Method writeMethod;
+
+  public Descriptor(Field field, TypeToken<?> typeToken, Method readMethod, Method writeMethod) {
+    this.field = field;
+    this.name = field.getName();
+    this.modifier = field.getModifiers();
+    this.declaringClass = field.getDeclaringClass().getName();
+    this.readMethod = readMethod;
+    this.writeMethod = writeMethod;
+    this.typeToken = typeToken;
+  }
+
+  public Descriptor(Field field) {
+    this.field = field;
+    this.name = field.getName();
+    this.modifier = field.getModifiers();
+    this.declaringClass = field.getDeclaringClass().getName();
+    this.readMethod = null;
+    this.writeMethod = null;
+    this.typeToken = null;
+  }
+
+  public Descriptor(TypeToken<?> typeToken, String name, int modifier, String declaringClass) {
+    this.field = null;
+    this.name = name;
+    this.modifier = modifier;
+    this.declaringClass = declaringClass;
+    this.typeToken = typeToken;
+    this.readMethod = null;
+    this.writeMethod = null;
+  }
+
+  public Descriptor(
+      TypeToken<?> typeToken,
+      String name,
+      int modifier,
+      String declaringClass,
+      Field field,
+      Method readMethod,
+      Method writeMethod) {
+    this.typeToken = typeToken;
+    this.name = name;
+    this.modifier = modifier;
+    this.declaringClass = declaringClass;
+    this.field = field;
+    this.readMethod = readMethod;
+    this.writeMethod = writeMethod;
+  }
+
+  public Descriptor copy(TypeToken<?> typeToken, Method readMethod, Method writeMethod) {
+    return new Descriptor(
+        typeToken, name, modifier, declaringClass, field, readMethod, writeMethod);
+  }
+
+  public Field getField() {
+    return field;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getModifiers() {
+    return modifier;
+  }
+
+  public String getDeclaringClass() {
+    return declaringClass;
+  }
+
+  public Method getReadMethod() {
+    return readMethod;
+  }
+
+  public Method getWriteMethod() {
+    return writeMethod;
+  }
+
+  /** Try not use {@link TypeToken#getRawType()} since it's expensive. */
+  public Class<?> getRawType() {
+    Class<?> type = this.type;
+    if (type == null) {
+      if (field != null) {
+        return this.type = field.getType();
+      } else {
+        return this.type = TypeUtils.getRawType(getTypeToken());
+      }
+    }
+    return Objects.requireNonNull(type);
+  }
+
+  public TypeToken<?> getTypeToken() {
+    TypeToken<?> typeToken = this.typeToken;
+    if (typeToken == null && field != null) {
+      this.typeToken = typeToken = TypeToken.of(field.getGenericType());
+    }
+    return typeToken;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("Descriptor{");
+    sb.append("name=").append(name);
+    sb.append(", field=").append(field);
+    sb.append(", readMethod=").append(readMethod);
+    sb.append(", writeMethod=").append(writeMethod);
+    sb.append(", typeToken=").append(typeToken);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /**
+   * Returns descriptors non-transient/non-static fields of class. If super class and sub class have
+   * same field, use subclass field.
+   */
+  public static List<Descriptor> getDescriptors(Class<?> clz) {
+    // TODO(chaokunyang) add cache by weak class key, see java.io.ObjectStreamClass.WeakClassKey.
+    SortedMap<Field, Descriptor> allDescriptorsMap = getAllDescriptorsMap(clz);
+    Map<String, List<Field>> duplicateNameFields = getDuplicateNameFields(allDescriptorsMap);
+    checkArgument(
+        duplicateNameFields.size() == 0, "%s has duplicate fields %s", clz, duplicateNameFields);
+    return new ArrayList<>(allDescriptorsMap.values());
+  }
+
+  /**
+   * Returns descriptors map non-transient/non-static fields of class. Super class and sub class are
+   * not allowed to have duplicate name field.
+   */
+  public static SortedMap<String, Descriptor> getDescriptorsMap(Class<?> clz) {
+    SortedMap<Field, Descriptor> allDescriptorsMap = getAllDescriptorsMap(clz);
+    Map<String, List<Field>> duplicateNameFields = getDuplicateNameFields(allDescriptorsMap);
+    Preconditions.checkArgument(
+        duplicateNameFields.size() == 0, "%s has duplicate fields %s", clz, duplicateNameFields);
+    TreeMap<String, Descriptor> map = new TreeMap<>();
+    allDescriptorsMap.forEach((k, v) -> map.put(k.getName(), v));
+    return map;
+  }
+
+  public static Map<String, List<Field>> getDuplicateNameFields(
+      SortedMap<Field, Descriptor> allDescriptorsMap) {
+    Map<String, List<Field>> duplicateNameFields = new HashMap<>();
+    for (Field field : allDescriptorsMap.keySet()) {
+      duplicateNameFields.compute(
+          field.getName(),
+          (fieldName, fields) -> {
+            if (fields == null) {
+              fields = new ArrayList<>();
+            }
+            fields.add(field);
+            return fields;
+          });
+    }
+    duplicateNameFields =
+        Maps.filterValues(duplicateNameFields, fields -> Objects.requireNonNull(fields).size() > 1);
+    return duplicateNameFields;
+  }
+
+  public static Map<String, List<Field>> getSortedDuplicatedFields(
+      SortedMap<Field, Descriptor> allFields) {
+    Map<String, List<Field>> duplicated = Descriptor.getDuplicateNameFields(allFields);
+    Map<String, List<Field>> map = new HashMap<>();
+    for (Map.Entry<String, List<Field>> e : duplicated.entrySet()) {
+      e.getValue()
+          .sort(
+              (f1, f2) -> {
+                if (f1.getDeclaringClass() == f2.getDeclaringClass()) {
+                  return 0;
+                } else {
+                  return f1.getDeclaringClass().isAssignableFrom(f2.getDeclaringClass()) ? -1 : 1;
+                }
+              });
+      if (map.put(e.getKey(), e.getValue()) != null) {
+        throw new IllegalStateException("Duplicate key");
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Return all non-transient/non-static fields of {@code clz} in a deterministic order with field
+   * name first and declaring class second. Super class and sub class can have same name field.
+   */
+  public static Set<Field> getFields(Class<?> clz) {
+    return getAllDescriptorsMap(clz).keySet();
+  }
+
+  /**
+   * Returns descriptors map non-transient/non-static fields of class in a deterministic order with
+   * field name first and declaring class second. Super class and subclass can have same names
+   * field.
+   */
+  public static SortedMap<Field, Descriptor> getAllDescriptorsMap(Class<?> clz) {
+    return getAllDescriptorsMap(clz, true);
+  }
+
+  private static final Comparator<Field> fieldComparator =
+      ((Field f1, Field f2) -> {
+        int compare = f1.getName().compareTo(f2.getName());
+        if (compare == 0) { // class and super classes have same named field
+          return f1.getDeclaringClass().getName().compareTo(f2.getDeclaringClass().getName());
+        } else {
+          return compare;
+        }
+      });
+
+  public static SortedMap<Field, Descriptor> getAllDescriptorsMap(
+      Class<?> clz, boolean searchParent) {
+    try {
+      Tuple2<SortedMap<Field, Descriptor>, SortedMap<Field, Descriptor>> tuple2 =
+          descCache.get(clz, () -> createAllDescriptorsMap(clz));
+      if (searchParent) {
+        return tuple2.f0;
+      } else {
+        return tuple2.f1;
+      }
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Tuple2<SortedMap<Field, Descriptor>, SortedMap<Field, Descriptor>>
+      createAllDescriptorsMap(Class<?> clz) {
+    // use TreeMap to sort to fix field order
+    TreeMap<Field, Descriptor> descriptorMap = new TreeMap<>(fieldComparator);
+    TreeMap<Field, Descriptor> currentDescriptorMap = new TreeMap<>(fieldComparator);
+    Class<?> clazz = clz;
+    // TODO(chaokunyang) use fury compiler thread pool
+    ExecutorService compilationService = ForkJoinPool.commonPool();
+    do {
+      Field[] fields = clazz.getDeclaredFields();
+      for (Field field : fields) {
+        warmField(clz, field, compilationService);
+        int modifiers = field.getModifiers();
+        // final and non-private field validation left to {@link isBean(clz)}
+        if (!Modifier.isTransient(modifiers)
+            && !Modifier.isStatic(modifiers)
+            && !field.isAnnotationPresent(Ignore.class)) {
+          descriptorMap.put(field, new Descriptor(field));
+        }
+      }
+      if (clazz == clz) {
+        currentDescriptorMap = new TreeMap<>(descriptorMap);
+      }
+      clazz = clazz.getSuperclass();
+    } while (clazz != null);
+    return Tuple2.of(descriptorMap, currentDescriptorMap);
+  }
+
+  /**
+   * Speedup generics resolve by multi-thread since {@link Field#getGenericType()} is slow and
+   * nested Descriptor is slow in single thread.
+   */
+  static void warmField(Class<?> context, Field field, ExecutorService compilationService) {
+    Class<?> fieldRawType = field.getType();
+    if (fieldRawType.isPrimitive()
+        || fieldRawType == String.class
+        || fieldRawType == Object.class) {
+      return;
+    }
+    if (TypeUtils.isBoxed(fieldRawType)) {
+      return;
+    }
+    if (fieldRawType == context) {
+      // avoid duplicate build.
+      return;
+    }
+    if (!fieldRawType.getName().startsWith("java")) {
+      compilationService.submit(
+          () -> {
+            // use a flag to avoid blocking thread.
+            AtomicBoolean flag = flags.computeIfAbsent(fieldRawType, k -> new AtomicBoolean(false));
+            if (flag.compareAndSet(false, true)) {
+              getAllDescriptorsMap(fieldRawType);
+            }
+          });
+    } else if (TypeUtils.isCollection(fieldRawType) || TypeUtils.isMap(fieldRawType)) {
+      // warm up generic type, sun.reflect.generics.repository.FieldRepository
+      // is expensive.
+      compilationService.submit(() -> warmGenericTask(TypeToken.of(field.getGenericType())));
+    } else if (fieldRawType.isArray()) {
+      Class<?> componentType = fieldRawType.getComponentType();
+      if (!componentType.isPrimitive()) {
+        compilationService.submit(() -> warmGenericTask(TypeToken.of(field.getGenericType())));
+      }
+    }
+  }
+
+  // this method should b executed in background thread pool.
+  static void warmGenericTask(TypeToken<?> typeToken) {
+    Class<?> rawType = TypeUtils.getRawType(typeToken);
+    if (rawType.isPrimitive() || rawType == String.class || rawType == Object.class) {
+      return;
+    }
+    if (TypeUtils.isBoxed(rawType)) {
+      return;
+    }
+    if (!rawType.getName().startsWith("java")) {
+      getAllDescriptorsMap(rawType);
+    } else if (TypeUtils.isCollection(rawType)) {
+      TypeToken<?> elementType = TypeUtils.getElementType(typeToken);
+      warmGenericTask(elementType);
+    } else if (TypeUtils.isMap(rawType)) {
+      Tuple2<TypeToken<?>, TypeToken<?>> mapKeyValueType = TypeUtils.getMapKeyValueType(typeToken);
+      warmGenericTask(mapKeyValueType.f0);
+      warmGenericTask(mapKeyValueType.f1);
+    } else if (rawType.isArray()) {
+      warmGenericTask(typeToken.getComponentType());
+    }
+  }
+
+  static SortedMap<Field, Descriptor> buildBeanedDescriptorsMap(
+      Class<?> clz, boolean searchParent) {
+    List<Field> fieldList = new ArrayList<>();
+    Class<?> clazz = clz;
+    Map<Tuple2<Class, String>, Method> methodMap = new HashMap<>();
+    do {
+      Field[] fields = clazz.getDeclaredFields();
+      for (Field field : fields) {
+        int modifiers = field.getModifiers();
+        // final and non-private field validation left to {@link isBean(clz)}
+        if (!Modifier.isTransient(modifiers)
+            && !Modifier.isStatic(modifiers)
+            && !field.isAnnotationPresent(Ignore.class)) {
+          fieldList.add(field);
+        }
+      }
+      Arrays.stream(clazz.getDeclaredMethods())
+          .filter(m -> !Modifier.isPrivate(m.getModifiers()))
+          // if override, use subClass method; getter/setter method won't overload
+          .forEach(m -> methodMap.put(Tuple2.of(m.getDeclaringClass(), m.getName()), m));
+      clazz = clazz.getSuperclass();
+    } while (clazz != null && searchParent);
+
+    for (Class<?> anInterface : clz.getInterfaces()) {
+      Method[] methods = anInterface.getDeclaredMethods();
+      for (Method method : methods) {
+        if (method.isDefault()) {
+          methodMap.put(Tuple2.of(method.getDeclaringClass(), method.getName()), method);
+        }
+      }
+    }
+
+    // use TreeMap to sort to fix field order
+    TreeMap<Field, Descriptor> descriptorMap = new TreeMap<>(fieldComparator);
+    for (Field field : fieldList) {
+      Class<?> fieldDeclaringClass = field.getDeclaringClass();
+      String fieldName = field.getName();
+      String cap = StringUtils.capitalize(fieldName);
+      Method getter;
+      if ("boolean".equalsIgnoreCase(field.getType().getSimpleName())) {
+        getter = methodMap.get(Tuple2.of(fieldDeclaringClass, "is" + cap));
+      } else {
+        getter = methodMap.get(Tuple2.of(fieldDeclaringClass, "get" + cap));
+      }
+      if (getter != null) {
+        if (getter.getParameterCount() != 0
+            || !getter
+                .getGenericReturnType()
+                .getTypeName()
+                .equals(field.getGenericType().getTypeName())) {
+          getter = null;
+        }
+      }
+      Method setter = methodMap.get(Tuple2.of(fieldDeclaringClass, "set" + cap));
+      if (setter != null) {
+        if (setter.getParameterCount() != 1
+            || !setter
+                .getGenericParameterTypes()[0]
+                .getTypeName()
+                .equals(field.getGenericType().getTypeName())) {
+          setter = null;
+        }
+      }
+      TypeToken fieldType = TypeToken.of(field.getGenericType());
+      descriptorMap.put(field, new Descriptor(field, fieldType, getter, setter));
+    }
+    // Don't cache descriptors using a static `WeakHashMap<Class<?>, SortedMap<Field, Descriptor>>`，
+    // otherwise classes can't be gc.
+    return descriptorMap;
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
+++ b/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
@@ -1,0 +1,689 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.type;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import io.fury.collection.IdentityMap;
+import io.fury.collection.Tuple2;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Type utils for common type inference and extraction. */
+@SuppressWarnings("UnstableApiUsage")
+public class TypeUtils {
+  public static final String JAVA_BOOLEAN = "boolean";
+  public static final String JAVA_BYTE = "byte";
+  public static final String JAVA_SHORT = "short";
+  public static final String JAVA_INT = "int";
+  public static final String JAVA_LONG = "long";
+  public static final String JAVA_FLOAT = "float";
+  public static final String JAVA_DOUBLE = "double";
+  public static final TypeToken<?> PRIMITIVE_VOID_TYPE = TypeToken.of(void.class);
+  public static final TypeToken<?> VOID_TYPE = TypeToken.of(Void.class);
+  public static final TypeToken<?> PRIMITIVE_BYTE_TYPE = TypeToken.of(byte.class);
+  public static final TypeToken<?> PRIMITIVE_BOOLEAN_TYPE = TypeToken.of(boolean.class);
+  public static final TypeToken<?> PRIMITIVE_CHAR_TYPE = TypeToken.of(char.class);
+  public static final TypeToken<?> PRIMITIVE_SHORT_TYPE = TypeToken.of(short.class);
+  public static final TypeToken<?> PRIMITIVE_INT_TYPE = TypeToken.of(int.class);
+  public static final TypeToken<?> PRIMITIVE_LONG_TYPE = TypeToken.of(long.class);
+  public static final TypeToken<?> PRIMITIVE_FLOAT_TYPE = TypeToken.of(float.class);
+  public static final TypeToken<?> PRIMITIVE_DOUBLE_TYPE = TypeToken.of(double.class);
+  public static final TypeToken<?> BYTE_TYPE = TypeToken.of(Byte.class);
+  public static final TypeToken<?> BOOLEAN_TYPE = TypeToken.of(Boolean.class);
+  public static final TypeToken<?> CHAR_TYPE = TypeToken.of(Character.class);
+  public static final TypeToken<?> SHORT_TYPE = TypeToken.of(Short.class);
+  public static final TypeToken<?> INT_TYPE = TypeToken.of(Integer.class);
+  public static final TypeToken<?> LONG_TYPE = TypeToken.of(Long.class);
+  public static final TypeToken<?> FLOAT_TYPE = TypeToken.of(Float.class);
+  public static final TypeToken<?> DOUBLE_TYPE = TypeToken.of(Double.class);
+  public static final TypeToken<?> STRING_TYPE = TypeToken.of(String.class);
+  public static final TypeToken<?> BIG_DECIMAL_TYPE = TypeToken.of(BigDecimal.class);
+  public static final TypeToken<?> BIG_INTEGER_TYPE = TypeToken.of(BigInteger.class);
+  public static final TypeToken<?> DATE_TYPE = TypeToken.of(Date.class);
+  public static final TypeToken<?> LOCAL_DATE_TYPE = TypeToken.of(LocalDate.class);
+  public static final TypeToken<?> TIMESTAMP_TYPE = TypeToken.of(Timestamp.class);
+  public static final TypeToken<?> INSTANT_TYPE = TypeToken.of(Instant.class);
+  public static final TypeToken<?> BINARY_TYPE = TypeToken.of(byte[].class);
+  public static final TypeToken<?> ITERABLE_TYPE = TypeToken.of(Iterable.class);
+  public static final TypeToken<?> COLLECTION_TYPE = TypeToken.of(Collection.class);
+  public static final TypeToken<?> LIST_TYPE = TypeToken.of(List.class);
+  public static final TypeToken<?> ARRAYLIST_TYPE = TypeToken.of(ArrayList.class);
+  public static final TypeToken<?> SET_TYPE = TypeToken.of(Set.class);
+  public static final TypeToken<?> HASHSET_TYPE = TypeToken.of(HashSet.class);
+  public static final TypeToken<?> MAP_TYPE = TypeToken.of(Map.class);
+  public static final TypeToken<?> HASHMAP_TYPE = TypeToken.of(HashMap.class);
+  public static final TypeToken<?> OBJECT_TYPE = TypeToken.of(Object.class);
+
+  public static Type ITERATOR_RETURN_TYPE;
+  public static Type NEXT_RETURN_TYPE;
+  public static Type KEY_SET_RETURN_TYPE;
+  public static Type VALUES_RETURN_TYPE;
+
+  public static final TypeToken<?> PRIMITIVE_BYTE_ARRAY_TYPE = TypeToken.of(byte[].class);
+  public static final TypeToken<?> PRIMITIVE_BOOLEAN_ARRAY_TYPE = TypeToken.of(boolean[].class);
+  public static final TypeToken<?> PRIMITIVE_SHORT_ARRAY_TYPE = TypeToken.of(short[].class);
+  public static final TypeToken<?> PRIMITIVE_INT_ARRAY_TYPE = TypeToken.of(int[].class);
+  public static final TypeToken<?> PRIMITIVE_LONG_ARRAY_TYPE = TypeToken.of(long[].class);
+  public static final TypeToken<?> PRIMITIVE_FLOAT_ARRAY_TYPE = TypeToken.of(float[].class);
+  public static final TypeToken<?> PRIMITIVE_DOUBLE_ARRAY_TYPE = TypeToken.of(double[].class);
+
+  public static final TypeToken<?> CLASS_TYPE = TypeToken.of(Class.class);
+  /**
+   * bean fields should all be in SUPPORTED_TYPES, enum, array/ITERABLE_TYPE/MAP_TYPE type, bean
+   * type.
+   *
+   * <p>If bean fields is ITERABLE_TYPE/MAP_TYPE, the type should be super class(inclusive) of
+   * List/Set/Map, or else should be a no arg constructor.
+   */
+  public static Set<TypeToken<?>> SUPPORTED_TYPES = new HashSet<>();
+
+  static {
+    SUPPORTED_TYPES.add(PRIMITIVE_BYTE_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_BOOLEAN_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_CHAR_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_SHORT_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_INT_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_LONG_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_FLOAT_TYPE);
+    SUPPORTED_TYPES.add(PRIMITIVE_DOUBLE_TYPE);
+
+    SUPPORTED_TYPES.add(BYTE_TYPE);
+    SUPPORTED_TYPES.add(BOOLEAN_TYPE);
+    SUPPORTED_TYPES.add(CHAR_TYPE);
+    SUPPORTED_TYPES.add(SHORT_TYPE);
+    SUPPORTED_TYPES.add(INT_TYPE);
+    SUPPORTED_TYPES.add(LONG_TYPE);
+    SUPPORTED_TYPES.add(FLOAT_TYPE);
+    SUPPORTED_TYPES.add(DOUBLE_TYPE);
+
+    SUPPORTED_TYPES.add(STRING_TYPE);
+    SUPPORTED_TYPES.add(BIG_DECIMAL_TYPE);
+    // SUPPORTED_TYPES.add(BIG_INTEGER_TYPE);
+    SUPPORTED_TYPES.add(DATE_TYPE);
+    SUPPORTED_TYPES.add(LOCAL_DATE_TYPE);
+    SUPPORTED_TYPES.add(TIMESTAMP_TYPE);
+    SUPPORTED_TYPES.add(INSTANT_TYPE);
+  }
+
+  static {
+    try {
+      ITERATOR_RETURN_TYPE = Iterable.class.getMethod("iterator").getGenericReturnType();
+      NEXT_RETURN_TYPE = Iterator.class.getMethod("next").getGenericReturnType();
+      KEY_SET_RETURN_TYPE = Map.class.getMethod("keySet").getGenericReturnType();
+      VALUES_RETURN_TYPE = Map.class.getMethod("values").getGenericReturnType();
+    } catch (NoSuchMethodException e) {
+      throw new Error(e); // should be impossible
+    }
+  }
+
+  public static boolean isNullable(Class<?> clz) {
+    return !isPrimitive(clz);
+  }
+
+  // sorted by size
+  private static final List<Class<?>> sortedPrimitiveClasses =
+      ImmutableList.of(
+          void.class,
+          boolean.class,
+          byte.class,
+          char.class,
+          short.class,
+          int.class,
+          float.class,
+          long.class,
+          double.class);
+  private static final List<Class<?>> sortedBoxedClasses =
+      ImmutableList.of(
+          Void.class,
+          Boolean.class,
+          Byte.class,
+          Character.class,
+          Short.class,
+          Integer.class,
+          Float.class,
+          Long.class,
+          Double.class);
+  private static final int[] sortedSizes = new int[] {0, 1, 1, 2, 2, 4, 4, 8, 8};
+  private static final IdentityMap<Class<?>, Class<?>> primToWrap = new IdentityMap<>(9);
+  private static final IdentityMap<Class<?>, Class<?>> wrapToPrim = new IdentityMap<>(9);
+
+  static {
+    add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
+    add(primToWrap, wrapToPrim, byte.class, Byte.class);
+    add(primToWrap, wrapToPrim, char.class, Character.class);
+    add(primToWrap, wrapToPrim, double.class, Double.class);
+    add(primToWrap, wrapToPrim, float.class, Float.class);
+    add(primToWrap, wrapToPrim, int.class, Integer.class);
+    add(primToWrap, wrapToPrim, long.class, Long.class);
+    add(primToWrap, wrapToPrim, short.class, Short.class);
+    add(primToWrap, wrapToPrim, void.class, Void.class);
+  }
+
+  private static void add(
+      IdentityMap<Class<?>, Class<?>> forward,
+      IdentityMap<Class<?>, Class<?>> backward,
+      Class<?> key,
+      Class<?> value) {
+    forward.put(key, value);
+    backward.put(value, key);
+  }
+
+  public static boolean isPrimitive(Class<?> clz) {
+    return clz.isPrimitive();
+  }
+
+  public static boolean isBoxed(Class<?> clz) {
+    return wrapToPrim.containsKey(clz);
+  }
+
+  public static Class<?> boxedType(Class<?> clz) {
+    Preconditions.checkArgument(clz.isPrimitive());
+    int index = sortedPrimitiveClasses.indexOf(clz);
+    return sortedBoxedClasses.get(index);
+  }
+
+  public static List<Class<?>> getSortedPrimitiveClasses() {
+    return sortedPrimitiveClasses;
+  }
+
+  public static List<Class<?>> getSortedBoxedClasses() {
+    return sortedBoxedClasses;
+  }
+
+  /** Returns a primitive type class that has has max size between numericTypes. */
+  public static Class<?> maxType(Class<?>... numericTypes) {
+    Preconditions.checkArgument(numericTypes.length >= 2);
+    int maxIndex = 0;
+    for (Class<?> numericType : numericTypes) {
+      int index;
+      if (isPrimitive(numericType)) {
+        index = sortedPrimitiveClasses.indexOf(numericType);
+      } else {
+        index = sortedBoxedClasses.indexOf(numericType);
+      }
+      if (index == -1) {
+        throw new IllegalArgumentException(
+            String.format("Wrong numericTypes %s", Arrays.toString(numericTypes)));
+      }
+      maxIndex = Math.max(maxIndex, index);
+    }
+    return sortedPrimitiveClasses.get(maxIndex);
+  }
+
+  /** Returns size of primitive type. */
+  public static int getSizeOfPrimitiveType(TypeToken<?> numericType) {
+    return getSizeOfPrimitiveType(getRawType(numericType));
+  }
+
+  public static int getSizeOfPrimitiveType(Class<?> numericType) {
+    if (isPrimitive(numericType)) {
+      int index = sortedPrimitiveClasses.indexOf(numericType);
+      return sortedSizes[index];
+    } else {
+      String msg = String.format("Class %s must be primitive", numericType);
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
+  /** Returns default value of class. */
+  public static String defaultValue(Class<?> type) {
+    return defaultValue(type.getSimpleName(), false);
+  }
+
+  /** Returns default value of class. */
+  public static String defaultValue(String type) {
+    return defaultValue(type, false);
+  }
+
+  /**
+   * Returns the representation of default value for a given Java Type.
+   *
+   * @param type the string name of the Java type
+   * @param typedNull if true, for null literals, return a typed (with a cast) version
+   */
+  public static String defaultValue(String type, boolean typedNull) {
+    switch (type) {
+      case JAVA_BOOLEAN:
+        return "false";
+      case JAVA_BYTE:
+        return "(byte)0";
+      case JAVA_SHORT:
+        return "(short)0";
+      case JAVA_INT:
+        return "0";
+      case JAVA_LONG:
+        return "0L";
+      case JAVA_FLOAT:
+        return "0.0f";
+      case JAVA_DOUBLE:
+        return "0.0";
+      default:
+        if (typedNull) {
+          return String.format("((%s)null)", type);
+        } else {
+          return "null";
+        }
+    }
+  }
+
+  /** Faster method to get raw type from {@link TypeToken} than {@link TypeToken#getRawType}. */
+  public static Class<?> getRawType(TypeToken<?> typeToken) {
+    Type type = typeToken.getType();
+    if (type.getClass() == Class.class) {
+      return (Class<?>) type;
+    } else {
+      return getRawType(typeToken.getType());
+    }
+  }
+
+  /** Faster method to get raw type from {@link TypeToken} than {@link TypeToken#getRawType}. */
+  public static Class<?> getRawType(Type type) {
+    if (type instanceof TypeVariable) {
+      return getRawType(((TypeVariable<?>) type).getBounds()[0]);
+    } else if (type instanceof WildcardType) {
+      return getRawType(((WildcardType) type).getUpperBounds()[0]);
+    } else if (type instanceof ParameterizedType) {
+      return (Class<?>) ((ParameterizedType) type).getRawType();
+    } else if (type instanceof Class) {
+      return ((Class<?>) type);
+    } else if (type instanceof GenericArrayType) {
+      Type componentType = ((GenericArrayType) type).getGenericComponentType();
+      return Array.newInstance(getRawType(TypeToken.of(componentType)), 0).getClass();
+    } else {
+      throw new AssertionError("Unknown type: " + type);
+    }
+  }
+
+  /** Returns dimensions of multi-dimension array. */
+  public static int getArrayDimensions(TypeToken<?> type) {
+    return getArrayDimensions(getRawType(type));
+  }
+
+  /** Returns dimensions of multi-dimension array. */
+  public static int getArrayDimensions(Class<?> type) {
+    return getArrayComponentInfo(type).f1;
+  }
+
+  public static Class<?> getArrayComponent(Class<?> type) {
+    return getArrayComponentInfo(type).f0;
+  }
+
+  public static Tuple2<Class<?>, Integer> getArrayComponentInfo(Class<?> type) {
+    Preconditions.checkArgument(type.isArray());
+    Class<?> t = type;
+    int dimension = 0;
+    while (t != null && t.isArray()) {
+      dimension++;
+      t = t.getComponentType();
+    }
+    return Tuple2.of(t, dimension);
+  }
+
+  /** Returns s string that represents array type declaration of type. */
+  public static String getArrayType(TypeToken<?> type) {
+    return getArrayType(getRawType(type));
+  }
+
+  /** Returns s string that represents array type declaration of type. */
+  public static String getArrayType(Class<?> type) {
+    Tuple2<Class<?>, Integer> info = getArrayComponentInfo(type);
+    StringBuilder typeBuilder = new StringBuilder(info.f0.getCanonicalName());
+    for (int i = 0; i < info.f1; i++) {
+      typeBuilder.append("[]");
+    }
+    return typeBuilder.toString();
+  }
+
+  /** Create an array type declaration from elemType and dimensions. */
+  public static String getArrayType(Class<?> elemType, int[] dimensions) {
+    StringBuilder typeBuilder = new StringBuilder(elemType.getCanonicalName());
+    for (int i = 0; i < dimensions.length; i++) {
+      typeBuilder.append('[').append(dimensions[i]).append(']');
+    }
+    return typeBuilder.toString();
+  }
+
+  /**
+   * Get element type of multi dimension array.
+   *
+   * @param type array type
+   * @return element type of multi-dimension array
+   */
+  public static TypeToken<?> getMultiDimensionArrayElementType(TypeToken<?> type) {
+    TypeToken<?> t = type;
+    while (t != null && t.isArray()) {
+      t = t.getComponentType();
+    }
+    return t;
+  }
+
+  /** Returns element type of iterable. */
+  public static TypeToken<?> getElementType(TypeToken<?> typeToken) {
+    Type type = typeToken.getType();
+    if (type instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+      if (parameterizedType.getRawType() == List.class) { // fastpath
+        Type[] actualTypeArguments = (parameterizedType).getActualTypeArguments();
+        Preconditions.checkState(actualTypeArguments.length == 1);
+        Type t = actualTypeArguments[0];
+        if (t.getClass() == Class.class) { // if t is wild type, upper should be parsed.
+          return TypeToken.of(t);
+        }
+      }
+    }
+    @SuppressWarnings("unchecked")
+    TypeToken<?> supertype =
+        ((TypeToken<? extends Iterable<?>>) typeToken).getSupertype(Iterable.class);
+    return supertype.resolveType(ITERATOR_RETURN_TYPE).resolveType(NEXT_RETURN_TYPE);
+  }
+
+  public static TypeToken<?> getCollectionType(TypeToken<?> typeToken) {
+    @SuppressWarnings("unchecked")
+    TypeToken<?> supertype =
+        ((TypeToken<? extends Iterable<?>>) typeToken).getSupertype(Iterable.class);
+    return supertype.getSubtype(Collection.class);
+  }
+
+  /** Returns key/value type of map. */
+  public static Tuple2<TypeToken<?>, TypeToken<?>> getMapKeyValueType(TypeToken<?> typeToken) {
+    Type type = typeToken.getType();
+    if (type instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+      if (parameterizedType.getRawType() == Map.class) { // fastpath
+        Type[] actualTypeArguments = (parameterizedType).getActualTypeArguments();
+        Preconditions.checkState(actualTypeArguments.length == 2);
+        if (actualTypeArguments[0].getClass() == Class.class
+            && actualTypeArguments[1].getClass() == Class.class) {
+          // if actualTypeArguments are wild type, upper should be parsed.
+          return Tuple2.of(
+              TypeToken.of(actualTypeArguments[0]), TypeToken.of(actualTypeArguments[1]));
+        }
+      }
+    }
+    @SuppressWarnings("unchecked")
+    TypeToken<?> supertype = ((TypeToken<? extends Map<?, ?>>) typeToken).getSupertype(Map.class);
+    TypeToken<?> keyType = getElementType(supertype.resolveType(KEY_SET_RETURN_TYPE));
+    TypeToken<?> valueType = getElementType(supertype.resolveType(VALUES_RETURN_TYPE));
+    return Tuple2.of(keyType, valueType);
+  }
+
+  public static <E> TypeToken<ArrayList<E>> arrayListOf(Class<E> elemType) {
+    return new TypeToken<ArrayList<E>>() {}.where(new TypeParameter<E>() {}, elemType);
+  }
+
+  public static <E> TypeToken<List<E>> listOf(Class<E> elemType) {
+    return new TypeToken<List<E>>() {}.where(new TypeParameter<E>() {}, elemType);
+  }
+
+  public static <E> TypeToken<Collection<E>> collectionOf(Class<E> elemType) {
+    return collectionOf(TypeToken.of(elemType));
+  }
+
+  public static <E> TypeToken<Collection<E>> collectionOf(TypeToken<E> elemType) {
+    return new TypeToken<Collection<E>>() {}.where(new TypeParameter<E>() {}, elemType);
+  }
+
+  public static <K, V> TypeToken<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
+    return mapOf(TypeToken.of(keyType), TypeToken.of(valueType));
+  }
+
+  public static <K, V> TypeToken<Map<K, V>> mapOf(TypeToken<K> keyType, TypeToken<V> valueType) {
+    return new TypeToken<Map<K, V>>() {}.where(new TypeParameter<K>() {}, keyType)
+        .where(new TypeParameter<V>() {}, valueType);
+  }
+
+  public static <K, V> TypeToken<? extends Map<K, V>> mapOf(
+      Class<?> mapType, TypeToken<K> keyType, TypeToken<V> valueType) {
+    TypeToken<Map<K, V>> mapTypeToken = mapOf(keyType, valueType);
+    return mapTypeToken.getSubtype(mapType);
+  }
+
+  public static <K, V> TypeToken<? extends Map<K, V>> mapOf(
+      Class<?> mapType, Class<K> keyType, Class<V> valueType) {
+    TypeToken<Map<K, V>> mapTypeToken = mapOf(keyType, valueType);
+    return mapTypeToken.getSubtype(mapType);
+  }
+
+  public static <K, V> TypeToken<HashMap<K, V>> hashMapOf(Class<K> keyType, Class<V> valueType) {
+    return new TypeToken<HashMap<K, V>>() {}.where(new TypeParameter<K>() {}, keyType)
+        .where(new TypeParameter<V>() {}, valueType);
+  }
+
+  public static boolean isCollection(Class<?> cls) {
+    return cls == ArrayList.class || Collection.class.isAssignableFrom(cls);
+  }
+
+  public static boolean isMap(Class<?> cls) {
+    return cls == HashMap.class || Map.class.isAssignableFrom(cls);
+  }
+
+  public static boolean isBean(Type type) {
+    return isBean(TypeToken.of(type));
+  }
+
+  public static boolean isBean(Class<?> clz) {
+    return isBean(TypeToken.of(clz));
+  }
+
+  /**
+   * Returns true if class is not array/iterable/map, and all fields is {@link
+   * TypeUtils#isSupported(TypeToken)}. Bean class can't be a non-static inner class. Public static
+   * nested class is ok.
+   */
+  public static boolean isBean(TypeToken<?> typeToken) {
+    return isBean(typeToken, new LinkedHashSet<>());
+  }
+
+  private static boolean isBean(TypeToken<?> typeToken, LinkedHashSet<TypeToken> walkedTypePath) {
+    Class<?> cls = getRawType(typeToken);
+    if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
+      return false;
+    }
+    // since we need to access class in generated code in our package, the class must be public
+    // if ReflectionUtils.hasNoArgConstructor(cls) return false, we use Unsafe to create object.
+    if (Modifier.isPublic(cls.getModifiers())) {
+      // bean class can be static nested class, but can't be not a non-static inner class
+      if (cls.getEnclosingClass() != null && !Modifier.isStatic(cls.getModifiers())) {
+        return false;
+      }
+      LinkedHashSet<TypeToken> newTypePath = new LinkedHashSet<>(walkedTypePath);
+      newTypePath.add(typeToken);
+      if (cls == Object.class) {
+        // return false for typeToken that point to un-specialized generic type.
+        return false;
+      }
+      boolean maybe =
+          !SUPPORTED_TYPES.contains(typeToken)
+              && !typeToken.isArray()
+              && !cls.isEnum()
+              && !ITERABLE_TYPE.isSupertypeOf(typeToken)
+              && !MAP_TYPE.isSupertypeOf(typeToken);
+      if (maybe) {
+        return Descriptor.getDescriptors(cls).stream()
+            .allMatch(
+                d -> {
+                  TypeToken<?> t = d.getTypeToken();
+                  // do field modifiers and getter/setter validation here, not in getDescriptors.
+                  // If Modifier.isFinal(d.getModifiers()), use reflection
+                  // private field that doesn't have getter/setter will be handled by reflection.
+                  return isSupported(t, newTypePath) || isBean(t, newTypePath);
+                });
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  /** Check if <code>typeToken</code> is supported by row-format. */
+  public static boolean isSupported(TypeToken<?> typeToken) {
+    return isSupported(typeToken, new LinkedHashSet<>());
+  }
+
+  private static boolean isSupported(
+      TypeToken<?> typeToken, LinkedHashSet<TypeToken> walkedTypePath) {
+    Class<?> cls = getRawType(typeToken);
+    if (!Modifier.isPublic(cls.getModifiers())) {
+      return false;
+    }
+    if (cls == Object.class) {
+      // return true for typeToken that point to un-specialized generic type, take it as a black
+      // box.
+      return true;
+    }
+    if (SUPPORTED_TYPES.contains(typeToken)) {
+      return true;
+    } else if (typeToken.isArray()) {
+      return isSupported(Objects.requireNonNull(typeToken.getComponentType()));
+    } else if (ITERABLE_TYPE.isSupertypeOf(typeToken)) {
+      boolean isSuperOfArrayList = cls.isAssignableFrom(ArrayList.class);
+      boolean isSuperOfHashSet = cls.isAssignableFrom(HashSet.class);
+      if ((!isSuperOfArrayList && !isSuperOfHashSet)
+          && (cls.isInterface() || Modifier.isAbstract(cls.getModifiers()))) {
+        return false;
+      }
+      return isSupported(getElementType(typeToken));
+    } else if (MAP_TYPE.isSupertypeOf(typeToken)) {
+      boolean isSuperOfHashMap = cls.isAssignableFrom(HashMap.class);
+      if (!isSuperOfHashMap && (cls.isInterface() || Modifier.isAbstract(cls.getModifiers()))) {
+        return false;
+      }
+      Tuple2<TypeToken<?>, TypeToken<?>> mapKeyValueType = getMapKeyValueType(typeToken);
+      return isSupported(mapKeyValueType.f0) && isSupported(mapKeyValueType.f1);
+    } else {
+      if (walkedTypePath.contains(typeToken)) {
+        throw new UnsupportedOperationException(
+            "cyclic type is not supported. walkedTypePath: " + walkedTypePath);
+      } else {
+        LinkedHashSet<TypeToken> newTypePath = new LinkedHashSet<>(walkedTypePath);
+        newTypePath.add(typeToken);
+        return isBean(typeToken, newTypePath);
+      }
+    }
+  }
+
+  /**
+   * listBeansRecursiveInclusive.
+   *
+   * @param beanClass beanClass
+   * @return a bean classes list in this <code>beanClass</code>, all its fields and all type
+   *     parameters recursively
+   */
+  public static LinkedHashSet<Class<?>> listBeansRecursiveInclusive(Class<?> beanClass) {
+    return listBeansRecursiveInclusive(beanClass, new LinkedHashSet<>());
+  }
+
+  private static LinkedHashSet<Class<?>> listBeansRecursiveInclusive(
+      Class<?> beanClass, LinkedHashSet<TypeToken<?>> walkedTypePath) {
+    LinkedHashSet<Class<?>> beans = new LinkedHashSet<>();
+    if (isBean(beanClass)) {
+      beans.add(beanClass);
+    }
+    LinkedHashSet<TypeToken<?>> typeTokens = new LinkedHashSet<>();
+    List<Descriptor> descriptors = Descriptor.getDescriptors(beanClass);
+    for (Descriptor descriptor : descriptors) {
+      TypeToken<?> typeToken = descriptor.getTypeToken();
+      typeTokens.add(descriptor.getTypeToken());
+      typeTokens.addAll(getAllTypeArguments(typeToken));
+    }
+
+    typeTokens.stream()
+        .filter(typeToken -> isBean(getRawType(typeToken)))
+        .forEach(
+            typeToken -> {
+              Class<?> cls = getRawType(typeToken);
+              beans.add(cls);
+              if (walkedTypePath.contains(typeToken)) {
+                throw new UnsupportedOperationException(
+                    "cyclic type is not supported. walkedTypePath: " + walkedTypePath);
+              } else {
+                LinkedHashSet<TypeToken<?>> newPath = new LinkedHashSet<>(walkedTypePath);
+                newPath.add(typeToken);
+                beans.addAll(listBeansRecursiveInclusive(cls, newPath));
+              }
+            });
+    return beans;
+  }
+
+  public static int computeStringHash(String str) {
+    byte[] strBytes = str.getBytes(StandardCharsets.UTF_8);
+    long hash = 17;
+    for (byte b : strBytes) {
+      hash = hash * 31 + b;
+      while (hash > Integer.MAX_VALUE) {
+        hash = hash / 7;
+      }
+    }
+    return (int) hash;
+  }
+
+  /** Returns generic type arguments of <code>typeToken</code>. */
+  public static List<TypeToken<?>> getTypeArguments(TypeToken typeToken) {
+    if (typeToken.getType() instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) typeToken.getType();
+      return Arrays.stream(parameterizedType.getActualTypeArguments())
+          .map(TypeToken::of)
+          .collect(Collectors.toList());
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  /**
+   * Returns generic type arguments of <code>typeToken</code>, includes generic type arguments of
+   * generic type arguments recursively.
+   */
+  public static List<TypeToken<?>> getAllTypeArguments(TypeToken typeToken) {
+    List<TypeToken<?>> types = getTypeArguments(typeToken);
+    LinkedHashSet<TypeToken<?>> allTypeArguments = new LinkedHashSet<>(types);
+    for (TypeToken<?> type : types) {
+      allTypeArguments.addAll(getAllTypeArguments(type));
+    }
+
+    return new ArrayList<>(allTypeArguments);
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/util/Utils.java
+++ b/java/fury-core/src/main/java/io/fury/util/Utils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.util;
+
+public class Utils {
+
+  public static void ignore(Object... args) {}
+
+  public static void checkArgument(boolean b, String errorMessage) {
+    if (!b) {
+      throw new IllegalArgumentException(errorMessage);
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   * Workaround for guava before 20.0.
+   *
+   * <p>See {@link com.google.common.base.Preconditions#checkArgument(boolean, String, Object...)}
+   * for details.
+   */
+  public static void checkArgument(
+      boolean expression,
+      String errorMessageTemplate,
+      Object errorMessageArg0,
+      Object... errorMessageArgs) {
+    if (!expression) {
+      Object[] args;
+      if (errorMessageArgs != null) {
+        args = new Object[errorMessageArgs.length + 1];
+        args[0] = errorMessageArg0;
+        System.arraycopy(errorMessageArgs, 0, args, 1, errorMessageArgs.length);
+      } else {
+        args = new Object[] {errorMessageArg0};
+      }
+      throw new IllegalArgumentException(String.format(errorMessageTemplate, args));
+    }
+  }
+}

--- a/java/fury-core/src/test/java/io/fury/type/DescriptorTest.java
+++ b/java/fury-core/src/test/java/io/fury/type/DescriptorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.type;
+
+import com.google.common.reflect.TypeToken;
+import io.fury.test.bean.BeanA;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DescriptorTest {
+
+  static class A {
+    int f1;
+  }
+
+  static class B extends A {
+    long f2;
+  }
+
+  @Test
+  public void testBuildBeanedDescriptorsMap() throws Exception {
+    Assert.assertEquals(BeanA.class.getDeclaredField("f1"), BeanA.class.getDeclaredField("f1"));
+    Assert.assertNotSame(BeanA.class.getDeclaredField("f1"), BeanA.class.getDeclaredField("f1"));
+    SortedMap<Field, Descriptor> map = Descriptor.buildBeanedDescriptorsMap(BeanA.class, true);
+    Assert.assertTrue(map.containsKey(BeanA.class.getDeclaredField("f1")));
+    Assert.assertEquals(
+        map.get(BeanA.class.getDeclaredField("doubleList")).getTypeToken(),
+        new TypeToken<List<Double>>() {});
+    Assert.assertNotNull(map.get(BeanA.class.getDeclaredField("longStringField")).getReadMethod());
+    Assert.assertEquals(
+        map.get(BeanA.class.getDeclaredField("longStringField")).getWriteMethod(),
+        BeanA.class.getDeclaredMethod("setLongStringField", String.class));
+
+    SortedMap<Field, Descriptor> map2 = Descriptor.buildBeanedDescriptorsMap(B.class, false);
+    Assert.assertEquals(map2.size(), 1);
+  }
+
+  @Test
+  public void getDescriptorsTest() throws IntrospectionException {
+    Class<?> clz = BeanA.class;
+    TypeToken<?> typeToken = TypeToken.of(clz);
+    // sort to fix field order
+    List<?> descriptors =
+        Arrays.stream(Introspector.getBeanInfo(clz).getPropertyDescriptors())
+            .filter(d -> !d.getName().equals("class"))
+            .filter(d -> !d.getName().equals("declaringClass"))
+            .filter(d -> d.getReadMethod() != null && d.getWriteMethod() != null)
+            .map(
+                p -> {
+                  TypeToken<?> returnType = typeToken.method(p.getReadMethod()).getReturnType();
+                  return Arrays.<Object>asList(
+                      p.getName(),
+                      returnType,
+                      p.getReadMethod().getName(),
+                      p.getWriteMethod().getName());
+                })
+            .collect(Collectors.toList());
+
+    Descriptor.getDescriptors(clz);
+  }
+
+  @Test
+  public void testWarmField() throws Exception {
+    Assert.assertEquals(int.class.getName(), "int");
+    Assert.assertEquals(Integer.class.getName(), "java.lang.Integer");
+    Descriptor.warmField(
+        BeanA.class, BeanA.class.getDeclaredField("beanB"), ForkJoinPool.commonPool());
+    Descriptor.getAllDescriptorsMap(BeanA.class);
+    Descriptor.clearDescriptorCache();
+    Descriptor.getAllDescriptorsMap(BeanA.class);
+  }
+}

--- a/java/fury-core/src/test/java/io/fury/type/TypeUtilsTest.java
+++ b/java/fury-core/src/test/java/io/fury/type/TypeUtilsTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.type;
+
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import io.fury.collection.Tuple2;
+import io.fury.test.bean.BeanA;
+import io.fury.test.bean.BeanB;
+import java.lang.reflect.Type;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@SuppressWarnings({"rawtypes", "UnstableApiUsage"})
+public class TypeUtilsTest {
+  @Test
+  public void getArrayTypeTest() {
+    assertEquals("int[][][][][]", TypeUtils.getArrayType(int[][][][][].class));
+    assertEquals("java.lang.Object[][][][][]", TypeUtils.getArrayType(Object[][][][][].class));
+    assertEquals("int[][][][][]", TypeUtils.getArrayType(TypeToken.of(int[][][][][].class)));
+    assertEquals(
+        "java.lang.Object[][][][][]", TypeUtils.getArrayType(TypeToken.of(Object[][][][][].class)));
+  }
+
+  @Test
+  public void getElementTypeTest() throws NoSuchMethodException {
+    TypeToken typeToken =
+        Descriptor.getDescriptorsMap(BeanA.class).get("doubleList").getTypeToken();
+
+    @SuppressWarnings("unchecked")
+    TypeToken<?> supertype =
+        ((TypeToken<? extends Iterable<?>>) typeToken).getSupertype(Iterable.class);
+    final Type iteratorReturnType = Iterable.class.getMethod("iterator").getGenericReturnType();
+    final Type nextReturnType = Iterator.class.getMethod("next").getGenericReturnType();
+    assertEquals(supertype.resolveType(iteratorReturnType), new TypeToken<Iterator<Double>>() {});
+    assertEquals(
+        supertype.resolveType(iteratorReturnType).resolveType(nextReturnType),
+        new TypeToken<Double>() {});
+  }
+
+  @Test
+  public void getSubclassElementTypeTest() {
+    abstract class A implements Collection<List<String>> {}
+    Assert.assertEquals(
+        TypeUtils.getElementType(TypeToken.of(A.class)), new TypeToken<List<String>>() {});
+  }
+
+  @Test
+  public void getMapKeyValueTypeTest() throws NoSuchMethodException {
+    TypeToken typeToken =
+        Descriptor.getDescriptorsMap(BeanA.class).get("stringBeanBMap").getTypeToken();
+
+    @SuppressWarnings("unchecked")
+    TypeToken<?> supertype = ((TypeToken<? extends Map<?, ?>>) typeToken).getSupertype(Map.class);
+
+    final Type keySetReturnType = Map.class.getMethod("keySet").getGenericReturnType();
+    final Type valuesReturnType = Map.class.getMethod("values").getGenericReturnType();
+    TypeToken<?> keyType = TypeUtils.getElementType(supertype.resolveType(keySetReturnType));
+    assertEquals(TypeToken.of(String.class), keyType);
+    TypeToken<?> valueType = TypeUtils.getElementType(supertype.resolveType(valuesReturnType));
+    assertEquals(TypeToken.of(BeanB.class), valueType);
+    Tuple2<TypeToken<?>, TypeToken<?>> mapKeyValueType =
+        TypeUtils.getMapKeyValueType(TypeToken.of(Map.class));
+    System.out.println(mapKeyValueType);
+  }
+
+  public static class Cyclic {
+    public Cyclic list;
+    public Bean bean;
+  }
+
+  public static class Bean {
+    public ArrayList list;
+    public AbstractList abstractList;
+  }
+
+  @Test
+  public void isBeanTest() {
+    Assert.assertTrue(TypeUtils.isBean(BeanA.class));
+    Assert.assertFalse(TypeUtils.isBean(Object.class));
+  }
+
+  @Test
+  public void listBeansRecursiveInclusiveTest() {
+    LinkedHashSet<Class<?>> classes = TypeUtils.listBeansRecursiveInclusive(BeanA.class);
+    // System.out.println(classes);
+    assertEquals(classes.size(), 2);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void listBeansCyclic() {
+    LinkedHashSet<Class<?>> classes = TypeUtils.listBeansRecursiveInclusive(Cyclic.class);
+    // System.out.println(classes);
+    assertEquals(classes.size(), 2);
+  }
+
+  @Test
+  public void isBean() {
+    Assert.assertTrue(TypeUtils.isBean(BeanA.class));
+    Assert.assertTrue(TypeUtils.isBean(Bean.class));
+    Assert.assertFalse(TypeUtils.isBean(ArrayList.class));
+  }
+
+  @Test
+  public void isSupported() {
+    TypeUtils.isSupported(TypeToken.of(AbstractList.class));
+  }
+
+  public static class A {
+    @Override
+    public String toString() {
+      return "A{}";
+    }
+  }
+
+  @Test
+  public void checkMethodOverride() throws NoSuchMethodException {
+    assertEquals(A.class.getMethod("toString").getDeclaringClass(), A.class);
+    assertEquals(A.class.getMethod("hashCode").getDeclaringClass(), Object.class);
+  }
+
+  @Test
+  public void testTypeConstruct() {
+    assertEquals(TypeUtils.arrayListOf(Integer.class), new TypeToken<ArrayList<Integer>>() {});
+    assertEquals(TypeUtils.listOf(Integer.class), new TypeToken<List<Integer>>() {});
+    assertEquals(
+        TypeUtils.mapOf(String.class, Integer.class), new TypeToken<Map<String, Integer>>() {});
+    assertEquals(
+        TypeUtils.hashMapOf(String.class, Integer.class),
+        new TypeToken<HashMap<String, Integer>>() {});
+  }
+
+  @Test
+  public void testMapOf() {
+    TypeToken<Map<String, Integer>> mapTypeToken = TypeUtils.mapOf(String.class, Integer.class);
+    Assert.assertEquals(mapTypeToken, new TypeToken<Map<String, Integer>>() {});
+    Assert.assertEquals(
+        TypeUtils.mapOf(HashMap.class, String.class, Integer.class),
+        new TypeToken<HashMap<String, Integer>>() {});
+    Assert.assertEquals(
+        TypeUtils.hashMapOf(String.class, Integer.class),
+        new TypeToken<HashMap<String, Integer>>() {});
+    Assert.assertEquals(
+        TypeUtils.mapOf(LinkedHashMap.class, String.class, Integer.class),
+        new TypeToken<LinkedHashMap<String, Integer>>() {});
+  }
+
+  @Test
+  public void testMaxType() {
+    assertEquals(TypeUtils.maxType(int.class, long.class), long.class);
+    assertEquals(TypeUtils.maxType(long.class, int.class), long.class);
+    assertEquals(TypeUtils.maxType(float.class, long.class), long.class);
+    assertEquals(TypeUtils.maxType(long.class, float.class), long.class);
+    List<Class<?>> classes =
+        Arrays.asList(
+            void.class,
+            boolean.class,
+            byte.class,
+            char.class,
+            short.class,
+            int.class,
+            float.class,
+            long.class,
+            double.class);
+    for (int i = 0; i < classes.size() - 1; i++) {
+      assertEquals(TypeUtils.maxType(classes.get(i), classes.get(i + 1)), classes.get(i + 1));
+    }
+  }
+
+  @Test
+  public void testGetSizeOfPrimitiveType() {
+    List<Integer> sizes =
+        ImmutableList.of(
+                void.class,
+                boolean.class,
+                byte.class,
+                char.class,
+                short.class,
+                int.class,
+                float.class,
+                long.class,
+                double.class)
+            .stream()
+            .map(TypeUtils::getSizeOfPrimitiveType)
+            .collect(Collectors.toList());
+    assertEquals(sizes, ImmutableList.of(0, 1, 1, 2, 2, 4, 4, 8, 8));
+  }
+
+  public static class Test3<T1 extends Number & Comparable, T2 extends Map> {
+    public ArrayList<String> fromField3;
+    public List raw;
+    public T2 unknown2;
+    public T2[] arrayUnknown2;
+    public ArrayList<?> unboundWildcard;
+    public ArrayList<? extends Number> upperBound;
+  }
+
+  @Test
+  public void testGetRawType() throws NoSuchFieldException {
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("fromField3").getGenericType()),
+        ArrayList.class);
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("raw").getGenericType()), List.class);
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("unknown2").getGenericType()), Map.class);
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("arrayUnknown2").getGenericType()),
+        Map[].class);
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("unboundWildcard").getGenericType()),
+        ArrayList.class);
+    assertEquals(
+        TypeUtils.getRawType(Test3.class.getDeclaredField("upperBound").getGenericType()),
+        ArrayList.class);
+  }
+
+  @Test
+  public void getTypeArguments() {
+    TypeToken<Tuple2<String, Map<String, Integer>>> typeToken =
+        new TypeToken<Tuple2<String, Map<String, Integer>>>() {};
+    assertEquals(TypeUtils.getTypeArguments(typeToken).size(), 2);
+  }
+
+  @Test
+  public void getAllTypeArguments() {
+    TypeToken<Tuple2<String, Map<String, BeanA>>> typeToken =
+        new TypeToken<Tuple2<String, Map<String, BeanA>>>() {};
+    List<TypeToken<?>> allTypeArguments = TypeUtils.getAllTypeArguments(typeToken);
+    assertEquals(allTypeArguments.size(), 3);
+    assertEquals(allTypeArguments.get(2).getRawType(), BeanA.class);
+  }
+}

--- a/java/fury-test-core/src/main/java/io/fury/test/bean/BeanA.java
+++ b/java/fury-test-core/src/main/java/io/fury/test/bean/BeanA.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.test.bean;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import lombok.Data;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@Data
+public class BeanA implements Serializable {
+  private short f1;
+  private Integer f2;
+  private long f3;
+  private Float f4;
+  private double f5;
+  private BeanB beanB;
+  private int[] intArray;
+  private byte[] bytes;
+  private boolean f12;
+  private transient BeanB f13;
+  public Integer f15;
+  public BigDecimal f16;
+  public String f17;
+  public String longStringField;
+  private List<Double> doubleList;
+  private Iterable<BeanB> beanBIterable;
+  private List<BeanB> beanBList;
+  private Map<String, BeanB> stringBeanBMap;
+  private int[][] int2DArray;
+  private List<List<Double>> double2DList;
+
+  public static BeanA createBeanA(int arrSize) {
+    BeanA beanA = new BeanA();
+    Random rnd = new Random(37);
+    beanA.setF1((short) rnd.nextInt());
+    beanA.setF2(rnd.nextInt());
+    beanA.setF3(rnd.nextLong());
+    beanA.setF4(rnd.nextFloat());
+    beanA.setF5(rnd.nextDouble());
+    beanA.f15 = rnd.nextInt();
+    beanA.setF12(true);
+    beanA.setBeanB(BeanB.createBeanB(arrSize));
+    BigDecimal decimal = new BigDecimal(new BigInteger("122222222222222225454657712222222222"), 18);
+    beanA.setF16(decimal);
+    beanA.setF17(RandomStringUtils.randomAlphabetic(40));
+    beanA.setLongStringField(RandomStringUtils.randomAlphabetic(20));
+
+    if (arrSize > 0) {
+      {
+        beanA.bytes = new byte[arrSize];
+        rnd.nextBytes(beanA.bytes);
+      }
+      {
+        List<Double> doubleList = new ArrayList<>();
+        for (int i = 0; i < arrSize; i++) {
+          doubleList.add(rnd.nextDouble());
+        }
+        doubleList.set(0, null);
+        beanA.setDoubleList(doubleList);
+      }
+      {
+        List<List<Double>> double2DList = new ArrayList<>();
+        for (int i = 0; i < arrSize; i++) {
+          List<Double> doubleArrayList = new ArrayList<>();
+          for (int j = 0; j < arrSize; j++) {
+            doubleArrayList.add(rnd.nextDouble());
+          }
+          double2DList.add(doubleArrayList);
+        }
+        beanA.setDouble2DList(double2DList);
+      }
+      {
+        int[] arr = new int[arrSize];
+        for (int i = 0; i < arr.length; i++) {
+          arr[i] = rnd.nextInt();
+        }
+        beanA.setIntArray(arr);
+      }
+      {
+        int[][] int2DArray = new int[arrSize][arrSize];
+        for (int i = 0; i < int2DArray.length; i++) {
+          int[] arr = int2DArray[i];
+          for (int j = 0; j < arr.length; j++) {
+            arr[i] = rnd.nextInt();
+          }
+        }
+        beanA.setInt2DArray(int2DArray);
+      }
+      {
+        List<BeanB> beanBList = new ArrayList<>();
+        for (int i = 0; i < arrSize; i++) {
+          beanBList.add(BeanB.createBeanB(arrSize));
+        }
+        beanA.setBeanBList(beanBList);
+      }
+      {
+        Map<String, BeanB> stringBeanBMap = new HashMap<>();
+        for (int i = 0; i < arrSize; i++) {
+          stringBeanBMap.put("key" + i, BeanB.createBeanB(arrSize));
+        }
+        beanA.setStringBeanBMap(stringBeanBMap);
+      }
+      {
+        List<BeanB> beanBList = new ArrayList<>();
+        for (int i = 0; i < arrSize; i++) {
+          beanBList.add(BeanB.createBeanB(arrSize));
+        }
+        beanA.setBeanBIterable(beanBList);
+      }
+    }
+
+    return beanA;
+  }
+}

--- a/java/fury-test-core/src/main/java/io/fury/test/bean/BeanB.java
+++ b/java/fury-test-core/src/main/java/io/fury/test/bean/BeanB.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.test.bean;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import lombok.Data;
+
+@Data
+public final class BeanB implements Serializable {
+  private short f1;
+  private Integer f2;
+  private long f3;
+  private Float f4;
+  private double f5;
+  private int[] intArr;
+  private List<Integer> intList;
+
+  public static BeanB createBeanB(int arrSize) {
+    Random rnd = new Random(37);
+    BeanB beanB = new BeanB();
+    beanB.setF1((short) rnd.nextInt());
+    beanB.setF2(rnd.nextInt());
+    beanB.setF3(rnd.nextLong());
+    beanB.setF4(rnd.nextFloat());
+    beanB.setF5(rnd.nextDouble());
+
+    if (arrSize > 0) {
+      {
+        int[] arr = new int[arrSize];
+        for (int i = 0; i < arr.length; i++) {
+          arr[i] = rnd.nextInt();
+        }
+        beanB.setIntArr(arr);
+      }
+      {
+        List<Integer> integers = new ArrayList<>();
+        for (int i = 0; i < arrSize; i++) {
+          integers.add(rnd.nextInt());
+        }
+        beanB.setIntList(integers);
+      }
+    }
+    return beanB;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
- extract java generics based on guava `TypeToken`
- parallel mutil-threaded generics parsing  
- guava generics parsing speedup
- sorted descriptors building
- descriptors cache
- ignore fields annotated by `@Ignore`
- bean check
- type parameters extract
- map/collection generics extract and building
- primitives type size computing
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #44 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
