### PR TITLE
feat(java): row encoder supports synthesizing interfaces nested inside of records

### DIFF
--- a/integration_tests/latest_jdk_tests/src/test/java/org/apache/fory/integration_tests/RecordRowTest.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/org/apache/fory/integration_tests/RecordRowTest.java
@@ -60,4 +60,30 @@ public class RecordRowTest {
     final OuterTestRecord deserializedBean = encoder.fromRow(row);
     Assert.assertEquals(deserializedBean, bean);
   }
+
+  public record TestRecordNestedInterface(NestedInterface f1) {}
+
+  public interface NestedInterface {
+    int f1();
+
+    class Impl implements NestedInterface {
+      @Override
+      public int f1() {
+        return 42;
+      }
+    }
+  }
+
+  @Test
+  public void testRecordNestedInterface() {
+    final TestRecordNestedInterface bean =
+        new TestRecordNestedInterface(new NestedInterface.Impl());
+    final RowEncoder<TestRecordNestedInterface> encoder =
+        Encoders.bean(TestRecordNestedInterface.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final TestRecordNestedInterface deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f1().f1(), bean.f1().f1());
+  }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/type/TypeResolutionContext.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/TypeResolutionContext.java
@@ -20,10 +20,7 @@
 package org.apache.fory.type;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.Set;
 import org.apache.fory.annotation.Internal;
 import org.apache.fory.reflect.TypeRef;
 
@@ -31,21 +28,26 @@ import org.apache.fory.reflect.TypeRef;
 public class TypeResolutionContext {
   private final CustomTypeRegistry customTypeRegistry;
   private final LinkedHashSet<TypeRef<?>> walkedTypePath;
-  private final Set<Class<?>> synthesizedBeanTypes;
+  private final boolean synthesizeInterfaces;
 
   public TypeResolutionContext(CustomTypeRegistry customTypeRegistry) {
+    this(customTypeRegistry, false);
+  }
+
+  public TypeResolutionContext(
+      CustomTypeRegistry customTypeRegistry, boolean synthesizeInterfaces) {
     this.customTypeRegistry = customTypeRegistry;
+    this.synthesizeInterfaces = synthesizeInterfaces;
     walkedTypePath = new LinkedHashSet<>();
-    synthesizedBeanTypes = Collections.emptySet();
   }
 
   public TypeResolutionContext(
       CustomTypeRegistry customTypeRegistry,
       LinkedHashSet<TypeRef<?>> walkedTypePath,
-      Set<Class<?>> synthesizedBeanTypes) {
+      boolean synthesizeInterfaces) {
     this.customTypeRegistry = customTypeRegistry;
     this.walkedTypePath = walkedTypePath;
-    this.synthesizedBeanTypes = synthesizedBeanTypes;
+    this.synthesizeInterfaces = synthesizeInterfaces;
   }
 
   public CustomTypeRegistry getCustomTypeRegistry() {
@@ -56,8 +58,8 @@ public class TypeResolutionContext {
     return walkedTypePath;
   }
 
-  public Set<Class<?>> getSynthesizedBeanTypes() {
-    return synthesizedBeanTypes;
+  public boolean isSynthesizeInterfaces() {
+    return synthesizeInterfaces;
   }
 
   public TypeRef<?> getEnclosingType() {
@@ -71,21 +73,11 @@ public class TypeResolutionContext {
   public TypeResolutionContext appendTypePath(TypeRef<?>... typeRef) {
     LinkedHashSet<TypeRef<?>> newWalkedTypePath = new LinkedHashSet<>(walkedTypePath);
     newWalkedTypePath.addAll(Arrays.asList(typeRef));
-    return new TypeResolutionContext(customTypeRegistry, newWalkedTypePath, synthesizedBeanTypes);
+    return new TypeResolutionContext(customTypeRegistry, newWalkedTypePath, synthesizeInterfaces);
   }
 
   public TypeResolutionContext appendTypePath(Class<?> clz) {
     return appendTypePath(TypeRef.of(clz));
-  }
-
-  public TypeResolutionContext withSynthesizedBeanType(Class<?> clz) {
-    Set<Class<?>> newSynthesizedBeanTypes = new HashSet<>(synthesizedBeanTypes);
-    newSynthesizedBeanTypes.add(clz);
-    return new TypeResolutionContext(customTypeRegistry, walkedTypePath, newSynthesizedBeanTypes);
-  }
-
-  public boolean isSynthesizedBeanType(Class<?> cls) {
-    return synthesizedBeanTypes.contains(cls);
   }
 
   public void checkNoCycle(Class<?> clz) {

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/ArrayDataForEach.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/ArrayDataForEach.java
@@ -88,10 +88,7 @@ public class ArrayDataForEach extends AbstractExpression {
       accessType = TypeRef.of(customEncoder.encodedType());
     }
     CustomTypeHandler customTypeHandler = CustomTypeEncoderRegistry.customTypeHandler();
-    TypeResolutionContext ctx = new TypeResolutionContext(customTypeHandler);
-    if (inputArrayData.type().getRawType().isInterface() && elemType.getRawType().isInterface()) {
-      ctx = ctx.withSynthesizedBeanType(elemType.getRawType());
-    }
+    TypeResolutionContext ctx = new TypeResolutionContext(customTypeHandler, true);
     this.accessMethod = BinaryUtils.getElemAccessMethodName(accessType, ctx);
     this.elemType = BinaryUtils.getElemReturnType(accessType, ctx);
     this.notNullAction = notNullAction;

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -49,6 +49,7 @@ import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.memory.MemoryUtils;
 import org.apache.fory.reflect.TypeRef;
+import org.apache.fory.type.TypeResolutionContext;
 import org.apache.fory.type.TypeUtils;
 
 /**
@@ -679,7 +680,8 @@ public class Encoders {
   public static Class<?> loadOrGenRowCodecClass(Class<?> beanClass) {
     Set<Class<?>> classes =
         TypeUtils.listBeansRecursiveInclusive(
-            beanClass, CustomTypeEncoderRegistry.customTypeHandler());
+            beanClass,
+            new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler(), true));
     LOG.info("Create RowCodec for classes {}", classes);
     CompileUnit[] compileUnits =
         classes.stream()

--- a/java/fory-format/src/main/java/org/apache/fory/format/type/TypeInference.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/type/TypeInference.java
@@ -121,11 +121,7 @@ public class TypeInference {
 
   private static Field inferField(TypeRef<?> arrayTypeRef, TypeRef<?> typeRef) {
     TypeResolutionContext ctx =
-        new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler());
-    Class<?> clz = getRawType(typeRef);
-    if (clz.isInterface()) {
-      ctx = ctx.withSynthesizedBeanType(clz);
-    }
+        new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler(), true);
     String name = "";
     if (arrayTypeRef != null) {
       Field f = inferField(DataTypes.ARRAY_ITEM_NAME, typeRef, ctx);
@@ -239,13 +235,8 @@ public class TypeInference {
               .map(
                   descriptor -> {
                     String n = StringUtils.lowerCamelToLowerUnderscore(descriptor.getName());
-                    TypeResolutionContext newCtx = ctx.appendTypePath(rawType);
                     TypeRef<?> fieldType = descriptor.getTypeRef();
-                    Class<?> rawFieldType = getRawType(fieldType);
-                    if (rawFieldType.isInterface()) {
-                      newCtx = newCtx.withSynthesizedBeanType(rawFieldType);
-                    }
-                    return inferField(n, fieldType, newCtx);
+                    return inferField(n, fieldType, ctx.appendTypePath(rawType));
                   })
               .collect(Collectors.toList());
       return DataTypes.structField(name, true, fields);


### PR DESCRIPTION
## What does this PR do?

Row encoder synthesized interfaces now work inside enclosing record classes.
The previous logic was over-complicated to work around the overly aggressive expanding of types. With the fix in #2265 this is no longer necessary and we can simplify the logic around detecting interfaces to synthesize, in a way that better supports nesting too.