### PR TITLE
[NOT FOR MERGE] experiment with making deserialize check the type

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -798,7 +798,7 @@ public final class Fory implements BaseFory {
   public <T> T deserialize(byte[] bytes, Class<T> type) {
     generics.pushGenericType(classResolver.buildGenericType(type));
     try {
-      return (T) deserialize(MemoryUtils.wrap(bytes), null);
+      return (T) checkedDeserialize(MemoryUtils.wrap(bytes), null, type);
     } finally {
       generics.popGenericType();
     }
@@ -834,6 +834,12 @@ public final class Fory implements BaseFory {
    */
   @Override
   public Object deserialize(MemoryBuffer buffer, Iterable<MemoryBuffer> outOfBandBuffers) {
+    return checkedDeserialize(buffer, outOfBandBuffers, null);
+  }
+
+  private Object checkedDeserialize(MemoryBuffer buffer,
+                                    Iterable<MemoryBuffer> outOfBandBuffers,
+                                    Class<?> expectedType) {
     try {
       jitContext.lock();
       if (depth != 0) {
@@ -843,9 +849,9 @@ public final class Fory implements BaseFory {
         short magicNumber = buffer.readInt16();
         assert magicNumber == MAGIC_NUMBER
             : String.format(
-                "The fory xlang serialization must start with magic number 0x%x. Please "
-                    + "check whether the serialization is based on the xlang protocol and the data didn't corrupt.",
-                MAGIC_NUMBER);
+            "The fory xlang serialization must start with magic number 0x%x. Please "
+                + "check whether the serialization is based on the xlang protocol and the data didn't corrupt.",
+            MAGIC_NUMBER);
       }
       byte bitmap = buffer.readByte();
       if ((bitmap & isNilFlag) == isNilFlag) {
@@ -878,7 +884,13 @@ public final class Fory implements BaseFory {
       }
       Object obj;
       if (isTargetXLang) {
-        obj = xreadRef(buffer);
+        if (expectedType != null) {
+          obj = checkedXreadRef(buffer, expectedType);
+        } else {
+          obj = xreadRef(buffer);
+        }
+      } else if (expectedType != null) {
+        obj = checkedReadRef(buffer, expectedType);
       } else {
         obj = readRef(buffer);
       }
@@ -927,6 +939,26 @@ public final class Fory implements BaseFory {
     if (nextReadRefId >= NOT_NULL_VALUE_FLAG) {
       // ref value or not-null value
       Object o = readDataInternal(buffer, classResolver.readClassInfo(buffer));
+      refResolver.setReadObject(nextReadRefId, o);
+      return o;
+    } else {
+      return refResolver.getReadObject();
+    }
+  }
+
+  private Object checkedReadRef(MemoryBuffer buffer, Class<?> expectedType) {
+    RefResolver refResolver = this.refResolver;
+    int nextReadRefId = refResolver.tryPreserveRefId(buffer);
+    if (nextReadRefId >= NOT_NULL_VALUE_FLAG) {
+      // ref value or not-null value
+      ClassInfo classInfo = classResolver.readClassInfo(buffer);
+      if (!expectedType.isAssignableFrom(classInfo.getCls())) {
+        throw new IllegalStateException(String.format(
+            "Unexpected type %s which is not assignable to %s",
+                classInfo.getClass().getName(),
+                expectedType.getName()));
+      }
+      Object o = readDataInternal(buffer, classInfo);
       refResolver.setReadObject(nextReadRefId, o);
       return o;
     } else {
@@ -1069,6 +1101,26 @@ public final class Fory implements BaseFory {
       return refResolver.getReadObject();
     }
   }
+
+  public Object checkedXreadRef(MemoryBuffer buffer, Class<?> expectedType) {
+    RefResolver refResolver = this.refResolver;
+    int nextReadRefId = refResolver.tryPreserveRefId(buffer);
+    if (nextReadRefId >= NOT_NULL_VALUE_FLAG) {
+      ClassInfo classInfo = xtypeResolver.readClassInfo(buffer);
+      if (!expectedType.isAssignableFrom(classInfo.getCls())) {
+        throw new IllegalStateException(String.format(
+            "Unexpected type %s which is not assignable to %s",
+            classInfo.getClass().getName(),
+            expectedType.getName()));
+      }
+      Object o = xreadNonRef(buffer, classInfo);
+      refResolver.setReadObject(nextReadRefId, o);
+      return o;
+    } else {
+      return refResolver.getReadObject();
+    }
+  }
+
 
   public Object xreadRef(MemoryBuffer buffer, Serializer<?> serializer) {
     if (serializer.needToWriteRef()) {

--- a/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
@@ -673,4 +673,20 @@ public class ForyTest extends ForyTestBase {
     Assert.assertEquals(struct1.f1, struct2.f1);
     Assert.assertEquals(struct1.f2, struct2.f2);
   }
+
+  @Test
+  public void testCheckedDeserialize() {
+    Fory fory = Fory.builder()
+        .withLanguage(Language.JAVA)
+        .withRefTracking(true)
+        .requireClassRegistration(false)
+        .build();
+    LocalDate now = LocalDate.now();
+    byte[] bytes = fory.serialize(now);
+    LocalDate ld0 = fory.deserialize(bytes, LocalDate.class);
+    Assert.assertEquals(ld0, LocalDate.now());
+    // Deserialize with wrong type and get an IllegalStateException
+    assertThrows(IllegalStateException.class,
+        () -> fory.deserialize(bytes, String.class));
+  }
 }


### PR DESCRIPTION
* Experiment related to #2391 
* very unlikely to ever get merged but I would like to support users who carefully write their classes to make them strongly typed minimising the risks with deserialization attacks - with strongly typed classes and us checking that the input bytes match the expected type means that in theory those careful users wouldn't need to go through the tedium of writing class checkers or registering all the classes they need
* this version is still naive and is possibly at risk at having an attacker hide a dangerous class instance nested inside the main class - I will add structured test classes to test this out
* so far, the implementation changes are small and do not add much overhead because the ClassInfo is already looked up when I do the checks