### PR TITLE
feat(java): array row encoder supports set of interface type

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
@@ -599,7 +599,8 @@ public class TypeUtils {
 
   public static boolean isBean(TypeRef<?> typeRef, TypeResolutionContext ctx) {
     Class<?> cls = getRawType(typeRef);
-    if (ctx.isSynthesizeInterfaces() && (RecordUtils.isRecord(cls) || (cls.isInterface()))) {
+    if (ctx.isSynthesizeInterfaces()
+        && (RecordUtils.isRecord(cls) || isSynthesizableInterface(cls))) {
       return true;
     }
     if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
@@ -649,6 +650,12 @@ public class TypeUtils {
     } else {
       return false;
     }
+  }
+
+  private static boolean isSynthesizableInterface(Class<?> cls) {
+    return cls.isInterface()
+        && !Collection.class.isAssignableFrom(cls)
+        && !Map.class.isAssignableFrom(cls);
   }
 
   /** Check if <code>typeToken</code> is supported by row-format. */

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/ArrayEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/ArrayEncoderBuilder.java
@@ -142,7 +142,8 @@ public class ArrayEncoderBuilder extends BaseBinaryEncoderBuilder {
     Expression.Reference inputObject =
         new Expression.Reference(ROOT_OBJECT_NAME, TypeUtils.COLLECTION_TYPE, false);
     Expression.Cast array =
-        new Expression.Cast(inputObject, arrayToken, ctx.newName(getRawType(arrayToken)));
+        new Expression.Cast(
+            inputObject, arrayToken, ctx.newName(getRawType(arrayToken)), false, false);
     expressions.add(array);
 
     Expression.Reference fieldExpr = new Expression.Reference(FIELD_NAME, ARROW_FIELD_TYPE, false);

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -343,7 +343,7 @@ public class Encoders {
       Class<? extends Collection> arrayCls, Class<B> elementType) {
     Preconditions.checkNotNull(elementType);
 
-    return (ArrayEncoder<T>) arrayEncoder(TypeUtils.listOf(elementType), null);
+    return (ArrayEncoder<T>) arrayEncoder(TypeUtils.collectionOf(elementType), null);
   }
 
   /**
@@ -581,7 +581,8 @@ public class Encoders {
 
   private static Set<TypeRef<?>> beanSet(TypeRef<?> token) {
     Set<TypeRef<?>> set = new HashSet<>();
-    if (TypeUtils.isBean(token)) {
+    if (TypeUtils.isBean(
+        token, new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler(), true))) {
       set.add(token);
       return set;
     }
@@ -645,6 +646,8 @@ public class Encoders {
   }
 
   private static void findBeanToken(TypeRef<?> typeRef, java.util.Set<TypeRef<?>> set) {
+    TypeResolutionContext typeCtx =
+        new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler(), true);
     Set<TypeRef<?>> visited = new LinkedHashSet<>();
     while (TypeUtils.ITERABLE_TYPE.isSupertypeOf(typeRef)
         || TypeUtils.MAP_TYPE.isSupertypeOf(typeRef)) {
@@ -654,20 +657,20 @@ public class Encoders {
       visited.add(typeRef);
       if (TypeUtils.ITERABLE_TYPE.isSupertypeOf(typeRef)) {
         typeRef = TypeUtils.getElementType(typeRef);
-        if (TypeUtils.isBean(typeRef)) {
+        if (TypeUtils.isBean(typeRef, typeCtx)) {
           set.add(typeRef);
         }
         findBeanToken(typeRef, set);
       } else {
         Tuple2<TypeRef<?>, TypeRef<?>> tuple2 = TypeUtils.getMapKeyValueType(typeRef);
-        if (TypeUtils.isBean(tuple2.f0)) {
+        if (TypeUtils.isBean(tuple2.f0, typeCtx)) {
           set.add(tuple2.f0);
         } else {
           typeRef = tuple2.f0;
           findBeanToken(tuple2.f0, set);
         }
 
-        if (TypeUtils.isBean(tuple2.f1)) {
+        if (TypeUtils.isBean(tuple2.f1, typeCtx)) {
           set.add(tuple2.f1);
         } else {
           typeRef = tuple2.f1;


### PR DESCRIPTION
## What does this PR do?

improve array row encoder to support custom collections that are not List, for example TreeSet
also supports interface types as value