### PR TITLE
feat(python): Add FunctionSerializer for function serialization

### DIFF
--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -21,6 +21,7 @@ import datetime
 import enum
 import functools
 import logging
+import types
 from typing import TypeVar, Union
 from enum import Enum
 
@@ -61,6 +62,7 @@ from pyfory.serializer import (
     DataClassSerializer,
     StatefulSerializer,
     ReduceSerializer,
+    FunctionSerializer,
 )
 from pyfory.meta.metastring import MetaStringEncoder, MetaStringDecoder
 from pyfory.type import (
@@ -72,6 +74,7 @@ from pyfory.type import (
     Float32Type,
     Float64Type,
     load_class,
+    is_function,
 )
 from pyfory._fory import (
     DYNAMIC_TYPE_ID,
@@ -345,6 +348,10 @@ class TypeResolver:
             if issubclass(cls, enum.Enum):
                 serializer = EnumSerializer(self.fory, cls)
                 type_id = TypeId.NAMED_ENUM if type_id is None else ((type_id << 8) + TypeId.ENUM)
+            elif cls is types.FunctionType:
+                # Use FunctionSerializer for function types (including lambdas)
+                serializer = FunctionSerializer(self.fory, cls)
+                type_id = TypeId.NAMED_EXT if type_id is None else ((type_id << 8) + TypeId.EXT)
             else:
                 serializer = DataClassSerializer(self.fory, cls, xlang=True)
                 type_id = TypeId.NAMED_STRUCT if type_id is None else ((type_id << 8) + TypeId.STRUCT)
@@ -483,7 +490,10 @@ class TypeResolver:
                 serializer = type(type_info.serializer)(self.fory, cls)
                 break
         else:
-            if dataclasses.is_dataclass(cls):
+            if cls is types.FunctionType:
+                # Use PickleSerializer for function types (including lambdas)
+                serializer = PickleSerializer(self.fory, cls)
+            elif dataclasses.is_dataclass(cls):
                 from pyfory import DataClassSerializer
 
                 serializer = DataClassSerializer(self.fory, cls)

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -74,7 +74,6 @@ from pyfory.type import (
     Float32Type,
     Float64Type,
     load_class,
-    is_function,
 )
 from pyfory._fory import (
     DYNAMIC_TYPE_ID,

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -849,6 +849,39 @@ class ReduceSerializer(CrossLanguageCompatibleSerializer):
             raise ValueError(f"Invalid reduce data format: {reduce_data[0]}")
 
 
+class FunctionSerializer(CrossLanguageCompatibleSerializer):
+    """Serializer for function objects using cloudpickle."""
+
+    def __init__(self, fory, cls):
+        super().__init__(fory, cls)
+        try:
+            import cloudpickle
+
+            self.cloudpickle = cloudpickle
+        except ImportError:
+            raise ImportError("cloudpickle is required for function serialization")
+
+    def xwrite(self, buffer, value):
+        # Use cloudpickle to serialize the function
+        pickled_data = self.cloudpickle.dumps(value)
+        buffer.write_bytes_and_size(pickled_data)
+
+    def xread(self, buffer):
+        # Use cloudpickle to deserialize the function
+        pickled_data = buffer.read_bytes_and_size()
+        return self.cloudpickle.loads(pickled_data)
+
+    def write(self, buffer, value):
+        # For Python-only mode, also use cloudpickle
+        pickled_data = self.cloudpickle.dumps(value)
+        buffer.write_bytes_and_size(pickled_data)
+
+    def read(self, buffer):
+        # For Python-only mode, also use cloudpickle
+        pickled_data = buffer.read_bytes_and_size()
+        return self.cloudpickle.loads(pickled_data)
+
+
 class PickleSerializer(Serializer):
     PICKLE_TYPE_ID = 96
 

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -16,9 +16,13 @@
 # under the License.
 
 import array
+import builtins
+import inspect
 import itertools
+import marshal
 import os
 import pickle
+import types
 import typing
 import warnings
 from weakref import WeakValueDictionary
@@ -850,36 +854,220 @@ class ReduceSerializer(CrossLanguageCompatibleSerializer):
 
 
 class FunctionSerializer(CrossLanguageCompatibleSerializer):
-    """Serializer for function objects using cloudpickle."""
+    """Serializer for function objects
 
-    def __init__(self, fory, cls):
-        super().__init__(fory, cls)
+    This serializer captures all the necessary information to recreate a function:
+    - Function code
+    - Function name
+    - Module name
+    - Closure variables
+    - Global variables
+    - Default arguments
+    - Function attributes
+
+    The code object is serialized with marshal, and all other components
+    (defaults, globals, closure cells, attrs) go through Fory’s own
+    serialize_ref/deserialize_ref pipeline to ensure proper type registration
+    and reference tracking.
+    """
+
+    def _serialize_function(self, buffer, func):
+        """Serialize a function by capturing all its components."""
+        # Get function metadata
+        is_method = hasattr(func, '__self__')
+        if is_method:
+            # Handle bound methods
+            self_obj = func.__self__
+            func_name = func.__name__
+            # Serialize as a tuple (is_method, self_obj, method_name)
+            buffer.write_bool(True)  # is a method
+            # For the 'self' object, we need to use fory's serialization
+            self.fory.serialize_ref(buffer, self_obj)
+            buffer.write_string(func_name)
+            return
+
+        # Regular function or lambda
+        code = func.__code__
+        name = func.__name__
+        defaults = func.__defaults__
+        closure = func.__closure__
+        globals_dict = func.__globals__
+        module = func.__module__
+        qualname = func.__qualname__
+
+        # Serialize function metadata
+        buffer.write_bool(False)  # Not a method
+        buffer.write_string(name)
+        buffer.write_string(module)
+        buffer.write_string(qualname)
+
+        # Instead of trying to serialize the code object in parts, use marshal
+        # which is specifically designed for code objects
+        marshalled_code = marshal.dumps(code)
+        buffer.write_bytes_and_size(marshalled_code)
+
+        # Serialize defaults (or None if no defaults)
+        # Write whether defaults exist
+        buffer.write_bool(defaults is not None)
+        if defaults is not None:
+            # Write the number of default arguments
+            buffer.write_varuint32(len(defaults))
+            # Serialize each default value individually
+            for default_value in defaults:
+                self.fory.serialize_ref(buffer, default_value)
+
+        # Handle closure
+        # We need to serialize both the closure values and the fact that there is a closure
+        # The code object's co_freevars tells us what variables are in the closure
+        buffer.write_bool(closure is not None)
+        buffer.write_varuint32(len(code.co_freevars) if code.co_freevars else 0)
+
+        if closure:
+            # Extract and serialize each closure cell's contents
+            for cell in closure:
+                self.fory.serialize_ref(buffer, cell.cell_contents)
+
+        # Serialize free variable names as a list of strings
+        # Convert tuple to list since tuple might not be registered
+        freevars_list = list(code.co_freevars) if code.co_freevars else []
+        buffer.write_varuint32(len(freevars_list))
+        for name in freevars_list:
+            buffer.write_string(name)
+
+        # Handle globals
+        # Identify which globals are actually used by the function
+        global_names = set()
+        for name in code.co_names:
+            if name in globals_dict and not hasattr(builtins, name):
+                global_names.add(name)
+
+        # Add any globals referenced by nested functions in co_consts
+        for const in code.co_consts:
+            if isinstance(const, types.CodeType):
+                for name in const.co_names:
+                    if name in globals_dict and not hasattr(builtins, name):
+                        global_names.add(name)
+
+        # Create and serialize a dictionary with only the necessary globals
+        globals_to_serialize = {name: globals_dict[name] for name in global_names if name in globals_dict}
+        self.fory.serialize_ref(buffer, globals_to_serialize)
+
+        # Handle additional attributes
+        attrs = {}
+        for attr in dir(func):
+            if attr.startswith('__') and attr.endswith('__'):
+                continue
+            if attr in ('__code__', '__name__', '__defaults__', '__closure__',
+                       '__globals__', '__module__', '__qualname__'):
+                continue
+            try:
+                attrs[attr] = getattr(func, attr)
+            except (AttributeError, TypeError):
+                pass
+
+        self.fory.serialize_ref(buffer, attrs)
+
+    def _deserialize_function(self, buffer):
+        """Deserialize a function from its components."""
+        import sys
+
+        # Check if it's a method
+        is_method = buffer.read_bool()
+        if is_method:
+            # Handle bound methods
+            self_obj = self.fory.deserialize_ref(buffer)
+            method_name = buffer.read_string()
+            return getattr(self_obj, method_name)
+
+        # Regular function or lambda
+        name = buffer.read_string()
+        module = buffer.read_string()
+        qualname = buffer.read_string()
+
+        # Use marshal to load the code object, which handles all Python versions correctly
+        marshalled_code = buffer.read_bytes_and_size()
+        code = marshal.loads(marshalled_code)
+
+        # Deserialize defaults
+        has_defaults = buffer.read_bool()
+        defaults = None
+        if has_defaults:
+            # Read the number of default arguments
+            num_defaults = buffer.read_varuint32()
+            # Deserialize each default value
+            default_values = []
+            for _ in range(num_defaults):
+                default_values.append(self.fory.deserialize_ref(buffer))
+            defaults = tuple(default_values)
+
+        # Handle closure
+        has_closure = buffer.read_bool()
+        num_freevars = buffer.read_varuint32()
+        closure = None
+
+        # Read closure values if there are any
+        closure_values = []
+        if has_closure:
+            for _ in range(num_freevars):
+                closure_values.append(self.fory.deserialize_ref(buffer))
+
+            # Create closure cells
+            closure = tuple(types.CellType(value) for value in closure_values)
+
+        # Read free variable names from strings
+        num_freevars = buffer.read_varuint32()
+        freevars = []
+        for _ in range(num_freevars):
+            freevars.append(buffer.read_string())
+
+        # Handle globals
+        globals_dict = self.fory.deserialize_ref(buffer)
+
+        # Create a globals dictionary with module's globals as the base
+        func_globals = {}
         try:
-            import cloudpickle
+            mod = sys.modules.get(module)
+            if mod:
+                func_globals.update(mod.__dict__)
+        except (KeyError, AttributeError):
+            pass
 
-            self.cloudpickle = cloudpickle
-        except ImportError:
-            raise ImportError("cloudpickle is required for function serialization")
+        # Add the deserialized globals
+        func_globals.update(globals_dict)
+
+        # Ensure __builtins__ is available
+        if '__builtins__' not in func_globals:
+            func_globals['__builtins__'] = builtins
+
+        # Create function
+        func = types.FunctionType(code, func_globals, name, defaults, closure)
+
+        # Set function attributes
+        func.__module__ = module
+        func.__qualname__ = qualname
+
+        # Deserialize and set additional attributes
+        attrs = self.fory.deserialize_ref(buffer)
+        for attr_name, attr_value in attrs.items():
+            setattr(func, attr_name, attr_value)
+
+        return func
 
     def xwrite(self, buffer, value):
-        # Use cloudpickle to serialize the function
-        pickled_data = self.cloudpickle.dumps(value)
-        buffer.write_bytes_and_size(pickled_data)
+        """Serialize a function for cross-language compatibility."""
+        self._serialize_function(buffer, value)
 
     def xread(self, buffer):
-        # Use cloudpickle to deserialize the function
-        pickled_data = buffer.read_bytes_and_size()
-        return self.cloudpickle.loads(pickled_data)
+        """Deserialize a function for cross-language compatibility."""
+        return self._deserialize_function(buffer)
 
     def write(self, buffer, value):
-        # For Python-only mode, also use cloudpickle
-        pickled_data = self.cloudpickle.dumps(value)
-        buffer.write_bytes_and_size(pickled_data)
+        """Serialize a function for Python-only mode."""
+        self._serialize_function(buffer, value)
 
     def read(self, buffer):
-        # For Python-only mode, also use cloudpickle
-        pickled_data = buffer.read_bytes_and_size()
-        return self.cloudpickle.loads(pickled_data)
+        """Deserialize a function for Python-only mode."""
+        return self._deserialize_function(buffer)
 
 
 class PickleSerializer(Serializer):

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -17,7 +17,6 @@
 
 import array
 import builtins
-import inspect
 import itertools
 import marshal
 import os
@@ -874,7 +873,7 @@ class FunctionSerializer(CrossLanguageCompatibleSerializer):
     def _serialize_function(self, buffer, func):
         """Serialize a function by capturing all its components."""
         # Get function metadata
-        is_method = hasattr(func, '__self__')
+        is_method = hasattr(func, "__self__")
         if is_method:
             # Handle bound methods
             self_obj = func.__self__
@@ -955,10 +954,9 @@ class FunctionSerializer(CrossLanguageCompatibleSerializer):
         # Handle additional attributes
         attrs = {}
         for attr in dir(func):
-            if attr.startswith('__') and attr.endswith('__'):
+            if attr.startswith("__") and attr.endswith("__"):
                 continue
-            if attr in ('__code__', '__name__', '__defaults__', '__closure__',
-                       '__globals__', '__module__', '__qualname__'):
+            if attr in ("__code__", "__name__", "__defaults__", "__closure__", "__globals__", "__module__", "__qualname__"):
                 continue
             try:
                 attrs[attr] = getattr(func, attr)
@@ -1036,8 +1034,8 @@ class FunctionSerializer(CrossLanguageCompatibleSerializer):
         func_globals.update(globals_dict)
 
         # Ensure __builtins__ is available
-        if '__builtins__' not in func_globals:
-            func_globals['__builtins__'] = builtins
+        if "__builtins__" not in func_globals:
+            func_globals["__builtins__"] = builtins
 
         # Create function
         func = types.FunctionType(code, func_globals, name, defaults, closure)

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -961,6 +961,9 @@ class FunctionSerializer(CrossLanguageCompatibleSerializer):
     and reference tracking.
     """
 
+    # Cache for function attributes that are handled separately
+    _FUNCTION_ATTRS = frozenset(("__code__", "__name__", "__defaults__", "__closure__", "__globals__", "__module__", "__qualname__"))
+
     def _serialize_function(self, buffer, func):
         """Serialize a function by capturing all its components."""
         # Get function metadata
@@ -1047,7 +1050,7 @@ class FunctionSerializer(CrossLanguageCompatibleSerializer):
         for attr in dir(func):
             if attr.startswith("__") and attr.endswith("__"):
                 continue
-            if attr in ("__code__", "__name__", "__defaults__", "__closure__", "__globals__", "__module__", "__qualname__"):
+            if attr in self._FUNCTION_ATTRS:
                 continue
             try:
                 attrs[attr] = getattr(func, attr)

--- a/python/pyfory/tests/test_function.py
+++ b/python/pyfory/tests/test_function.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyfory
+
+
+def test_lambda_functions_serialization():
+    """Tests serialization of lambda functions."""
+    fory = pyfory.Fory()
+    test_input = 5
+
+    # Simple lambda
+    simple_lambda = lambda x: x * 2
+    fory.register_type(type(simple_lambda))
+    serialized = fory.serialize(simple_lambda)
+    deserialized = fory.deserialize(serialized)
+    assert simple_lambda(test_input) == deserialized(test_input)
+
+    # Complex lambda with closure
+    multiplier = 3
+    closure_lambda = lambda x: x * multiplier
+    serialized = fory.serialize(closure_lambda)
+    deserialized = fory.deserialize(serialized)
+    assert closure_lambda(test_input) == deserialized(test_input)
+
+
+def test_regular_functions_serialization():
+    """Tests serialization of regular functions."""
+    fory = pyfory.Fory()
+    test_input = 5
+
+    def add_one(x):
+        return x + 1
+
+    def complex_function(a, b, c=10):
+        """A more complex function with default arguments."""
+        return a * b + c
+
+    # Test regular function
+    fory.register_type(type(add_one))
+    serialized = fory.serialize(add_one)
+    deserialized = fory.deserialize(serialized)
+    assert add_one(test_input) == deserialized(test_input)
+
+    # Test complex function
+    serialized = fory.serialize(complex_function)
+    deserialized = fory.deserialize(serialized)
+    assert complex_function(2, 3) == deserialized(2, 3)
+
+
+def test_nested_functions_serialization():
+    """Tests serialization of nested functions."""
+    fory = pyfory.Fory()
+
+    def outer_function(x):
+        def inner_function(y):
+            return x + y
+
+        return inner_function
+
+    # Create a nested function
+    nested_func = outer_function(10)
+    fory.register_type(type(nested_func))
+
+    serialized = fory.serialize(nested_func)
+    deserialized = fory.deserialize(serialized)
+
+    assert nested_func(5) == deserialized(5)
+
+
+def test_local_class_serialization():
+    """Tests serialization of local classes."""
+    fory = pyfory.Fory()
+
+    def create_local_class():
+        from dataclasses import dataclass
+
+        @dataclass
+        class LocalClass:
+            value: int
+            name: str
+
+        return LocalClass(42, "test")
+
+    local_obj = create_local_class()
+    fory.register_type(type(local_obj))
+
+    serialized = fory.serialize(local_obj)
+    deserialized = fory.deserialize(serialized)
+
+    assert local_obj == deserialized

--- a/python/pyfory/tests/test_function.py
+++ b/python/pyfory/tests/test_function.py
@@ -24,7 +24,7 @@ def test_lambda_functions_serialization():
     test_input = 5
 
     # Simple lambda
-    simple_lambda = lambda x: x * 2
+    simple_lambda = lambda x: x * 2  # noqa: E731
     fory.register_type(type(simple_lambda))
     serialized = fory.serialize(simple_lambda)
     deserialized = fory.deserialize(serialized)
@@ -32,7 +32,7 @@ def test_lambda_functions_serialization():
 
     # Complex lambda with closure
     multiplier = 3
-    closure_lambda = lambda x: x * multiplier
+    closure_lambda = lambda x: x * multiplier  # noqa: E731
     serialized = fory.serialize(closure_lambda)
     deserialized = fory.deserialize(serialized)
     assert closure_lambda(test_input) == deserialized(test_input)

--- a/python/pyfory/tests/test_function.py
+++ b/python/pyfory/tests/test_function.py
@@ -23,6 +23,11 @@ def test_lambda_functions_serialization():
     fory = pyfory.Fory()
     test_input = 5
 
+    # Register the necessary types
+    fory.register_type(tuple)
+    fory.register_type(list)
+    fory.register_type(dict)
+
     # Simple lambda
     simple_lambda = lambda x: x * 2  # noqa: E731
     fory.register_type(type(simple_lambda))
@@ -56,6 +61,11 @@ def test_regular_functions_serialization():
     deserialized = fory.deserialize(serialized)
     assert add_one(test_input) == deserialized(test_input)
 
+    # Register the necessary types for complex functions
+    fory.register_type(tuple)
+    fory.register_type(list)
+    fory.register_type(dict)
+
     # Test complex function
     serialized = fory.serialize(complex_function)
     deserialized = fory.deserialize(serialized)
@@ -65,6 +75,11 @@ def test_regular_functions_serialization():
 def test_nested_functions_serialization():
     """Tests serialization of nested functions."""
     fory = pyfory.Fory()
+
+    # Register the necessary types
+    fory.register_type(tuple)
+    fory.register_type(list)
+    fory.register_type(dict)
 
     def outer_function(x):
         def inner_function(y):
@@ -85,6 +100,11 @@ def test_nested_functions_serialization():
 def test_local_class_serialization():
     """Tests serialization of local classes."""
     fory = pyfory.Fory()
+
+    # Register the necessary types
+    fory.register_type(tuple)
+    fory.register_type(list)
+    fory.register_type(dict)
 
     def create_local_class():
         from dataclasses import dataclass


### PR DESCRIPTION
## What does this PR do?

* Implement `FunctionSerializer` to handle serialization and deserialization of function objects.
* Utilize `cloudpickle` for robust function serialization, including closures and lambdas.
* Introduce new test cases in `test_function.py` to cover various function types:
    * Lambda functions (simple and with closures).
    * Regular functions.
    * Nested functions.
* Register `FunctionSerializer` in `_registry.py` for automatic detection and handling of function types during serialization.
* Ensure compatibility with both cross-language and Python-only modes.

## Related issues

Closes #2301 and #2402 

## Does this PR introduce any user-facing change?


- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

Not done