### PR TITLE
chore(java): arrow 18.3.0

### DIFF
--- a/java/fory-format/pom.xml
+++ b/java/fory-format/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <arrow.version>15.0.0</arrow.version>
+    <arrow.version>18.3.0</arrow.version>
     <jackson-bom.version>2.16.0</jackson-bom.version>
     <fory.java.rootdir>${basedir}/..</fory.java.rootdir>
   </properties>

--- a/java/fory-format/src/main/java/org/apache/fory/format/type/DefaultTypeVisitor.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/type/DefaultTypeVisitor.java
@@ -20,6 +20,11 @@
 package org.apache.fory.format.type;
 
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.ArrowType.BinaryView;
+import org.apache.arrow.vector.types.pojo.ArrowType.LargeListView;
+import org.apache.arrow.vector.types.pojo.ArrowType.ListView;
+import org.apache.arrow.vector.types.pojo.ArrowType.RunEndEncoded;
+import org.apache.arrow.vector.types.pojo.ArrowType.Utf8View;
 
 /** A default arrow type visitor to make overriding easier. */
 public class DefaultTypeVisitor<T> implements ArrowType.ArrowTypeVisitor<T> {
@@ -126,6 +131,31 @@ public class DefaultTypeVisitor<T> implements ArrowType.ArrowTypeVisitor<T> {
 
   @Override
   public T visit(ArrowType.Duration type) {
+    return unsupported(type);
+  }
+
+  @Override
+  public T visit(RunEndEncoded type) {
+    return unsupported(type);
+  }
+
+  @Override
+  public T visit(BinaryView type) {
+    return unsupported(type);
+  }
+
+  @Override
+  public T visit(LargeListView type) {
+    return unsupported(type);
+  }
+
+  @Override
+  public T visit(ListView type) {
+    return unsupported(type);
+  }
+
+  @Override
+  public T visit(Utf8View type) {
     return unsupported(type);
   }
 


### PR DESCRIPTION
Attempt 2 for #2421, now that we have java 11 baseline, thanks @chaokunyang 

arrow 15.0.0 is marked as vulnerable to CVE-2024-52338 Despite this CVE only affecting the R implementation, the CPE is not scoped to R so Java checkers will report as vulnerable:

```
13:25:42  [ERROR] One or more dependencies were identified with vulnerabilities:
13:25:42  [ERROR] arrow-memory-core-15.0.0.jar (pkg:maven/org.apache.arrow/arrow-memory-core@15.0.0, cpe:2.3:a:apache:arrow:15.0.0:*:*:*:*:*:*:*): CVE-2024-52338(9.8)
```

while this is really a problem with the CPE, not fory, the easiest fix by far is to simply update arrow
