### PR TITLE
[Java] move ExpressionOptimizer into codegen package

### DIFF
--- a/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
@@ -57,6 +57,7 @@ import io.fury.codegen.Expression.Invoke;
 import io.fury.codegen.Expression.ListExpression;
 import io.fury.codegen.Expression.Reference;
 import io.fury.codegen.Expression.Return;
+import io.fury.codegen.ExpressionOptimizer;
 import io.fury.codegen.ExpressionUtils;
 import io.fury.codegen.ExpressionVisitor;
 import io.fury.collection.Tuple2;

--- a/java/fury-core/src/main/java/io/fury/builder/CompatibleCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/CompatibleCodecBuilder.java
@@ -48,6 +48,7 @@ import io.fury.codegen.Expression.ListExpression;
 import io.fury.codegen.Expression.Literal;
 import io.fury.codegen.Expression.Return;
 import io.fury.codegen.Expression.While;
+import io.fury.codegen.ExpressionOptimizer;
 import io.fury.codegen.ExpressionUtils;
 import io.fury.collection.Tuple2;
 import io.fury.resolver.ClassInfo;

--- a/java/fury-core/src/main/java/io/fury/builder/ObjectCodecOptimizer.java
+++ b/java/fury-core/src/main/java/io/fury/builder/ObjectCodecOptimizer.java
@@ -21,6 +21,7 @@ package io.fury.builder;
 import io.fury.annotation.Internal;
 import io.fury.codegen.CodegenContext;
 import io.fury.codegen.Expression;
+import io.fury.codegen.ExpressionOptimizer;
 import io.fury.collection.Tuple3;
 import io.fury.type.Descriptor;
 import io.fury.type.DescriptorGrouper;

--- a/java/fury-core/src/main/java/io/fury/codegen/ExpressionOptimizer.java
+++ b/java/fury-core/src/main/java/io/fury/codegen/ExpressionOptimizer.java
@@ -16,16 +16,12 @@
  * limitations under the License.
  */
 
-package io.fury.builder;
+package io.fury.codegen;
 
 import static io.fury.type.TypeUtils.PRIMITIVE_VOID_TYPE;
 import static io.fury.type.TypeUtils.getRawType;
 
 import com.google.common.base.Preconditions;
-import io.fury.codegen.CodegenContext;
-import io.fury.codegen.Expression;
-import io.fury.codegen.ExpressionUtils;
-import io.fury.codegen.ExpressionVisitor;
 import io.fury.util.Functions;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,8 +32,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Optimizer to generate expression logic in a new method and return an {@link Expression} to invoke
- * the new generated method.
+ * Optimizer to generate expression logic in a new method and return an {@link
+ * io.fury.codegen.Expression} to invoke the new generated method.
  *
  * @author chaokunyang
  */

--- a/java/fury-core/src/test/java/io/fury/codegen/ExpressionOptimizerTest.java
+++ b/java/fury-core/src/test/java/io/fury/codegen/ExpressionOptimizerTest.java
@@ -16,16 +16,11 @@
  * limitations under the License.
  */
 
-package io.fury.builder;
+package io.fury.codegen;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import io.fury.codegen.Code;
-import io.fury.codegen.CodeGenerator;
-import io.fury.codegen.CodegenContext;
-import io.fury.codegen.CompileUnit;
-import io.fury.codegen.Expression;
 import io.fury.codegen.Expression.Add;
 import io.fury.codegen.Expression.Literal;
 import io.fury.codegen.Expression.Return;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR moves ExpressionOptimizer into codegen package
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
