### PR TITLE
chore(java): ProtobufDispatcher should trigger log warning at most once

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/serializer/shim/ProtobufDispatcher.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/shim/ProtobufDispatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.fory.serializer.shim;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.reflect.ReflectionUtils;
@@ -33,6 +34,7 @@ public class ProtobufDispatcher {
   private static Class<? extends Serializer> pbByteStringSerializerClass;
   private static Class<?> pbMessageClass;
   private static Class<? extends Serializer> pbMessageSerializerClass;
+  private static final AtomicBoolean warningLogged = new AtomicBoolean(false);
 
   static {
     try {
@@ -52,9 +54,6 @@ public class ProtobufDispatcher {
                   Serializer.class.getPackage().getName() + "." + "ByteStringSerializer");
     } catch (Exception e) {
       ExceptionUtils.ignore(e);
-      if (pbMessageClass != null) {
-        LOG.warn("ProtobufSerializer not loaded, please add fory-extensions dependency.");
-      }
     }
   }
 
@@ -63,7 +62,9 @@ public class ProtobufDispatcher {
       return null;
     }
     if (pbMessageSerializerClass == null) {
-      LOG.warn("ProtobufSerializer not loaded, please add fory-extensions dependency.");
+      if (type.getName().startsWith("com.google.protobuf") && !warningLogged.getAndSet(true)) {
+        LOG.warn("ProtobufSerializer not loaded, please add fory-extensions dependency.");
+      }
       return null;
     }
     if (pbMessageClass.isAssignableFrom(type)) {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fory.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Fory has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

This PR addresses these 2 issues:
- It's possible the `ProtobufSerializer not loaded...` log warning to fire even if you aren't trying to serialise a Protobuf class.
- The warning is fired every time `ProtobufSerializer.getSerializerClass()` is called which can result in the log line to be constantly fired and displayed in logs.

With these changes, the log warning can only be fired once and only the first time you try to serialise a Protobuf class.

## Related issues

This has been discussed in https://github.com/apache/fory/discussions/2349

## Does this PR introduce any user-facing change?
- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

I believe it should have an insubstantial benchmark effect.
