### PR TITLE
feat(java): Adding explanatory message to `deserializeNonexistentClass` misconfiguration in `Config`

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/config/Config.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/Config.java
@@ -90,9 +90,11 @@ public class Config implements Serializable {
     metaCompressor = builder.metaCompressor;
     deserializeNonexistentClass = builder.deserializeNonexistentClass;
     if (deserializeNonexistentClass) {
-      // Only in meta share mode or compatibleMode, fory knows how to deserialize
-      // unexisted class by type info in data.
-      Preconditions.checkArgument(metaShareEnabled || compatibleMode == CompatibleMode.COMPATIBLE);
+      Preconditions.checkArgument(
+          metaShareEnabled || compatibleMode == CompatibleMode.COMPATIBLE,
+          "Configuration error: deserializeNonexistentClass=true requires either "
+              + "metaShareEnabled=true to access type information OR compatibleMode=COMPATIBLE "
+              + "to automatically resolve class schemas.");
     }
     asyncCompilationEnabled = builder.asyncCompilationEnabled;
     scalaOptimizationEnabled = builder.scalaOptimizationEnabled;


### PR DESCRIPTION
## What does this PR do?

#2272: adding a clear message when failing `deserializeNonexistentClass` precondition check in `Config`.
