### PR TITLE
[Java] implement jdk proxy serialization

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -31,6 +31,7 @@ import io.fury.memory.MemoryBuffer;
 import io.fury.serializer.ArraySerializers;
 import io.fury.serializer.BufferSerializers;
 import io.fury.serializer.JavaSerializer;
+import io.fury.serializer.JdkProxySerializer;
 import io.fury.serializer.LocaleSerializer;
 import io.fury.serializer.OptionalSerializers;
 import io.fury.serializer.Serializer;
@@ -177,6 +178,7 @@ public class ClassResolver {
   }
 
   public void initialize() {
+    register(JdkProxySerializer.ReplaceStub.class, JDK_PROXY_STUB_ID);
     registerWithCheck(void.class, PRIMITIVE_VOID_CLASS_ID);
     registerWithCheck(boolean.class, PRIMITIVE_BOOLEAN_CLASS_ID);
     registerWithCheck(byte.class, PRIMITIVE_BYTE_CLASS_ID);
@@ -223,6 +225,9 @@ public class ClassResolver {
     TimeSerializers.registerDefaultSerializers(fury);
     OptionalSerializers.registerDefaultSerializers(fury);
     addDefaultSerializer(Locale.class, new LocaleSerializer(fury));
+    addDefaultSerializer(
+        JdkProxySerializer.ReplaceStub.class,
+        new JdkProxySerializer(fury, JdkProxySerializer.ReplaceStub.class));
   }
 
   private void addDefaultSerializer(Class<?> type, Class<? extends Serializer> serializerClass) {
@@ -542,6 +547,8 @@ public class ClassResolver {
       } else if (cls.isArray()) {
         Preconditions.checkArgument(!cls.getComponentType().isPrimitive());
         return ArraySerializers.ObjectArraySerializer.class;
+      } else if (ReflectionUtils.isJdkProxy(cls)) {
+        return JdkProxySerializer.class;
       } else if (ByteBuffer.class.isAssignableFrom(cls)) {
         return BufferSerializers.ByteBufferSerializer.class;
       } else if (Charset.class.isAssignableFrom(cls)) {

--- a/java/fury-core/src/main/java/io/fury/serializer/JavaSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/JavaSerializer.java
@@ -18,7 +18,6 @@
 
 package io.fury.serializer;
 
-import com.google.common.base.Preconditions;
 import io.fury.Fury;
 import io.fury.io.ClassLoaderObjectInputStream;
 import io.fury.io.FuryObjectInput;
@@ -54,7 +53,8 @@ public class JavaSerializer extends Serializer {
 
   public JavaSerializer(Fury fury, Class<?> cls) {
     super(fury, cls);
-    Preconditions.checkArgument(ClassResolver.requireJavaSerialization(cls));
+    // TODO(chgaokunyang) enable this check when ObjectSerializer is implemented.
+    // Preconditions.checkArgument(ClassResolver.requireJavaSerialization(cls));
     if (cls != SerializedLambda.class) {
       LOG.warn(
           "{} use java built-in serialization, which is inefficient. "

--- a/java/fury-core/src/main/java/io/fury/serializer/JdkProxySerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/JdkProxySerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import com.google.common.base.Preconditions;
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import io.fury.util.ReflectionUtils;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+/**
+ * Serializer for jdk {@link Proxy}.
+ *
+ * @author chaokunyang
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class JdkProxySerializer extends Serializer {
+
+  public JdkProxySerializer(Fury fury, Class cls) {
+    super(fury, cls);
+    if (cls != ReplaceStub.class) {
+      Preconditions.checkArgument(ReflectionUtils.isJdkProxy(cls), "Require a jdk proxy class");
+    }
+  }
+
+  @Override
+  public void write(MemoryBuffer buffer, Object value) {
+    fury.writeReferencableToJava(buffer, Proxy.getInvocationHandler(value));
+    fury.writeReferencableToJava(buffer, value.getClass().getInterfaces());
+  }
+
+  @Override
+  public Object read(MemoryBuffer buffer) {
+    InvocationHandler invocationHandler = (InvocationHandler) fury.readReferencableFromJava(buffer);
+    Preconditions.checkNotNull(invocationHandler);
+    final Class<?>[] interfaces = (Class<?>[]) fury.readReferencableFromJava(buffer);
+    Preconditions.checkNotNull(interfaces);
+    return Proxy.newProxyInstance(fury.getClassLoader(), interfaces, invocationHandler);
+  }
+
+  public static class ReplaceStub {}
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/JdkProxySerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/JdkProxySerializerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import static org.testng.Assert.assertEquals;
+
+import io.fury.Fury;
+import io.fury.FuryTestBase;
+import io.fury.Language;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.Function;
+import org.testng.annotations.Test;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class JdkProxySerializerTest extends FuryTestBase {
+
+  private static class TestInvocationHandler implements InvocationHandler, Serializable {
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      return 1;
+    }
+  }
+
+  @Test(dataProvider = "referenceTrackingConfig")
+  public void testJdkProxy(boolean referenceTracking) {
+    Fury fury =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withReferenceTracking(referenceTracking)
+            .disableSecureMode()
+            .build();
+    Function function =
+        (Function)
+            Proxy.newProxyInstance(
+                fury.getClassLoader(), new Class[] {Function.class}, new TestInvocationHandler());
+    Function deserializedFunction = (Function) fury.deserialize(fury.serialize(function));
+    assertEquals(deserializedFunction.apply(null), 1);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR implement jdk proxy serialization.

To serialize inner `InvocationHandler`, we used `JavaSerializer` to handle object serialization. This will be changed ObjectSerializer when it's supported
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #142 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
