### PR TITLE
fix(java): row format generated bean types handling Optional

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/TypeUtils.java
@@ -656,6 +656,17 @@ public class TypeUtils {
     }
   }
 
+  /**
+   * Check if a class is one of {@link Optional), {@link OptionalInt},
+   * {@link OptionaLong}, or {@link OptionalDouble}.
+   */
+  public static boolean isOptionalType(Class<?> type) {
+    return type == Optional.class
+        || type == OptionalInt.class
+        || type == OptionalLong.class
+        || type == OptionalDouble.class;
+  }
+
   private static boolean isSynthesizableInterface(Class<?> cls) {
     return cls.isInterface()
         && !Collection.class.isAssignableFrom(cls)

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/RowEncoderBuilder.java
@@ -285,10 +285,7 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
 
   private static Expression nullValue(TypeRef<?> fieldType) {
     Class<?> rawType = fieldType.getRawType();
-    if (rawType == Optional.class
-        || rawType == OptionalInt.class
-        || rawType == OptionalLong.class
-        || rawType == OptionalDouble.class) {
+    if (TypeUtils.isOptionalType(rawType)) {
       return new Expression.StaticInvoke(rawType, "empty", "", fieldType, false, true);
     }
     return new Expression.Reference(TypeUtils.defaultValue(rawType), fieldType);
@@ -361,7 +358,7 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
         Expression storeValue =
             new Expression.SetField(new Expression.Reference("this"), fieldName, decodeValue);
         Expression shouldLoad;
-        if (rawFieldType == Optional.class) {
+        if (TypeUtils.isOptionalType(rawFieldType)) {
           shouldLoad =
               new Expression.Not(
                   Expression.Invoke.inlineInvoke(fieldRef, "isPresent", TypeUtils.BOOLEAN_TYPE));

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
@@ -22,7 +22,11 @@ package org.apache.fory.format.encoder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.TreeSet;
+
 import lombok.Data;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.fory.annotation.ForyField;
@@ -141,41 +145,98 @@ public class ImplementInterfaceTest {
 
   public interface OptionalType {
     Optional<String> f1();
+    OptionalInt f2();
+    OptionalLong f3();
+    OptionalDouble f4();
   }
 
   static class OptionalTypeImpl implements OptionalType {
-    private final Optional<String> f1;
-
-    OptionalTypeImpl(final Optional<String> f1) {
-      this.f1 = f1;
-    }
+    Optional<String> f1;
+    OptionalInt f2;
+    OptionalLong f3;
+    OptionalDouble f4;
 
     @Override
     public Optional<String> f1() {
       return f1;
     }
+
+    @Override
+    public OptionalInt f2() {
+        return f2;
+    }
+
+    @Override
+    public OptionalLong f3() {
+        return f3;
+    }
+
+    @Override
+    public OptionalDouble f4() {
+        return f4;
+    }
   }
 
   @Test
   public void testNullOptional() {
-    final OptionalType bean1 = new OptionalTypeImpl(null);
+    final OptionalType bean1 = new OptionalTypeImpl();
     final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
     final BinaryRow row = encoder.toRow(bean1);
     final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
     row.pointTo(buffer, 0, buffer.size());
     final OptionalType deserializedBean = encoder.fromRow(row);
     Assert.assertEquals(deserializedBean.f1(), Optional.empty());
+    Assert.assertEquals(deserializedBean.f2(), OptionalInt.empty());
+    Assert.assertEquals(deserializedBean.f3(), OptionalLong.empty());
+    Assert.assertEquals(deserializedBean.f4(), OptionalDouble.empty());
   }
 
   @Test
   public void testPresentOptional() {
-    final OptionalType bean1 = new OptionalTypeImpl(Optional.of("42"));
+    final OptionalTypeImpl bean1 = new OptionalTypeImpl();
+    bean1.f1 = Optional.of("42");
     final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
     final BinaryRow row = encoder.toRow(bean1);
     final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
     row.pointTo(buffer, 0, buffer.size());
     final OptionalType deserializedBean = encoder.fromRow(row);
     Assert.assertEquals(deserializedBean.f1(), Optional.of("42"));
+  }
+
+  @Test
+  public void testPresentOptionalInteger() {
+    final OptionalTypeImpl bean1 = new OptionalTypeImpl();
+    bean1.f2 = OptionalInt.of(42);
+    final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OptionalType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f2(), OptionalInt.of(42));
+  }
+
+  @Test
+  public void testPresentOptionalLong() {
+    final OptionalTypeImpl bean1 = new OptionalTypeImpl();
+    bean1.f3 = OptionalLong.of(42);
+    final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OptionalType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f3(), OptionalLong.of(42));
+  }
+
+  @Test
+  public void testPresentOptionalDouble() {
+    final OptionalTypeImpl bean1 = new OptionalTypeImpl();
+    bean1.f4 = OptionalDouble.of(42.42);
+    final RowEncoder<OptionalType> encoder = Encoders.bean(OptionalType.class);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final OptionalType deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f4(), OptionalDouble.of(42.42));
   }
 
   public static class Id<T> {


### PR DESCRIPTION
Incorrect check leads to losing OptionalInt, OptionalLong, and OptionalDouble values with generated bean implementation
