### PR TITLE
[Java] add unsafe accessor test for duplicate fields

### DIFF
--- a/java/fury-core/src/test/java/io/fury/util/UnsafeFieldAccessorTest.java
+++ b/java/fury-core/src/test/java/io/fury/util/UnsafeFieldAccessorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.util;
+
+import static org.testng.Assert.assertEquals;
+
+import io.fury.util.UnsafeFieldAccessor;
+import org.testng.annotations.Test;
+
+public class UnsafeFieldAccessorTest {
+
+  class A {
+    int f1 = 1;
+    int f2 = 2;
+  }
+
+  class B extends A {
+    int f1 = 2;
+  }
+
+  @Test
+  public void testRepeatedFields() {
+    assertEquals(new UnsafeFieldAccessor(A.class, "f1").getInt(new A()), 1);
+    assertEquals(new UnsafeFieldAccessor(A.class, "f2").getInt(new A()), 2);
+    assertEquals(new UnsafeFieldAccessor(B.class, "f1").getInt(new B()), 2);
+    assertEquals(new UnsafeFieldAccessor(B.class, "f2").getInt(new B()), 2);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #298 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
