### PR TITLE
chore(Scala): Create DurationTest.scala

### DIFF
--- a/scala/src/test/scala/org/apache/fory/serializer/scala/DurationTest.scala
+++ b/scala/src/test/scala/org/apache/fory/serializer/scala/DurationTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer.scala
+
+import scala.concurrent.duration.DurationInt
+
+import org.apache.fory.Fory
+import org.apache.fory.config.Language
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DurationTest extends AnyWordSpec with Matchers {
+  val fory: Fory = Fory.builder()
+    .withLanguage(Language.JAVA)
+    .withRefTracking(true)
+    .withScalaOptimizationEnabled(true)
+    .requireClassRegistration(false).build()
+
+  "fory scala duration support" should {
+    "serialize/deserialize DurationInt" in {
+      val d = 100.millis
+      fory.deserialize(fory.serialize(d)) shouldEqual d
+    }
+  }
+}


### PR DESCRIPTION
* the way that Scala Durations have been represented internally has changed between recent Scala versions
* it is useful to test that serialization/deserialization works
* it would be a breaking change but it might be useful for fory-scala to have a dedicated serializer for Scala Durations that converted the duration to ISO-8601 duration string (eg `PT1H` for 1 hour).
* this would mean that we wouldn't be relying on the internal state of class instances but have a format that is independent of the Duration class internal state but that still is easy for us to deserialize and match to meaningful new Scala Duration instance when we deserialize 