### PR TITLE
fix: Correct pyarrow installation check and add bazel troubleshooting

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,16 @@ pip install pyarrow==15.0.0 Cython wheel pytest
 pip install -v -e .
 ```
 
+If the last steps fails with an error like `libarrow_python.dylib: No such file or directory`,
+you are probably suffering from bazel's aggressive caching; the sought library is longer at the
+temporary directory it was the last time bazel ran. To remedy this run
+
+> bazel clean --expunge
+
+In this situation, you might also find it fruitful to run bazel yourself before pip:
+
+> bazel build -s //:cp_fory_so
+
 ### Environment Requirements
 
 - python 3.8+

--- a/python/pyfory/tests/core.py
+++ b/python/pyfory/tests/core.py
@@ -24,6 +24,6 @@ except ImportError:
 
 
 def require_pyarrow(func):
-    arrow_not_installed = pa is None or hasattr(pa, "get_library_dirs")
+    arrow_not_installed = pa is None or not hasattr(pa, "get_library_dirs")
     mark_decorator = pytest.mark.skipif(arrow_not_installed, reason="pyarrow not installed")(func)
     return mark_decorator


### PR DESCRIPTION
I made a mistake in #2396 when I changed

```python
func = pytest.mark.fory_format(func)
arrow_installed = False
if pa is not None and hasattr(pa, "get_library_dirs"):
    arrow_installed = True
func = pytest.mark.skipif(not arrow_installed, reason="pyarrow not installed")(func)
return func
```
to
```python
arrow_not_installed = pa is None or hasattr(pa, "get_library_dirs")
mark_decorator = pytest.mark.skipif(arrow_not_installed, reason="pyarrow not installed")(func)
return mark_decorator

```

The second condition, `hasattr(pa, "get_library_dirs")`, should have been negated. I noticed this when [arrow tests were incorrectly being skipped](https://github.com/apache/fory/actions/runs/16297878100/job/46024343029) :|

## What does this PR do?

* Fix incorrect pyarrow installation check in core.py
* Add troubleshooting steps for bazel caching issues in README.md