### PR TITLE
feat: Replace cloudpickle with native Fory serialization

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,12 @@ pip install pyarrow==15.0.0 Cython wheel pytest
 pip install -v -e .
 ```
 
+If the last steps fails with an error like `libarrow_python.dylib: No such file or directory`,
+you are probably suffering from bazel's aggressive caching; the sought library is longer at the
+temporary directory it was the last time bazel ran. To remedy this run
+
+> bazel clean --expunge
+
 ### Environment Requirements
 
 - python 3.8+

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -127,9 +127,7 @@ class Fory:
         """
         self.language = language
         self.is_py = language == Language.PYTHON
-        self.require_type_registration = (
-            _ENABLE_TYPE_REGISTRATION_FORCIBLY or require_type_registration
-        )
+        self.require_type_registration = _ENABLE_TYPE_REGISTRATION_FORCIBLY or require_type_registration
         self.ref_tracking = ref_tracking
         if self.ref_tracking:
             self.ref_resolver = MapRefResolver()
@@ -329,10 +327,7 @@ class Fory:
         if get_bit(buffer, reader_index, 0):
             return None
         is_little_endian_ = get_bit(buffer, reader_index, 1)
-        assert is_little_endian_, (
-            "Big endian is not supported for now, "
-            "please ensure peer machine is little endian."
-        )
+        assert is_little_endian_, "Big endian is not supported for now, please ensure peer machine is little endian."
         is_target_x_lang = get_bit(buffer, reader_index, 2)
         if is_target_x_lang:
             self._peer_language = Language(buffer.read_int8())
@@ -340,16 +335,10 @@ class Fory:
             self._peer_language = Language.PYTHON
         is_out_of_band_serialization_enabled = get_bit(buffer, reader_index, 3)
         if is_out_of_band_serialization_enabled:
-            assert buffers is not None, (
-                "buffers shouldn't be null when the serialized stream is "
-                "produced with buffer_callback not null."
-            )
+            assert buffers is not None, "buffers shouldn't be null when the serialized stream is produced with buffer_callback not null."
             self._buffers = iter(buffers)
         else:
-            assert buffers is None, (
-                "buffers should be null when the serialized stream is "
-                "produced with buffer_callback null."
-            )
+            assert buffers is None, "buffers should be null when the serialized stream is produced with buffer_callback null."
         if is_target_x_lang:
             obj = self.xdeserialize_ref(buffer)
         else:
@@ -498,9 +487,7 @@ class SerializationContext:
             self.objects.clear()
 
 
-_ENABLE_TYPE_REGISTRATION_FORCIBLY = os.getenv(
-    "ENABLE_TYPE_REGISTRATION_FORCIBLY", "0"
-) in {
+_ENABLE_TYPE_REGISTRATION_FORCIBLY = os.getenv("ENABLE_TYPE_REGISTRATION_FORCIBLY", "0") in {
     "1",
     "true",
 }

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -468,6 +468,8 @@ class TypeResolver:
                 type_id = TypeId.NAMED_ENUM
             elif type(serializer) is PickleSerializer:
                 type_id = PickleSerializer.PICKLE_TYPE_ID
+            elif isinstance(serializer, FunctionSerializer):
+                type_id = TypeId.NAMED_EXT
             elif isinstance(serializer, (ObjectSerializer, StatefulSerializer, ReduceSerializer)):
                 type_id = TypeId.NAMED_EXT
             if not self.require_registration:
@@ -491,8 +493,8 @@ class TypeResolver:
                 break
         else:
             if cls is types.FunctionType:
-                # Use PickleSerializer for function types (including lambdas)
-                serializer = PickleSerializer(self.fory, cls)
+                # Use FunctionSerializer for function types (including lambdas)
+                serializer = FunctionSerializer(self.fory, cls)
             elif dataclasses.is_dataclass(cls):
                 serializer = DataClassSerializer(self.fory, cls)
             elif issubclass(cls, enum.Enum):

--- a/python/pyfory/tests/test_serializer.py
+++ b/python/pyfory/tests/test_serializer.py
@@ -470,14 +470,18 @@ def test_pickle_fallback():
 def helper_f1(x):
     return x
 
+
 def helper_f2(x):
     return x + x
+
 
 def helper_double(x):
     return x * 2
 
+
 def helper_multiply(x):
     return x * 2
+
 
 def test_unsupported_callback():
     """
@@ -501,6 +505,7 @@ def test_unsupported_callback():
 
     # Create a closure that captures a variable from the outer scope
     outer_value = 42
+
     def closure_function(x):
         return x + outer_value
 
@@ -508,12 +513,12 @@ def test_unsupported_callback():
     obj1 = [
         1,
         True,
-        helper_f1,           # Global function
-        helper_f2,           # Another global function
-        local_function,      # Local function
-        lambda_function,     # Lambda function
-        closure_function,    # Function with closure
-        {1: 2}
+        helper_f1,  # Global function
+        helper_f2,  # Another global function
+        local_function,  # Local function
+        lambda_function,  # Lambda function
+        closure_function,  # Function with closure
+        {1: 2},
     ]
 
     # Create an empty list for unsupported objects - we won't need to use it
@@ -535,11 +540,11 @@ def test_unsupported_callback():
 
     # Verify all functions have the same behavior
     test_input = 5
-    assert new_obj1[2](test_input) == helper_f1(test_input)      # helper_f1(5) = 5
-    assert new_obj1[3](test_input) == helper_f2(test_input)      # helper_f2(5) = 10
-    assert new_obj1[4](test_input) == local_function(test_input) # local_function(5) = 15
-    assert new_obj1[5](test_input) == lambda_function(test_input) # lambda_function(5) = 15
-    assert new_obj1[6](test_input) == closure_function(test_input) # closure_function(5) = 47
+    assert new_obj1[2](test_input) == helper_f1(test_input)  # helper_f1(5) = 5
+    assert new_obj1[3](test_input) == helper_f2(test_input)  # helper_f2(5) = 10
+    assert new_obj1[4](test_input) == local_function(test_input)  # local_function(5) = 15
+    assert new_obj1[5](test_input) == lambda_function(test_input)  # lambda_function(5) = 15
+    assert new_obj1[6](test_input) == closure_function(test_input)  # closure_function(5) = 47
 
     # Verify the dictionary
     assert new_obj1[7] == obj1[7]  # {1: 2}


### PR DESCRIPTION
## What does this PR do?

* Removed cloudpickle dependency and related logic.
* Replaced cloudpickle serialization with Fory's native serialization for unsupported types.
* Updated serializers for Python arrays, NumPy arrays, and Objects to use native serialization.
* Modified tests to reflect the removal of cloudpickle and use of native serialization.
* Added global helper functions for testing to avoid issues with local function serialization.
* Updated README.md with a note about bazel caching issues.

## Related issues

Contributes to #2409 

## Notes

Next `PickleSerializer` will be removed bit by bit.