### PR TITLE
feat(python): Make PickleSerializer a CrossLanguageCompatibleSerializer

### DIFF
--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -479,8 +479,9 @@ class TypeResolver:
             return type_info
         elif not create:
             return None
-        if self.require_registration and \
-           (self.language != Language.PYTHON or not issubclass(cls, Enum)):
+        if self.require_registration and (
+           self.language != Language.PYTHON or not issubclass(cls, Enum)
+        ):
             raise TypeUnregisteredError(f"{cls} not registered")
         logger.info("Type %s not registered", cls)
         serializer = self._create_serializer(cls)
@@ -490,7 +491,7 @@ class TypeResolver:
                 type_id = TypeId.NAMED_ENUM
             elif type(serializer) is PickleSerializer:
                 type_id = PickleSerializer.PICKLE_TYPE_ID
-            if not self.require_registration: # This applies only if language is PYTHON
+            if not self.require_registration:
                 if isinstance(serializer, DataClassSerializer):
                     type_id = TypeId.NAMED_STRUCT
         elif self.language == Language.XLANG:

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -480,7 +480,7 @@ class TypeResolver:
         elif not create:
             return None
         if self.require_registration and (
-           self.language != Language.PYTHON or not issubclass(cls, Enum)
+            self.language != Language.PYTHON or not issubclass(cls, Enum)
         ):
             raise TypeUnregisteredError(f"{cls} not registered")
         logger.info("Type %s not registered", cls)

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -653,14 +653,11 @@ class BytesBufferObject(BufferObject):
         return Buffer(self.binary)
 
 
-class PickleSerializer(Serializer):
+class PickleSerializer(CrossLanguageCompatibleSerializer):
     PICKLE_TYPE_ID = 96
 
-    def xwrite(self, buffer, value):
-        raise NotImplementedError
-
-    def xread(self, buffer):
-        raise NotImplementedError
+    # xwrite will now call write due to CrossLanguageCompatibleSerializer
+    # xread will now call read due to CrossLanguageCompatibleSerializer
 
     def write(self, buffer, value):
         self.fory.handle_unsupported_write(buffer, value)


### PR DESCRIPTION


## What does this PR do?

*   Enable correct serialization/deserialization of objects using `__getstate__` and `__setstate__` when Fory's Python serialization falls back to the standard pickle mechanism.
*   Modify `_registry.py` to allow `PickleSerializer` fallback for `Language.XLANG` when `require_type_registration=False`.
*   Update `serializer.py` to make `PickleSerializer` inherit from `CrossLanguageCompatibleSerializer`, ensuring `xwrite` and `xread` delegate to `write` and `read`.
*   Add tests in `test_serializer.py` to verify `__getstate__` and `__setstate__` behavior during Fory's pickle fallback.

## Related issues

Completes #2293, #2294

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
