### PR TITLE
[Java] fix jdk11 string jit serialization

### DIFF
--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/NewJava11StringSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/NewJava11StringSuite.java
@@ -70,7 +70,7 @@ public class NewJava11StringSuite {
 
   // @Benchmark
   public Object createJDK8StringByMethodHandle() {
-    return StringSerializer.newJava11StringByZeroCopy(strBytes, coder);
+    return StringSerializer.newJava11StringByZeroCopy(coder, strBytes);
   }
 
   // @Benchmark

--- a/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
@@ -92,7 +92,7 @@ public class StringSerializerTest extends FuryTestBase {
   static String readJDK11String(MemoryBuffer buffer) {
     byte coder = buffer.readByte();
     byte[] value = buffer.readBytesWithSizeEmbedded();
-    return newJava11StringByZeroCopy(value, coder);
+    return newJava11StringByZeroCopy(coder, value);
   }
 
   private static boolean writeJavaStringZeroCopy(MemoryBuffer buffer, String value) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
 fix jdk11 string jit serialization:
- Fix `newJava11StringByZeroCopy` access level to public forjit access
- Change `newJava11StringByZeroCopy` signatures for inline call params.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #534 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
