### PR TITLE
feat(python): support xlang metashare (WIP)

### DIFF
--- a/python/pyfory/__init__.py
+++ b/python/pyfory/__init__.py
@@ -20,6 +20,7 @@ from pyfory._fory import (  # noqa: F401 # pylint: disable=unused-import
     Fory,
     Language,
 )
+from pyfory.meta.meta_share import CompatibleMode
 
 try:
     from pyfory._serialization import ENABLE_FORY_CYTHON_SERIALIZATION

--- a/python/pyfory/_util.pxd
+++ b/python/pyfory/_util.pxd
@@ -94,6 +94,8 @@ cdef class Buffer:
 
     cpdef inline write_bool(self, c_bool value)
 
+    cpdef inline write_uint8(self, uint8_t value)
+
     cpdef inline write_int8(self, int8_t value)
 
     cpdef inline write_int16(self, int16_t value)

--- a/python/pyfory/_util.pyx
+++ b/python/pyfory/_util.pyx
@@ -168,6 +168,11 @@ cdef class Buffer:
         (<c_bool *>(self._c_address + self.writer_index))[0] = value
         self.writer_index += <int32_t>1
 
+    cpdef inline write_uint8(self, uint8_t value):
+        self.grow(<int32_t> 1)
+        (<uint8_t *> (self._c_address + self.writer_index))[0] = value
+        self.writer_index += <int32_t> 1
+
     cpdef inline write_int8(self, int8_t value):
         self.grow(<int32_t>1)
         (<int8_t *>(self._c_address + self.writer_index))[0] = value

--- a/python/pyfory/meta/field_info.py
+++ b/python/pyfory/meta/field_info.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass
+from pyfory.type import TypeId
+from .metastring import MetaStringEncoder, MetaStringDecoder, Encoding
+
+XLANG_FIELD_NAME_SIZE_THRESHOLD = 0b1111
+USE_TAG_AS_FIELD = 0b11
+
+@dataclass
+class FieldType:
+    def __init__(self, type_id: int, is_monomorphic: bool, nullable: bool, tracking_ref: bool):
+        self.type_id = type_id
+        self.is_monomorphic = is_monomorphic
+        self.nullable = nullable
+        self.tracking_ref = tracking_ref
+
+    def xwrite(self, buffer:"Buffer", write_header:bool=False):
+        type_id = self.type_id
+        if write_header:
+            header = type_id << 2
+            if self.tracking_ref:
+                header |= 1
+            if self.nullable:
+                header |= 0b10
+            type_id = header
+        buffer.write_varuint32(type_id)
+        if type_id in (TypeId.LIST, TypeId.SET):
+            assert isinstance(self, CollectionFieldType)
+            self.element_type.xwrite(buffer, True)
+        elif type_id == TypeId.MAP:
+            assert isinstance(self, MapFieldType)
+            self.key_type.xwrite(buffer, True)
+            self.value_type.xwrite(buffer, True)
+        else:
+            pass
+
+    @staticmethod
+    def xread(buffer, read_header:bool=False):
+        header = buffer.read_varuint32()
+        tracking_ref = None
+        nullable = None
+        if not read_header:
+            tracking_ref = header | 1
+            nullable = header | 0b10
+            type_id = header | 0b100
+        else:
+            type_id = header
+
+        field_type = None
+        if type_id in (TypeId.LIST, TypeId.SET):
+            field_type = CollectionFieldType(type_id, True, nullable,tracking_ref, FieldType.xread(buffer, True))
+        elif type_id == TypeId.MAP:
+            field_type = MapFieldType(type_id,True, nullable,tracking_ref, FieldType.xread(buffer, True), FieldType.xread(buffer, True))
+        else:
+            field_type = FieldType(type_id, False, nullable, tracking_ref)
+        return field_type
+
+
+@dataclass
+class CollectionFieldType(FieldType):
+    def __init__(self, type_id: int, is_monomorphic: bool, nullable: bool, tracking_ref:bool, element_type:FieldType):
+        super().__init__(type_id,is_monomorphic,nullable,tracking_ref)
+        self.element_type = element_type
+
+@dataclass
+class MapFieldType(FieldType):
+    def __init__(self, type_id: int, is_monomorphic: bool, nullable: bool, tracking_ref:bool, key_type:FieldType, value_type:FieldType):
+        super().__init__(type_id,is_monomorphic,nullable,tracking_ref)
+        self.key_type = key_type
+        self.value_type = value_type
+
+
+# FieldInfo: {in_what_class, name, type<sub_type>}
+@dataclass
+class FieldInfo:
+    field_name_encoder: MetaStringEncoder = MetaStringEncoder("$", "_")
+    field_name_decoder: MetaStringDecoder = MetaStringDecoder("$", "_")
+    field_name_encodings = [Encoding.UTF_8, Encoding.LOWER_UPPER_DIGIT_SPECIAL, Encoding.ALL_TO_LOWER_SPECIAL]
+    __slots__ = (
+        "defined_class",
+        "field_name",
+        "field_type",
+    )
+
+    def __init__(self, defined_class:str, field_name:str, field_type:FieldType):
+        self.defined_class = defined_class
+        self.field_name = field_name
+        self.field_type = field_type
+
+    # Returns annotated tag id for the field.
+    def get_tag(self):
+        return None
+
+    @staticmethod
+    def xread(buffer: "Buffer", defined_class:str):
+        header = buffer.read_uint8()
+        tracking_ref = header & 1
+        nullable = (header >> 1) & 1
+        encoding_idx = header >> 6
+        if encoding_idx == USE_TAG_AS_FIELD:
+            raise NotImplementedError("Type tag not supported currently")
+        else:
+            size = (header >> 2) & XLANG_FIELD_NAME_SIZE_THRESHOLD
+            if size == XLANG_FIELD_NAME_SIZE_THRESHOLD:
+                size += buffer.read_varuint32()
+
+        field_type = FieldType.xread(buffer)
+        field_type.tracking_ref = tracking_ref
+        field_type.nullable = nullable
+
+        field_name = None
+        if encoding_idx != USE_TAG_AS_FIELD:
+            encoding = FieldInfo.field_name_encodings[encoding_idx]
+            field_name = FieldInfo.field_name_decoder.decode(buffer.read_bytes(size), encoding)
+
+        return FieldInfo(defined_class, field_name, field_type)
+
+
+    def xwrite(self, buffer: "Buffer"):
+        '''
+        field_info:
+            header(8bits): size(3bits) + field_name_encoding(2bits) + polymorphism_flag(1bit) + nullability_flag(1bit) + ref_tracking_flag(1bit)
+            type_id: field_type_id(if have sub_type, write as well, but should write its header)
+            field_name: has_tag()? 0bit: field_name_bytes
+        '''
+        field_type = self.field_type
+        header = field_type.tracking_ref
+        header |= field_type.nullable << 1
+        # if exist tag, use tag_id as field_name
+        tag = self.get_tag()
+        field_name_bytes = None
+        if tag:
+            raise NotImplementedError("Type tag not supported currently")
+            header |= tag << 2
+            header |= USE_TAG_AS_FIELD << 6
+            buffer.write_uint8(header)
+        else:
+            field_name_meta_str = FieldInfo.field_name_encoder.encode(self.field_name, FieldInfo.field_name_encodings)
+            encoding_idx = FieldInfo.field_name_encodings.index(field_name_meta_str.encoding)
+            header |= encoding_idx << 6
+            field_name_bytes = field_name_meta_str.encoded_data
+            size = len(field_name_bytes)
+            header |= (size & XLANG_FIELD_NAME_SIZE_THRESHOLD) << 2
+            buffer.write_uint8(header)
+            if size >= XLANG_FIELD_NAME_SIZE_THRESHOLD:
+                buffer.write_varuint32(size-XLANG_FIELD_NAME_SIZE_THRESHOLD)
+
+        field_type.xwrite(buffer)
+        if field_name_bytes:
+            buffer.write_bytes(field_name_bytes)

--- a/python/pyfory/meta/meta_share.py
+++ b/python/pyfory/meta/meta_share.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from enum import IntEnum
+
+class CompatibleMode(IntEnum):
+    SCHEMA_CONSISTENT = 1
+    COMPATIBLE = 2
+
+class MetaContext:
+    __slots__ = (
+        # Classes which has sent definitions to peer.
+        "class_map",
+        # Class definitions read from peer.
+        "read_class_defs",
+        "read_class_infos",
+        # New class definition which needs sending to peer.
+        "writing_class_defs"
+    )
+    def __init__(self):
+        self.class_map = dict()
+        self.read_class_defs = list()
+        self.read_class_defs = list()
+        self.writing_class_defs = list()
+

--- a/python/pyfory/meta/metastring.py
+++ b/python/pyfory/meta/metastring.py
@@ -31,7 +31,6 @@ class Encoding(Enum):
     FIRST_TO_LOWER_SPECIAL = 0x03
     ALL_TO_LOWER_SPECIAL = 0x04
 
-
 Statistics = namedtuple(
     "Statistics",
     [
@@ -280,7 +279,7 @@ class MetaStringEncoder:
         self.special_char1 = special_char1
         self.special_char2 = special_char2
 
-    def encode(self, input_string: str) -> MetaString:
+    def encode(self, input_string: str, encoding_options:list|None=None) -> MetaString:
         """
         Encodes the input string into a MetaString object.
 
@@ -305,7 +304,7 @@ class MetaStringEncoder:
                 self.special_char2,
             )
 
-        encoding = self.compute_encoding(input_string)
+        encoding = self.compute_encoding(input_string, encoding_options)
         return self.encode_with_encoding(input_string, encoding)
 
     def encode_with_encoding(self, input_string: str, encoding: Encoding) -> MetaString:
@@ -388,7 +387,7 @@ class MetaStringEncoder:
                 self.special_char2,
             )
 
-    def compute_encoding(self, input_string: str) -> Encoding:
+    def compute_encoding(self, input_string: str, encoding_options:list|None) -> Encoding:
         """
         Determines the encoding type of the input string.
 
@@ -404,18 +403,23 @@ class MetaStringEncoder:
         chars = list(input_string)
         statistics = self._compute_statistics(chars)
         if statistics.can_lower_special_encoded:
-            return Encoding.LOWER_SPECIAL
-        elif statistics.can_lower_upper_digit_special_encoded:
+            if encoding_options and Encoding.LOWER_SPECIAL in encoding_options:
+                return Encoding.LOWER_SPECIAL
+        if statistics.can_lower_upper_digit_special_encoded:
             if statistics.digit_count != 0:
-                return Encoding.LOWER_UPPER_DIGIT_SPECIAL
+                if encoding_options and Encoding.LOWER_UPPER_DIGIT_SPECIAL in encoding_options:
+                    return Encoding.LOWER_UPPER_DIGIT_SPECIAL
             else:
                 upper_count = statistics.upper_count
                 if upper_count == 1 and chars[0].isupper():
-                    return Encoding.FIRST_TO_LOWER_SPECIAL
+                    if encoding_options and Encoding.FIRST_TO_LOWER_SPECIAL in encoding_options:
+                        return Encoding.FIRST_TO_LOWER_SPECIAL
                 if (len(chars) + upper_count) * 5 < len(chars) * 6:
-                    return Encoding.ALL_TO_LOWER_SPECIAL
+                    if encoding_options and Encoding.ALL_TO_LOWER_SPECIAL in encoding_options:
+                        return Encoding.ALL_TO_LOWER_SPECIAL
                 else:
-                    return Encoding.LOWER_UPPER_DIGIT_SPECIAL
+                    if encoding_options and Encoding.LOWER_UPPER_DIGIT_SPECIAL in encoding_options:
+                        return Encoding.LOWER_UPPER_DIGIT_SPECIAL
         return Encoding.UTF_8
 
     def _compute_statistics(self, chars: List[str]) -> Statistics:

--- a/python/pyfory/meta/type_info.py
+++ b/python/pyfory/meta/type_info.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from dataclasses import dataclass
+from pyfory.buffer import Buffer
+from .field_info import FieldInfo
+from .xtype_resolver import XtypeResolver
+from .metastring import MetaStringEncoder,MetaStringDecoder
+from pyfory.lib.mmh3 import hash_buffer
+
+NUM_FIELDS_SIZE_THRESHOLD = 0b11111
+REGISTER_BY_NAME_FLAG     = 0b100000
+
+COMPRESS_META_FLAG = 0b1 << 13
+HAS_FIELDS_META_FLAG = 0b1 << 12
+META_SIZE_MASKS = 0b111_1111_1111
+NUM_HASH_BITS = 50
+
+
+@dataclass
+class TypeInfo:
+    namespace_encoder = MetaStringEncoder(".", "_")
+    namespace_decoder = MetaStringDecoder(".", "_")
+    type_name_encoder = namespace_encoder
+    type_name_decoder = namespace_decoder
+
+    def __init__(self, field_infos:list[FieldInfo], type_id=None, cls=None, namespace=None, type_name=None):
+        self.type_id = type_id
+        self.cls = cls
+        self.field_infos = field_infos
+        self.namespace = namespace
+        self.type_name = type_name
+
+    def xwrite(self, buffer:Buffer, resolver:XtypeResolver=None):
+        sub_buffer = Buffer.allocate(128)
+        # TODO: fields_num only relate to compatible fields
+        fields_num = len(self.field_infos) - 1
+        sub_header = fields_num & NUM_FIELDS_SIZE_THRESHOLD
+        # is_registered_by_name = resolver.is_registered_by_name(self.cls)
+        is_registered_by_name = False
+        if is_registered_by_name:
+            sub_header |= REGISTER_BY_NAME_FLAG
+        sub_buffer.write_uint8(sub_header)
+
+        if fields_num >= NUM_FIELDS_SIZE_THRESHOLD:
+            sub_buffer.write_varuint32(fields_num - NUM_FIELDS_SIZE_THRESHOLD)
+
+        if is_registered_by_name:
+            raise NotImplementedError()
+        else:
+            sub_buffer.write_varuint32(self.type_id)
+
+        for field_info in self.field_infos:
+            field_info.xwrite(sub_buffer)
+
+        is_compressed = False
+        has_fields_meta = True
+
+        meta_size = sub_buffer.writer_index
+        sub_buffer_data = sub_buffer.get_bytes(0, sub_buffer.writer_index)
+
+        hash_value = hash_buffer(sub_buffer_data,47)[0]
+        hash_value = (hash_value << (64-NUM_HASH_BITS)) & ((1 << 64) - 1)
+        global_header = abs(hash_value)
+
+
+        if is_compressed:
+            global_header |= COMPRESS_META_FLAG
+        if has_fields_meta:
+            global_header |= HAS_FIELDS_META_FLAG
+        global_header |= (meta_size & META_SIZE_MASKS)
+
+        buffer.write_int64(global_header)
+        if meta_size >= META_SIZE_MASKS:
+            buffer.write_varuint32(meta_size - META_SIZE_MASKS)
+        buffer.write_bytes(sub_buffer_data)
+
+
+    @staticmethod
+    def xread(buffer:Buffer)->"TypeInfo":
+        global_header = buffer.read_int64()
+
+        is_compressed = (global_header & COMPRESS_META_FLAG) != 0
+        has_fields_meta = (global_header & HAS_FIELDS_META_FLAG) != 0
+        meta_size = global_header & META_SIZE_MASKS
+        if meta_size >= META_SIZE_MASKS:
+            extra = buffer.read_varuint32()
+            meta_size += extra
+
+        if is_compressed:
+            raise NotImplementedError()
+
+        if not has_fields_meta:
+            raise NotImplementedError()
+
+        sub_header = buffer.read_uint8()
+        fields_num = sub_header & NUM_FIELDS_SIZE_THRESHOLD
+        if fields_num == NUM_FIELDS_SIZE_THRESHOLD:
+            fields_num += buffer.read_varuint32()
+
+        true_fields_num = fields_num + 1
+
+        is_register_by_name = (sub_header & REGISTER_BY_NAME_FLAG) >> 5
+
+        namespace = None
+        type_name = None
+        type_id = None
+        cls = None
+        if is_register_by_name:
+            raise NotImplementedError()
+            namespace = None
+            type_name = None
+        else:
+            type_id = buffer.read_varuint32()
+            cls = None
+        field_infos = list()
+        for _ in range(true_fields_num):
+            field_info = FieldInfo.xread(buffer, "defined_class")
+            field_infos.append(field_info)
+        return TypeInfo(
+            field_infos,
+            type_id,
+            cls,
+            namespace,
+            type_name
+        )
+
+

--- a/python/pyfory/meta/xtype_resolver.py
+++ b/python/pyfory/meta/xtype_resolver.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class XtypeResolver:
+    def __init__(self):
+        self.type_def_map = dict()
+
+    # TODO
+    def is_registered_by_id(self, typ)->bool:
+        return True
+
+    # TODO
+    def is_registered_by_name(self, typ)->bool:
+        return False

--- a/python/pyfory/tests/test_metastring.py
+++ b/python/pyfory/tests/test_metastring.py
@@ -200,3 +200,9 @@ def test_non_ascii_encoding_and_non_utf8():
         ValueError, match="Unsupported character for LOWER_SPECIAL encoding: こ"
     ):
         encoder.encode_with_encoding(non_ascii_string, Encoding.LOWER_SPECIAL)
+
+
+def test_encode_metastring_with_options():
+    encoder = MetaStringEncoder(special_char1="$", special_char2="_")
+    res = encoder.encode("_a", [Encoding.UTF_8, Encoding.LOWER_UPPER_DIGIT_SPECIAL, Encoding.ALL_TO_LOWER_SPECIAL])
+    assert res.encoding == Encoding.ALL_TO_LOWER_SPECIAL

--- a/python/pyfory/tests/test_type_def.py
+++ b/python/pyfory/tests/test_type_def.py
@@ -1,0 +1,28 @@
+import os
+from dataclasses import dataclass
+
+from ..meta.field_info import FieldInfo,FieldType
+from ..meta.type_info import TypeInfo
+from pyfory.buffer import Buffer
+
+def test_field_info():
+    os.environ["ENABLE_FORY_CYTHON_SERIALIZATION"] = "0"
+    t = FieldType(1,True,False,True)
+    field_info = FieldInfo("class_a", "field_b", t)
+    buffer = Buffer.allocate(32)
+    field_info.xwrite(buffer)
+    new_field_info = FieldInfo.xread(buffer, field_info.defined_class)
+    assert new_field_info == field_info
+
+def test_type_info():
+    defined_class = "class_a"
+    field_infos = [
+        FieldInfo(defined_class, "f_b", FieldType(1,True,True,False)),
+        FieldInfo(defined_class, "f_c", FieldType(2, True, False, True)),
+    ]
+    type_info = TypeInfo(field_infos, 3)
+    buffer = Buffer.allocate(32)
+    type_info.xwrite(buffer)
+    new_type_info = TypeInfo.xread(buffer)
+    for i,info in enumerate(field_infos):
+        assert info == new_type_info.field_infos[i]


### PR DESCRIPTION
## What does this PR do?
Prepare to implement xlang metashare encode&decode in pyfory. 
Now finish `field_info` and `type_info(TypeDef)` in python not cython. 
I will continue to finish type_resolver for registry.

other small change:
- Add `Buffer::write_uint8` for writing 1 byte header.
- Add metastring encoding options for field_name and namespace metastring encode.

## Some Question
- Still confused about naming. For me, I want to change all `class_` prefix to `type_`, like `class_info -> type_info`, `class_resolver -> type_resolver`. So it will be unified. 
- There is not `writeVarUint32Small7` in pyfury cython. Now I use `write_varuint32`. Should I add this function?
- Now I just finish the xlang TypeDefMeta specification. As the java version is too complex to imitate, I use my way to implement this: not use outer Encoder/Decoder/Resolver class, just implement the  `xread/xwrite` logic in `type_info/field_info` class. If this is not good, I will rewrite this part.
- Is Java now support testing with python using Xlang&Compatible mode? 


## Related issues
#2160


## Does this PR introduce any user-facing change?
WIP

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

TODO