### PR TITLE
[Java] add forward serializer

### DIFF
--- a/java/fury-core/src/main/java/io/fury/serializer/ForwardSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ForwardSerializer.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import io.fury.Fury;
+import io.fury.Language;
+import io.fury.memory.MemoryBuffer;
+import io.fury.memory.MemoryUtils;
+import io.fury.util.LoaderBinding;
+import io.fury.util.LoaderBinding.StagingType;
+import io.fury.util.Platform;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A thread-safe serializer used to forward serialization to different serializer implementation.
+ *
+ * @author chaokunyang
+ */
+@ThreadSafe
+@SuppressWarnings("unchecked")
+public class ForwardSerializer {
+
+  public abstract static class SerializerProxy<T> {
+    /** Register custom serializers should be done in this method. */
+    protected abstract T newSerializer();
+
+    protected void setClassLoader(T serializer, ClassLoader classLoader) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void setClassLoader(T serializer, ClassLoader classLoader, StagingType stagingType) {
+      setClassLoader(serializer, classLoader);
+    }
+
+    protected ClassLoader getClassLoader(T serializer) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void clearClassLoader(T serializer, ClassLoader loader) {}
+
+    protected void register(T serializer, Class<?> clz) {
+      throw new UnsupportedOperationException();
+    }
+
+    protected void register(T serializer, Class<?> clz, int id) {
+      throw new UnsupportedOperationException();
+    }
+
+    protected abstract byte[] serialize(T serializer, Object obj);
+
+    protected MemoryBuffer serialize(T serializer, MemoryBuffer buffer, Object obj) {
+      byte[] bytes = serialize(serializer, obj);
+      buffer.writeBytes(bytes);
+      return buffer;
+    }
+
+    protected ByteBuffer serialize(T serializer, ByteBuffer buffer, Object obj) {
+      byte[] bytes = serialize(serializer, obj);
+      buffer.put(bytes);
+      return buffer;
+    }
+
+    protected abstract Object deserialize(T serializer, byte[] bytes);
+
+    protected Object deserialize(T serializer, long address, int size) {
+      byte[] bytes = new byte[size];
+      Platform.copyMemory(null, address, bytes, Platform.BYTE_ARRAY_OFFSET, size);
+      return deserialize(serializer, bytes);
+    }
+
+    protected Object deserialize(T serializer, ByteBuffer byteBuffer) {
+      return deserialize(serializer, MemoryUtils.wrap(byteBuffer));
+    }
+
+    protected Object deserialize(T serializer, MemoryBuffer buffer) {
+      byte[] bytes = buffer.getRemainingBytes();
+      return deserialize(serializer, bytes);
+    }
+  }
+
+  public static class DefaultFuryProxy extends SerializerProxy<LoaderBinding> {
+
+    private final ThreadLocal<MemoryBuffer> bufferLocal =
+        ThreadLocal.withInitial(() -> MemoryUtils.buffer(32));
+
+    /** Override this method to register custom serializers. */
+    @Override
+    protected LoaderBinding newSerializer() {
+      LoaderBinding loaderBinding = new LoaderBinding(this::newFurySerializer);
+      loaderBinding.setClassLoader(Thread.currentThread().getContextClassLoader());
+      return loaderBinding;
+    }
+
+    protected Fury newFurySerializer(ClassLoader loader) {
+      return Fury.builder()
+          .withLanguage(Language.JAVA)
+          .withReferenceTracking(true)
+          .withClassLoader(loader)
+          .disableSecureMode()
+          .build();
+    }
+
+    @Override
+    protected void setClassLoader(LoaderBinding binding, ClassLoader classLoader) {
+      binding.setClassLoader(classLoader);
+    }
+
+    @Override
+    public void setClassLoader(
+        LoaderBinding binding, ClassLoader classLoader, StagingType stagingType) {
+      binding.setClassLoader(classLoader, stagingType);
+    }
+
+    @Override
+    protected ClassLoader getClassLoader(LoaderBinding binding) {
+      return binding.getClassLoader();
+    }
+
+    @Override
+    public void clearClassLoader(LoaderBinding loaderBinding, ClassLoader loader) {
+      loaderBinding.clearClassLoader(loader);
+    }
+
+    @Override
+    protected void register(LoaderBinding binding, Class<?> clz) {
+      binding.register(clz);
+    }
+
+    @Override
+    protected void register(LoaderBinding binding, Class<?> clz, int id) {
+      binding.register(clz, (short) id);
+    }
+
+    @Override
+    protected byte[] serialize(LoaderBinding binding, Object obj) {
+      MemoryBuffer buffer = bufferLocal.get();
+      buffer.writerIndex(0);
+      binding.get().serialize(buffer, obj);
+      return buffer.getBytes(0, buffer.writerIndex());
+    }
+
+    @Override
+    protected MemoryBuffer serialize(LoaderBinding binding, MemoryBuffer buffer, Object obj) {
+      binding.get().serialize(buffer, obj);
+      return buffer;
+    }
+
+    @Override
+    protected Object deserialize(LoaderBinding serializer, byte[] bytes) {
+      return serializer.get().deserialize(bytes);
+    }
+
+    @Override
+    protected Object deserialize(LoaderBinding serializer, MemoryBuffer buffer) {
+      return serializer.get().deserialize(buffer);
+    }
+  }
+
+  private final SerializerProxy proxy;
+  private final ThreadLocal<Object> serializerLocal;
+  private Set<Object> serializerSet = Collections.newSetFromMap(new IdentityHashMap<>());
+  private Consumer<Object> serializerCallback = obj -> {};
+
+  public ForwardSerializer(SerializerProxy proxy) {
+    this.proxy = proxy;
+    serializerLocal =
+        ThreadLocal.withInitial(
+            () -> {
+              Object serializer = proxy.newSerializer();
+              synchronized (ForwardSerializer.this) {
+                serializerCallback.accept(serializer);
+              }
+              serializerSet.add(serializer);
+              return serializer;
+            });
+  }
+
+  /** Set classLoader of serializer for current thread only. */
+  public void setClassLoader(ClassLoader classLoader) {
+    proxy.setClassLoader(serializerLocal.get(), classLoader);
+  }
+
+  public void setClassLoader(ClassLoader classLoader, StagingType stagingType) {
+    proxy.setClassLoader(serializerLocal.get(), classLoader, stagingType);
+  }
+
+  /** Returns classLoader of serializer for current thread. */
+  public ClassLoader getClassLoader() {
+    return proxy.getClassLoader(serializerLocal.get());
+  }
+
+  /**
+   * Clean up classloader set by {@link #setClassLoader(ClassLoader, StagingType)}, <code>
+   * classLoader
+   * </code> won't be referenced by {@link Fury} after this call and can be gc if it's not
+   * referenced by other objects.
+   */
+  public void clearClassLoader(ClassLoader loader) {
+    proxy.clearClassLoader(serializerLocal.get(), loader);
+  }
+
+  public synchronized void register(Class<?> clz) {
+    serializerSet.forEach(serializer -> proxy.register(serializer, clz));
+    serializerCallback =
+        serializerCallback.andThen(
+            serializer -> {
+              proxy.register(serializer, clz);
+            });
+  }
+
+  public synchronized void register(Class<?> clz, int id) {
+    serializerSet.forEach(serializer -> proxy.register(serializer, clz, id));
+    serializerCallback =
+        serializerCallback.andThen(
+            serializer -> {
+              proxy.register(serializer, clz, id);
+            });
+  }
+
+  public byte[] serialize(Object obj) {
+    return proxy.serialize(serializerLocal.get(), obj);
+  }
+
+  public MemoryBuffer serialize(MemoryBuffer buffer, Object obj) {
+    return proxy.serialize(serializerLocal.get(), buffer, obj);
+  }
+
+  public ByteBuffer serialize(ByteBuffer buffer, Object obj) {
+    return proxy.serialize(serializerLocal.get(), buffer, obj);
+  }
+
+  public <T> T deserialize(byte[] bytes) {
+    return (T) proxy.deserialize(serializerLocal.get(), bytes);
+  }
+
+  public <T> T deserialize(long address, int size) {
+    return (T) proxy.deserialize(serializerLocal.get(), address, size);
+  }
+
+  public <T> T deserialize(ByteBuffer byteBuffer) {
+    return (T) proxy.deserialize(serializerLocal.get(), byteBuffer);
+  }
+
+  public <T> T deserialize(MemoryBuffer buffer) {
+    return (T) proxy.deserialize(serializerLocal.get(), buffer);
+  }
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/ForwardSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/ForwardSerializerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.fury.Fury;
+import io.fury.codegen.CompileUnit;
+import io.fury.codegen.JaninoUtils;
+import io.fury.test.bean.BeanA;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+public class ForwardSerializerTest {
+
+  private ForwardSerializer createSerializer(String serializerType) {
+    switch (serializerType) {
+      case "Fury":
+        return new ForwardSerializer(
+            new ForwardSerializer.DefaultFuryProxy() {
+              @Override
+              protected Fury newFurySerializer(ClassLoader loader) {
+                Fury fury = super.newFurySerializer(loader);
+                // We can register custom serializers here.
+                System.out.printf("Created serializer %s, start to do init staff.\n", fury);
+                return fury;
+              }
+            });
+      case "Kryo":
+        return new ForwardSerializer(
+            new ForwardSerializer.SerializerProxy<Kryo>() {
+              private final ThreadLocal<Output> outputLocal =
+                  ThreadLocal.withInitial(() -> new Output(32, Integer.MAX_VALUE));
+
+              @Override
+              protected Kryo newSerializer() {
+                // We can register custom serializers here.
+                return new Kryo();
+              }
+
+              @Override
+              protected void register(Kryo serializer, Class clz) {
+                serializer.register(clz);
+              }
+
+              @Override
+              protected byte[] serialize(Kryo serializer, Object obj) {
+                Output output = outputLocal.get();
+                output.clear();
+                serializer.writeClassAndObject(output, obj);
+                return output.toBytes();
+              }
+
+              @Override
+              protected Object deserialize(Kryo serializer, byte[] bytes) {
+                Input input = new Input(bytes);
+                return serializer.readClassAndObject(input);
+              }
+            });
+      default:
+        throw new UnsupportedOperationException("Unsupported serializer type " + serializerType);
+    }
+  }
+
+  @Test
+  public void testSerialize() {
+    BeanA beanA = BeanA.createBeanA(3);
+    ForwardSerializer kryo = createSerializer("Kryo");
+    assertEquals(kryo.deserialize(kryo.serialize(beanA)), beanA);
+    ForwardSerializer fury = createSerializer("Fury");
+    assertEquals(fury.deserialize(fury.serialize(beanA)), beanA);
+  }
+
+  private volatile boolean hasException;
+
+  @Test
+  public void testConcurrent() throws InterruptedException {
+    BeanA beanA = BeanA.createBeanA(3);
+    for (String type : new String[] {"Kryo", "Fury"}) {
+      ForwardSerializer serializer = createSerializer(type);
+      serializer.register(BeanA.class);
+      assertEquals(serializer.deserialize(serializer.serialize(beanA)), beanA);
+      ExecutorService executorService = Executors.newFixedThreadPool(12);
+      for (int i = 0; i < 1000; i++) {
+        executorService.execute(
+            () -> {
+              for (int j = 0; j < 10; j++) {
+                try {
+                  assertEquals(serializer.deserialize(serializer.serialize(beanA)), beanA);
+                } catch (Exception e) {
+                  hasException = true;
+                  e.printStackTrace();
+                  throw e;
+                }
+              }
+            });
+      }
+      executorService.shutdown();
+      assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
+      assertFalse(hasException);
+    }
+  }
+
+  @Test
+  public void testClassLoader() throws Exception {
+    ForwardSerializer serializer = createSerializer("Fury");
+    CompileUnit unit =
+        new CompileUnit(
+            "demo.pkg1",
+            "A",
+            (""
+                + "package demo.pkg1;\n"
+                + "public class A {\n"
+                + "  public String f1 = \"str1\";\n"
+                + "  public String f2 = \"str2\";\n"
+                + "}"));
+    ClassLoader loader = null;
+    for (int i = 0; i < 5; i++) {
+      ClassLoader newLoader = JaninoUtils.compile(getClass().getClassLoader(), unit);
+      assertNotSame(loader, newLoader);
+      assertNotEquals(loader, newLoader);
+      loader = newLoader;
+      Class<?> clz = loader.loadClass("demo.pkg1.A");
+      Object a = clz.newInstance();
+      serializer.setClassLoader(loader);
+      serializer.deserialize(serializer.serialize(a));
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR a `ForwardSerializer` to support forward serialization to other serialization libraries. In this way, the serialization lib switch will be more convinient
<!-- Please give a short brief about these changes. -->

Example:
```java
ForwardSerializer serializer = new ForwardSerializer(
    new ForwardSerializer.SerializerProxy<Kryo>() {
      private final ThreadLocal<Output> outputLocal =
          ThreadLocal.withInitial(() -> new Output(32, Integer.MAX_VALUE));

      @Override
      protected Kryo newSerializer() {
        // We can register custom serializers here.
        return new Kryo();
      }

      @Override
      protected void register(Kryo serializer, Class clz) {
        serializer.register(clz);
      }

      @Override
      protected byte[] serialize(Kryo serializer, Object obj) {
        Output output = outputLocal.get();
        output.clear();
        serializer.writeClassAndObject(output, obj);
        return output.toBytes();
      }

      @Override
      protected Object deserialize(Kryo serializer, byte[] bytes) {
        Input input = new Input(bytes);
        return serializer.readClassAndObject(input);
      }
    });

ForwardSerializer kryo = createSerializer("Kryo");
assertEquals(kryo.deserialize(kryo.serialize(beanA)), beanA);
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #277 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
