### PR TITLE
chore: add release note generate tool

### DIFF
--- a/ci/generate_release_note.py
+++ b/ci/generate_release_note.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import defaultdict
+
+
+def generate_release_notes(content_text):
+    sections = defaultdict(list)
+    new_contributors = []
+
+    current_section = None
+    full_changelog_link = None
+
+    for line in content_text.strip().split("\n"):
+        if line.startswith("##"):
+            continue  # Skip section headers
+
+        # Check for the Full Changelog line
+        if "Full Changelog" in line:
+            full_changelog_link = line
+            continue
+
+        # Remove the trailing ')' character, if present, from the line
+        line = line.rstrip(")")
+
+        if (
+            line.startswith("* feat")
+            or line.startswith("* perf")
+            or line.startswith("* refactor")
+        ):
+            current_section = "Features"
+        elif line.startswith("* fix"):
+            current_section = "Bug Fix"
+        elif (
+            line.startswith("* chore")
+            or line.startswith("* docs")
+            or line.startswith("* style")
+        ):
+            current_section = "Other Improvements"
+        elif line.startswith("* @"):
+            current_section = "New Contributors"
+
+        if current_section == "New Contributors":
+            new_contributors.append(line)
+        elif current_section:
+            sections[current_section].append(line)
+
+    markdown_text = "## Highlights\n* xxx\n* xxx\n\n"
+
+    if "Features" in sections:
+        markdown_text += "## Features\n" + "\n".join(sections["Features"]) + "\n\n"
+
+    if "Bug Fix" in sections:
+        markdown_text += "## Bug Fix\n" + "\n".join(sections["Bug Fix"]) + "\n\n"
+
+    if "Other Improvements" in sections:
+        markdown_text += (
+            "## Other Improvements\n"
+            + "\n".join(sections["Other Improvements"])
+            + "\n\n"
+        )
+
+    if new_contributors:
+        markdown_text += "## New Contributors\n" + "\n".join(new_contributors) + "\n\n"
+
+    if full_changelog_link:
+        markdown_text += full_changelog_link
+
+    print(markdown_text)
+
+
+# Example input
+input_text = """
+## What's Changed
+* feat(java): xxx by @xxx in https://github.com/apache/fory/pull/xxx
+* fix(doc): xxx by @xxx in https://github.com/apache/fory/pull/xxx
+* perf(python): xxx by @xxx in https://github.com/apache/fory/pull/xxx
+* chore: xxx by @xxx in https://github.com/apache/fory/pull/xxx
+* feat(python): xxx by @xxx in https://github.com/apache/fory/pull/xxx
+
+## New Contributors
+* @XXX made their first contribution in https://github.com/apache/fory/pull/XXX
+
+**Full Changelog**: https://github.com/apache/fory/compare/v0.10.3...v0.11.0-rc2
+"""
+
+# Generate release notes from given input
+generate_release_notes(input_text)

--- a/ci/generate_release_note.py
+++ b/ci/generate_release_note.py
@@ -19,6 +19,9 @@ from collections import defaultdict
 
 
 def generate_release_notes(content_text):
+    """
+    Generate release notes from the github auto generated release note.
+    """
     sections = defaultdict(list)
     new_contributors = []
 


### PR DESCRIPTION


## What does this PR do?

A tool to generate release note from github generated release note

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
