### PR TITLE
fix(java): row encoders custom codec accepts class supertype

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -237,7 +237,7 @@ public class Encoders {
    * @param codec the codec to use
    */
   public static <T> void registerCustomCodec(
-      Class<?> beanType, Class<T> type, CustomCodec<T, ?> codec) {
+      Class<?> beanType, Class<? super T> type, CustomCodec<T, ?> codec) {
     TypeInference.registerCustomCodec(new CustomTypeRegistration(beanType, type), codec);
   }
 
@@ -247,7 +247,7 @@ public class Encoders {
    * @param type the type of field to handle
    * @param codec the codec to use
    */
-  public static <T> void registerCustomCodec(Class<T> type, CustomCodec<T, ?> codec) {
+  public static <T> void registerCustomCodec(Class<? super T> type, CustomCodec<T, ?> codec) {
     registerCustomCodec(Object.class, type, codec);
   }
 


### PR DESCRIPTION
## What does this PR do?
`Encoders.registerCustomCodec` now allows class token to be supertype of T
this matters for e.g. `registerCustomCodec(Id.class, new CustomCodec<Id<T>, ...>);` since `Id.class` is not `Id<T>` but `Id` is super of `Id<T>`
