### PR TITLE
feat(serializer): primite array compression using SIMD 

### DIFF
--- a/docs/guide/java_serialization_guide.md
+++ b/docs/guide/java_serialization_guide.md
@@ -113,6 +113,8 @@ public class Example {
 | `timeRefIgnored`                    | Whether to ignore reference tracking of all time types registered in `TimeSerializers` and subclasses of those types when ref tracking is enabled. If ignored, ref tracking of every time type can be enabled by invoking `Fory#registerSerializer(Class, Serializer)`. For example, `fory.registerSerializer(Date.class, new DateSerializer(fory, true))`. Note that enabling ref tracking should happen before serializer codegen of any types which contain time fields. Otherwise, those fields will still skip ref tracking. | `true`                                                         |
 | `compressInt`                       | Enables or disables int compression for smaller size.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `true`                                                         |
 | `compressLong`                      | Enables or disables long compression for smaller size.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `true`                                                         |
+| `compressIntArray`                  | Enables or disables SIMD-accelerated compression for int arrays when values can fit in smaller data types. Requires Java 16+.                                                                                                                                                                                                                                                                                                                                                                                                    | `true`                                                         |
+| `compressLongArray`                 | Enables or disables SIMD-accelerated compression for long arrays when values can fit in smaller data types. Requires Java 16+.                                                                                                                                                                                                                                                                                                                                                                                                   | `true`                                                         |
 | `compressString`                    | Enables or disables string compression for smaller size.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `false`                                                        |
 | `classLoader`                       | The classloader should not be updated; Fory caches class metadata. Use `LoaderBinding` or `ThreadSafeFory` for classloader updates.                                                                                                                                                                                                                                                                                                                                                                                               | `Thread.currentThread().getContextClassLoader()`               |
 | `compatibleMode`                    | Type forward/backward compatibility config. Also Related to `checkClassVersion` config. `SCHEMA_CONSISTENT`: Class schema must be consistent between serialization peer and deserialization peer. `COMPATIBLE`: Class schema can be different between serialization peer and deserialization peer. They can add/delete fields independently. [See more](#class-inconsistency-and-class-version-check).                                                                                                                            | `CompatibleMode.SCHEMA_CONSISTENT`                             |
@@ -244,6 +246,32 @@ result,
 not worthy compared to performance cost. Maybe you should try to disable long compression if you find it didn't bring
 much
 space savings.
+
+### Array Compression
+
+Fory supports SIMD-accelerated compression for primitive arrays (`int[]` and `long[]`) when array values can fit in smaller data types. This feature is available on Java 16+ and uses the Vector API for optimal performance.
+
+#### How Array Compression Works
+
+Array compression analyzes arrays to determine if values can be stored using fewer bytes:
+
+- **`int[]` → `byte[]`**: When all values are in range [-128, 127] (75% size reduction)  
+- **`int[]` → `short[]`**: When all values are in range [-32768, 32767] (50% size reduction)
+- **`long[]` → `int[]`**: When all values fit in integer range (50% size reduction)
+
+#### Configuration
+
+Array compression can be configured independently for int and long arrays:
+
+```java
+Fory fory = Fory.builder()
+  .withLanguage(Language.JAVA)
+  // Enable int array compression (enabled by default)
+  .withIntArrayCompressed(true)
+  // Enable long array compression (enabled by default)
+  .withLongArrayCompressed(true)
+  .build();
+```
 
 ### Object deep copy
 

--- a/java/benchmark/src/main/java/org/apache/fory/benchmark/ArrayCompressionSuite.java
+++ b/java/benchmark/src/main/java/org/apache/fory/benchmark/ArrayCompressionSuite.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.benchmark;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.fory.Fory;
+import org.apache.fory.config.ForyBuilder;
+import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.util.ArrayCompressionUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@CompilerControl(value = CompilerControl.Mode.INLINE)
+public class ArrayCompressionSuite {
+    @State(Scope.Thread)
+    public static class StateClass {
+
+        private Fory foryNormal;
+        private Fory foryWithCompression;
+        private MemoryBuffer buffer;
+        private MemoryBuffer normalIntBuffer;
+        private MemoryBuffer compressedIntBuffer;
+        private MemoryBuffer normalLongBuffer;
+        private MemoryBuffer compressedLongBuffer;
+
+        @Param({"100", "1000", "10000", "100000", "1000000", "10000000"})
+        public int arraySize;
+
+        private int[] normalIntArray;
+        private int[] compressibleIntArray;
+        private long[] normalLongArray;
+        private long[] compressibleLongArray;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            foryNormal = new ForyBuilder().build();
+            foryWithCompression = new ForyBuilder()
+                    .withIntArrayCompressed(true)
+                    .withLongArrayCompressed(true)
+                    .build();
+
+            normalIntArray = createLargeValueArray(arraySize);
+            compressibleIntArray = createByteRangeArray(arraySize);
+            normalLongArray = createLargeLongValueArray(arraySize);
+            compressibleLongArray = createIntRangeLongArray(arraySize);
+
+            buffer = MemoryBuffer.newHeapBuffer(1024 * 1024 * 16);
+            normalIntBuffer = MemoryBuffer.newHeapBuffer(1024 * 1024 * 16);
+            compressedIntBuffer = MemoryBuffer.newHeapBuffer(1024 * 1024 * 16);
+            normalLongBuffer = MemoryBuffer.newHeapBuffer(1024 * 1024 * 16);
+            compressedLongBuffer = MemoryBuffer.newHeapBuffer(1024 * 1024 * 16);
+
+            // Pre-serialize the arrays for clean deserialization benchmarks
+            foryNormal.serialize(normalIntBuffer, normalIntArray);
+            normalIntBuffer.readerIndex(0);
+            foryWithCompression.serialize(compressedIntBuffer, compressibleIntArray);
+            compressedIntBuffer.readerIndex(0);
+            foryNormal.serialize(normalLongBuffer, normalLongArray);
+            normalLongBuffer.readerIndex(0);
+            foryWithCompression.serialize(compressedLongBuffer, compressibleLongArray);
+            compressedLongBuffer.readerIndex(0);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            String commandLine =
+                    "org.apache.fory.*ArrayCompressionSuite.* -f 1 -wi 3 -i 3 -t 1 -w 2s -r 2s -rf csv";
+            System.out.println(commandLine);
+            args = commandLine.split(" ");
+        }
+        org.openjdk.jmh.Main.main(args);
+    }
+
+    @Benchmark
+    public void serializeNormalIntArray(StateClass state, Blackhole bh) {
+        state.buffer.writerIndex(0);
+        state.foryNormal.serialize(state.buffer, state.normalIntArray);
+        bh.consume(state.buffer.writerIndex());
+    }
+
+    @Benchmark
+    public void serializeCompressedIntArray(StateClass state, Blackhole bh) {
+        state.buffer.writerIndex(0);
+        state.foryWithCompression.serialize(state.buffer, state.compressibleIntArray);
+        bh.consume(state.buffer.writerIndex());
+    }
+
+    @Benchmark
+    public void serializeNormalLongArray(StateClass state, Blackhole bh) {
+        state.buffer.writerIndex(0);
+        state.foryNormal.serialize(state.buffer, state.normalLongArray);
+        bh.consume(state.buffer.writerIndex());
+    }
+
+    @Benchmark
+    public void serializeCompressedLongArray(StateClass state, Blackhole bh) {
+        state.buffer.writerIndex(0);
+        state.foryWithCompression.serialize(state.buffer, state.compressibleLongArray);
+        bh.consume(state.buffer.writerIndex());
+    }
+
+    @Benchmark
+    public int[] deserializeNormalIntArray(StateClass state) {
+        state.normalIntBuffer.readerIndex(0);
+        return (int[]) state.foryNormal.deserialize(state.normalIntBuffer);
+    }
+
+    @Benchmark
+    public int[] deserializeCompressedIntArray(StateClass state) {
+        state.compressedIntBuffer.readerIndex(0);
+        return (int[]) state.foryWithCompression.deserialize(state.compressedIntBuffer);
+    }
+
+    @Benchmark
+    public long[] deserializeNormalLongArray(StateClass state) {
+        state.normalLongBuffer.readerIndex(0);
+        return (long[]) state.foryNormal.deserialize(state.normalLongBuffer);
+    }
+
+    @Benchmark
+    public long[] deserializeCompressedLongArray(StateClass state) {
+        state.compressedLongBuffer.readerIndex(0);
+        return (long[]) state.foryWithCompression.deserialize(state.compressedLongBuffer);
+    }
+
+    @Benchmark
+    public void determineIntArrayCompressionTypeSIMD(StateClass state, Blackhole bh) {
+        int compressionType = ArrayCompressionUtils.determineIntCompressionType(state.compressibleIntArray);
+        bh.consume(compressionType);
+    }
+
+    @Benchmark
+    public void determineLongArrayCompressionTypeSIMD(StateClass state, Blackhole bh) {
+        int compressionType = ArrayCompressionUtils.determineLongCompressionType(state.compressibleLongArray);
+        bh.consume(compressionType);
+    }
+
+    @Benchmark
+    public void determineIntCompressionTypeScalar(StateClass state, Blackhole bh) {
+        int compressionType = determineIntCompressionTypeScalar(state.compressibleIntArray);
+        bh.consume(compressionType);
+    }
+
+    @Benchmark
+    public void determineLongCompressionTypeScalar(StateClass state, Blackhole bh) {
+        int compressionType = determineLongCompressionTypeScalar(state.compressibleLongArray);
+        bh.consume(compressionType);
+    }
+
+    // Helper methods to create test data
+    private static final int[] createByteRangeArray(int size) {
+        int[] array = new int[size];
+        Random random = new Random(42);
+        for (int i = 0; i < size; i++) {
+            array[i] = random.nextInt(200) - 100; // -100 to 99 (byte range)
+        }
+        return array;
+    }
+
+    private static final int[] createSortedArray(int size) {
+        int[] array = createByteRangeArray(size);
+        Arrays.sort(array);
+        return array;
+    }
+
+    private static final int[] createZeroArray(int size) {
+        return new int[size]; // all zeros
+    }
+
+    private static final int[] createSequentialArray(int size) {
+        int[] array = new int[size];
+        for (int i = 0; i < size; i++) {
+            array[i] = i % 256; // 0-255 repeating
+        }
+        return array;
+    }
+
+    private static final int[] createLargeValueArray(int size) {
+        int[] array = new int[size];
+        Random random = new Random(42);
+        for (int i = 0; i < size; i++) {
+            array[i] = random.nextInt();
+        }
+        return array;
+    }
+
+    private static final long[] createIntRangeLongArray(int size) {
+        long[] array = new long[size];
+        Random random = new Random(42);
+        for (int i = 0; i < size; i++) {
+            array[i] = random.nextInt(); // int range values
+        }
+        return array;
+    }
+
+    private static final long[] createLargeLongValueArray(int size) {
+        long[] array = new long[size];
+        Random random = new Random(42);
+        for (int i = 0; i < size; i++) {
+            array[i] = random.nextLong();
+        }
+        return array;
+    }
+
+    private static int determineIntCompressionTypeScalar(int[] array) {
+        boolean canCompressToByte = true;
+        boolean canCompressToShort = true;
+
+        for (int i = 0; i < array.length && (canCompressToByte || canCompressToShort); i++) {
+            int value = array[i];
+            if (canCompressToByte && (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE)) {
+                canCompressToByte = false;
+            }
+            if (value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+                canCompressToShort = false;
+            }
+        }
+
+        if (canCompressToByte) {
+            return 1;
+        }
+        if (canCompressToShort) {
+            return 2;
+        }
+        return 0;
+    }
+
+    private static int determineLongCompressionTypeScalar(long[] array) {
+        boolean canCompressToInt = true;
+        for (long value : array) {
+            if (value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
+                canCompressToInt = false;
+                break;
+            }
+        }
+        return canCompressToInt ? 3 : 0;
+    }
+
+    /**
+     * Compress int array to byte array.
+     */
+    public static byte[] compressToBytes(int[] array) {
+        byte[] compressed = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            compressed[i] = (byte) array[i];
+        }
+        return compressed;
+    }
+}

--- a/java/fory-core/pom.xml
+++ b/java/fory-core/pom.xml
@@ -125,6 +125,44 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Profile for Java 16+ with Vector API support -->
+    <profile>
+      <id>java16-plus</id>
+      <activation>
+        <jdk>[16,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>16</source>
+              <target>16</target>
+              <compilerArgs>
+                <arg>--add-modules</arg>
+                <arg>jdk.incubator.vector</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-modules jdk.incubator.vector</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/java/fory-core/src/main/java/org/apache/fory/config/Config.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/Config.java
@@ -50,6 +50,8 @@ public class Config implements Serializable {
   private final boolean compressInt;
   private final boolean compressLong;
   private final LongEncoding longEncoding;
+  private final boolean compressIntArray;
+  private final boolean compressLongArray;
   private final boolean requireClassRegistration;
   private final boolean suppressClassRegistrationWarnings;
   private final boolean registerGuavaTypes;
@@ -77,6 +79,8 @@ public class Config implements Serializable {
     compressInt = builder.compressInt;
     longEncoding = builder.longEncoding;
     compressLong = longEncoding != LongEncoding.LE_RAW_BYTES;
+    compressIntArray = builder.compressIntArray;
+    compressLongArray = builder.compressLongArray;
     requireClassRegistration = builder.requireClassRegistration;
     suppressClassRegistrationWarnings = builder.suppressClassRegistrationWarnings;
     registerGuavaTypes = builder.registerGuavaTypes;
@@ -197,6 +201,14 @@ public class Config implements Serializable {
     return longEncoding;
   }
 
+  public boolean compressIntArray() {
+    return compressIntArray;
+  }
+
+  public boolean compressLongArray() {
+    return compressLongArray;
+  }
+
   public int bufferSizeLimitBytes() {
     return bufferSizeLimitBytes;
   }
@@ -298,6 +310,8 @@ public class Config implements Serializable {
         && writeNumUtf16BytesForUtf8Encoding == config.writeNumUtf16BytesForUtf8Encoding
         && compressInt == config.compressInt
         && compressLong == config.compressLong
+        && compressIntArray == config.compressIntArray
+        && compressLongArray == config.compressLongArray
         && bufferSizeLimitBytes == config.bufferSizeLimitBytes
         && requireClassRegistration == config.requireClassRegistration
         && suppressClassRegistrationWarnings == config.suppressClassRegistrationWarnings
@@ -334,6 +348,8 @@ public class Config implements Serializable {
         compressInt,
         compressLong,
         longEncoding,
+        compressIntArray,
+        compressLongArray,
         bufferSizeLimitBytes,
         requireClassRegistration,
         suppressClassRegistrationWarnings,

--- a/java/fory-core/src/main/java/org/apache/fory/config/ForyBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/ForyBuilder.java
@@ -68,6 +68,8 @@ public final class ForyBuilder {
   ClassLoader classLoader;
   boolean compressInt = true;
   public LongEncoding longEncoding = LongEncoding.SLI;
+  boolean compressIntArray = true;
+  boolean compressLongArray = true;
   boolean compressString = false;
   Boolean writeNumUtf16BytesForUtf8Encoding;
   CompatibleMode compatibleMode = CompatibleMode.SCHEMA_CONSISTENT;
@@ -180,6 +182,18 @@ public final class ForyBuilder {
   /** Use variable length encoding for long. */
   public ForyBuilder withLongCompressed(LongEncoding longEncoding) {
     this.longEncoding = Objects.requireNonNull(longEncoding);
+    return this;
+  }
+
+  /** Whether compress int arrays when values are small. */
+  public ForyBuilder withIntArrayCompressed(boolean intArrayCompressed) {
+    this.compressIntArray = intArrayCompressed;
+    return this;
+  }
+
+  /** Whether compress long arrays when values are small. */
+  public ForyBuilder withLongArrayCompressed(boolean longArrayCompressed) {
+    this.compressLongArray = longArrayCompressed;
     return this;
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ArraySerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ArraySerializers.java
@@ -35,6 +35,7 @@ import org.apache.fory.serializer.collection.ForyArrayAsListSerializer;
 import org.apache.fory.type.GenericType;
 import org.apache.fory.type.TypeUtils;
 import org.apache.fory.type.Types;
+import org.apache.fory.util.ArrayCompressionUtils;
 import org.apache.fory.util.Preconditions;
 
 /** Serializers for array types. */
@@ -451,6 +452,34 @@ public class ArraySerializers {
 
     @Override
     public void write(MemoryBuffer buffer, int[] value) {
+      if (fory.getBufferCallback() == null && fory.getConfig().compressIntArray()) {
+        final int compressionType = ArrayCompressionUtils.determineIntCompressionType(value);
+
+        if (compressionType != ArrayCompressionUtils.COMPRESSION_NONE) {
+          buffer.writeByte((byte) compressionType);
+          buffer.writeVarUint32Small7(value.length);
+          if (compressionType == ArrayCompressionUtils.COMPRESSION_BYTE) {
+            byte[] bytes = ArrayCompressionUtils.compressToBytes(value);
+            int wi = buffer.writerIndex();
+            int end = wi + bytes.length;
+            buffer.ensure(end);
+            buffer.copyFromUnsafe(wi, bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length);
+            buffer.writerIndex(end);
+            return;
+          } else if (compressionType == ArrayCompressionUtils.COMPRESSION_SHORT) {
+            short[] shorts = ArrayCompressionUtils.compressToShorts(value);
+            int payloadLen = shorts.length * 2;
+            int wi = buffer.writerIndex();
+            int end = wi + payloadLen;
+            buffer.ensure(end);
+            buffer.copyFromUnsafe(wi, shorts, Platform.SHORT_ARRAY_OFFSET, payloadLen);
+            buffer.writerIndex(end);
+            return;
+          }
+        }
+      }
+
+      // Legacy uncompressed format
       if (fory.getBufferCallback() == null) {
         int size = Math.multiplyExact(value.length, elemSize);
         buffer.writePrimitiveArrayWithSize(value, offset, size);
@@ -467,18 +496,54 @@ public class ArraySerializers {
 
     @Override
     public int[] read(MemoryBuffer buffer) {
+      // OOB remains legacy/raw
       if (fory.isPeerOutOfBandEnabled()) {
         MemoryBuffer buf = fory.readBufferObject(buffer);
         int size = buf.remaining();
         int numElements = size / elemSize;
         int[] values = new int[numElements];
-        buf.copyToUnsafe(0, values, offset, size);
+        if (size > 0) {
+          buf.copyToUnsafe(0, values, offset, size);
+        }
         return values;
-      } else {
+      }
+
+      if (fory.getConfig().compressIntArray()) {
+        int readerIndex = buffer.readerIndex();
+        int compressionType = buffer.readByte() & 0xFF;
+
+        if (compressionType == ArrayCompressionUtils.COMPRESSION_BYTE
+            || compressionType == ArrayCompressionUtils.COMPRESSION_SHORT) {
+          int originalLen = buffer.readVarUint32Small7();
+          if (originalLen == 0) {
+            return new int[0];
+          }
+
+          if (compressionType == ArrayCompressionUtils.COMPRESSION_BYTE) {
+            byte[] payload = new byte[originalLen];
+            buffer.readToUnsafe(payload, Platform.BYTE_ARRAY_OFFSET, originalLen);
+            return ArrayCompressionUtils.decompressFromBytes(payload);
+          } else {
+            {
+              int payloadSize = originalLen * 2;
+              short[] tmp = new short[originalLen];
+              buffer.readToUnsafe(tmp, Platform.SHORT_ARRAY_OFFSET, payloadSize);
+              return ArrayCompressionUtils.decompressFromShorts(tmp);
+            }
+          }
+        } else {
+          // Not a compressed format, reset and fall through to legacy format
+          buffer.readerIndex(readerIndex);
+        }
+      }
+      // Legacy uncompressed format
+      {
         int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         int[] values = new int[numElements];
-        buffer.readToUnsafe(values, offset, size);
+        if (size > 0) {
+          buffer.readToUnsafe(values, offset, size);
+        }
         return values;
       }
     }
@@ -492,12 +557,38 @@ public class ArraySerializers {
 
     @Override
     public void write(MemoryBuffer buffer, long[] value) {
-      if (fory.getBufferCallback() == null) {
-        int size = Math.multiplyExact(value.length, elemSize);
-        buffer.writePrimitiveArrayWithSize(value, offset, size);
+      // Use config to determine format
+      if (fory.getBufferCallback() == null && fory.getConfig().compressLongArray()) {
+        final int compressionType = ArrayCompressionUtils.determineLongCompressionType(value);
+        buffer.writeByte((byte) compressionType);
+        buffer.writeVarUint32Small7(value.length);
+
+        if (compressionType == ArrayCompressionUtils.COMPRESSION_INT) {
+          int[] ints = ArrayCompressionUtils.compressToInts(value);
+          int payloadLen = ints.length * 4;
+          int wi = buffer.writerIndex();
+          int end = wi + payloadLen;
+          buffer.ensure(end);
+          buffer.copyFromUnsafe(wi, ints, Platform.INT_ARRAY_OFFSET, payloadLen);
+          buffer.writerIndex(end);
+        } else {
+          int size = Math.multiplyExact(value.length, elemSize);
+          int wi = buffer.writerIndex();
+          int end = wi + size;
+          buffer.ensure(end);
+          if (size > 0) {
+            buffer.copyFromUnsafe(wi, value, offset, size);
+          }
+          buffer.writerIndex(end);
+        }
       } else {
-        fory.writeBufferObject(
-            buffer, new PrimitiveArrayBufferObject(value, offset, elemSize, value.length));
+        if (fory.getBufferCallback() == null) {
+          int size = Math.multiplyExact(value.length, elemSize);
+          buffer.writePrimitiveArrayWithSize(value, offset, size);
+        } else {
+          fory.writeBufferObject(
+              buffer, new PrimitiveArrayBufferObject(value, offset, elemSize, value.length));
+        }
       }
     }
 
@@ -513,13 +604,47 @@ public class ArraySerializers {
         int size = buf.remaining();
         int numElements = size / elemSize;
         long[] values = new long[numElements];
-        buf.copyToUnsafe(0, values, offset, size);
+        if (size > 0) {
+          buf.copyToUnsafe(0, values, offset, size);
+        }
         return values;
+      }
+
+      if (fory.getConfig().compressLongArray()) {
+        int compressionType = buffer.readByte() & 0xFF;
+        int originalLen = buffer.readVarUint32Small7();
+
+        if (originalLen == 0) {
+          return new long[0];
+        }
+
+        switch (compressionType) {
+          case ArrayCompressionUtils.COMPRESSION_INT:
+            {
+              int payloadSize = originalLen * 4;
+              int[] ints = new int[originalLen];
+              buffer.readToUnsafe(ints, Platform.INT_ARRAY_OFFSET, payloadSize);
+              return ArrayCompressionUtils.decompressFromInts(ints);
+            }
+          case ArrayCompressionUtils.COMPRESSION_NONE:
+            {
+              long[] values = new long[originalLen];
+              int size = originalLen * elemSize;
+              if (size > 0) {
+                buffer.readToUnsafe(values, offset, size);
+              }
+              return values;
+            }
+          default:
+            throw new IllegalStateException("Unknown long[] compression type: " + compressionType);
+        }
       } else {
         int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         long[] values = new long[numElements];
-        buffer.readToUnsafe(values, offset, size);
+        if (size > 0) {
+          buffer.readToUnsafe(values, offset, size);
+        }
         return values;
       }
     }

--- a/java/fory-core/src/main/java/org/apache/fory/util/ArrayCompressionUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/ArrayCompressionUtils.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.util;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * SIMD-accelerated compression utilities for primitive arrays.
+ *
+ * <p>This utility provides compression for primitive arrays by detecting when values can fit in
+ * smaller data types:
+ *
+ * <ul>
+ *   <li>int[] → byte[] when all values are in [-128, 127] range (75% size reduction)
+ *   <li>int[] → short[] when all values are in [-32768, 32767] range (50% size reduction)
+ *   <li>long[] → int[] when all values fit in integer range (50% size reduction)
+ * </ul>
+ *
+ * <p>Uses SIMD operations (Vector API) when available on Java 16+ for optimal performance. Falls
+ * back to scalar processing on older versions or when arrays are too small.
+ *
+ * <p>Compression is only applied to arrays with at least 16 elements to justify the analysis
+ * overhead.
+ */
+public final class ArrayCompressionUtils {
+
+  // Compression type constants
+  public static final int COMPRESSION_NONE = 0;
+  public static final int COMPRESSION_BYTE = 1; // int[] → byte[]
+  public static final int COMPRESSION_SHORT = 2; // int[] → short[]
+  public static final int COMPRESSION_INT = 3; // long[] → int[]
+
+  // Java version and Vector API availability check
+  private static final int JAVA_VERSION = getJavaVersion();
+  private static final boolean COMPRESSION_ENABLED = JAVA_VERSION >= 16;
+  private static final boolean VECTOR_API_AVAILABLE;
+  private static final VectorSpecies<Integer> INT_SPECIES;
+  private static final VectorSpecies<Long> LONG_SPECIES;
+  private static final int INT_VECTOR_LENGTH;
+  private static final int LONG_VECTOR_LENGTH;
+
+  // Minimum array size to justify compression overhead
+  private static final int MIN_COMPRESSION_SIZE = 16;
+
+  static {
+    boolean vectorAvailable = false;
+    VectorSpecies<Integer> intSpecies = null;
+    VectorSpecies<Long> longSpecies = null;
+    int intVectorLength = 1;
+    int longVectorLength = 1;
+
+    if (COMPRESSION_ENABLED) {
+        intSpecies = IntVector.SPECIES_PREFERRED;
+        longSpecies = LongVector.SPECIES_PREFERRED;
+        intVectorLength = intSpecies.length();
+        longVectorLength = longSpecies.length();
+        vectorAvailable = intVectorLength > 1 && longVectorLength > 1;
+    }
+
+    VECTOR_API_AVAILABLE = vectorAvailable;
+    INT_SPECIES = intSpecies;
+    LONG_SPECIES = longSpecies;
+    INT_VECTOR_LENGTH = intVectorLength;
+    LONG_VECTOR_LENGTH = longVectorLength;
+  }
+
+  private static int getJavaVersion() {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dot = version.indexOf(".");
+      if (dot != -1) {
+        version = version.substring(0, dot);
+      }
+    }
+    try {
+      return Integer.parseInt(version);
+    } catch (NumberFormatException e) {
+      return 8; // Default to Java 8 if parsing fails
+    }
+  }
+
+  /**
+   * Determine the best compression type for int array using SIMD.
+   *
+   * @param array the int array to analyze
+   * @return compression type constant (COMPRESSION_NONE, COMPRESSION_BYTE, or COMPRESSION_SHORT)
+   * @throws NullPointerException if array is null
+   */
+  public static int determineIntCompressionType(int[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    if (!COMPRESSION_ENABLED || array.length < MIN_COMPRESSION_SIZE || !VECTOR_API_AVAILABLE) {
+      return COMPRESSION_NONE;
+    }
+    return determineIntCompressionTypeSIMD(array);
+  }
+
+  /**
+   * Determine the best compression type for long array using SIMD.
+   *
+   * @param array the long array to analyze
+   * @return compression type constant (COMPRESSION_NONE or COMPRESSION_INT)
+   * @throws NullPointerException if array is null
+   */
+  public static int determineLongCompressionType(long[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    if (!COMPRESSION_ENABLED || array.length < MIN_COMPRESSION_SIZE || !VECTOR_API_AVAILABLE) {
+      return COMPRESSION_NONE;
+    }
+    return determineLongCompressionTypeSIMD(array);
+  }
+
+  private static int determineIntCompressionTypeSIMD(int[] array) {
+    final int byteMax = Byte.MAX_VALUE;
+    final int shortMax = Short.MAX_VALUE;
+    final int byteMin = Byte.MIN_VALUE;
+    final int shortMin = Short.MIN_VALUE;
+
+    boolean canCompressToByte = true;
+    boolean canCompressToShort = true;
+
+    int i = 0;
+    final int loopBound = INT_VECTOR_LENGTH * (array.length / INT_VECTOR_LENGTH);
+
+    // SIMD processing
+    for (; i < loopBound && (canCompressToByte || canCompressToShort); i += INT_VECTOR_LENGTH) {
+      IntVector vector = IntVector.fromArray(INT_SPECIES, array, i);
+
+      // Calculate min/max once per vector
+      int max = vector.reduceLanes(VectorOperators.MAX);
+      int min = vector.reduceLanes(VectorOperators.MIN);
+
+      // Combined boundary check for byte compression
+      if (canCompressToByte && (max > byteMax || min < byteMin)) {
+        canCompressToByte = false;
+      }
+
+      // Only check short compression if still viable
+      if (canCompressToShort && (max > shortMax || min < shortMin)) {
+        canCompressToShort = false;
+      }
+    }
+
+    // Handle remaining elements
+    for (; i < array.length && (canCompressToByte || canCompressToShort); i++) {
+      int value = array[i];
+      if (canCompressToByte && (value > byteMax || value < byteMin)) {
+        canCompressToByte = false;
+      }
+      if (value > shortMax || value < shortMin) {
+        canCompressToShort = false;
+      }
+    }
+
+    if (canCompressToByte) {
+      return COMPRESSION_BYTE;
+    }
+    if (canCompressToShort) {
+      return COMPRESSION_SHORT;
+    }
+    return COMPRESSION_NONE;
+  }
+
+  private static int determineLongCompressionTypeSIMD(long[] array) {
+    final long intMax = Integer.MAX_VALUE;
+    final long intMin = Integer.MIN_VALUE;
+
+    boolean canCompressToInt = true;
+
+    int i = 0;
+    final int loopBound = LONG_VECTOR_LENGTH * (array.length / LONG_VECTOR_LENGTH);
+
+    // SIMD processing
+    for (; i < loopBound && canCompressToInt; i += LONG_VECTOR_LENGTH) {
+      LongVector vector = LongVector.fromArray(LONG_SPECIES, array, i);
+
+      long max = vector.reduceLanes(VectorOperators.MAX);
+      long min = vector.reduceLanes(VectorOperators.MIN);
+      if (max > intMax || min < intMin) {
+        canCompressToInt = false;
+        break;
+      }
+    }
+
+    // Handle remaining elements
+    for (; i < array.length && canCompressToInt; i++) {
+      long value = array[i];
+      if (value > intMax || value < intMin) {
+        canCompressToInt = false;
+      }
+    }
+
+    return canCompressToInt ? COMPRESSION_INT : COMPRESSION_NONE;
+  }
+
+  /**
+   * Compress int array to byte array.
+   *
+   * @param array the int array to compress
+   * @return compressed byte array
+   * @throws NullPointerException if array is null
+   */
+  public static byte[] compressToBytes(int[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    byte[] compressed = new byte[array.length];
+    for (int i = 0; i < array.length; i++) {
+      compressed[i] = (byte) array[i];
+    }
+    return compressed;
+  }
+
+  /**
+   * Compress int array to short array.
+   *
+   * @param array the int array to compress (values must be in short range)
+   * @return compressed short array
+   * @throws NullPointerException if array is null
+   */
+  public static short[] compressToShorts(int[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    short[] compressed = new short[array.length];
+    for (int i = 0; i < array.length; i++) {
+      compressed[i] = (short) array[i];
+    }
+    return compressed;
+  }
+
+  /**
+   * Compress long array to int array.
+   *
+   * @param array the long array to compress (values must be in int range)
+   * @return compressed int array
+   * @throws NullPointerException if array is null
+   */
+  public static int[] compressToInts(long[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    int[] compressed = new int[array.length];
+    for (int i = 0; i < array.length; i++) {
+      compressed[i] = (int) array[i];
+    }
+    return compressed;
+  }
+
+  /**
+   * Decompress byte array to int array.
+   *
+   * @param array the byte array to decompress
+   * @return decompressed int array
+   * @throws NullPointerException if array is null
+   */
+  public static int[] decompressFromBytes(byte[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    int[] decompressed = new int[array.length];
+    for (int i = 0; i < array.length; i++) {
+      decompressed[i] = array[i];
+    }
+    return decompressed;
+  }
+
+  /**
+   * Decompress short array to int array.
+   *
+   * @param array the short array to decompress
+   * @return decompressed int array
+   * @throws NullPointerException if array is null
+   */
+  public static int[] decompressFromShorts(short[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    int[] decompressed = new int[array.length];
+    for (int i = 0; i < array.length; i++) {
+      decompressed[i] = array[i];
+    }
+    return decompressed;
+  }
+
+  /**
+   * Decompress int array to long array.
+   *
+   * @param array the int array to decompress
+   * @return decompressed long array
+   * @throws NullPointerException if array is null
+   */
+  public static long[] decompressFromInts(int[] array) {
+    if (array == null) {
+      throw new NullPointerException("Array cannot be null");
+    }
+    long[] decompressed = new long[array.length];
+    for (int i = 0; i < array.length; i++) {
+      decompressed[i] = array[i];
+    }
+    return decompressed;
+  }
+
+  /** Check if array compression is supported (requires Java 16+). */
+  public static boolean isCompressionSupported() {
+    return COMPRESSION_ENABLED;
+  }
+
+  /** Get the current Java version. */
+  public static int getCurrentJavaVersion() {
+    return JAVA_VERSION;
+  }
+}

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ArrayCompressionTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ArrayCompressionTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Random;
+import org.apache.fory.Fory;
+import org.apache.fory.config.ForyBuilder;
+import org.apache.fory.util.ArrayCompressionUtils;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ArrayCompressionTest {
+
+  @BeforeMethod
+  public void checkJavaVersion() {
+    if (!ArrayCompressionUtils.isCompressionSupported()) {
+      throw new SkipException(
+          "Array compression requires Java 16+, current version: "
+              + ArrayCompressionUtils.getCurrentJavaVersion());
+    }
+  }
+
+  @DataProvider(name = "intArrayData")
+  public Object[][] intArrayData() {
+    return new Object[][] {
+      // {description, array }
+      {"Empty array", new int[] {}},
+      {"Small array", new int[] {1, 2, 3}},
+      {"Byte range array", createByteRangeArray(1000)},
+      {"Short range array", createShortRangeArray(1000)},
+      {"Large value array", createLargeValueArray(1000)},
+      {"Mixed value array", createMixedValueArray(1000)}
+    };
+  }
+
+  @DataProvider(name = "longArrayData")
+  public Object[][] longArrayData() {
+    return new Object[][] {
+      // {description, array }
+      {"Empty array", new long[] {}},
+      {"Small array", new long[] {1L, 2L, 3L}},
+      {"Int range array", createIntRangeLongArray(1000)},
+      {"Large value array", createLargeLongValueArray(1000)}
+    };
+  }
+
+  @Test(dataProvider = "intArrayData")
+  public void testIntArrayCompressionRoundTrip(String description, int[] originalArray) {
+    Fory foryWithCompression = new ForyBuilder().withIntArrayCompressed(true).build();
+    Fory foryWithoutCompression = new ForyBuilder().withIntArrayCompressed(false).build();
+
+    // Test with compression enabled
+    byte[] serializedWithCompression = foryWithCompression.serialize(originalArray);
+    int[] deserializedWithCompression =
+        (int[]) foryWithCompression.deserialize(serializedWithCompression);
+    assertEquals(
+        deserializedWithCompression,
+        originalArray,
+        "Round trip failed with compression: " + description);
+
+    // Test with compression disabled
+    byte[] serializedWithoutCompression = foryWithoutCompression.serialize(originalArray);
+    int[] deserializedWithoutCompression =
+        (int[]) foryWithoutCompression.deserialize(serializedWithoutCompression);
+    assertEquals(
+        deserializedWithoutCompression,
+        originalArray,
+        "Round trip failed without compression: " + description);
+  }
+
+  @Test(dataProvider = "longArrayData")
+  public void testLongArrayCompressionRoundTrip(String description, long[] originalArray) {
+    Fory foryWithCompression = new ForyBuilder().withLongArrayCompressed(true).build();
+
+    Fory foryWithoutCompression = new ForyBuilder().withLongArrayCompressed(false).build();
+
+    // Test with compression enabled
+    byte[] serializedWithCompression = foryWithCompression.serialize(originalArray);
+    long[] deserializedWithCompression =
+        (long[]) foryWithCompression.deserialize(serializedWithCompression);
+    assertEquals(
+        deserializedWithCompression,
+        originalArray,
+        "Round trip failed with compression: " + description);
+
+    // Test with compression disabled
+    byte[] serializedWithoutCompression = foryWithoutCompression.serialize(originalArray);
+    long[] deserializedWithoutCompression =
+        (long[]) foryWithoutCompression.deserialize(serializedWithoutCompression);
+    assertEquals(
+        deserializedWithoutCompression,
+        originalArray,
+        "Round trip failed without compression: " + description);
+  }
+
+  @Test
+  public void testCompressionRatios() {
+    Fory foryWithCompression =
+        new ForyBuilder().withIntArrayCompressed(true).withLongArrayCompressed(true).build();
+
+    Fory foryWithoutCompression =
+        new ForyBuilder().withIntArrayCompressed(false).withLongArrayCompressed(false).build();
+
+    // Test byte-range int array compression (should achieve ~4x compression)
+    int[] byteRangeArray = createByteRangeArray(10000);
+    byte[] compressedBytes = foryWithCompression.serialize(byteRangeArray);
+    byte[] uncompressedBytes = foryWithoutCompression.serialize(byteRangeArray);
+
+    double compressionRatio = (double) compressedBytes.length / uncompressedBytes.length;
+    assertTrue(
+        compressionRatio < 0.30,
+        "Expected significant compression for byte-range array, got ratio: " + compressionRatio);
+
+    // Test short-range int array compression (should achieve ~2x compression)
+    int[] shortRangeArray = createShortRangeArray(10000);
+    compressedBytes = foryWithCompression.serialize(shortRangeArray);
+    uncompressedBytes = foryWithoutCompression.serialize(shortRangeArray);
+
+    compressionRatio = (double) compressedBytes.length / uncompressedBytes.length;
+    assertTrue(
+        compressionRatio < 0.55,
+        "Expected moderate compression for short-range array, got ratio: " + compressionRatio);
+
+    // Test int-range long array compression (should achieve ~2x compression)
+    long[] intRangeLongArray = createIntRangeLongArray(10000);
+    compressedBytes = foryWithCompression.serialize(intRangeLongArray);
+    uncompressedBytes = foryWithoutCompression.serialize(intRangeLongArray);
+
+    compressionRatio = (double) compressedBytes.length / uncompressedBytes.length;
+    assertTrue(
+        compressionRatio < 0.55,
+        "Expected compression for int-range long array, got ratio: " + compressionRatio);
+  }
+
+  @Test
+  public void testLargeArrays() {
+    Fory fory =
+        new ForyBuilder().withIntArrayCompressed(true).withLongArrayCompressed(true).build();
+
+    // Test very large compressible arrays
+    int[] largeIntArray = createByteRangeArray(100000);
+    byte[] serialized = fory.serialize(largeIntArray);
+    int[] deserialized = (int[]) fory.deserialize(serialized);
+    assertEquals(deserialized, largeIntArray);
+
+    long[] largeLongArray = createIntRangeLongArray(100000);
+    serialized = fory.serialize(largeLongArray);
+    long[] deserializedLong = (long[]) fory.deserialize(serialized);
+    assertEquals(deserializedLong, largeLongArray);
+  }
+
+  // Helper methods to create test data
+  private int[] createByteRangeArray(int size) {
+    int[] array = new int[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      array[i] = random.nextInt(256) - 128; // -128 to 127
+    }
+    return array;
+  }
+
+  private int[] createShortRangeArray(int size) {
+    int[] array = new int[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      array[i] = random.nextInt(65536) - 32768; // -32768 to 32767
+    }
+    return array;
+  }
+
+  private int[] createLargeValueArray(int size) {
+    int[] array = new int[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      array[i] = random.nextInt();
+    }
+    return array;
+  }
+
+  private int[] createMixedValueArray(int size) {
+    int[] array = new int[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      if (i < size / 2) {
+        array[i] = random.nextInt(256) - 128; // byte range
+      } else {
+        array[i] = random.nextInt(); // full int range
+      }
+    }
+    return array;
+  }
+
+  private long[] createIntRangeLongArray(int size) {
+    long[] array = new long[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      array[i] = random.nextInt(); // int range
+    }
+    return array;
+  }
+
+  private long[] createLargeLongValueArray(int size) {
+    long[] array = new long[size];
+    Random random = new Random(42);
+    for (int i = 0; i < size; i++) {
+      array[i] = random.nextLong();
+    }
+    return array;
+  }
+}

--- a/java/fory-core/src/test/java/org/apache/fory/util/ArrayCompressionUtilsTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/util/ArrayCompressionUtilsTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Random;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ArrayCompressionUtilsTest {
+
+  @BeforeMethod
+  public void checkJavaVersion() {
+    if (!ArrayCompressionUtils.isCompressionSupported()) {
+      throw new SkipException(
+          "Array compression requires Java 16+, current version: "
+              + ArrayCompressionUtils.getCurrentJavaVersion());
+    }
+  }
+
+  @Test
+  public void testIntArrayCompressionDetection() {
+    // Test byte range compression - make array size >= 16
+    int[] byteRangeArray = new int[16];
+    for (int i = 0; i < 16; i++) {
+      byteRangeArray[i] = (i % 256) - 128; // byte range values
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(byteRangeArray),
+        ArrayCompressionUtils.COMPRESSION_BYTE);
+
+    // Test short range compression - make array size >= 16
+    int[] shortRangeArray = new int[16];
+    for (int i = 0; i < 16; i++) {
+      shortRangeArray[i] = (i % 65536) - 32768; // short range values
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(shortRangeArray),
+        ArrayCompressionUtils.COMPRESSION_SHORT);
+
+    // Test no compression for large values - make array size >= 16
+    int[] largeArray = new int[16];
+    for (int i = 0; i < 16; i++) {
+      largeArray[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(largeArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+
+    // Test small arrays don't compress
+    int[] smallArray = {1, 2, 3};
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(smallArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testLongArrayCompressionDetection() {
+    // Test int range compression - make array size >= 16
+    long[] intRangeArray = new long[16];
+    for (int i = 0; i < 16; i++) {
+      intRangeArray[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(intRangeArray),
+        ArrayCompressionUtils.COMPRESSION_INT);
+
+    // Test no compression for large values - make array size >= 16
+    long[] largeArray = new long[16];
+    for (int i = 0; i < 16; i++) {
+      largeArray[i] = i % 2 == 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(largeArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+
+    // Test small arrays don't compress
+    long[] smallArray = {1L, 2L, 3L};
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(smallArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testCompressionRoundTrip() {
+    // Test int to byte compression - use arrays >= 16 for proper testing
+    int[] originalInts = new int[16];
+    for (int i = 0; i < 16; i++) {
+      originalInts[i] = (i % 201) - 100; // byte range values
+    }
+    byte[] compressed = ArrayCompressionUtils.compressToBytes(originalInts);
+    int[] decompressed = ArrayCompressionUtils.decompressFromBytes(compressed);
+    assertEquals(decompressed, originalInts);
+
+    // Test int to short compression
+    int[] originalShorts = new int[16];
+    for (int i = 0; i < 16; i++) {
+      originalShorts[i] = (i % 60001) - 30000; // short range values
+    }
+    short[] compressedShorts = ArrayCompressionUtils.compressToShorts(originalShorts);
+    int[] decompressedShorts = ArrayCompressionUtils.decompressFromShorts(compressedShorts);
+    assertEquals(decompressedShorts, originalShorts);
+
+    // Test long to int compression
+    long[] originalLongs = new long[16];
+    for (int i = 0; i < 16; i++) {
+      originalLongs[i] = i % 2 == 0 ? -2000000000L : 2000000000L; // int range values
+    }
+    int[] compressedInts = ArrayCompressionUtils.compressToInts(originalLongs);
+    long[] decompressedLongs = ArrayCompressionUtils.decompressFromInts(compressedInts);
+    assertEquals(decompressedLongs, originalLongs);
+  }
+
+  @Test
+  public void testLargeArraysWithSIMD() {
+    Random random = new Random(42);
+
+    // Test large array that compresses to bytes
+    int[] largeByteArray = new int[10000];
+    for (int i = 0; i < largeByteArray.length; i++) {
+      largeByteArray[i] = random.nextInt(256) - 128; // byte range
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(largeByteArray),
+        ArrayCompressionUtils.COMPRESSION_BYTE);
+
+    // Test large array that compresses to shorts
+    int[] largeShortArray = new int[10000];
+    for (int i = 0; i < largeShortArray.length; i++) {
+      largeShortArray[i] = random.nextInt(65536) - 32768; // short range
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(largeShortArray),
+        ArrayCompressionUtils.COMPRESSION_SHORT);
+
+    // Test large array that doesn't compress
+    int[] largeArray = new int[10000];
+    for (int i = 0; i < largeArray.length; i++) {
+      largeArray[i] = random.nextInt();
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(largeArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testLargeLongArraysWithSIMD() {
+    Random random = new Random(42);
+
+    // Test large array that compresses to ints
+    long[] largeIntArray = new long[10000];
+    for (int i = 0; i < largeIntArray.length; i++) {
+      largeIntArray[i] = random.nextInt(); // int range
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(largeIntArray),
+        ArrayCompressionUtils.COMPRESSION_INT);
+
+    // Test large array that doesn't compress
+    long[] largeArray = new long[10000];
+    for (int i = 0; i < largeArray.length; i++) {
+      largeArray[i] = random.nextLong();
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(largeArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testEdgeCases() {
+    // Test empty arrays
+    int[] emptyIntArray = {};
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(emptyIntArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+
+    long[] emptyLongArray = {};
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(emptyLongArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+
+    // Test boundary values - use arrays >= 16
+    int[] byteBoundary = new int[16];
+    for (int i = 0; i < 16; i++) {
+      byteBoundary[i] = i % 2 == 0 ? Byte.MIN_VALUE : Byte.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(byteBoundary),
+        ArrayCompressionUtils.COMPRESSION_BYTE);
+
+    int[] shortBoundary = new int[16];
+    for (int i = 0; i < 16; i++) {
+      shortBoundary[i] = i % 2 == 0 ? Short.MIN_VALUE : Short.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(shortBoundary),
+        ArrayCompressionUtils.COMPRESSION_SHORT);
+
+    long[] intBoundary = new long[16];
+    for (int i = 0; i < 16; i++) {
+      intBoundary[i] = i % 2 == 0 ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(intBoundary),
+        ArrayCompressionUtils.COMPRESSION_INT);
+
+    // Test just outside boundaries
+    int[] outsideByte = new int[16];
+    for (int i = 0; i < 16; i++) {
+      outsideByte[i] = i % 2 == 0 ? Byte.MIN_VALUE - 1 : Byte.MAX_VALUE + 1;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(outsideByte),
+        ArrayCompressionUtils.COMPRESSION_SHORT);
+
+    int[] outsideShort = new int[16];
+    for (int i = 0; i < 16; i++) {
+      outsideShort[i] = i % 2 == 0 ? Short.MIN_VALUE - 1 : Short.MAX_VALUE + 1;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(outsideShort),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+
+    long[] outsideInt = new long[16];
+    for (int i = 0; i < 16; i++) {
+      outsideInt[i] = i % 2 == 0 ? Integer.MIN_VALUE - 1L : Integer.MAX_VALUE + 1L;
+    }
+    assertEquals(
+        ArrayCompressionUtils.determineLongCompressionType(outsideInt),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testCompressionEffectiveness() {
+    // Test compression size reduction
+    int[] byteRangeArray = new int[1000];
+    for (int i = 0; i < byteRangeArray.length; i++) {
+      byteRangeArray[i] = i % 200 - 100; // byte range
+    }
+
+    byte[] compressed = ArrayCompressionUtils.compressToBytes(byteRangeArray);
+    assertEquals(compressed.length, byteRangeArray.length); // 4x smaller
+    assertTrue(compressed.length < byteRangeArray.length * 4);
+
+    // Verify decompression
+    int[] decompressed = ArrayCompressionUtils.decompressFromBytes(compressed);
+    assertEquals(decompressed, byteRangeArray);
+  }
+
+  @Test
+  public void testMixedValues() {
+    // Test array with mixed compression potential
+    int[] mixedArray = new int[1000];
+    // First half can compress to byte
+    for (int i = 0; i < 500; i++) {
+      mixedArray[i] = i % 200 - 100;
+    }
+    // Second half requires full int
+    for (int i = 500; i < 1000; i++) {
+      mixedArray[i] = Integer.MAX_VALUE - i;
+    }
+
+    assertEquals(
+        ArrayCompressionUtils.determineIntCompressionType(mixedArray),
+        ArrayCompressionUtils.COMPRESSION_NONE);
+  }
+
+  @Test
+  public void testConsistencyBetweenSIMDAndScalar() {
+    Random random = new Random(12345);
+
+    // Generate test arrays of various sizes and value ranges
+    int[][] testArrays = {
+      generateRandomIntArray(random, 100, -100, 100), // byte range
+      generateRandomIntArray(random, 1000, -30000, 30000), // short range
+      generateRandomIntArray(random, 50, -1000000000, 1000000000), // large range
+      generateRandomIntArray(random, 10000, -10, 10) // large array, byte range
+    };
+
+    long[][] testLongArrays = {
+      generateRandomLongArray(random, 100, -1000000000L, 1000000000L), // int range
+      generateRandomLongArray(random, 1000, -1000000000000L, 1000000000000L), // large range
+      generateRandomLongArray(random, 10000, -100L, 100L) // large array, int range
+    };
+
+    // Test that results are consistent regardless of SIMD availability
+    for (int[] array : testArrays) {
+      int result = ArrayCompressionUtils.determineIntCompressionType(array);
+      assertTrue(
+          result >= ArrayCompressionUtils.COMPRESSION_NONE
+              && result <= ArrayCompressionUtils.COMPRESSION_SHORT);
+    }
+
+    for (long[] array : testLongArrays) {
+      int result = ArrayCompressionUtils.determineLongCompressionType(array);
+      assertTrue(
+          result >= ArrayCompressionUtils.COMPRESSION_NONE
+              && result <= ArrayCompressionUtils.COMPRESSION_INT);
+    }
+  }
+
+  private int[] generateRandomIntArray(Random random, int size, int min, int max) {
+    int[] array = new int[size];
+    for (int i = 0; i < size; i++) {
+      if (min == max) {
+        array[i] = min;
+      } else {
+        array[i] = random.nextInt(max - min + 1) + min;
+      }
+    }
+    return array;
+  }
+
+  private long[] generateRandomLongArray(Random random, int size, long min, long max) {
+    long[] array = new long[size];
+    for (int i = 0; i < size; i++) {
+      if (min == max) {
+        array[i] = min;
+      } else {
+        long range = max - min + 1;
+        array[i] = Math.abs(random.nextLong()) % range + min;
+      }
+    }
+    return array;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Currently, primitive array are serialized by copy the data buffer directly using `sun.misc.Unsafe`. After this PR, if the config values are specified, we check with SIMD operations if the values inside are small enough and then we compress its values. For example:

```
int[] → byte[] when all values ∈ [-128, 127]
Size goes from 4B/elem → 1B/elem (≈ 75% smaller).

int[] → short[] when all values ∈ [-32768, 32767] (but some fall outside [-128,127])
4B/elem → 2B/elem (≈ 50% smaller).

long[] → int[] when all values ∈ [Integer.MIN_VALUE, Integer.MAX_VALUE]
8B/elem → 4B/elem (≈ 50% smaller).
```

Please take a look at the benchmark section to know more about the performance impact. 

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

Yes, it adds `withIntArrayCompressed` and `withLongArrayCompressed` options to the Fory builder which is a breaking change with previously compressed arrays. 

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
Check the file `src/main/java/org/apache/fory/benchmark/ArrayCompressionSuite.java` to see the benchmark code. To run it, go to the `/benchmark` directory and:
1. Compile the benchmark
```
javac -cp "../fory-core/target/classes:$(mvn dependency:build-classpath -q -Dmdep.outputFile=/dev/stdout -Pjmh)" -d target/classes src/main/java/org/apache/fory/benchmark/ArrayCompressionSuite.java
```
2. Run benchmark
The benchmarks performed in `ArrayCompressionSuite` show that:
- Compression has negligible cost: Deserialization and serialization throughput are almost identical between compressed and uncompressed arrays.
- Massive SIMD advantage: Determining compression type with SIMD is orders of magnitude faster than scalar.
- Memory savings with compression (e.g., int[] → byte[] gives 75% smaller arrays) delivers significant space reductions with no meaningful performance trade-off.

```
Benchmark                                          (arraySize)   Mode  Cnt          Score          Error  Units
# deserialize
ArrayCompressionSuite.deserializeCompressedIntArray        100  thrpt   3   39337995.386 ±  5360760.131  ops/s
ArrayCompressionSuite.deserializeNormalIntArray            100  thrpt   3   38295765.689 ±  1245305.149  ops/s

ArrayCompressionSuite.deserializeCompressedIntArray       1000  thrpt   3    5551302.526 ±   137012.772  ops/s
ArrayCompressionSuite.deserializeNormalIntArray           1000  thrpt   3    5437271.349 ±   607905.314  ops/s

ArrayCompressionSuite.deserializeCompressedIntArray      10000  thrpt   3     646854.523 ±   162819.346  ops/s
ArrayCompressionSuite.deserializeNormalIntArray          10000  thrpt   3     622439.409 ±   156114.438  ops/s

ArrayCompressionSuite.deserializeCompressedIntArray     100000  thrpt   3      72575.767 ±     1516.885  ops/s
ArrayCompressionSuite.deserializeNormalIntArray         100000  thrpt   3      71451.258 ±     8428.635  ops/s

ArrayCompressionSuite.deserializeCompressedIntArray    1000000  thrpt   3       7333.304 ±     5231.423  ops/s
ArrayCompressionSuite.deserializeNormalIntArray        1000000  thrpt   3       6763.321 ±     6402.086  ops/s

ArrayCompressionSuite.deserializeCompressedIntArray   10000000  thrpt   3        617.388 ±       20.088  ops/s
ArrayCompressionSuite.deserializeNormalIntArray       10000000  thrpt   3        615.323 ±        4.986  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray        100  thrpt   3   25497542.958 ±   409763.148  ops/s
ArrayCompressionSuite.deserializeNormalLongArray            100  thrpt   3   25509274.001 ±   709963.309  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray       1000  thrpt   3     955670.779 ±  1113862.949  ops/s
ArrayCompressionSuite.deserializeNormalLongArray           1000  thrpt   3     923666.161 ±  1873719.259  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray      10000  thrpt   3     358903.335 ±    73728.335  ops/s
ArrayCompressionSuite.deserializeNormalLongArray          10000  thrpt   3     356203.511 ±    60149.652  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray     100000  thrpt   3      36963.012 ±      316.502  ops/s
ArrayCompressionSuite.deserializeNormalLongArray         100000  thrpt   3      41915.010 ±    26587.942  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray    1000000  thrpt   3       3783.469 ±     1564.800  ops/s
ArrayCompressionSuite.deserializeNormalLongArray        1000000  thrpt   3       3834.763 ±      762.397  ops/s

ArrayCompressionSuite.deserializeCompressedLongArray   10000000  thrpt   3        323.378 ±       35.506  ops/s
ArrayCompressionSuite.deserializeNormalLongArray       10000000  thrpt   3        332.769 ±       20.246  ops/s
```

```
Benchmark                                        (arraySize)   Mode  Cnt          Score          Error  Units
# serialize compression
ArrayCompressionSuite.serializeCompressedIntArray        100  thrpt   3   37687667.146 ±   649284.080  ops/s
ArrayCompressionSuite.serializeNormalIntArray            100  thrpt   3   30217468.757 ± 10126179.430  ops/s

ArrayCompressionSuite.serializeCompressedIntArray       1000  thrpt   3   11754790.584 ±  6487913.872  ops/s
ArrayCompressionSuite.serializeNormalIntArray           1000  thrpt   3   11455357.054 ±  1020061.625  ops/s

ArrayCompressionSuite.serializeCompressedIntArray      10000  thrpt   3    1214061.700 ±   438135.395  ops/s
ArrayCompressionSuite.serializeNormalIntArray          10000  thrpt   3    1149324.112 ±    64148.031  ops/s

ArrayCompressionSuite.serializeCompressedIntArray     100000  thrpt   3     130141.077 ±    51758.369  ops/s
ArrayCompressionSuite.serializeNormalIntArray         100000  thrpt   3     125215.129 ±    21495.372  ops/s

ArrayCompressionSuite.serializeCompressedIntArray    1000000  thrpt   3       8399.914 ±     1440.360  ops/s
ArrayCompressionSuite.serializeNormalIntArray        1000000  thrpt   3      10310.840 ±    18645.102  ops/s

ArrayCompressionSuite.serializeCompressedIntArray   10000000  thrpt   3        753.918 ±       97.084  ops/s
ArrayCompressionSuite.serializeNormalIntArray       10000000  thrpt   3        764.189 ±       79.020  ops/s

ArrayCompressionSuite.serializeCompressedLongArray        100  thrpt   3   39784594.200 ±  2699436.390  ops/s
ArrayCompressionSuite.serializeNormalLongArray            100  thrpt   3   40270803.004 ±   864536.346  ops/s

ArrayCompressionSuite.serializeCompressedLongArray       1000  thrpt   3    6477672.225 ±   686396.963  ops/s
ArrayCompressionSuite.serializeNormalLongArray           1000  thrpt   3    6545549.418 ±  1019871.296  ops/s

ArrayCompressionSuite.serializeCompressedLongArray      10000  thrpt   3     617183.974 ±    55659.620  ops/s
ArrayCompressionSuite.serializeNormalLongArray          10000  thrpt   3     635196.999 ±   149026.050  ops/s

ArrayCompressionSuite.serializeCompressedLongArray     100000  thrpt   3      53462.482 ±    35638.133  ops/s
ArrayCompressionSuite.serializeNormalLongArray         100000  thrpt   3      52004.432 ±    23252.382  ops/s

ArrayCompressionSuite.serializeCompressedLongArray    1000000  thrpt   3       6026.037 ±    16709.968  ops/s
ArrayCompressionSuite.serializeNormalLongArray        1000000  thrpt   3       5552.551 ±      466.382  ops/s

ArrayCompressionSuite.serializeCompressedLongArray   10000000  thrpt   3        429.205 ±      105.545  ops/s
ArrayCompressionSuite.serializeNormalLongArray       10000000  thrpt   3        429.779 ±       45.038  ops/s
```

```
Benchmark                                                    (arraySize)   Mode  Cnt          Score          Error  Units
# determine compression type
ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD           100  thrpt    3  466402307.389 ±  2555334.745  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar              100  thrpt    3   26427884.309 ±   962450.255  ops/s

ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD          1000  thrpt    3  466744123.120 ± 12228234.474  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar             1000  thrpt    3    2757905.535 ±     6773.933  ops/s

ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD         10000  thrpt    3  467446373.509 ±  2354677.669  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar            10000  thrpt    3     281539.120 ±    32260.205  ops/s

ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD        100000  thrpt    3  467496144.240 ±  5141955.783  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar           100000  thrpt    3      28332.792 ±     1172.081  ops/s

ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD       1000000  thrpt    3  457251328.679 ± 67039627.791  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar          1000000  thrpt    3       2814.572 ±       83.414  ops/s

ArrayCompressionSuite.determineIntArrayCompressionTypeSIMD      10000000  thrpt    3  465654341.115 ± 15778486.010  ops/s
ArrayCompressionSuite.determineIntCompressionTypeScalar         10000000  thrpt    3        280.622 ±        4.857  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD          100  thrpt    3  473362303.009 ± 19310541.495  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar             100  thrpt    3   28186064.314 ±   504616.686  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD         1000  thrpt    3  467564131.215 ± 76322855.052  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar            1000  thrpt    3    2918411.197 ±    44589.191  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD        10000  thrpt    3  472648299.254 ± 21619910.950  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar           10000  thrpt    3     300527.267 ±      956.579  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD       100000  thrpt    3  473998295.136 ± 11659405.795  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar          100000  thrpt    3      30140.257 ±       25.836  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD      1000000  thrpt    3  474356048.064 ± 28979532.447  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar         1000000  thrpt    3       2972.073 ±       66.983  ops/s

ArrayCompressionSuite.determineLongArrayCompressionTypeSIMD     10000000  thrpt    3  471544347.771 ± 99677479.793  ops/s
ArrayCompressionSuite.determineLongCompressionTypeScalar        10000000  thrpt    3        298.815 ±        0.287  ops/s
```