### PR TITLE
[Java] support serializing byte buffer

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -29,6 +29,7 @@ import io.fury.collection.ObjectMap;
 import io.fury.exception.InsecureException;
 import io.fury.memory.MemoryBuffer;
 import io.fury.serializer.ArraySerializers;
+import io.fury.serializer.BufferSerializers;
 import io.fury.serializer.Serializer;
 import io.fury.serializer.SerializerFactory;
 import io.fury.serializer.Serializers;
@@ -507,6 +508,8 @@ public class ClassResolver {
       } else if (cls.isArray()) {
         Preconditions.checkArgument(!cls.getComponentType().isPrimitive());
         return ArraySerializers.ObjectArraySerializer.class;
+      } else if (ByteBuffer.class.isAssignableFrom(cls)) {
+        return BufferSerializers.ByteBufferSerializer.class;
       }
       throw new UnsupportedOperationException();
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/BufferSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/BufferSerializers.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import io.fury.type.Type;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Serializers for buffer related classes.
+ *
+ * @author chaokunyang
+ */
+public class BufferSerializers {
+  /**
+   * Note that this serializer only serialize data, but not the byte buffer meta. Since ByteBuffer
+   * doesn't implement {@link java.io.Serializable}, it's ok to only serialize data. Also Note that
+   * a direct buffer may be returned if the serialized buffer is a heap buffer.
+   */
+  public static final class ByteBufferSerializer
+      extends Serializers.CrossLanguageCompatibleSerializer<ByteBuffer> {
+
+    public ByteBufferSerializer(Fury fury, Class<ByteBuffer> cls) {
+      super(fury, cls, Type.FURY_BUFFER.getId());
+    }
+
+    @Override
+    public void write(MemoryBuffer buffer, ByteBuffer value) {
+      fury.writeBufferObject(buffer, new BufferObject.ByteBufferBufferObject(value));
+    }
+
+    @Override
+    public ByteBuffer read(MemoryBuffer buffer) {
+      MemoryBuffer newBuffer = fury.readBufferObject(buffer);
+      int readerIndex = newBuffer.readerIndex();
+      int size = newBuffer.remaining();
+      ByteBuffer originalBuffer = newBuffer.sliceAsByteBuffer(readerIndex, size - 1);
+      byte isBigEndian = newBuffer.get(readerIndex + size - 1);
+      originalBuffer.order(
+          isBigEndian == (byte) 1 ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
+      return originalBuffer;
+    }
+  }
+
+  // TODO(chaokunyang) add support for MemoryBuffer serialization.
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/BufferSerializersTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/BufferSerializersTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import io.fury.Fury;
+import io.fury.FuryTestBase;
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+public class BufferSerializersTest extends FuryTestBase {
+
+  @Test
+  public void testByteBuffer() {
+    Fury fury = Fury.builder().build();
+    ByteBuffer buffer1 = ByteBuffer.allocate(32);
+    buffer1.putLong(1000L);
+    buffer1.rewind();
+    serDeCheck(fury, buffer1);
+    ByteBuffer buffer2 = ByteBuffer.allocateDirect(32);
+    buffer2.putDouble(1.0 / 3);
+    buffer2.rewind();
+    serDeCheck(fury, buffer2);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR  implements byte buffer serialization:
- HeapByteBuffer will be deserialized as it is.
- DirectByteBuffer will be deserialized as HeapByteBuffer.
- Buffer position/mark will be set it 0
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #111 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
