### PR TITLE
refactor(python): Unify DataClassSerializer and ComplexObjectSerializer

### DIFF
--- a/python/pyfory/_struct.py
+++ b/python/pyfory/_struct.py
@@ -18,16 +18,8 @@
 import datetime
 import enum
 import logging
-import typing
 
-from pyfory.buffer import Buffer
-from pyfory.error import TypeNotCompatibleError
-from pyfory.serializer import (
-    # ListSerializer, # Moved to local import in ComplexTypeVisitor
-    # MapSerializer,  # Moved to local import in ComplexTypeVisitor
-    # PickleSerializer, # Re-localizing this
-    Serializer,
-)
+from pyfory.serializer import Serializer
 from pyfory.type import (
     TypeVisitor,
     infer_field,

--- a/python/pyfory/_struct.py
+++ b/python/pyfory/_struct.py
@@ -25,7 +25,7 @@ from pyfory.error import TypeNotCompatibleError
 from pyfory.serializer import (
     # ListSerializer, # Moved to local import in ComplexTypeVisitor
     # MapSerializer,  # Moved to local import in ComplexTypeVisitor
-    PickleSerializer, # Restoring top-level import
+    # PickleSerializer, # Re-localizing this
     Serializer,
 )
 from pyfory.type import (
@@ -97,7 +97,7 @@ class ComplexTypeVisitor(TypeVisitor):
         return None
 
     def visit_other(self, field_name, type_, types_path=None):
-        # from pyfory.serializer import PickleSerializer  # Local import # Removing local import
+        from pyfory.serializer import PickleSerializer  # Local import
 
         if is_subclass(type_, enum.Enum):
             return self.fory.type_resolver.get_serializer(type_)
@@ -225,7 +225,7 @@ class StructHashVisitor(TypeVisitor):
         self._hash = self._compute_field_hash(self._hash, hash_value)
 
     def visit_other(self, field_name, type_, types_path=None):
-        # from pyfory.serializer import PickleSerializer  # Local import # Removing local import
+        from pyfory.serializer import PickleSerializer  # Local import
         typeinfo = self.fory.type_resolver.get_typeinfo(type_, create=False)
         if typeinfo is None:
             id_ = 0

--- a/python/pyfory/_struct.py
+++ b/python/pyfory/_struct.py
@@ -74,12 +74,14 @@ class ComplexTypeVisitor(TypeVisitor):
 
     def visit_list(self, field_name, elem_type, types_path=None):
         from pyfory.serializer import ListSerializer  # Local import
+
         # Infer type recursively for type such as List[Dict[str, str]]
         elem_serializer = infer_field("item", elem_type, self, types_path=types_path)
         return ListSerializer(self.fory, list, elem_serializer)
 
     def visit_dict(self, field_name, key_type, value_type, types_path=None):
         from pyfory.serializer import MapSerializer  # Local import
+
         # Infer type recursively for type such as Dict[str, Dict[str, str]]
         key_serializer = infer_field("key", key_type, self, types_path=types_path)
         value_serializer = infer_field("value", value_type, self, types_path=types_path)
@@ -171,8 +173,10 @@ def _sort_fields(type_resolver, field_names, serializers):
 
 
 import warnings
+
 # Removed DataClassSerializer from here to break the cycle for the alias target.
 # Other serializers like ListSerializer, MapSerializer, Serializer are still imported at the top.
+
 
 class ComplexObjectSerializer(Serializer):
     def __new__(cls, fory, clz):
@@ -218,6 +222,7 @@ class StructHashVisitor(TypeVisitor):
 
     def visit_other(self, field_name, type_, types_path=None):
         from pyfory.serializer import PickleSerializer  # Local import
+
         typeinfo = self.fory.type_resolver.get_typeinfo(type_, create=False)
         if typeinfo is None:
             id_ = 0

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -32,7 +32,7 @@ from pyfory.codegen import (
 from pyfory.error import TypeNotCompatibleError
 from pyfory.lib.collection import WeakIdentityKeyDictionary
 from pyfory.resolver import NULL_FLAG, NOT_NULL_VALUE_FLAG
-from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor
+# from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor # MOVED
 from pyfory import Language
 
 try:
@@ -285,6 +285,10 @@ _ENABLE_FORY_PYTHON_JIT = os.environ.get("ENABLE_FORY_PYTHON_JIT", "True").lower
     "1",
 )
 
+# Moved from L32 to here, after all Serializer base classes and specific serializers
+# like ListSerializer, MapSerializer, PickleSerializer are defined or imported
+# and before DataClassSerializer which uses ComplexTypeVisitor from _struct.
+from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor
 
 class DataClassSerializer(Serializer):
     def __init__(self, fory, clz: type, xlang: bool = False):

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -32,7 +32,6 @@ from pyfory.codegen import (
 from pyfory.error import TypeNotCompatibleError
 from pyfory.lib.collection import WeakIdentityKeyDictionary
 from pyfory.resolver import NULL_FLAG, NOT_NULL_VALUE_FLAG
-# from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor # MOVED
 from pyfory import Language
 
 try:

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -32,6 +32,8 @@ from pyfory.codegen import (
 from pyfory.error import TypeNotCompatibleError
 from pyfory.lib.collection import WeakIdentityKeyDictionary
 from pyfory.resolver import NULL_FLAG, NOT_NULL_VALUE_FLAG
+from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor
+from pyfory import Language
 
 try:
     import numpy as np
@@ -285,20 +287,44 @@ _ENABLE_FORY_PYTHON_JIT = os.environ.get("ENABLE_FORY_PYTHON_JIT", "True").lower
 
 
 class DataClassSerializer(Serializer):
-    def __init__(self, fory, clz: type):
+    def __init__(self, fory, clz: type, xlang: bool = False):
         super().__init__(fory, clz)
+        self._xlang = xlang
         # This will get superclass type hints too.
         self._type_hints = typing.get_type_hints(clz)
         self._field_names = sorted(self._type_hints.keys())
         self._has_slots = hasattr(clz, "__slots__")
-        # TODO compute hash
-        self._hash = len(self._field_names)
-        self._generated_write_method = self._gen_write_method()
-        self._generated_read_method = self._gen_read_method()
-        if _ENABLE_FORY_PYTHON_JIT:
-            # don't use `__slots__`, which will make instance method readonly
-            self.write = self._gen_write_method()
-            self.read = self._gen_read_method()
+
+        if self._xlang:
+            self._serializers = [None] * len(self._field_names)
+            visitor = ComplexTypeVisitor(fory)
+            for index, key in enumerate(self._field_names):
+                serializer = self.fory.infer_field(
+                    key, self._type_hints[key], visitor, types_path=[]
+                )
+                self._serializers[index] = serializer
+            self._serializers, self._field_names = _sort_fields(
+                fory.type_resolver, self._field_names, self._serializers
+            )
+            self._hash = 0  # Will be computed on first xwrite/xread
+            if self.fory.language == Language.PYTHON:
+                import logging  # Import here to avoid circular dependency
+
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    "Type of class %s shouldn't be serialized using cross-language "
+                    "serializer",
+                    clz,
+                )
+        else:
+            # TODO compute hash for non-xlang mode more robustly
+            self._hash = len(self._field_names)
+            self._generated_write_method = self._gen_write_method()
+            self._generated_read_method = self._gen_read_method()
+            if _ENABLE_FORY_PYTHON_JIT:
+                # don't use `__slots__`, which will make instance method readonly
+                self.write = self._generated_write_method
+                self.read = self._generated_read_method
 
     def _gen_write_method(self):
         context = {}
@@ -415,10 +441,42 @@ class DataClassSerializer(Serializer):
         return obj
 
     def xwrite(self, buffer: Buffer, value):
-        raise NotImplementedError
+        if not self._xlang:
+            raise TypeError(
+                "xwrite can only be called when DataClassSerializer is in xlang mode"
+            )
+        if self._hash == 0:
+            self._hash = _get_hash(self.fory, self._field_names, self._type_hints)
+        buffer.write_int32(self._hash)
+        for index, field_name in enumerate(self._field_names):
+            field_value = getattr(value, field_name)
+            serializer = self._serializers[index]
+            self.fory.xserialize_ref(buffer, field_value, serializer=serializer)
 
     def xread(self, buffer):
-        raise NotImplementedError
+        if not self._xlang:
+            raise TypeError(
+                "xread can only be called when DataClassSerializer is in xlang mode"
+            )
+        if self._hash == 0:
+            self._hash = _get_hash(self.fory, self._field_names, self._type_hints)
+        hash_ = buffer.read_int32()
+        if hash_ != self._hash:
+            raise TypeNotCompatibleError(
+                f"Hash {hash_} is not consistent with {self._hash} "
+                f"for type {self.type_}",
+            )
+        obj = self.type_.__new__(self.type_)
+        self.fory.ref_resolver.reference(obj)
+        for index, field_name in enumerate(self._field_names):
+            serializer = self._serializers[index]
+            field_value = self.fory.xdeserialize_ref(buffer, serializer=serializer)
+            setattr(
+                obj,
+                field_name,
+                field_value,
+            )
+        return obj
 
 
 # Use numpy array or python array module.

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -111,6 +111,7 @@ from pyfory.type import (
     Float32NDArrayType,
     Float64NDArrayType,
     TypeId,
+    infer_field, # Added infer_field
 )
 
 
@@ -303,7 +304,8 @@ class DataClassSerializer(Serializer):
             self._serializers = [None] * len(self._field_names)
             visitor = ComplexTypeVisitor(fory)
             for index, key in enumerate(self._field_names):
-                serializer = self.fory.infer_field(
+                # Changed from self.fory.infer_field to infer_field
+                serializer = infer_field(
                     key, self._type_hints[key], visitor, types_path=[]
                 )
                 self._serializers[index] = serializer

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -110,7 +110,7 @@ from pyfory.type import (
     Float32NDArrayType,
     Float64NDArrayType,
     TypeId,
-    infer_field, # Added infer_field
+    infer_field,  # Added infer_field
 )
 
 
@@ -289,6 +289,7 @@ _ENABLE_FORY_PYTHON_JIT = os.environ.get("ENABLE_FORY_PYTHON_JIT", "True").lower
 # like ListSerializer, MapSerializer, PickleSerializer are defined or imported
 # and before DataClassSerializer which uses ComplexTypeVisitor from _struct.
 from pyfory._struct import _get_hash, _sort_fields, ComplexTypeVisitor
+
 
 class DataClassSerializer(Serializer):
     def __init__(self, fory, clz: type, xlang: bool = False):


### PR DESCRIPTION
## What does this PR do?

- Extended DataClassSerializer to support both Python native and xlang serialization modes.
- ComplexObjectSerializer is now a deprecated alias for DataClassSerializer (in xlang mode).
- Added tests for DataClassSerializer in xlang mode.

## Related issues

Completes #2157 

## Does this PR introduce any user-facing change?

Not yet: we deprecate `ComplexObjectSerializer` in order give users time to migrate.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?