### PR TITLE
chore(Scala): remove var that can be mutated

### DIFF
--- a/scala/src/main/scala/org/apache/fory/serializer/scala/MapSerializer.scala
+++ b/scala/src/main/scala/org/apache/fory/serializer/scala/MapSerializer.scala
@@ -78,7 +78,7 @@ abstract class AbstractScalaMapSerializer[K, V, T](fory: Fory, cls: Class[T])
  *
  *
  */
-private class MapAdapter[K, V](var map: scala.collection.Map[K, V])
+private class MapAdapter[K, V](map: scala.collection.Map[K, V])
   extends util.AbstractMap[K, V] {
   override def entrySet(): util.Set[util.Map.Entry[K, V]] = new util.AbstractSet[util.Map.Entry[K, V]] {
     override def size(): Int = map.size


### PR DESCRIPTION
Not good in scala to expose a `var` like that can be used to mutate state from outside the class