### PR TITLE
[Java] reduce string serializer caller stack by jit

### DIFF
--- a/java/fury-format/src/test/java/io/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/io/fury/format/CrossLanguageTest.java
@@ -75,7 +75,7 @@ import org.testng.annotations.Test;
 public class CrossLanguageTest {
   private static final Logger LOG = LoggerFactory.getLogger(CrossLanguageTest.class);
   private static final String PYTHON_MODULE = "pyfury.tests.test_cross_language";
-  private static final String PYTHON_EXECUTABLE = "/Users/chaokunyang/anaconda3/envs/py3.7/bin/python";
+  private static final String PYTHON_EXECUTABLE = "python";
 
   @Data
   public static class A {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR reduce string serializer caller stack by moving runtime check into jit stage for better inline.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #530

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
