### PR TITLE
[Java] support compatible map serialization

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -655,7 +655,7 @@ public class ClassResolver {
           return serializerClass;
         }
         if (requireJavaSerialization(cls) || useReplaceResolveSerializer(cls)) {
-          return getJavaSerializer(cls);
+          return MapSerializers.JDKCompatibleMapSerializer.class;
         }
         if (fury.getLanguage() == Language.JAVA) {
           return MapSerializers.DefaultJavaMapSerializer.class;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR optimizes jdk compatible map serialization by forward it to fury DefaultJDKStreamSerializer/ReplaceResolveSerializer


<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #211 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
