### PR TITLE
fix(java): fix row format handling Optional of type with custom codec

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
@@ -536,7 +536,6 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
       Set<TypeRef<?>> visitedCustomTypes) {
     Class<?> rawType = getRawType(typeRef);
     TypeRef<?> rewrittenType = customTypeHandler.replacementTypeFor(beanType.getRawType(), rawType);
-    ;
     if (rewrittenType != null
         && !visitedCustomTypes.contains(typeRef)
         && !typeRef.equals(rewrittenType)) {

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
@@ -286,16 +286,14 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
       Descriptor d = getDescriptorByFieldName(schema.getFields().get(i).getName());
       TypeRef<?> fieldType = d.getTypeRef();
       Class<?> rawFieldType = fieldType.getRawType();
-      TypeRef<?> columnAccessType;
+      TypeRef<?> columnAccessType = fieldType;
       if (rawFieldType == Optional.class) {
         columnAccessType = TypeUtils.getTypeArguments(fieldType).get(0);
-      } else {
-        CustomCodec<?, ?> customEncoder = customTypeHandler.findCodec(beanClass, rawFieldType);
-        if (customEncoder == null) {
-          columnAccessType = fieldType;
-        } else {
-          columnAccessType = customEncoder.encodedType();
-        }
+      }
+      TypeRef<?> replacementType =
+          customTypeHandler.replacementTypeFor(beanClass, columnAccessType.getRawType());
+      if (replacementType != null) {
+        columnAccessType = replacementType;
       }
       String columnAccessMethodName =
           BinaryUtils.getElemAccessMethodName(columnAccessType, typeCtx);


### PR DESCRIPTION
## What does this PR do?

Fix the logic for type with custom codec wrapped in Optional, currently causes compile error

Please review #2320 first; this PR depends on that fix

And please consider for a 0.11.0-rc2 if that happens, otherwise 0.11.1