### PR TITLE
feat(python): Add Python Linux ARM64 support and optimize Bazel installation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,13 +46,3 @@ build:macos --cxxopt="-std=c++17" --linkopt="-pthread"
 build:clang-cl --cxxopt="-std=c++17"
 build:windows --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
 build:msvc --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
-
-# CPU-specific optimizations for x86_64
-build:x86_64 --copt=-mavx
-build:x86_64 --copt=-mavx2
-build:x86_64 --copt=-mbmi
-build:x86_64 --copt=-mbmi2
-
-# ARM64-specific optimizations (if any needed in the future)
-build:arm64 --copt=-march=armv8-a
-

--- a/.bazelrc
+++ b/.bazelrc
@@ -17,16 +17,20 @@
 
 # Must be first. Enables build:windows, build:linux, build:macos, build:freebsd, build:openbsd
 build --enable_platform_specific_config
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python
 ###############################################################################
 build --action_env=PATH
+
 # For --compilation_mode=dbg, consider enabling checks in the standard library as well (below).
 build --compilation_mode=opt
+
 # This workaround is needed to prevent Bazel from compiling the same file twice (once PIC and once not).
 build:linux --force_pic
 build:macos --force_pic
+
 build:clang-cl --compiler=clang-cl
 build:msvc --compiler=msvc-cl
 build:windows --compiler=msvc-cl
@@ -36,14 +40,19 @@ test --build_tests_only
 test --cache_test_results=no
 test --test_output=all
 
+# Platform-specific C++ options
 build:linux --cxxopt="-std=c++17" --linkopt="-pthread"
 build:macos --cxxopt="-std=c++17" --linkopt="-pthread"
 build:clang-cl --cxxopt="-std=c++17"
 build:windows --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
 build:msvc --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
 
-build --copt=-mavx
-build --copt=-mavx2
-build --copt=-mbmi
-build --copt=-mbmi2
+# CPU-specific optimizations for x86_64
+build:x86_64 --copt=-mavx
+build:x86_64 --copt=-mavx2
+build:x86_64 --copt=-mbmi
+build:x86_64 --copt=-mbmi2
+
+# ARM64-specific optimizations (if any needed in the future)
+build:arm64 --copt=-march=armv8-a
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -46,3 +46,13 @@ build:macos --cxxopt="-std=c++17" --linkopt="-pthread"
 build:clang-cl --cxxopt="-std=c++17"
 build:windows --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
 build:msvc --cxxopt="/std:c++17" --cxxopt="/Zc:preprocessor" --cxxopt="/utf-8"
+
+# CPU-specific optimizations for x86_64
+build:x86_64 --copt=-mavx
+build:x86_64 --copt=-mavx2
+build:x86_64 --copt=-mbmi
+build:x86_64 --copt=-mbmi2
+
+# ARM64-specific optimizations (if any needed in the future)
+build:arm64 --copt=-march=armv8-a
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.12, 3.13.3]
-        os: [ubuntu-latest, macos-13, macos-14, windows-2022]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
-        os: [ubuntu-latest, macos-13, macos-14, windows-2022]  # macos-13: x86, macos-14: arm64
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-2022]  # macos-13: x86, macos-14: arm64
 
     steps:
       - uses: actions/checkout@v4

--- a/BUILD
+++ b/BUILD
@@ -19,30 +19,6 @@ load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 load("@compile_commands_extractor//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 
-config_setting(
-    name = "is_x86_64",
-    values = {"cpu": "x86_64"},
-)
-
-config_setting(
-    name = "is_arm64",
-    values = {"cpu": "aarch64"}, # Note: Bazel often identifies arm64 as 'aarch64'
-)
-
-ARCH_COPTS = select({
-    ":is_x86_64": [
-        "-mavx",
-        "-mavx2",
-        "-mbmi",
-        "-mbmi2",
-    ],
-    ":is_arm64": [
-        "-march=armv8-a",
-        "-fsigned-char",
-    ],
-    "//conditions:default": [],
-})
-
 pyx_library(
     name = "_util",
     srcs = glob([
@@ -53,7 +29,6 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
-        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/util:fory_util",
@@ -69,7 +44,6 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
-        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/thirdparty:libmmh3",
@@ -86,7 +60,6 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
-        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/util:fory_util",
@@ -109,7 +82,6 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
-        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory:fory",

--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,30 @@ load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 load("@compile_commands_extractor//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 
+config_setting(
+    name = "is_x86_64",
+    values = {"cpu": "x86_64"},
+)
+
+config_setting(
+    name = "is_arm64",
+    values = {"cpu": "aarch64"}, # Note: Bazel often identifies arm64 as 'aarch64'
+)
+
+ARCH_COPTS = select({
+    ":is_x86_64": [
+        "-mavx",
+        "-mavx2",
+        "-mbmi",
+        "-mbmi2",
+    ],
+    ":is_arm64": [
+        "-march=armv8-a",
+        "-fsigned-char",
+    ],
+    "//conditions:default": [],
+})
+
 pyx_library(
     name = "_util",
     srcs = glob([
@@ -29,6 +53,7 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
+        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/util:fory_util",
@@ -44,6 +69,7 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
+        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/thirdparty:libmmh3",
@@ -60,6 +86,7 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
+        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory/util:fory_util",
@@ -82,6 +109,7 @@ pyx_library(
     ]),
     cc_kwargs = dict(
         linkstatic = 1,
+        copts = ARCH_COPTS,
     ),
     deps = [
         "//cpp/fory:fory",

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -123,7 +123,13 @@ build_pyfory() {
   # Fix strange installed deps not found
   pip install setuptools -U
 
-  bazel build //:cp_fory_so
+  # Detect host architecture and only pass x86_64 config when appropriate
+  ARCH=$(uname -m)
+  if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
+    bazel build --config=x86_64 //:cp_fory_so
+  else
+    bazel build //:cp_fory_so
+  fi
 
   python setup.py bdist_wheel --dist-dir=../dist
   popd

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -123,13 +123,7 @@ build_pyfory() {
   # Fix strange installed deps not found
   pip install setuptools -U
 
-  # Detect host architecture and only pass x86_64 config when appropriate
-  ARCH=$(uname -m)
-  if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
-    bazel build --config=x86_64 //:cp_fory_so
-  else
-    bazel build //:cp_fory_so
-  fi
+  bazel build //:cp_fory_so
 
   python setup.py bdist_wheel --dist-dir=../dist
   popd

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -122,7 +122,15 @@ build_pyfory() {
   echo "Install pyfory"
   # Fix strange installed deps not found
   pip install setuptools -U
-  bazel build //:cp_fory_so
+
+  # Detect host architecture and only pass x86_64 config when appropriate
+  ARCH=$(uname -m)
+  if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
+    bazel build --config=x86_64 //:cp_fory_so
+  else
+    bazel build //:cp_fory_so
+  fi
+
   python setup.py bdist_wheel --dist-dir=../dist
   popd
 }

--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -89,9 +89,11 @@ def _cd_project_subdir(subdir):
 
 def _run_cpp():
     _install_cpp_deps()
-    # run test
+    # collect all C++ targets
     query_result = _bazel("query //...")
-    _bazel("test {}".format(query_result.replace("\n", " ").replace("\r", " ")))
+    targets = query_result.replace("\n", " ").replace("\r", " ")
+    # run tests with the x86_64 config
+    _bazel(f"test --config=x86_64 {targets}")
 
 
 def _run_rust():

--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -92,8 +92,10 @@ def _run_cpp():
     # collect all C++ targets
     query_result = _bazel("query //...")
     targets = query_result.replace("\n", " ").replace("\r", " ")
-    # run tests with the x86_64 config
-    _bazel(f"test --config=x86_64 {targets}")
+    test_command = "test"
+    if _get_os_machine() == "x86_64":
+        test_command += " --config=x86_64"
+    _bazel(f"{test_command} {targets}")
 
 
 def _run_rust():

--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -25,7 +25,9 @@ import os
 import logging
 import importlib
 
-BAZEL_VERSION = "6.3.2"
+def _get_bazel_version():
+    with open(os.path.join(PROJECT_ROOT_DIR, ".bazelversion")) as f:
+        return f.read().strip()
 
 PYARROW_VERSION = "15.0.0"
 
@@ -68,12 +70,13 @@ def _get_os_machine():
 
 
 def _get_bazel_download_url():
+    bazel_version = _get_bazel_version()
     download_url_base = (
-        f"https://github.com/bazelbuild/bazel/releases/download/{BAZEL_VERSION}"
+        f"https://github.com/bazelbuild/bazel/releases/download/{bazel_version}"
     )
     suffix = "exe" if _is_windows() else "sh"
     return (
-        f"{download_url_base}/bazel-{BAZEL_VERSION}{'' if _is_windows() else '-installer'}-"
+        f"{download_url_base}/bazel-{bazel_version}{'' if _is_windows() else '-installer'}-"
         f"{_get_os_name_lower()}-{_get_os_machine()}.{suffix}"
     )
 

--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -25,9 +25,11 @@ import os
 import logging
 import importlib
 
+
 def _get_bazel_version():
     with open(os.path.join(PROJECT_ROOT_DIR, ".bazelversion")) as f:
         return f.read().strip()
+
 
 PYARROW_VERSION = "15.0.0"
 

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -96,7 +96,7 @@ install_bazel() {
   if [[ "$MACHINE" == linux ]]; then
     MEM=$(grep MemTotal < /proc/meminfo | awk '{print $2}')
     JOBS=$(( MEM / 1024 / 1024 / 3 ))
-    echo "build --jobs=$JOBS" >> /etc/bazel.bazelrc
+    echo "build --jobs=$JOBS" >> ~/.bazelrc
     grep "jobs" ~/.bazelrc
   fi
 }

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -46,41 +46,65 @@ install_pyfory() {
   popd
 }
 
+get_bazel_version() {
+    cat "$ROOT/.bazelversion"
+}
+
 install_bazel() {
   if command -v bazel >/dev/null; then
     echo "existing bazel location $(which bazel)"
     echo "existing bazel version $(bazel version)"
+    return
   fi
-  # GRPC support bazel 6.3.2 https://grpc.github.io/grpc/core/md_doc_bazel_support.html
-  UNAME_OUT="$(uname -s)"
-  case "${UNAME_OUT}" in
-    Linux*)     MACHINE=linux;;
-    Darwin*)    MACHINE=darwin;;
-    *)          echo "unknown machine: $UNAME_OUT"
+
+  ARCH="$(uname -m)"
+  OPERATING_SYSTEM="$(uname -s)"
+
+  # Normalize architecture names
+  case "${ARCH}" in
+    x86_64|amd64)  ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
   esac
-  URL="https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-installer-$MACHINE-x86_64.sh"
-  wget -q -O install.sh $URL
-  chmod +x install.sh
-  set +x
-  ./install.sh --user
-  source ~/.bazel/bin/bazel-complete.bash
-  set -x
-  export PATH=~/bin:$PATH
-  echo "$HOME/bin/bazel version: $(~/bin/bazel version)"
-  rm -f install.sh
-  VERSION=`bazel version`
-  echo "bazel version: $VERSION"
+
+  # Handle OS-specific logic. Windows handled elsewhere
+  case "${OPERATING_SYSTEM}" in
+    Linux*)     OS="linux" ;;
+    Darwin*)    OS="darwin" ;;
+    *)          echo "Unsupported OS: $OPERATING_SYSTEM"; exit 1 ;;
+  esac
+
+  BAZEL_VERSION=$(get_bazel_version)
+  BAZEL_DIR="/usr/local/bin"
+
+  # Construct platform-specific URL
+  BINARY_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${OS}-${ARCH}"
+
+  echo "Downloading bazel from: $BINARY_URL"
+  sudo wget -q -O "$BAZEL_DIR/bazel" "$BINARY_URL" || { echo "Failed to download bazel"; exit 1; }
+
+  sudo chmod +x "$BAZEL_DIR/bazel"
+
+  # Add to current shell's PATH
+  export PATH="$BAZEL_DIR:$PATH"
+
+  # Verify installation
+  echo "Checking bazel installation..."
+  bazel version || { echo "Bazel installation verification failed"; exit 1; }
+
+  # Configure number of jobs based on memory
   if [[ "$MACHINE" == linux ]]; then
-    MEM=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
-    JOBS=`expr $MEM / 1024 / 1024 / 3`
-    echo "build --jobs="$JOBS >> ~/.bazelrc
+    MEM=$(grep MemTotal < /proc/meminfo | awk '{print $2}')
+    JOBS=$(( MEM / 1024 / 1024 / 3 ))
+    echo "build --jobs=$JOBS" >> /etc/bazel.bazelrc
     grep "jobs" ~/.bazelrc
   fi
 }
 
 install_bazel_windows() {
-  choco install bazel --version=6.3.2 --force
-  VERSION=`bazel version`
+  BAZEL_VERSION=$(get_bazel_version)
+  choco install bazel --version="${BAZEL_VERSION}" --force
+  VERSION=$(bazel version)
   echo "bazel version: $VERSION"
 }
 

--- a/cpp/fory/type/BUILD
+++ b/cpp/fory/type/BUILD
@@ -4,8 +4,14 @@ cc_library(
     name = "fory_type",
     srcs = glob(["*.cc"], exclude=["*test.cc"]),
     hdrs = glob(["*.h"]),
-    copts = ["-mavx2"],  # Enable AVX2 support
-    linkopts = ["-mavx2"],  # Ensure linker also knows about AVX2
+    copts = select({
+        "@platforms//cpu:x86_64": ["-mavx2"],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@platforms//cpu:x86_64": ["-mavx2"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "/cpp",
     alwayslink=True,
     linkstatic=True,

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+import platform
 import subprocess
 from os.path import abspath, join as pjoin
 
@@ -43,7 +44,13 @@ class BinaryDistribution(Distribution):
     def __init__(self, attrs=None):
         super().__init__(attrs=attrs)
         if BAZEL_BUILD_EXT:
-            subprocess.check_call(["bazel", "build", "-s", "//:cp_fory_so"])
+            bazel_args = ["bazel", "build", "-s"]
+            arch = platform.machine().lower()
+            if arch in ("x86_64", "amd64"):
+                bazel_args += ["--config=x86_64"]
+            bazel_args += ["//:cp_fory_so"]
+            subprocess.check_call(bazel_args)
+
 
     def has_ext_modules(self):
         return True

--- a/python/setup.py
+++ b/python/setup.py
@@ -51,7 +51,6 @@ class BinaryDistribution(Distribution):
             bazel_args += ["//:cp_fory_so"]
             subprocess.check_call(bazel_args)
 
-
     def has_ext_modules(self):
         return True
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import os
-import platform
 import subprocess
 from os.path import abspath, join as pjoin
 
@@ -44,13 +43,7 @@ class BinaryDistribution(Distribution):
     def __init__(self, attrs=None):
         super().__init__(attrs=attrs)
         if BAZEL_BUILD_EXT:
-            bazel_args = ["bazel", "build", "-s"]
-            arch = platform.machine().lower()
-            if arch in ("x86_64", "amd64"):
-                bazel_args += ["--config=x86_64"]
-            elif arch in ("aarch64", "arm64"):
-                bazel_args += ["--copt=-fsigned-char"]
-            bazel_args += ["//:cp_fory_so"]
+            bazel_args = ["bazel", "build", "-s", "//:cp_fory_so"]
             subprocess.check_call(bazel_args)
 
     def has_ext_modules(self):

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+import platform
 import subprocess
 from os.path import abspath, join as pjoin
 
@@ -43,7 +44,13 @@ class BinaryDistribution(Distribution):
     def __init__(self, attrs=None):
         super().__init__(attrs=attrs)
         if BAZEL_BUILD_EXT:
-            bazel_args = ["bazel", "build", "-s", "//:cp_fory_so"]
+            bazel_args = ["bazel", "build", "-s"]
+            arch = platform.machine().lower()
+            if arch in ("x86_64", "amd64"):
+                bazel_args += ["--config=x86_64"]
+            elif arch in ("aarch64", "arm64"):
+                bazel_args += ["--copt=-fsigned-char"]
+            bazel_args += ["//:cp_fory_so"]
             subprocess.check_call(bazel_args)
 
     def has_ext_modules(self):

--- a/python/setup.py
+++ b/python/setup.py
@@ -48,6 +48,8 @@ class BinaryDistribution(Distribution):
             arch = platform.machine().lower()
             if arch in ("x86_64", "amd64"):
                 bazel_args += ["--config=x86_64"]
+            elif arch in ("aarch64", "arm64"):
+                bazel_args += ["--copt=-fsigned-char"]
             bazel_args += ["//:cp_fory_so"]
             subprocess.check_call(bazel_args)
 


### PR DESCRIPTION
## What does this PR do?

- Enable Ubuntu 24.04 ARM builds in CI matrix
- Update `ci/run_ci.sh` to detect architecture and install Bazel accordingly
- Use `.bazelversion` for centralized Bazel version management
- Refactor Bazel download logic for Linux and macOS architectures
- Adjust build configurations for CPU-specific compiler flags
- Update `.bazelrc` with platform-specific C++ compilation and optimization flags

## Related issues

Fixes #1915 and #2330 

## Does this PR introduce any user-facing change?

Sort of: Mac users can now run pyfury in Ubuntu containers (for testing etc.)

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Testing

I used the following scripts to locally create the python wheel:

```bash
#!/bin/bash
set -e

IMAGE_NAME="fory-ubuntu24-arm64-build:latest"

# Enable BuildKit
export DOCKER_BUILDKIT=1

echo "Building Docker image..."
docker buildx build --load -t "$IMAGE_NAME" -f ubuntu-arm64-build.Dockerfile .

echo "Running build in container..."
docker run --rm -v $(pwd):/workspace "$IMAGE_NAME" bash -c "
set -e
echo 'Running in Ubuntu 24.04 container...'
python --version

echo 'Installing pyarrow and other dependencies first'
./ci/deploy.sh install_pyarrow
pip install Cython wheel pytest setuptools -U

echo 'Installing bazel and configuring build environment'
./ci/run_ci.sh install_bazel

echo 'Building with preprocessed input to see compile commands...'
cd python
# Verify pyarrow installation
python -c 'import pyarrow; print(pyarrow.__version__)'
bazel --bazelrc=/etc/bazel.bazelrc build --subcommands --verbose_failures //:cp_fory_so
cd ..

echo 'Building pyfory'
./ci/deploy.sh build_pyfory
echo 'Renaming wheels'
./ci/deploy.sh rename_wheels dist
"
echo "Build completed. Check ./dist directory for wheels"
```

and `ubuntu-arm64-build.Dockerfile`:

```Dockerfile
FROM ubuntu:24.04

# Set non-interactive installation
ENV DEBIAN_FRONTEND=noninteractive

# Add before your main build steps:
RUN mkdir -p /usr/local/cache/bazel
COPY ci/bazel-6.3.2-linux-arm64 /usr/local/cache/bazel/bazel-6.3.2-linux-arm64
RUN chmod +x /usr/local/cache/bazel/bazel-6.3.2-linux-arm64

# System dependencies
RUN apt-get update && apt-get install -y \
    python3 \
    python3-dev \
    python3-venv \
    python3-pip \
    wget \
    git \
    curl \
    build-essential \
    zip \
    unzip \
    sudo \
    && rm -rf /var/lib/apt/lists/*

# Create and activate a Python virtual environment
RUN python3 -m venv /venv
ENV PATH="/venv/bin:$PATH"

# Install base Python packages
RUN pip install --no-cache-dir \
    setuptools \
    wheel \
    cython \
    numpy \
    psutil

# Set working directory
WORKDIR /workspace

# Configure git to trust the workspace directory
RUN git config --global --add safe.directory /workspace

# Allow running sudo without password for all users
RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

# Copy base bazelrc and add ARM configuration
COPY .bazelrc /etc/bazel.bazelrc
RUN echo "build:arm64 --copt=-march=armv8-a" >> /etc/bazel.bazelrc && \
    echo "build --config=arm64" >> /etc/bazel.bazelrc
```

The resulting file was `pyfory-0.12.0.dev0-cp312-cp312-manylinux1_aarch64.whl`