### PR TITLE
refactor(python): Simplify require_pyarrow, remove undefined pytest.mark

### DIFF
--- a/python/pyfory/tests/core.py
+++ b/python/pyfory/tests/core.py
@@ -24,9 +24,6 @@ except ImportError:
 
 
 def require_pyarrow(func):
-    func = pytest.mark.fory_format(func)
-    arrow_installed = False
-    if pa is not None and hasattr(pa, "get_library_dirs"):
-        arrow_installed = True
-    func = pytest.mark.skipif(not arrow_installed, reason="pyarrow not installed")(func)
-    return func
+    arrow_not_installed = pa is None or hasattr(pa, "get_library_dirs")
+    mark_decorator = pytest.mark.skipif(arrow_not_installed, reason="pyarrow not installed")(func)
+    return mark_decorator


### PR DESCRIPTION
I was encountering this warning in tests:
```
pyfory/tests/core.py:27
  /workspace/python/pyfory/tests/core.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.fory_format - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    func = pytest.mark.fory_format(func)
```

`fory_format` is [not currently defined](https://github.com/search?q=repo%3Aapache%2Ffory%20fory_format&type=code) so I decided to remove it.

## What does this PR do?

* Rewrote the skip condition logic for pyarrow tests.
* The previous logic was a bit verbose and could be simplified.
* The new implementation directly checks if pyarrow is not installed or lacks the necessary attribute.

## Does this PR introduce any user-facing change?

No

## Benchmark

N/A