### PR TITLE
fix(java): Encoders.mapEncoder(TypeRef, TypeRef, TypeRef, Fory) should load bean classes

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -474,7 +474,7 @@ public class Encoders {
     TypeRef<?> keyToken = token4BeanLoad(set1, tuple2.f0);
     TypeRef<?> valToken = token4BeanLoad(set2, tuple2.f1);
 
-    MapEncoder<T> encoder = mapEncoder(token, keyToken, valToken, fory);
+    MapEncoder<T> encoder = mapEncoder0(token, keyToken, valToken, fory);
     return createMapEncoder(encoder);
   }
 
@@ -490,6 +490,22 @@ public class Encoders {
    * java bean.
    */
   public static <T extends Map, K, V> MapEncoder<T> mapEncoder(
+      TypeRef<? extends Map> mapToken, TypeRef<K> keyToken, TypeRef<V> valToken, Fory fory) {
+    Preconditions.checkNotNull(mapToken);
+    Preconditions.checkNotNull(keyToken);
+    Preconditions.checkNotNull(valToken);
+
+    Set<TypeRef<?>> set1 = beanSet(keyToken);
+    Set<TypeRef<?>> set2 = beanSet(valToken);
+    LOG.info("Find beans to load: {}, {}", set1, set2);
+
+    token4BeanLoad(set1, keyToken);
+    token4BeanLoad(set2, valToken);
+
+    return mapEncoder0(mapToken, keyToken, valToken, fory);
+  }
+
+  private static <T extends Map, K, V> MapEncoder<T> mapEncoder0(
       TypeRef<? extends Map> mapToken, TypeRef<K> keyToken, TypeRef<V> valToken, Fory fory) {
     Preconditions.checkNotNull(mapToken);
     Preconditions.checkNotNull(keyToken);
@@ -685,6 +701,9 @@ public class Encoders {
         TypeUtils.listBeansRecursiveInclusive(
             beanClass,
             new TypeResolutionContext(CustomTypeEncoderRegistry.customTypeHandler(), true));
+    if (classes.isEmpty()) {
+      return null;
+    }
     LOG.info("Create RowCodec for classes {}", classes);
     CompileUnit[] compileUnits =
         classes.stream()

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/MapEncoderTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/MapEncoderTest.java
@@ -134,9 +134,9 @@ public class MapEncoderTest {
   @Test
   public void testKVStructMap() {
     Map<SimpleFoo, SimpleFoo> map = ImmutableMap.of(SimpleFoo.create(), SimpleFoo.create());
-    MapEncoder encoder = Encoders.mapEncoder(new TypeRef<Map<SimpleFoo, SimpleFoo>>() {});
+    var encoder = Encoders.mapEncoder(new TypeRef<Map<SimpleFoo, SimpleFoo>>() {});
     testStreamingEncode(encoder, map);
-    MapEncoder encoder1 = Encoders.mapEncoder(new TypeRef<Map<Foo, Foo>>() {});
+    var encoder1 = Encoders.mapEncoder(new TypeRef<Map<Foo, Foo>>() {});
     testStreamingEncode(encoder1, ImmutableMap.of(Foo.create(), Foo.create()));
   }
 
@@ -191,5 +191,19 @@ public class MapEncoderTest {
     Assert.assertEquals(decodeMap.size(), 10);
 
     testStreamingEncode(encoder, lmap);
+  }
+
+  @Test
+  public <K, V> void testDynamicTypeDeclaration() {
+    Encoders.mapEncoder(
+            new TypeRef<HashMap<Integer, Bean>>() {},
+            TypeRef.of(Integer.class),
+            TypeRef.of(Bean.class),
+            null)
+        .encode(new HashMap<>());
+  }
+
+  public static class Bean {
+    int f1;
   }
 }


### PR DESCRIPTION
We dynamically select the key and value type, and tried using this overload of Encoders.mapEncoder
With the single-arg mapEncoder invocation, bean codec classes are loaded with `token4BeanLoad`
    
But this overload never loads the bean classes leading to unexpected exceptions during Map codec compile since bean codecs are not loaded