### PR TITLE
[Java] fury native lambda serialization for java

### DIFF
--- a/java/fury-core/src/main/java/io/fury/Config.java
+++ b/java/fury-core/src/main/java/io/fury/Config.java
@@ -58,6 +58,7 @@ public class Config implements Serializable {
   private final boolean compressNumber;
   private final boolean compressString;
   private final boolean checkClassVersion;
+  private final Class<? extends Serializer> defaultJDKStreamSerializerType;
   private final boolean secureModeEnabled;
   private final boolean classRegistrationRequired;
   private final boolean metaContextShareEnabled;
@@ -72,6 +73,7 @@ public class Config implements Serializable {
     compressNumber = builder.compressNumber;
     compressString = builder.compressString;
     checkClassVersion = builder.checkClassVersion;
+    defaultJDKStreamSerializerType = builder.defaultJDKStreamSerializerType;
     secureModeEnabled = builder.secureModeEnabled;
     classRegistrationRequired = builder.requireClassRegistration;
     metaContextShareEnabled = builder.metaContextShareEnabled;
@@ -121,6 +123,14 @@ public class Config implements Serializable {
 
   public boolean checkClassVersion() {
     return checkClassVersion;
+  }
+
+  /**
+   * Returns default serializer type for class which implements jdk serialization method such as
+   * `writeObject/readObject`.
+   */
+  public Class<? extends Serializer> getDefaultJDKStreamSerializerType() {
+    return defaultJDKStreamSerializerType;
   }
 
   public boolean isClassRegistrationRequired() {

--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -32,6 +32,7 @@ import io.fury.resolver.SerializationContext;
 import io.fury.serializer.ArraySerializers;
 import io.fury.serializer.BufferCallback;
 import io.fury.serializer.BufferObject;
+import io.fury.serializer.JavaSerializer;
 import io.fury.serializer.OpaqueObjects;
 import io.fury.serializer.Serializer;
 import io.fury.serializer.SerializerFactory;
@@ -991,6 +992,10 @@ public final class Fury {
     return config;
   }
 
+  public Class<? extends Serializer> getDefaultJDKStreamSerializerType() {
+    return config.getDefaultJDKStreamSerializerType();
+  }
+
   public boolean compressString() {
     return config.compressString();
   }
@@ -1030,6 +1035,8 @@ public final class Fury {
     ClassLoader classLoader;
     boolean compressNumber = false;
     boolean compressString = true;
+    // TODO(chaokunyang) switch to object stream serializer.
+    Class<? extends Serializer> defaultJDKStreamSerializerType = JavaSerializer.class;
     boolean secureModeEnabled = true;
     boolean requireClassRegistration = true;
     boolean metaContextShareEnabled = false;

--- a/java/fury-core/src/main/java/io/fury/serializer/LambdaSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/LambdaSerializer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import com.google.common.base.Preconditions;
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import io.fury.util.ReflectionUtils;
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Serializer for java serializable lambda. Use fury to serialize java lambda instead of JDK
+ * serialization to avoid serialization captured values in closure using JDK, which mis slow and not
+ * secure(will work around type white-list).
+ *
+ * @author chaokunyang
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class LambdaSerializer extends Serializer {
+  private static final Class<SerializedLambda> SERIALIZED_LAMBDA = SerializedLambda.class;
+  private static final Method READ_RESOLVE_METHOD =
+      (Method)
+          Objects.requireNonNull(
+              ReflectionUtils.getObjectFieldValue(
+                  ObjectStreamClass.lookup(SERIALIZED_LAMBDA), "readResolveMethod"));
+  private static final boolean SERIALIZED_LAMBDA_HAS_JDK_WRITE =
+      JavaSerializer.getWriteObjectMethod(SERIALIZED_LAMBDA) != null;
+  private static final boolean SERIALIZED_LAMBDA_HAS_JDK_READ =
+      JavaSerializer.getReadObjectMethod(SERIALIZED_LAMBDA) != null;
+  private final Method writeReplaceMethod;
+  private Serializer dataSerializer;
+
+  public LambdaSerializer(Fury fury, Class cls) {
+    super(fury, cls);
+    if (cls != ReplaceStub.class) {
+      if (!Serializable.class.isAssignableFrom(cls)) {
+        String msg =
+            String.format("Lambda needs to implement %s for serialization", Serializable.class);
+        throw new UnsupportedOperationException(msg);
+      }
+      writeReplaceMethod =
+          (Method)
+              ReflectionUtils.getObjectFieldValue(
+                  ObjectStreamClass.lookup(cls), "writeReplaceMethod");
+    } else {
+      writeReplaceMethod = null;
+    }
+  }
+
+  @Override
+  public void write(MemoryBuffer buffer, Object value) {
+    assert value.getClass() != ReplaceStub.class;
+    try {
+      Object replacement = writeReplaceMethod.invoke(value);
+      Preconditions.checkArgument(SERIALIZED_LAMBDA.isInstance(replacement));
+      getDataSerializer().write(buffer, replacement);
+    } catch (Exception e) {
+      throw new RuntimeException("Can't serialize lambda " + value, e);
+    }
+  }
+
+  @Override
+  public Object read(MemoryBuffer buffer) {
+    try {
+      Object replacement = getDataSerializer().read(buffer);
+      return READ_RESOLVE_METHOD.invoke(replacement);
+    } catch (Exception e) {
+      throw new RuntimeException("Can't deserialize lambda", e);
+    }
+  }
+
+  private Serializer getDataSerializer() {
+    // Create serializer lazily to avoid creation cost if no lambda to be serialized.
+    Serializer dataSerializer = this.dataSerializer;
+    if (dataSerializer == null) {
+      Class<? extends Serializer> sc;
+      if (SERIALIZED_LAMBDA_HAS_JDK_WRITE || SERIALIZED_LAMBDA_HAS_JDK_READ) {
+        sc = fury.getDefaultJDKStreamSerializerType();
+      } else {
+        // TODO(chaokunyang) add jit serialization support
+        sc = ObjectSerializer.class;
+      }
+      this.dataSerializer = dataSerializer = Serializers.newSerializer(fury, SERIALIZED_LAMBDA, sc);
+      fury.getClassResolver().clearSerializer(SERIALIZED_LAMBDA);
+    }
+    return dataSerializer;
+  }
+
+  /**
+   * Class name of dynamic generated class is not fixed, so we use a stub class to mock dynamic
+   * class.
+   */
+  public static class ReplaceStub {}
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/LambdaSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/LambdaSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import io.fury.Fury;
+import io.fury.FuryTestBase;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("unchecked")
+public class LambdaSerializerTest extends FuryTestBase {
+
+  @Test(dataProvider = "javaFury")
+  public void testLambda(Fury fury) {
+    {
+      BiFunction<Fury, Object, byte[]> function =
+          (Serializable & BiFunction<Fury, Object, byte[]>) Fury::serialize;
+      fury.deserialize(fury.serialize(function));
+    }
+    {
+      Function<Integer, Integer> function =
+          (Serializable & Function<Integer, Integer>) (x) -> x + x;
+      Function<Integer, Integer> newFunc =
+          (Function<Integer, Integer>) fury.deserialize(fury.serialize(function));
+      assertEquals(newFunc.apply(10), Integer.valueOf(20));
+      List<Function<Integer, Integer>> list = serDe(fury, Arrays.asList(function, function));
+      assertSame(list.get(0), list.get(1));
+      assertEquals(list.get(0).apply(20), Integer.valueOf(40));
+    }
+    assertSame(
+        fury.getClassResolver().getSerializerClass(Class.class), Serializers.ClassSerializer.class);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR implements lambda serialization natively by using `SerializableLambda` and Fury `ObjectSerializer`.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #182 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
