### PR TITLE
feat(java): store OptionalInt, OptionalLong, OptionalDouble same as nullable values

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
@@ -1041,6 +1041,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     } else {
       return new ForEach(
           collection,
+          false,
           (i, elem) ->
               writeContainerElement(
                   exprHolder.get("buffer"),

--- a/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
@@ -44,6 +44,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.fory.collection.IdentityMap;
@@ -104,6 +107,9 @@ public class TypeUtils {
   public static final TypeRef<?> MAP_ENTRY_TYPE = TypeRef.of(Map.Entry.class);
   public static final TypeRef<?> HASHMAP_TYPE = TypeRef.of(HashMap.class);
   public static final TypeRef<?> OPTIONAL_TYPE = TypeRef.of(Optional.class);
+  public static final TypeRef<?> OPTIONAL_INT_TYPE = TypeRef.of(OptionalInt.class);
+  public static final TypeRef<?> OPTIONAL_LONG_TYPE = TypeRef.of(OptionalLong.class);
+  public static final TypeRef<?> OPTIONAL_DOUBLE_TYPE = TypeRef.of(OptionalDouble.class);
   public static final TypeRef<?> OBJECT_TYPE = TypeRef.of(Object.class);
 
   public static Type ITERATOR_RETURN_TYPE;
@@ -159,6 +165,9 @@ public class TypeUtils {
     SUPPORTED_TYPES.add(TIMESTAMP_TYPE);
     SUPPORTED_TYPES.add(INSTANT_TYPE);
     SUPPORTED_TYPES.add(OPTIONAL_TYPE);
+    SUPPORTED_TYPES.add(OPTIONAL_INT_TYPE);
+    SUPPORTED_TYPES.add(OPTIONAL_LONG_TYPE);
+    SUPPORTED_TYPES.add(OPTIONAL_DOUBLE_TYPE);
   }
 
   static {

--- a/java/fory-core/src/test/java/org/apache/fory/codegen/ExpressionVisitorTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/codegen/ExpressionVisitorTest.java
@@ -52,6 +52,7 @@ public class ExpressionVisitorTest {
     Expression.ForEach forLoop =
         new Expression.ForEach(
             list,
+            false,
             (i, expr) -> ((Expression.ListExpression) (holder.get("e2"))).add(holder.get("e1")));
     List<Expression> expressions = new ArrayList<>();
     new ExpressionVisitor()

--- a/java/fory-format/src/main/java/org/apache/fory/format/row/binary/BinaryUtils.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/row/binary/BinaryUtils.java
@@ -35,13 +35,19 @@ public class BinaryUtils {
       return "getBoolean";
     } else if (TypeUtils.PRIMITIVE_SHORT_TYPE.equals(type) || TypeUtils.SHORT_TYPE.equals(type)) {
       return "getInt16";
-    } else if (TypeUtils.PRIMITIVE_INT_TYPE.equals(type) || TypeUtils.INT_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_INT_TYPE.equals(type)
+        || TypeUtils.INT_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_INT_TYPE.equals(type)) {
       return "getInt32";
-    } else if (TypeUtils.PRIMITIVE_LONG_TYPE.equals(type) || TypeUtils.LONG_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_LONG_TYPE.equals(type)
+        || TypeUtils.LONG_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_LONG_TYPE.equals(type)) {
       return "getInt64";
     } else if (TypeUtils.PRIMITIVE_FLOAT_TYPE.equals(type) || TypeUtils.FLOAT_TYPE.equals(type)) {
       return "getFloat32";
-    } else if (TypeUtils.PRIMITIVE_DOUBLE_TYPE.equals(type) || TypeUtils.DOUBLE_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_DOUBLE_TYPE.equals(type)
+        || TypeUtils.DOUBLE_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_DOUBLE_TYPE.equals(type)) {
       return "getFloat64";
     } else if (TypeUtils.BIG_DECIMAL_TYPE.equals(type)) {
       return "getDecimal";
@@ -81,13 +87,19 @@ public class BinaryUtils {
       return TypeUtils.PRIMITIVE_BOOLEAN_TYPE;
     } else if (TypeUtils.PRIMITIVE_SHORT_TYPE.equals(type) || TypeUtils.SHORT_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_SHORT_TYPE;
-    } else if (TypeUtils.PRIMITIVE_INT_TYPE.equals(type) || TypeUtils.INT_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_INT_TYPE.equals(type)
+        || TypeUtils.INT_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_INT_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_INT_TYPE;
-    } else if (TypeUtils.PRIMITIVE_LONG_TYPE.equals(type) || TypeUtils.LONG_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_LONG_TYPE.equals(type)
+        || TypeUtils.LONG_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_LONG_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_LONG_TYPE;
     } else if (TypeUtils.PRIMITIVE_FLOAT_TYPE.equals(type) || TypeUtils.FLOAT_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_FLOAT_TYPE;
-    } else if (TypeUtils.PRIMITIVE_DOUBLE_TYPE.equals(type) || TypeUtils.DOUBLE_TYPE.equals(type)) {
+    } else if (TypeUtils.PRIMITIVE_DOUBLE_TYPE.equals(type)
+        || TypeUtils.DOUBLE_TYPE.equals(type)
+        || TypeUtils.OPTIONAL_DOUBLE_TYPE.equals(type)) {
       return TypeUtils.PRIMITIVE_DOUBLE_TYPE;
     } else if (TypeUtils.BIG_DECIMAL_TYPE.equals(type)) {
       return TypeUtils.BIG_DECIMAL_TYPE;

--- a/java/fory-format/src/main/java/org/apache/fory/format/type/TypeInference.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/type/TypeInference.java
@@ -28,6 +28,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -185,14 +188,14 @@ public class TypeInference {
       return field(name, FieldType.nullable((new ArrowType.Int(8, true))));
     } else if (rawType == Short.class) {
       return field(name, FieldType.nullable((new ArrowType.Int(16, true))));
-    } else if (rawType == Integer.class) {
+    } else if (rawType == Integer.class || rawType == OptionalInt.class) {
       return field(name, FieldType.nullable((new ArrowType.Int(32, true))));
-    } else if (rawType == Long.class) {
+    } else if (rawType == Long.class || rawType == OptionalLong.class) {
       return field(name, FieldType.nullable((new ArrowType.Int(64, true))));
     } else if (rawType == Float.class) {
       return field(
           name, FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)));
-    } else if (rawType == Double.class) {
+    } else if (rawType == Double.class || rawType == OptionalDouble.class) {
       return field(
           name, FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
     } else if (rawType == java.math.BigDecimal.class) {


### PR DESCRIPTION
## What does this PR do?

currently, optional wrappers are stored as a bean with two fields - present and value, taking 32 bytes
with this change, stored as nullable primitive, taking 8 bytes plus 1 bit for null

this is a breaking change to the row format, but since support is relatively recent, hopefully that is ok?
