### PR TITLE
perf(java): Improve zone offset deserialization performance by overriding JDK caching

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/serializer/TimeSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/TimeSerializers.java
@@ -493,9 +493,10 @@ public class TimeSerializers {
 
   public static class ZoneOffsetSerializer extends ImmutableTimeSerializer<ZoneOffset> {
 
-    // cached zone offsets for the single byte representation, using this overrides the JDK zone offset caching
-    // which uses a concurrent hash map for zone offsets that causes a noticeable overhead
-    // (see ZoneOffset.ofTotalSeconds impl), cached each 15 minutes (in line with the compression -72 to +72)
+    // cached zone offsets for the single byte representation, using this overrides the JDK zone
+    // offset caching which uses a concurrent hash map for zone offsets that causes a noticeable
+    // overhead (see ZoneOffset.ofTotalSeconds impl), cached each 15 minutes (in line with the
+    // compression -72 to +72)
     private static final ZoneOffset[] COMPRESSED_ZONE_OFFSETS = new ZoneOffset[145];
 
     static {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/TimeSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/TimeSerializers.java
@@ -492,6 +492,18 @@ public class TimeSerializers {
   }
 
   public static class ZoneOffsetSerializer extends ImmutableTimeSerializer<ZoneOffset> {
+
+    // cached zone offsets for the single byte representation, using this overrides the JDK zone offset caching
+    // which uses a concurrent hash map for zone offsets that causes a noticeable overhead
+    // (see ZoneOffset.ofTotalSeconds impl), cached each 15 minutes (in line with the compression -72 to +72)
+    private static final ZoneOffset[] COMPRESSED_ZONE_OFFSETS = new ZoneOffset[145];
+
+    static {
+      for (int i = 0; i < COMPRESSED_ZONE_OFFSETS.length; i++) {
+        COMPRESSED_ZONE_OFFSETS[i] = ZoneOffset.ofTotalSeconds((i - 72) * 900);
+      }
+    }
+
     public ZoneOffsetSerializer(Fory fory) {
       super(fory, ZoneOffset.class);
     }
@@ -519,9 +531,10 @@ public class TimeSerializers {
 
     public static ZoneOffset readZoneOffset(MemoryBuffer buffer) {
       int offsetByte = buffer.readByte();
-      return (offsetByte == 127
-          ? ZoneOffset.ofTotalSeconds(buffer.readInt32())
-          : ZoneOffset.ofTotalSeconds(offsetByte * 900));
+      if (offsetByte == 127) {
+        return ZoneOffset.ofTotalSeconds(buffer.readInt32());
+      }
+      return COMPRESSED_ZONE_OFFSETS[offsetByte + 72];
     }
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/TimeSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/TimeSerializersTest.java
@@ -99,6 +99,16 @@ public class TimeSerializersTest extends ForyTestBase {
   }
 
   @Test
+  public void testZoneOffset() {
+    Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
+    serDeCheckSerializerAndEqual(fory, ZoneOffset.UTC, "ZoneOffsetSerializer");
+    serDeCheckSerializerAndEqual(fory, ZoneOffset.ofHoursMinutes(1, 15), "ZoneOffsetSerializer");
+    serDeCheckSerializerAndEqual(fory, ZoneOffset.ofHoursMinutes(1, 13), "ZoneOffsetSerializer");
+    serDeCheckSerializerAndEqual(fory, ZoneOffset.ofHoursMinutes(-8, -15), "ZoneOffsetSerializer");
+    serDeCheckSerializerAndEqual(fory, ZoneOffset.ofHoursMinutes(-8, -13), "ZoneOffsetSerializer");
+  }
+
+  @Test
   public void testZone() {
     Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
     serDeCheckSerializerAndEqual(


### PR DESCRIPTION
## What does this PR do?

The JDK `ZoneOffset.ofTotalSeconds(...)` method uses a concurrent hash map for caching zone offsets with values for each 15 minutes (UTC, +01:00, +01:15, etc.), this causes a noticeable overhead when deserializing a lot of zone offsets. This PR overrides that caching for the single byte representation using an array, which is in line with the 15 minute JDK caching.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
