### PR TITLE
chore(Java): handle deserialization scenario that currently throws an IndexOutOfBoundsException

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
@@ -63,8 +63,7 @@ public class ExceptionUtils {
       throw new DeserializationException(objects, t);
     } else if (t instanceof Exception) {
       throw new DeserializationException(
-          String.format("Failed to deserialize input"),
-          t);
+          "Failed to deserialize input", t);
     } else {
       Platform.throwException(t);
       throw new IllegalStateException("unreachable");

--- a/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.fory.Fory;
 import org.apache.fory.collection.ObjectArray;
 import org.apache.fory.exception.DeserializationException;
+import org.apache.fory.exception.ForyException;
 import org.apache.fory.memory.Platform;
 import org.apache.fory.reflect.ReflectionUtils;
 import org.apache.fory.resolver.MapRefResolver;
@@ -61,7 +62,7 @@ public class ExceptionUtils {
       // carry with read objects for better trouble shooting.
       List<Object> objects = Arrays.asList(readObjects.objects).subList(0, readObjects.size);
       throw new DeserializationException(objects, t);
-    } else if (t instanceof Exception) {
+    } else if (t instanceof Exception && !(t instanceof ForyException)) {
       throw new DeserializationException(
           "Failed to deserialize input", t);
     } else {

--- a/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
@@ -63,8 +63,7 @@ public class ExceptionUtils {
       List<Object> objects = Arrays.asList(readObjects.objects).subList(0, readObjects.size);
       throw new DeserializationException(objects, t);
     } else if (t instanceof Exception && !(t instanceof ForyException)) {
-      throw new DeserializationException(
-          "Failed to deserialize input", t);
+      throw new DeserializationException("Failed to deserialize input", t);
     } else {
       Platform.throwException(t);
       throw new IllegalStateException("unreachable");

--- a/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/ExceptionUtils.java
@@ -61,6 +61,10 @@ public class ExceptionUtils {
       // carry with read objects for better trouble shooting.
       List<Object> objects = Arrays.asList(readObjects.objects).subList(0, readObjects.size);
       throw new DeserializationException(objects, t);
+    } else if (t instanceof Exception) {
+      throw new DeserializationException(
+          String.format("Failed to deserialize input"),
+          t);
     } else {
       Platform.throwException(t);
       throw new IllegalStateException("unreachable");

--- a/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
@@ -49,7 +49,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.WeakHashMap;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -679,15 +678,13 @@ public class ForyTest extends ForyTestBase {
 
   @Test
   public void testDeserializeJavaObjectWrongType() {
-    Fory fory = Fory.builder()
-        .requireClassRegistration(false)
-        .build();
+    Fory fory = Fory.builder().requireClassRegistration(false).build();
     Struct1 struct1 = new Struct1(10, "abc");
     byte[] bytes = fory.serializeJavaObject(struct1);
     // first deserialize as Struct1 (correct type)
     Assert.assertEquals(fory.deserializeJavaObject(bytes, Struct1.class), struct1);
     // then deserialize as Struct2 (wrong type)
-    Assert.assertThrows(DeserializationException.class,
-        () -> fory.deserializeJavaObject(bytes, Struct2.class));
+    Assert.assertThrows(
+        DeserializationException.class, () -> fory.deserializeJavaObject(bytes, Struct2.class));
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
@@ -59,6 +59,7 @@ import org.apache.fory.builder.Generated;
 import org.apache.fory.config.CompatibleMode;
 import org.apache.fory.config.ForyBuilder;
 import org.apache.fory.config.Language;
+import org.apache.fory.exception.DeserializationException;
 import org.apache.fory.exception.ForyException;
 import org.apache.fory.exception.InsecureException;
 import org.apache.fory.memory.MemoryBuffer;
@@ -686,6 +687,7 @@ public class ForyTest extends ForyTestBase {
     // first deserialize as Struct1 (correct type)
     Assert.assertEquals(fory.deserializeJavaObject(bytes, Struct1.class), struct1);
     // then deserialize as Struct2 (wrong type)
-    Assert.assertEquals(fory.deserializeJavaObject(bytes, Struct2.class), struct1);
+    Assert.assertThrows(DeserializationException.class,
+        () -> fory.deserializeJavaObject(bytes, Struct2.class));
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.io.*;
+import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -49,6 +49,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.WeakHashMap;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -641,6 +642,7 @@ public class ForyTest extends ForyTestBase {
     assertEquals(fory.getBuffer().size(), limitInBytes);
   }
 
+  @EqualsAndHashCode
   static class Struct1 {
     int f1;
     String f2;
@@ -672,5 +674,18 @@ public class ForyTest extends ForyTestBase {
     struct1 = (Struct1) fory1.deserialize(fory2.serialize(struct2));
     Assert.assertEquals(struct1.f1, struct2.f1);
     Assert.assertEquals(struct1.f2, struct2.f2);
+  }
+
+  @Test
+  public void testDeserializeJavaObjectWrongType() {
+    Fory fory = Fory.builder()
+        .requireClassRegistration(false)
+        .build();
+    Struct1 struct1 = new Struct1(10, "abc");
+    byte[] bytes = fory.serializeJavaObject(struct1);
+    // first deserialize as Struct1 (correct type)
+    Assert.assertEquals(fory.deserializeJavaObject(bytes, Struct1.class), struct1);
+    // then deserialize as Struct2 (wrong type)
+    Assert.assertEquals(fory.deserializeJavaObject(bytes, Struct2.class), struct1);
   }
 }


### PR DESCRIPTION
This test fails. I had expected it to fail with null when wrong type was used (because of #2392 but this fails differently from that - the use case where I saw a null returned was a Scala use case)

Fails with IndexOutOfBoundsException while I would expect a nicer exception. Maybe should be a Fory DeserializationException.
```
java.lang.IndexOutOfBoundsException: readerIndex(1) + length(2) exceeds size(7): org.apache.fory.memory.MemoryBuffer$BoundChecker@4e268090

	at org.apache.fory.memory.MemoryBuffer$BoundChecker.fillBuffer(MemoryBuffer.java:186)
	at org.apache.fory.memory.MemoryBuffer.checkReadableBytes(MemoryBuffer.java:2440)
	at org.apache.fory.ForyTest_Struct2ForyCodec_0.read(ForyTest_Struct2ForyCodec_0.java:59)
	at org.apache.fory.Fory.readDataInternal(Fory.java:1055)
	at org.apache.fory.Fory.deserializeJavaObject(Fory.java:1223)
	at org.apache.fory.Fory.deserializeJavaObject(Fory.java:1200)
	at org.apache.fory.ForyTest.testDeserializeJavaObjectWrongType(ForyTest.java:689)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
