### PR TITLE
feat(java): row encoder array deserialization into List supports lazy access

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -680,9 +681,16 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
 
   /** Returns an expression that deserialize <code>arrayData</code> as a java collection. */
   protected Expression deserializeForCollection(Expression arrayData, TypeRef<?> typeRef) {
+    TypeRef<?> elemType = TypeUtils.getElementType(typeRef);
+    if (typeRef.getRawType() == List.class) {
+      return new LazyArrayData(
+          arrayData,
+          elemType,
+          (i, value) -> deserializeFor(value, elemType, typeCtx, new HashSet<>()),
+          ExpressionUtils.nullValue(elemType));
+    }
     Expression collection = newCollection(arrayData, typeRef);
     try {
-      TypeRef<?> elemType = TypeUtils.getElementType(typeRef);
       ArrayDataForEach addElemsOp =
           new ArrayDataForEach(
               arrayData,

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/LazyArray.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/LazyArray.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.format.encoder;
+
+import java.util.AbstractList;
+import java.util.RandomAccess;
+import org.apache.fory.annotation.Internal;
+import org.apache.fory.format.row.binary.BinaryArray;
+
+@Internal
+public abstract class LazyArray<E> extends AbstractList<E> implements RandomAccess {
+  private final BinaryArray array;
+  private final Object[] storage;
+
+  public LazyArray(final BinaryArray array) {
+    this.array = array;
+    storage = new Object[array.numElements()];
+  }
+
+  protected BinaryArray array() {
+    return array;
+  }
+
+  @Override
+  public int size() {
+    return array.numElements();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public E get(final int index) {
+    Object value = storage[index];
+    if (value == null) {
+      storage[index] = value = deserialize(index);
+    }
+    return (E) value;
+  }
+
+  protected abstract Object deserialize(int index);
+}

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/LazyArrayData.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/LazyArrayData.java
@@ -21,6 +21,7 @@ package org.apache.fory.format.encoder;
 
 import static org.apache.fory.type.TypeUtils.getRawType;
 
+import java.awt.List;
 import org.apache.fory.annotation.Internal;
 import org.apache.fory.codegen.ClosureVisitable;
 import org.apache.fory.codegen.Code;
@@ -38,14 +39,13 @@ import org.apache.fory.type.TypeUtils;
 import org.apache.fory.util.Preconditions;
 import org.apache.fory.util.StringUtils;
 import org.apache.fory.util.function.SerializableBiFunction;
-import org.apache.fory.util.function.SerializableFunction;
 
 /**
- * Expression for iterate {@link org.apache.fory.format.row.ArrayData} with specified not null
- * element action expression and null element action expression.
+ * Expression to represent {@link org.apache.fory.format.row.ArrayData} as a lazy List implemented
+ * with array backing storage.
  */
 @Internal
-public class ArrayDataForEach extends AbstractExpression {
+public class LazyArrayData extends AbstractExpression {
   private final Expression inputArrayData;
   private final String accessMethod;
   private final TypeRef<?> elemType;
@@ -53,13 +53,13 @@ public class ArrayDataForEach extends AbstractExpression {
   @ClosureVisitable
   private final SerializableBiFunction<Expression, Expression, Expression> notNullAction;
 
-  @ClosureVisitable private final SerializableFunction<Expression, Expression> nullAction;
+  @ClosureVisitable private final Expression nullValue;
 
   /**
    * inputArrayData.type() must be multi-dimension array or Collection, not allowed to be primitive
    * array
    */
-  public ArrayDataForEach(
+  public LazyArrayData(
       Expression inputArrayData,
       TypeRef<?> elemType,
       SerializableBiFunction<Expression, Expression, Expression> notNullAction) {
@@ -70,11 +70,11 @@ public class ArrayDataForEach extends AbstractExpression {
    * inputArrayData.type() must be multi-dimension array or Collection, not allowed to be primitive
    * array
    */
-  public ArrayDataForEach(
+  public LazyArrayData(
       Expression inputArrayData,
       TypeRef<?> elemType,
       SerializableBiFunction<Expression, Expression, Expression> notNullAction,
-      SerializableFunction<Expression, Expression> nullAction) {
+      Expression nullValue) {
     super(inputArrayData);
     Preconditions.checkArgument(getRawType(inputArrayData.type()) == BinaryArray.class);
     this.inputArrayData = inputArrayData;
@@ -91,12 +91,12 @@ public class ArrayDataForEach extends AbstractExpression {
     this.accessMethod = BinaryUtils.getElemAccessMethodName(accessType, ctx);
     this.elemType = BinaryUtils.getElemReturnType(accessType, ctx);
     this.notNullAction = notNullAction;
-    this.nullAction = nullAction;
+    this.nullValue = nullValue;
   }
 
   @Override
   public TypeRef<?> type() {
-    return TypeUtils.PRIMITIVE_VOID_TYPE;
+    return TypeUtils.listOf(elemType.getRawType());
   }
 
   @Override
@@ -106,76 +106,41 @@ public class ArrayDataForEach extends AbstractExpression {
     if (StringUtils.isNotBlank(targetExprCode.code())) {
       codeBuilder.append(targetExprCode.code()).append("\n");
     }
-    String[] freshNames = ctx.newNames("i", "elemValue", "len");
-    String i = freshNames[0];
-    String elemValue = freshNames[1];
-    String len = freshNames[2];
-    // elemValue is only used in notNullAction, so set elemValueRef'nullable to false.
-    Reference elemValueRef = new Reference(elemValue, elemType);
     Code.ExprCode notNullElemExprCode =
-        notNullAction.apply(new Reference(i), elemValueRef).genCode(ctx);
-    if (nullAction == null) {
-      String code =
-          StringUtils.format(
-              ""
-                  + "int ${len} = ${arr}.numElements();\n"
-                  + "int ${i} = 0;\n"
-                  + "while (${i} < ${len}) {\n"
-                  + "    if (!${arr}.isNullAt(${i})) {\n"
-                  + "        ${elemType} ${elemValue} = ${arr}.${method}(${i});\n"
-                  + "        ${notNullElemExprCode}\n"
-                  + "    }\n"
-                  + "    ${i}++;\n"
-                  + "}",
-              "arr",
-              targetExprCode.value(),
-              "len",
-              len,
-              "i",
-              i,
-              "elemType",
-              ctx.type(elemType),
-              "elemValue",
-              elemValue,
-              "method",
-              accessMethod,
-              "notNullElemExprCode",
-              CodeGenerator.alignIndent(notNullElemExprCode.code(), 8));
-      codeBuilder.append(code);
-    } else {
-      Code.ExprCode nullExprCode = nullAction.apply(new Reference(i)).genCode(ctx);
-      String code =
-          StringUtils.format(
-              ""
-                  + "int ${len} = ${arr}.numElements();\n"
-                  + "int ${i} = 0;\n"
-                  + "while (${i} < ${len}) {\n"
-                  + "    if (!${arr}.isNullAt(${i})) {\n"
-                  + "        ${elemType} ${elemValue} = ${arr}.${method}(${i});\n"
-                  + "        ${notNullElemExprCode}\n"
-                  + "    } else {\n"
-                  + "        ${nullElemExprCode}\n"
-                  + "    }\n"
-                  + "    ${i}++;\n"
-                  + "}",
-              "arr",
-              targetExprCode.value(),
-              "len",
-              len,
-              "i",
-              i,
-              "elemType",
-              ctx.type(elemType),
-              "elemValue",
-              elemValue,
-              "method",
-              accessMethod,
-              "notNullElemExprCode",
-              CodeGenerator.alignIndent(notNullElemExprCode.code(), 8),
-              "nullElemExprCode",
-              CodeGenerator.alignIndent(nullExprCode.code(), 8));
-      codeBuilder.append(code);
-    }
-    return new Code.ExprCode(codeBuilder.toString(), null, null);
+        new Expression.Return(
+                notNullAction.apply(
+                    new Reference("index", TypeUtils.INT_TYPE),
+                    new Reference("elemValue", elemType)))
+            .genCode(ctx);
+    Code.ExprCode nullElemCode = nullValue.genCode(ctx);
+    String result = ctx.newName("lazyArray");
+    String code =
+        StringUtils.format(
+            ""
+                + "java.util.List ${result} = \n"
+                + "  new org.apache.fory.format.encoder.LazyArray(${arr}) {\n"
+                + "    protected Object deserialize(int index) {\n"
+                + "      if (!array().isNullAt(index)) {\n"
+                + "        ${elemType} elemValue = array().${method}(index);\n"
+                + "        ${notNullElemExprCode}\n"
+                + "      } else {\n"
+                + "        return ${nullElemCode};\n"
+                + "      }\n"
+                + "    }\n"
+                + "  };",
+            "result",
+            result,
+            "arr",
+            targetExprCode.value(),
+            "elemType",
+            ctx.type(elemType),
+            "method",
+            accessMethod,
+            "notNullElemExprCode",
+            CodeGenerator.alignIndent(notNullElemExprCode.code(), 8),
+            "nullElemCode",
+            nullElemCode.value());
+    codeBuilder.append(code);
+    return new Code.ExprCode(codeBuilder.toString(), null, Code.variable(List.class, result));
   }
 }


### PR DESCRIPTION
this way if you use only some indexes, you don't pay deserialization costs for any unread indexes

## Does this PR introduce any user-facing change?

When List subtype is not specified, now we use our own lazy list. Since the user did not specify type, it should be ok, and you can always specify `ArrayList` to materialize the list eagerly