### PR TITLE
[Java] add usertype benchmarks

### DIFF
--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/UserTypeDeserializeSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/UserTypeDeserializeSuite.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark;
+
+import io.fury.benchmark.state.FstState;
+import io.fury.benchmark.state.FuryState;
+import io.fury.benchmark.state.HessionState;
+import io.fury.benchmark.state.JDKState;
+import io.fury.benchmark.state.JsonbState;
+import io.fury.benchmark.state.KryoState;
+import io.fury.benchmark.state.ProtostuffState;
+import java.io.IOException;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class UserTypeDeserializeSuite {
+
+  @Benchmark
+  public Object kryo_deserialize(KryoState.KryoUserTypeState state) {
+    state.input.setPosition(0);
+    state.input.setLimit(state.serializedLength);
+    return state.kryo.readClassAndObject(state.input);
+  }
+
+  @Benchmark
+  public Object kryo_deserialize_compatible(KryoState.KryoCompatibleState state) {
+    state.input.setPosition(0);
+    state.input.setLimit(state.serializedLength);
+    return state.kryo.readClassAndObject(state.input);
+  }
+
+  @Benchmark
+  public Object fury_deserialize(FuryState.FuryUserTypeState state) {
+    state.buffer.readerIndex(0);
+    Object o = state.fury.readReferencableFromJava(state.buffer);
+    state.fury.resetRead();
+    return o;
+  }
+
+  @Benchmark
+  public Object fury_deserialize_compatible(FuryState.FuryCompatibleState state) {
+    state.buffer.readerIndex(0);
+    Object o = state.fury.readReferencableFromJava(state.buffer);
+    state.fury.resetRead();
+    return o;
+  }
+
+  @Benchmark
+  public Object fst_deserialize(FstState.FstUserTypeState state, Blackhole bh) {
+    return FstState.FstBenchmarkState.deserialize(bh, state);
+  }
+
+  @Benchmark
+  public Object hession_deserialize(HessionState.HessionUserTypeState state) {
+    state.bis.reset();
+    state.input.reset();
+    return HessionState.deserialize(state.input);
+  }
+
+  @Benchmark
+  public Object hession_deserialize_compatible(HessionState.HessianCompatibleState state) {
+    state.bis.reset();
+    state.input.reset();
+    return HessionState.deserialize(state.input);
+  }
+
+  @Benchmark
+  public Object protostuff_deserialize(ProtostuffState.ProtostuffUserTypeState state) {
+    return ProtostuffState.deserialize(state.schema, state.protoStuff);
+  }
+
+  @Benchmark
+  public Object jdk_deserialize(JDKState.JDKUserTypeState state) {
+    state.bis.reset();
+    return JDKState.deserialize(state.bis);
+  }
+
+  @Benchmark
+  public Object jsonb_deserialize(JsonbState.JsonbUserTypeState state, Blackhole bh) {
+    return JsonbState.deserialize(bh, state);
+  }
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      String commandLine =
+          "io.*UserTypeDeserializeSuite.* -f 3 -wi 3 -i 3 -t 1 -w 2s -r 2s -rf csv";
+      System.out.println(commandLine);
+      args = commandLine.split(" ");
+    }
+    Main.main(args);
+  }
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/UserTypeSerializeSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/UserTypeSerializeSuite.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark;
+
+import io.fury.benchmark.state.FstState;
+import io.fury.benchmark.state.FuryState;
+import io.fury.benchmark.state.HessionState;
+import io.fury.benchmark.state.JDKState;
+import io.fury.benchmark.state.JsonbState;
+import io.fury.benchmark.state.KryoState;
+import io.fury.benchmark.state.ProtostuffState;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class UserTypeSerializeSuite {
+
+  @org.openjdk.jmh.annotations.Benchmark
+  public Object kryo_serialize(KryoState.KryoUserTypeState state) {
+    state.output.setPosition(0);
+    state.kryo.writeClassAndObject(state.output, state.object);
+    return state.output;
+  }
+
+  @org.openjdk.jmh.annotations.Benchmark
+  public Object kryo_serialize_compatible(KryoState.KryoCompatibleState state) {
+    state.output.setPosition(0);
+    state.kryo.writeClassAndObject(state.output, state.object);
+    return state.output;
+  }
+
+  @Benchmark
+  public Object fury_serialize(FuryState.FuryUserTypeState state) {
+    state.buffer.writerIndex(0);
+    state.fury.writeReferencableToJava(state.buffer, state.object);
+    state.fury.resetWrite();
+    return state.buffer;
+  }
+
+  @Benchmark
+  public Object fury_serialize_compatible(FuryState.FuryCompatibleState state) {
+    state.buffer.writerIndex(0);
+    state.fury.writeReferencableToJava(state.buffer, state.object);
+    state.fury.resetWrite();
+    return state.buffer;
+  }
+
+  @Benchmark
+  public byte[] fst_serialize(FstState.FstUserTypeState state, Blackhole bh) {
+    return FstState.FstBenchmarkState.serialize(bh, state, state.object);
+  }
+
+  @Benchmark
+  public ByteArrayOutputStream hession_serialize(HessionState.HessionUserTypeState state) {
+    state.bos.reset();
+    state.out.reset();
+    HessionState.serialize(state.out, state.object);
+    return state.bos;
+  }
+
+  @Benchmark
+  public ByteArrayOutputStream hession_serialize_compatible(
+      HessionState.HessianCompatibleState state) {
+    state.bos.reset();
+    state.out.reset();
+    HessionState.serialize(state.out, state.object);
+    return state.bos;
+  }
+
+  @Benchmark
+  public byte[] protostuff_serialize(ProtostuffState.ProtostuffUserTypeState state) {
+    return ProtostuffState.serialize(state.object, state.schema, state.buffer);
+  }
+
+  @Benchmark
+  public ByteArrayOutputStream jdk_serialize(JDKState.JDKUserTypeState state) {
+    state.bos.reset();
+    JDKState.serialize(state.bos, state.object);
+    return state.bos;
+  }
+
+  @Benchmark
+  public byte[] jsonb_serialize(JsonbState.JsonbUserTypeState state, Blackhole bh) {
+    return JsonbState.serialize(bh, state, state.object);
+  }
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      String commandLine = "io.*UserTypeSerializeSuite.* -f 3 -wi 3 -i 3 -t 1 -w 2s -r 2s -rf csv";
+      System.out.println(commandLine);
+      args = commandLine.split(" ");
+    }
+    Main.main(args);
+  }
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/FstState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/FstState.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.google.common.base.Preconditions;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.Image;
+import io.fury.benchmark.data.Media;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import org.nustaq.serialization.FSTConfiguration;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class FstState {
+
+  public static void main(String[] args) {
+    FstUserTypeState state = new FstUserTypeState();
+    state.objectType = ObjectType.SAMPLE;
+    state.bufferType = BufferType.directBuffer;
+    state.setup();
+    FstBenchmarkState.serialize(null, state, state.object);
+    FstBenchmarkState.deserialize(null, state);
+  }
+
+  @State(Scope.Thread)
+  public abstract static class FstBenchmarkState extends BenchmarkState {
+    FSTConfiguration fst;
+    byte[] buffer;
+    ByteBuffer directBuffer;
+    int[] out = new int[1];
+
+    @Setup(Level.Trial)
+    public void setup() {
+      fst = FSTConfiguration.createDefaultConfiguration();
+      fst.setPreferSpeed(true);
+      fst.setShareReferences(references);
+      if (bufferType == BufferType.directBuffer) {
+        directBuffer = ByteBuffer.allocateDirect(10 * 1024 * 1024);
+      }
+    }
+
+    public static byte[] serialize(Blackhole blackhole, FstBenchmarkState state, Object value) {
+      return serialize(
+          state.fst, state.bufferType, value, state.out, state.directBuffer, blackhole);
+    }
+
+    public static byte[] serialize(
+        FSTConfiguration fst,
+        BufferType bufferType,
+        Object value,
+        int[] out,
+        ByteBuffer directBuffer,
+        Blackhole blackhole) {
+      byte[] bytes = fst.asSharedByteArray(value, out);
+      if (bufferType == BufferType.directBuffer) {
+        directBuffer.clear();
+        directBuffer.put(bytes, 0, out[0]);
+      }
+      if (blackhole != null) {
+        blackhole.consume(directBuffer);
+        blackhole.consume(bytes);
+      }
+      return bytes;
+    }
+
+    public static Object deserialize(Blackhole blackhole, FstBenchmarkState state) {
+      return deserialize(
+          state.fst, state.bufferType, state.buffer, state.out, state.directBuffer, blackhole);
+    }
+
+    public static Object deserialize(
+        FSTConfiguration fst,
+        BufferType bufferType,
+        byte[] buffer,
+        int[] out,
+        ByteBuffer directBuffer,
+        Blackhole blackhole) {
+      if (bufferType == BufferType.directBuffer) {
+        directBuffer.rewind();
+        byte[] bytes = new byte[out[0]];
+        directBuffer.get(bytes);
+        Object newObj = fst.asObject(bytes);
+        if (blackhole != null) {
+          blackhole.consume(bytes);
+          blackhole.consume(newObj);
+        }
+        return newObj;
+      }
+      return fst.asObject(buffer);
+    }
+  }
+
+  public static class FstUserTypeState extends FstBenchmarkState {
+    @Param() public ObjectType objectType;
+    public Object object;
+
+    @Override
+    public void setup() {
+      super.setup();
+
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          if (registerClass) {
+            fst.registerClass(object.getClass());
+          }
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          if (registerClass) {
+            fst.registerClass(Image.class);
+            fst.registerClass(Image.Size.class);
+            fst.registerClass(Media.class);
+            fst.registerClass(Media.Player.class);
+            fst.registerClass(ArrayList.class);
+            fst.registerClass(MediaContent.class);
+          }
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          if (registerClass) {
+            fst.registerClass(object.getClass());
+          }
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          if (registerClass) {
+            fst.registerClass(object.getClass());
+          }
+          break;
+      }
+      buffer = serialize(null, this, object);
+      Preconditions.checkArgument(object.equals(deserialize(null, this)));
+    }
+  }
+
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/FuryState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/FuryState.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.google.common.base.Preconditions;
+import io.fury.Fury;
+import io.fury.Language;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.Image;
+import io.fury.benchmark.data.Media;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import io.fury.memory.MemoryBuffer;
+import io.fury.memory.MemoryUtils;
+import io.fury.serializer.CompatibleMode;
+import io.fury.util.LoggerFactory;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class FuryState {
+  private static final Logger LOG = LoggerFactory.getLogger(FuryState.class);
+
+  @State(Scope.Thread)
+  public abstract static class FuryBenchmarkState extends BenchmarkState {
+    public Fury fury;
+    public MemoryBuffer buffer;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      fury =
+          Fury.builder()
+              .withLanguage(Language.JAVA)
+              .withClassVersionCheck(false)
+              .ignoreStringReference(true) // for compare with fastjson
+              .withReferenceTracking(references)
+              .disableSecureMode()
+              .build();
+      switch (bufferType) {
+        case array:
+          buffer = MemoryUtils.buffer(1024 * 512);
+          break;
+        case directBuffer:
+          buffer = MemoryUtils.wrap(ByteBuffer.allocateDirect(1024 * 512));
+          break;
+      }
+    }
+  }
+
+  public static void main(String[] args) {
+    Object o = Struct.create(true);
+    Fury fury =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withReferenceTracking(true)
+            .disableSecureMode()
+            .build();
+    Object o1 = fury.deserialize(fury.serialize(o));
+    Preconditions.checkArgument(o.equals(o1));
+    FuryUserTypeState state = new FuryUserTypeState();
+    state.objectType = ObjectType.MEDIA_CONTENT;
+    state.bufferType = BufferType.directBuffer;
+    state.setup();
+    fury.serialize(new MediaContent().populate(false));
+    fury.serialize(Struct.create(true));
+    fury.serialize(Struct.create(false));
+  }
+
+  public static class FuryUserTypeState extends FuryBenchmarkState {
+    @Param() public ObjectType objectType;
+
+    public Object object;
+    public int serializedLength;
+
+    @Override
+    public void setup() {
+      super.setup();
+      Fury.FuryBuilder furyBuilder =
+          Fury.builder()
+              .withLanguage(Language.JAVA)
+              .withClassVersionCheck(false)
+              .ignoreStringReference(true) // for compare with fastjson
+              .withReferenceTracking(references)
+              .disableSecureMode();
+      if (compatible()) {
+        furyBuilder.withCompatibleMode(CompatibleMode.COMPATIBLE);
+        fury = furyBuilder.build();
+      }
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          if (registerClass) {
+            fury.register(object.getClass());
+          }
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          if (registerClass) {
+            fury.register(Image.class);
+            fury.register(Image.Size.class);
+            fury.register(Media.class);
+            fury.register(Media.Player.class);
+            fury.register(ArrayList.class);
+            fury.register(MediaContent.class);
+            fury.register(Struct.class);
+          }
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          if (registerClass) {
+            fury.register(object.getClass());
+          }
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          if (registerClass) {
+            fury.register(object.getClass());
+          }
+          break;
+      }
+
+      fury.writeReferencableToJava(buffer, object);
+      serializedLength = buffer.writerIndex();
+      LOG.info(
+          "======> Fury | {} | {} | {} | {} |",
+          objectType,
+          references,
+          bufferType,
+          serializedLength);
+      buffer.writerIndex(0);
+      Preconditions.checkArgument(object.equals(fury.readReferencableFromJava(buffer)));
+      buffer.readerIndex(0);
+    }
+
+    public boolean compatible() {
+      return false;
+    }
+  }
+
+  public static class FuryCompatibleState extends FuryUserTypeState {
+    @Override
+    public void setup() {
+      super.setup();
+      if (objectType == ObjectType.STRUCT) {
+        Thread.currentThread()
+            .setContextClassLoader(Struct.createStructClass(110, false).getClassLoader());
+        fury =
+            Fury.builder()
+                .withLanguage(Language.JAVA)
+                .withClassVersionCheck(false)
+                .ignoreStringReference(true) // for compare with fastjson
+                .withReferenceTracking(references)
+                .disableSecureMode()
+                .withCompatibleMode(CompatibleMode.COMPATIBLE)
+                .build();
+        if (registerClass) {
+          fury.register(object.getClass());
+        }
+      }
+    }
+
+    @Override
+    public boolean compatible() {
+      return true;
+    }
+  }
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/HessionState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/HessionState.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.Hessian2Output;
+import com.google.common.base.Preconditions;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import io.fury.util.LoggerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class HessionState {
+  private static final Logger LOG = LoggerFactory.getLogger(HessionState.class);
+
+  public static void main(String[] args) {
+    HessionUserTypeState userTypeState = new HessionUserTypeState();
+    userTypeState.objectType = ObjectType.STRUCT;
+    userTypeState.setup();
+  }
+
+  public static void serialize(Hessian2Output out, Object o) {
+    try {
+      out.startMessage();
+      out.writeObject(o);
+      out.completeMessage();
+      out.flush();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Object deserialize(Hessian2Input input) {
+    try {
+      input.startMessage();
+      Object o = input.readObject();
+      input.completeMessage();
+      return o;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @State(Scope.Thread)
+  public abstract static class HessionBenchmarkState extends BenchmarkState {
+    public ByteArrayOutputStream bos;
+    public Hessian2Output out;
+    public ByteArrayInputStream bis;
+    public Hessian2Input input;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      bos = new ByteArrayOutputStream();
+      out = new Hessian2Output(bos);
+    }
+  }
+
+  public static class HessionUserTypeState extends HessionBenchmarkState {
+    @Param() public ObjectType objectType;
+
+    public Object object;
+    public int serializedLength;
+
+    @Override
+    public void setup() {
+      super.setup();
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          break;
+      }
+
+      bos.reset();
+      out.reset();
+      serialize(out, object);
+      serializedLength = bos.size();
+      LOG.info(
+          "======> Hession | {} | {} | {} | {} |",
+          objectType,
+          references,
+          bufferType,
+          serializedLength);
+      Object o2 =
+          HessionState.deserialize(new Hessian2Input(new ByteArrayInputStream(bos.toByteArray())));
+      Preconditions.checkArgument(object.equals(o2));
+      bis = new ByteArrayInputStream(bos.toByteArray());
+      input = new Hessian2Input(bis);
+    }
+  }
+
+  public static class HessianCompatibleState extends HessionUserTypeState {
+    @Override
+    public void setup() {
+      super.setup();
+      if (objectType == ObjectType.STRUCT) {
+        Thread.currentThread()
+            .setContextClassLoader(Struct.createStructClass(110, false).getClassLoader());
+      }
+    }
+  }
+
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/JDKState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/JDKState.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.google.common.base.Preconditions;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import io.fury.io.ClassLoaderObjectInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+public class JDKState {
+  @State(Scope.Thread)
+  public abstract static class JDKBenchmarkState extends BenchmarkState {
+    public ByteArrayOutputStream bos;
+    public ByteArrayInputStream bis;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      bos = new ByteArrayOutputStream();
+    }
+  }
+
+  public static class JDKUserTypeState extends JDKBenchmarkState {
+    @Param() public ObjectType objectType;
+
+    public Object object;
+    public int serializedLength;
+
+    @Override
+    public void setup() {
+      super.setup();
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          break;
+      }
+
+      bos.reset();
+      serialize(bos, object);
+      serializedLength = bos.size();
+      Object o2 = deserialize(new ByteArrayInputStream(bos.toByteArray()));
+      Preconditions.checkArgument(object.equals(o2));
+      bis = new ByteArrayInputStream(bos.toByteArray());
+    }
+  }
+
+  public static void serialize(ByteArrayOutputStream bas, Object data) {
+    bas.reset();
+    try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(bas)) {
+      objectOutputStream.writeObject(data);
+      objectOutputStream.flush();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Object deserialize(ByteArrayInputStream bis) {
+    bis.reset();
+    try (ObjectInputStream objectInputStream =
+        new ClassLoaderObjectInputStream(Thread.currentThread().getContextClassLoader(), bis)) {
+      return objectInputStream.readObject();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/JsonbState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/JsonbState.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.google.common.base.Preconditions;
+import io.fury.Fury;
+import io.fury.benchmark.data.CustomJDKSerialization;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import io.fury.util.LoggerFactory;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class JsonbState {
+  private static final Logger LOG = LoggerFactory.getLogger(JsonbState.class);
+
+  @State(Scope.Thread)
+  public abstract static class JsonbBenchmarkState extends BenchmarkState {
+    public JSONWriter.Feature[] jsonbWriteFeatures;
+    public JSONReader.Feature[] jsonbReaderFeatures;
+    byte[] buffer;
+    ByteBuffer directBuffer;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      if (bufferType == BufferType.directBuffer) {
+        directBuffer = ByteBuffer.allocateDirect(10 * 1024 * 1024);
+      }
+      jsonbWriteFeatures = getJsonbWriterConfig(references);
+      jsonbReaderFeatures = getJsonbReaderConfig(references);
+    }
+  }
+
+  public static class JsonbUserTypeState extends JsonbBenchmarkState {
+    @Param() public ObjectType objectType;
+    public Object object;
+
+    @Override
+    public void setup() {
+      super.setup();
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          break;
+      }
+      Thread.currentThread().setContextClassLoader(object.getClass().getClassLoader());
+      JSONFactory.setContextObjectReaderProvider(new ObjectReaderProvider());
+      buffer = serialize(null, this, object);
+      LOG.info(
+          "======> Jsonb | {} | {} | {} | {} |", objectType, references, bufferType, buffer.length);
+      if (bufferType == BufferType.directBuffer) {
+        directBuffer.put(buffer);
+        directBuffer.clear();
+      }
+      Preconditions.checkArgument(object.equals(deserialize(null, this)));
+    }
+  }
+
+  public static JSONWriter.Feature[] getJsonbWriterConfig(boolean refTracking) {
+    List<JSONWriter.Feature> features =
+        new ArrayList<>(
+            Arrays.asList(
+                JSONWriter.Feature.WriteClassName,
+                JSONWriter.Feature.FieldBased,
+                JSONWriter.Feature.WriteNulls,
+                JSONWriter.Feature.NotWriteHashMapArrayListClassName,
+                JSONWriter.Feature.WriteNameAsSymbol,
+                JSONWriter.Feature.BeanToArray));
+    if (refTracking) {
+      features.add(JSONWriter.Feature.ReferenceDetection);
+    }
+    return features.toArray(new JSONWriter.Feature[0]);
+  }
+
+  public static JSONReader.Feature[] getJsonbReaderConfig(boolean refTracking) {
+    List<JSONReader.Feature> features =
+        new ArrayList<>(
+            Arrays.asList(
+                JSONReader.Feature.SupportAutoType,
+                JSONReader.Feature.UseDefaultConstructorAsPossible,
+                JSONReader.Feature.UseNativeObject,
+                JSONReader.Feature.FieldBased,
+                JSONReader.Feature.SupportArrayToBean));
+    return features.toArray(new JSONReader.Feature[0]);
+  }
+
+  public static byte[] serialize(Blackhole blackhole, JsonbBenchmarkState state, Object value) {
+    byte[] bytes = JSONB.toBytes(value, state.jsonbWriteFeatures);
+    if (state.bufferType == BufferType.directBuffer) {
+      state.directBuffer.clear();
+      state.directBuffer.put(bytes);
+    }
+    if (blackhole != null) {
+      blackhole.consume(state.directBuffer);
+      blackhole.consume(bytes);
+    }
+    return bytes;
+  }
+
+  public static Object deserialize(Blackhole blackhole, JsonbBenchmarkState state) {
+    if (state.bufferType == BufferType.directBuffer) {
+      state.directBuffer.rewind();
+      byte[] bytes = new byte[state.buffer.length];
+      state.directBuffer.get(bytes);
+      Object newObj = JSONB.parseObject(bytes, Object.class, state.jsonbReaderFeatures);
+      if (blackhole != null) {
+        blackhole.consume(bytes);
+        blackhole.consume(newObj);
+      }
+      return newObj;
+    }
+    return JSONB.parseObject(state.buffer, Object.class, state.jsonbReaderFeatures);
+  }
+
+  public static void testLambda() {
+    Function<String, String> f = (Function<String, String> & Serializable) String::toLowerCase;
+    Fury fury = Fury.builder().disableSecureMode().build();
+    fury.deserialize(fury.serialize(f));
+    byte[] data = JSONB.toBytes(f, getJsonbWriterConfig(true));
+    JSONB.parseObject(data, Object.class, getJsonbReaderConfig(true));
+  }
+
+  private static class TestInvocationHandler implements InvocationHandler {
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      System.out.printf("invoke %s\n", method);
+      return method.invoke(args);
+    }
+  }
+
+  public static void testProxy() {
+    Function function =
+        (Function)
+            Proxy.newProxyInstance(
+                Thread.currentThread().getContextClassLoader(),
+                new Class[] {Function.class},
+                new TestInvocationHandler());
+    Fury fury = Fury.builder().disableSecureMode().build();
+    fury.deserialize(fury.serialize(function));
+    byte[] data1 = JSONB.toBytes(function, getJsonbWriterConfig(true));
+    System.out.println(JSONB.parseObject(data1, Object.class, getJsonbReaderConfig(true)));
+  }
+
+  public static void testWriteObject() {
+    CustomJDKSerialization obj = new CustomJDKSerialization();
+    byte[] data1 = JSONB.toBytes(obj, getJsonbWriterConfig(true));
+    CustomJDKSerialization newObj =
+        (CustomJDKSerialization) JSONB.parseObject(data1, Object.class, getJsonbReaderConfig(true));
+    System.out.println(newObj.age);
+  }
+
+  static class A {
+    // String f1;
+  }
+
+  static class B extends A {
+    // String f1;
+  }
+
+  static class C {
+    A f1;
+    B f2;
+  }
+
+  public static void testSubclass() {
+    C c = new C();
+    c.f1 = new A();
+    c.f2 = new B();
+    Fury fury = Fury.builder().disableSecureMode().build();
+    System.out.println(fury.serialize(c).length);
+    System.out.println(fury.serialize(c).length);
+    byte[] bytes = JSONB.toBytes(c, getJsonbWriterConfig(true));
+    System.out.println(bytes.length);
+    C newObj = (C) JSONB.parseObject(bytes, Object.class, getJsonbReaderConfig(true));
+    System.out.println(newObj.f1);
+  }
+
+  public static void main(String[] args) {
+    // testSubclass();
+    // testLambda();
+    // testProxy();
+    // testWriteObject();
+    JsonbUserTypeState state = new JsonbUserTypeState();
+    state.objectType = ObjectType.MEDIA_CONTENT;
+    state.bufferType = BufferType.array;
+    state.setup();
+    state.bufferType = BufferType.directBuffer;
+    state.setup();
+
+    ;
+    JSONObject json = new JSONObject();
+    json.put("k", 1);
+    Fury fury = Fury.builder().requireClassRegistration(false).build();
+    byte[] bytes = fury.serialize(json);
+    System.out.println(fury.deserialize(bytes));
+  }
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/KryoState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/KryoState.java
@@ -1,0 +1,183 @@
+/* Copyright (c) 2008-2023, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package io.fury.benchmark.state;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.io.UnsafeMemoryInput;
+import com.esotericsoftware.kryo.io.UnsafeMemoryOutput;
+import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.google.common.base.Preconditions;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.Image;
+import io.fury.benchmark.data.Media;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import java.util.ArrayList;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class KryoState {
+  private static final Logger LOG = LoggerFactory.getLogger(KryoState.class);
+
+  public static void main(String[] args) {
+    KryoUserTypeState state = new KryoUserTypeState();
+    state.objectType = ObjectType.SAMPLE;
+    state.bufferType = BufferType.directBuffer;
+    state.setup();
+  }
+
+  @State(Scope.Thread)
+  public abstract static class KryoBenchmarkState extends BenchmarkState {
+    public Kryo kryo;
+    public Output output;
+    public Input input;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      kryo = new Kryo();
+      switch (bufferType) {
+        case array:
+          output = new Output(1024 * 512);
+          input = new Input(output.getBuffer());
+          break;
+        case directBuffer:
+          output = new UnsafeMemoryOutput(1024 * 512);
+          input = new UnsafeMemoryInput(((UnsafeMemoryOutput) output).getByteBuffer());
+          break;
+      }
+
+      kryo.setReferences(references);
+    }
+  }
+
+  public static class KryoUserTypeState extends KryoBenchmarkState {
+    @Param() public ObjectType objectType;
+
+    public Object object;
+    public int serializedLength;
+
+    @Override
+    public void setup() {
+      super.setup();
+      if (compatible()) {
+        kryo = new Kryo();
+        kryo.setReferences(references);
+        kryo.setDefaultSerializer(CompatibleFieldSerializer.class);
+      }
+
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          if (registerClass) {
+            kryo.register(double[].class);
+            kryo.register(int[].class);
+            kryo.register(long[].class);
+            kryo.register(float[].class);
+            kryo.register(double[].class);
+            kryo.register(short[].class);
+            kryo.register(char[].class);
+            kryo.register(boolean[].class);
+            kryo.register(object.getClass());
+          }
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          if (registerClass) {
+            kryo.register(Image.class);
+            kryo.register(Image.Size.class);
+            kryo.register(Media.class);
+            kryo.register(Media.Player.class);
+            kryo.register(ArrayList.class);
+            kryo.register(MediaContent.class);
+          }
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          if (registerClass) {
+            kryo.register(object.getClass());
+          }
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          if (registerClass) {
+            kryo.register(object.getClass());
+          }
+          break;
+      }
+      kryo.setDefaultSerializer(FieldSerializer.class);
+
+      output.setPosition(0);
+      kryo.writeClassAndObject(output, object);
+      serializedLength = output.position();
+      LOG.info(
+          "======> Kryo | {} | {} | {} | {} |",
+          objectType,
+          references,
+          bufferType,
+          serializedLength);
+      input.setPosition(0);
+      input.setLimit(serializedLength);
+      Preconditions.checkArgument(object.equals(kryo.readClassAndObject(input)));
+    }
+
+    public boolean compatible() {
+      return false;
+    }
+  }
+
+  public static class KryoCompatibleState extends KryoUserTypeState {
+
+    @Override
+    public void setup() {
+      super.setup();
+      if (objectType == ObjectType.STRUCT) {
+        Thread.currentThread()
+            .setContextClassLoader(Struct.createStructClass(110, false).getClassLoader());
+      }
+    }
+
+    @Override
+    public boolean compatible() {
+      return true;
+    }
+  }
+
+}

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/state/ProtostuffState.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/state/ProtostuffState.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 The Fury authors
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.benchmark.state;
+
+import com.google.common.base.Preconditions;
+import io.fury.benchmark.IntsSerializationSuite;
+import io.fury.benchmark.LongStringSerializationSuite;
+import io.fury.benchmark.LongsSerializationSuite;
+import io.fury.benchmark.StringSerializationSuite;
+import io.fury.benchmark.data.Data;
+import io.fury.benchmark.data.MediaContent;
+import io.fury.benchmark.data.Sample;
+import io.fury.benchmark.data.Struct;
+import io.protostuff.LinkedBuffer;
+import io.protostuff.ProtostuffIOUtil;
+import io.protostuff.Schema;
+import io.protostuff.runtime.RuntimeSchema;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@Fork(value = 0)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class ProtostuffState {
+
+  public static byte[] serialize(Object o, Schema schema, LinkedBuffer buffer) {
+    byte[] protoStuff = ProtostuffIOUtil.toByteArray(o, schema, buffer);
+    buffer.clear();
+    return protoStuff;
+  }
+
+  public static Object deserialize(Schema schema, byte[] bytes) {
+    Object o = schema.newMessage();
+    ProtostuffIOUtil.mergeFrom(bytes, o, schema);
+    return o;
+  }
+
+  public static void main(String[] args) {
+    ProtostuffUserTypeState userTypeState = new ProtostuffUserTypeState();
+    userTypeState.objectType = ObjectType.STRUCT;
+    userTypeState.setup();
+  }
+
+  @State(Scope.Thread)
+  public abstract static class ProtostuffBenchmarkState extends BenchmarkState {
+    @Param({"false"})
+    public boolean references;
+
+    public Schema schema;
+    public LinkedBuffer buffer = LinkedBuffer.allocate(512);
+    public byte[] protoStuff;
+
+    @Setup(Level.Trial)
+    public void setup() {}
+  }
+
+  public static class ProtostuffUserTypeState extends ProtostuffBenchmarkState {
+    @Param() public ObjectType objectType;
+    public Object object;
+
+    @Override
+    public void setup() {
+      super.setup();
+
+      switch (objectType) {
+        case SAMPLE:
+          object = new Sample().populate(references);
+          break;
+        case MEDIA_CONTENT:
+          object = new MediaContent().populate(references);
+          break;
+        case STRUCT:
+          object = Struct.create(false);
+          break;
+        case STRUCT2:
+          object = Struct.create(true);
+          break;
+      }
+      schema = RuntimeSchema.getSchema(object.getClass());
+      protoStuff = serialize(object, schema, buffer);
+      Preconditions.checkArgument(object.equals(deserialize(schema, protoStuff)));
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->
This PR adds user type benchmarks for FURY/JDK/HESSION/Kryo/Fst/Jsonb/Protostuff
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #398 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
