### PR TITLE
[Java] add thread-safe fury serializer

### DIFF
--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -1430,5 +1430,23 @@ public final class Fury {
       this.classLoader = null;
       return new Fury(this, loader);
     }
+
+    /** Build thread safe fury. */
+    public ThreadSafeFury buildThreadSafeFury() {
+      return buildThreadLocalFury();
+    }
+
+    /** Build thread safe fury backed by {@link ThreadLocalFury}. */
+    public ThreadLocalFury buildThreadLocalFury() {
+      finish();
+      ClassLoader loader = this.classLoader;
+      // clear classLoader to avoid `LoaderBinding#furyFactory` lambda capture classLoader by
+      // capturing `FuryBuilder`,  which make `classLoader` not able to be gc.
+      this.classLoader = null;
+      ThreadLocalFury threadSafeFury =
+          new ThreadLocalFury(classLoader -> new Fury(FuryBuilder.this, classLoader));
+      threadSafeFury.setClassLoader(loader);
+      return threadSafeFury;
+    }
   }
 }

--- a/java/fury-core/src/main/java/io/fury/ThreadSafeFury.java
+++ b/java/fury-core/src/main/java/io/fury/ThreadSafeFury.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury;
+
+import io.fury.memory.MemoryBuffer;
+import io.fury.util.LoaderBinding;
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+
+/**
+ * Thread safe serializer interface. {@link Fury} is not thread-safe, the implementation of this
+ * interface will be thread-safe. And support switch classloader dynamically.
+ *
+ * @author chaokunyang
+ */
+public interface ThreadSafeFury {
+
+  /**
+   * Provide a context to execution operations on {@link Fury} directly and return the executed
+   * result.
+   */
+  <R> R execute(Function<Fury, R> action);
+
+  byte[] serialize(Object obj);
+
+  MemoryBuffer serialize(MemoryBuffer buffer, Object obj);
+
+  Object deserialize(byte[] bytes);
+
+  Object deserialize(long address, int size);
+
+  Object deserialize(MemoryBuffer buffer);
+
+  Object deserialize(ByteBuffer byteBuffer);
+
+  /**
+   * Set classLoader of serializer for current thread only.
+   *
+   * @see LoaderBinding#setClassLoader(ClassLoader)
+   */
+  void setClassLoader(ClassLoader classLoader);
+
+  /**
+   * Set classLoader of serializer for current thread only.
+   *
+   * <p>If <code>staging</code> is true, a cached {@link Fury} instance will be returned if not
+   * null, and the previous classloader and associated {@link Fury} instance won't be gc unless
+   * {@link #clearClassLoader} is called explicitly. If false, and the passed <code>classLoader
+   * </code> is different, a new {@link Fury} instance will be created, previous classLoader and
+   * associated {@link Fury} instance will be cleared.
+   *
+   * @param classLoader {@link ClassLoader} for resolving unregistered class name to class
+   * @param stagingType Whether cache previous classloader and associated {@link Fury} instance.
+   * @see LoaderBinding#setClassLoader(ClassLoader, LoaderBinding.StagingType)
+   */
+  void setClassLoader(ClassLoader classLoader, LoaderBinding.StagingType stagingType);
+
+  /** Returns classLoader of serializer for current thread. */
+  ClassLoader getClassLoader();
+
+  /**
+   * Clean up classloader set by {@link #setClassLoader(ClassLoader, LoaderBinding.StagingType)},
+   * <code>
+   * classLoader
+   * </code> won't be referenced by {@link Fury} after this call and can be gc if it's not
+   * referenced by other objects.
+   *
+   * @see LoaderBinding#clearClassLoader(ClassLoader)
+   */
+  void clearClassLoader(ClassLoader loader);
+
+  Fury getCurrentFury();
+}

--- a/java/fury-core/src/test/java/io/fury/ThreadSafeFuryTest.java
+++ b/java/fury-core/src/test/java/io/fury/ThreadSafeFuryTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import io.fury.resolver.MetaContext;
+import io.fury.serializer.Serializer;
+import io.fury.test.bean.BeanA;
+import io.fury.test.bean.Struct;
+import io.fury.util.LoaderBinding.StagingType;
+import java.util.ArrayList;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ThreadSafeFuryTest extends FuryTestBase {
+  private volatile boolean hasException;
+
+  @Test
+  public void testSerialize() throws Exception {
+    BeanA beanA = BeanA.createBeanA(2);
+    ThreadSafeFury fury =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withReferenceTracking(true)
+            .disableSecureMode()
+            .withAsyncCompilationEnabled(true)
+            .buildThreadSafeFury();
+    ExecutorService executorService = Executors.newFixedThreadPool(12);
+    for (int i = 0; i < 2000; i++) {
+      executorService.execute(
+          () -> {
+            for (int j = 0; j < 10; j++) {
+              try {
+                fury.setClassLoader(beanA.getClass().getClassLoader());
+                assertEquals(fury.deserialize(fury.serialize(beanA)), beanA);
+              } catch (Exception e) {
+                hasException = true;
+                e.printStackTrace();
+              }
+            }
+          });
+    }
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
+    assertFalse(hasException);
+  }
+
+  @Test
+  public void testSerializeWithMetaShare() throws InterruptedException {
+    ThreadSafeFury fury1 =
+        Fury.builder().withLanguage(Language.JAVA).disableSecureMode().buildThreadSafeFury();
+    ThreadSafeFury fury2 =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withMetaContextShareEnabled(true)
+            .disableSecureMode()
+            .buildThreadSafeFury();
+    BeanA beanA = BeanA.createBeanA(2);
+    ExecutorService executorService = Executors.newFixedThreadPool(12);
+    ConcurrentHashMap<Thread, MetaContext> metaMap = new ConcurrentHashMap<>();
+    for (int i = 0; i < 2000; i++) {
+      executorService.execute(
+          () -> {
+            for (int j = 0; j < 10; j++) {
+              try {
+                {
+                  fury1.setClassLoader(beanA.getClass().getClassLoader());
+                  byte[] serialized = fury1.execute(f -> f.serialize(beanA));
+                  Object newObj = fury1.execute(f -> f.deserialize(serialized));
+                  assertEquals(newObj, beanA);
+                }
+                {
+                  fury2.setClassLoader(beanA.getClass().getClassLoader());
+                  byte[] serialized =
+                      fury2.execute(
+                          f -> {
+                            f.getSerializationContext().setMetaContext(new MetaContext());
+                            return f.serialize(beanA);
+                          });
+                  Object newObj =
+                      fury2.execute(
+                          f -> {
+                            f.getSerializationContext().setMetaContext(new MetaContext());
+                            return f.deserialize(serialized);
+                          });
+                  assertEquals(newObj, beanA);
+                }
+                {
+                  MetaContext metaContext =
+                      metaMap.computeIfAbsent(Thread.currentThread(), k -> new MetaContext());
+                  fury2.setClassLoader(beanA.getClass().getClassLoader());
+                  byte[] serialized =
+                      fury2.execute(
+                          f -> {
+                            f.getSerializationContext().setMetaContext(metaContext);
+                            return f.serialize(beanA);
+                          });
+                  Object newObj =
+                      fury2.execute(
+                          f -> {
+                            f.getSerializationContext().setMetaContext(metaContext);
+                            return f.deserialize(serialized);
+                          });
+                  assertEquals(newObj, beanA);
+                }
+              } catch (Exception e) {
+                hasException = true;
+                e.printStackTrace();
+                throw e;
+              }
+            }
+          });
+    }
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
+    assertFalse(hasException);
+  }
+
+  @DataProvider(name = "stagingConfig")
+  public static Object[][] stagingConfig() {
+    return new Object[][] {{StagingType.NO_STAGING}, {StagingType.STRONG_STAGING}};
+  }
+
+  @Test(dataProvider = "stagingConfig")
+  public void testClassDuplicateName(StagingType staging) {
+    ThreadSafeFury fury = Fury.builder().withClassRegistrationRequired(false).buildThreadSafeFury();
+    String className = "DuplicateStruct";
+
+    Class<?> structClass1 = Struct.createStructClass(className, 1);
+    Object struct1 = Struct.createPOJO(structClass1);
+    byte[] bytes1 = fury.serialize(struct1);
+    Assert.assertEquals(fury.deserialize(bytes1), struct1);
+    Class<? extends Serializer> serializerClass1 =
+        fury.getCurrentFury().getClassResolver().getSerializerClass(structClass1);
+    Assert.assertTrue(serializerClass1.getName().contains("Codec"));
+
+    Class<?> structClass2 = Struct.createStructClass(className, 2);
+    Object struct2 = Struct.createPOJO(structClass2);
+    assertEquals(
+        struct2.getClass().getDeclaredFields().length,
+        struct1.getClass().getDeclaredFields().length * 2);
+    AtomicReference<byte[]> bytesReference = new AtomicReference<>();
+    CompletableFuture.runAsync(
+            () -> {
+              fury.setClassLoader(structClass2.getClassLoader(), staging);
+              byte[] bytes2 = fury.serialize(struct2);
+              bytesReference.set(bytes2);
+            })
+        .join();
+    byte[] bytes2 = bytesReference.get();
+    fury.setClassLoader(structClass2.getClassLoader());
+    Assert.assertEquals(fury.deserialize(bytes2), struct2);
+    Class<? extends Serializer> serializerClass2 =
+        fury.getCurrentFury().getClassResolver().getSerializerClass(structClass2);
+    Assert.assertTrue(serializerClass2.getName().contains("Codec"));
+    Assert.assertNotSame(serializerClass2, serializerClass1);
+
+    byte[] newBytes1 = fury.serialize(struct1);
+    CompletableFuture.runAsync(
+            () -> {
+              fury.setClassLoader(structClass1.getClassLoader(), staging);
+              Assert.assertEquals(fury.deserialize(newBytes1), struct1);
+            })
+        .join();
+  }
+
+  @Test(timeOut = 60_000)
+  public void testClassGC() throws Exception {
+    // Can't inline `generateClassForGC` in current method, generated classes won't be gc.
+    WeakHashMap<Class<?>, Boolean> map = generateClassForGC();
+    while (map.size() > 0) {
+      // Force an OoM
+      try {
+        final ArrayList<Object[]> allocations = new ArrayList<>();
+        int size;
+        while ((size =
+                Math.min(Math.abs((int) Runtime.getRuntime().freeMemory()), Integer.MAX_VALUE))
+            > 0) allocations.add(new Object[size]);
+      } catch (OutOfMemoryError e) {
+        System.out.println("Trigger OOM to clear LoaderBinding.furySoftMap soft references.");
+      }
+      System.gc();
+      Thread.sleep(1000);
+      System.out.printf("Wait classes %s gc.\n", map.keySet());
+    }
+  }
+
+  private WeakHashMap<Class<?>, Boolean> generateClassForGC() {
+    ThreadSafeFury fury = Fury.builder().withClassRegistrationRequired(false).buildThreadSafeFury();
+    String className = "DuplicateStruct";
+    WeakHashMap<Class<?>, Boolean> map = new WeakHashMap<>();
+    {
+      Class<?> structClass1 = Struct.createStructClass(className, 1);
+      Object struct1 = Struct.createPOJO(structClass1);
+      byte[] bytes = fury.serialize(struct1);
+      Assert.assertEquals(fury.deserialize(bytes), struct1);
+      map.put(structClass1, true);
+      System.out.printf(
+          "structClass1 %s %s\n",
+          structClass1.hashCode(), structClass1.getClassLoader().hashCode());
+    }
+    {
+      Class<?> structClass2 = Struct.createStructClass(className, 2);
+      map.put(structClass2, true);
+      System.out.printf(
+          "structClass2 %s %s\n ",
+          structClass2.hashCode(), structClass2.getClassLoader().hashCode());
+      fury.setClassLoader(structClass2.getClassLoader());
+      Object struct2 = Struct.createPOJO(structClass2);
+      byte[] bytes2 = fury.serialize(struct2);
+      Assert.assertEquals(fury.deserialize(bytes2), struct2);
+      fury.clearClassLoader(structClass2.getClassLoader());
+    }
+    return map;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR implements a thread-safe fury wrapper by using thead-local to bind fury to different thread.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #279

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
