### PR TITLE
fix(java): row encoder interface synthesis handle `(Optional) null` correctly

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
@@ -315,7 +315,6 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
     implClass.setClassName(generatedBeanImplName);
     implClass.implementsInterfaces(implClass.type(beanClass));
     implClass.addField(true, implClass.type(BinaryRow.class), "row", null);
-    implClass.addConstructor("this.row = row;", BinaryRow.class, "row");
 
     int numFields = schema.getFields().size();
     for (int i = 0; i < numFields; i++) {
@@ -330,7 +329,8 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
         getterImpl = new Expression.Return(decodeValue);
       } else {
         String fieldName = "f" + i + "_" + d.getName();
-        implClass.addField(fieldType.getRawType(), fieldName);
+        implClass.addField(
+            false, ctx.type(fieldType.getRawType()), fieldName, nullValue(fieldType));
 
         Expression fieldRef = new Expression.Reference(fieldName, fieldType, true);
         Expression storeValue =
@@ -353,6 +353,8 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
       implClass.addMethod(
           d.getName(), getterImpl.genCode(implClass).code(), fieldType.getRawType());
     }
+    // Note: adding constructor captures init code, so must happen after all fields are collected
+    implClass.addConstructor("this.row = row;", BinaryRow.class, "row");
 
     return implClass;
   }

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.fory.format.encoder;
 
+import java.util.Optional;
 import lombok.Data;
 import org.apache.fory.annotation.ForyField;
 import org.apache.fory.format.row.binary.BinaryRow;
@@ -127,5 +128,27 @@ public class ImplementInterfaceTest {
     public PoisonPill decode(final byte[] value) {
       throw new AssertionError();
     }
+  }
+
+  public interface OptionalType {
+    Optional<String> f1();
+  }
+
+  static class OptionalTypeImpl implements OptionalType {
+    @Override
+    public Optional<String> f1() {
+      return null;
+    }
+  }
+
+  @Test
+  public void testNullOptional() {
+    final OptionalType bean1 = new OptionalTypeImpl();
+    final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OptionalType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f1(), Optional.empty());
   }
 }

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/OptionalTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/OptionalTest.java
@@ -54,6 +54,18 @@ public class OptionalTest {
   }
 
   @Test
+  public void testOptionalNull() {
+    final OptionalType bean = new OptionalType();
+    final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
+    final BinaryRow row = encoder.toRow(bean);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OptionalType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f1, Optional.empty());
+    Assert.assertEquals(deserializedBean.f2, Optional.empty());
+  }
+
+  @Test
   public void testOptionalPresent() {
     final OptionalType bean = new OptionalType();
     bean.f1 = Optional.of(42);


### PR DESCRIPTION

## What does this PR do?

fix incorrect handling of lazy-read `(Optional) null` values

