### PR TITLE
docs: add row format guide for ext and interface types

### DIFF
--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -115,6 +115,7 @@ for (int i = 0; i < 10; i++) {
 }
 return arrowWriter.finishAsRecordBatch();
 ```
+
 ### Support for Interface and Extension Types
 
 Fury now supports row format mapping for Java `interface` types and subclassed (`extends`) types, enabling more dynamic and flexible data schemas.
@@ -158,8 +159,8 @@ fury.getLanguage(Fury.Language.JAVA)
     .getClassResolver()
     .register(Parent.class);
 
-
 ```
+
 Python:
 
 ```python

--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -122,7 +122,7 @@ Fury now supports row format mapping for Java `interface` types and subclassed (
 
 These enhancements were introduced in [#2243](https://github.com/apache/fury/pull/2243), [#2250](https://github.com/apache/fury/pull/2250), and [#2256](https://github.com/apache/fury/pull/2256).
 
-#### Example: Interface Mapping
+#### Example: Interface Mapping with RowEncoder
 
 ```java
 public interface Animal {
@@ -138,26 +138,34 @@ public class Dog implements Animal {
   }
 }
 
-// Registering interface mapping
-fury.getLanguage(Fury.Language.JAVA)
-    .getClassResolver()
-    .registerInterfaceMapping(Animal.class, Dog.class);
+// Encode and decode using RowEncoder with interface type
+RowEncoder<Animal> encoder = Encoders.bean(Animal.class);
+Dog dog = new Dog();
+dog.name = "Bingo";
+BinaryRow row = encoder.toRow(dog);
+Animal decoded = encoder.fromRow(row);
+System.out.println(decoded.speak()); // Woof
 
 ```
 
+#### Example: Extension Type with RowEncoder
+
 ```java
 public class Parent {
-  public String parentField;
+    public String parentField;
 }
 
 public class Child extends Parent {
-  public String childField;
+    public String childField;
 }
 
-// Registering superclass for use with polymorphic decoding
-fury.getLanguage(Fury.Language.JAVA)
-    .getClassResolver()
-    .register(Parent.class);
+// Encode and decode using RowEncoder with parent class type
+RowEncoder<Parent> encoder = Encoders.bean(Parent.class);
+Child child = new Child();
+child.parentField = "Hello";
+child.childField = "World";
+BinaryRow row = encoder.toRow(child);
+Parent decoded = encoder.fromRow(row);
 
 ```
 

--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -115,7 +115,51 @@ for (int i = 0; i < 10; i++) {
 }
 return arrowWriter.finishAsRecordBatch();
 ```
+### Support for Interface and Extension Types
 
+Fury now supports row format mapping for Java `interface` types and subclassed (`extends`) types, enabling more dynamic and flexible data schemas.
+
+These enhancements were introduced in [#2243](https://github.com/apache/fury/pull/2243), [#2250](https://github.com/apache/fury/pull/2250), and [#2256](https://github.com/apache/fury/pull/2256).
+
+#### Example: Interface Mapping
+
+```java
+public interface Animal {
+  String speak();
+}
+
+public class Dog implements Animal {
+  public String name;
+
+  @Override
+  public String speak() {
+    return "Woof";
+  }
+}
+
+// Registering interface mapping
+fury.getLanguage(Fury.Language.JAVA)
+    .getClassResolver()
+    .registerInterfaceMapping(Animal.class, Dog.class);
+
+```
+
+```java
+public class Parent {
+  public String parentField;
+}
+
+public class Child extends Parent {
+  public String childField;
+}
+
+// Registering superclass for use with polymorphic decoding
+fury.getLanguage(Fury.Language.JAVA)
+    .getClassResolver()
+    .register(Parent.class);
+
+
+```
 Python:
 
 ```python


### PR DESCRIPTION
## What does this PR do?

This PR adds documentation to `row_format_guide.md` for recent enhancements that support Java `interface` types and class inheritance (`extends`) in row format mapping.

The update includes code examples demonstrating how to register interface mappings and superclass support using Fury's Java API.

## Related issues

- #2310
- [#2243](https://github.com/apache/fory/pull/2243)
- [#2250](https://github.com/apache/fory/pull/2250)
- [#2256](https://github.com/apache/fory/pull/2256)

## Does this PR introduce any user-facing change?

Yes. It introduces user-facing documentation explaining how to use interface and extension types with row encoding in Java.
