### PR TITLE
chore(Scala): refactor scala test so it asserts something

### DIFF
--- a/scala/src/test/scala/org/apache/fory/serializer/scala/ScalaTest.scala
+++ b/scala/src/test/scala/org/apache/fory/serializer/scala/ScalaTest.scala
@@ -89,5 +89,8 @@ object PkgObjectMain2 extends App {
 
   case class SomeClass(v: List[IdAnyVal])
   val p = SomeClass(List.empty)
-  println(fory.deserialize(fory.serialize(p)))
+  val result = fory.deserialize(fory.serialize(p))
+  if (result != p) {
+    throw new RuntimeException(s"$result is not equal to $p")
+  }
 }


### PR DESCRIPTION
I presume the test used to fail with an exception but now it passes, it is better not to have printlns and to actually compare the result of the deserialization to the original.