### PR TITLE
docs: Improve pyfory PyPI documentation

### DIFF
--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Apache Fory Python
+
+This document provides instructions for building and testing the `pyfory` package.
+
+## Building
+
+```bash
+cd python
+# Uninstall numpy first so that when we install pyarrow, it will install the correct numpy version automatically.
+# For Python versions less than 3.13, numpy 2 is not currently supported.
+pip uninstall -y numpy
+# Install necessary environment for Python < 3.13.
+pip install pyarrow==15.0.0 Cython wheel pytest
+# For Python 3.13, pyarrow 18.0.0 is available and requires numpy version greater than 2.
+# pip install pyarrow==18.0.0 Cython wheel pytest
+pip install -v -e .
+```
+
+If the last steps fails with an error like `libarrow_python.dylib: No such file or directory`,
+you are probably suffering from bazel's aggressive caching; the sought library is longer at the
+temporary directory it was the last time bazel ran. To remedy this run
+
+> bazel clean --expunge
+
+In this situation, you might also find it fruitful to run bazel yourself before pip:
+
+> bazel build -s //:cp_fory_so
+
+### Environment Requirements
+
+- python 3.8+
+
+## Testing
+
+```bash
+cd python
+pytest -v -s .
+```
+
+## Formatting
+
+```bash
+cd python
+pip install ruff
+ruff format python
+```
+
+## Debugging
+
+```bash
+cd python
+python setup.py develop
+```
+
+- Use `cython --cplus -a  pyfory/_serialization.pyx` to produce an annotated HTML file of the source code. Then you can
+  analyze interaction between Python objects and Python's C API.
+- Read more: <https://cython.readthedocs.io/en/latest/src/userguide/debugging.html>
+
+```bash
+FORY_DEBUG=true python setup.py build_ext --inplace
+# For linux
+cygdb build
+```
+
+### Debugging with lldb
+
+```bash
+lldb
+(lldb) target create -- python
+(lldb) settings set -- target.run-args "-c" "from pyfory.tests.test_serializer import test_enum; test_enum()"
+(lldb) run
+(lldb) bt
+```

--- a/python/README.md
+++ b/python/README.md
@@ -1,73 +1,104 @@
 # Apache Fory™ Python
 
-Fory is a blazingly-fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
+[![Build Status](https://img.shields.io/github/actions/workflow/status/apache/fory/ci.yml?branch=main&style=for-the-badge&label=GITHUB%20ACTIONS&logo=github)](https://github.com/apache/fory/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/pyfory.svg?logo=PyPI)](https://pypi.org/project/pyfory/)
+[![Slack Channel](https://img.shields.io/badge/slack-join-3f0e40?logo=slack&style=for-the-badge)](https://join.slack.com/t/fory-project/shared_invite/zt-36g0qouzm-kcQSvV_dtfbtBKHRwT5gsw)
+[![X](https://img.shields.io/badge/@ApacheFory-follow-blue?logo=x&style=for-the-badge)](https://x.com/ApacheFory)
 
-## Build Fory Python
+**Apache Fory** (formerly _Fury_) is a blazing fast multi-language serialization framework powered by **JIT** (just-in-time compilation) and **zero-copy**, providing up to 170x performance and ease of use.
 
-```bash
-cd python
-# Uninstall numpy first so that when we install pyarrow, it will install the correct numpy version automatically.
-# For Python versions less than 3.13, numpy 2 is not currently supported.
-pip uninstall -y numpy
-# Install necessary environment for Python < 3.13.
-pip install pyarrow==15.0.0 Cython wheel pytest
-# For Python 3.13, pyarrow 18.0.0 is available and requires numpy version greater than 2.
-# pip install pyarrow==18.0.0 Cython wheel pytest
-pip install -v -e .
-```
+This package provides the Python bindings for Apache Fory.
 
-If the last steps fails with an error like `libarrow_python.dylib: No such file or directory`,
-you are probably suffering from bazel's aggressive caching; the sought library is longer at the
-temporary directory it was the last time bazel ran. To remedy this run
+## Installation
 
-> bazel clean --expunge
-
-In this situation, you might also find it fruitful to run bazel yourself before pip:
-
-> bazel build -s //:cp_fory_so
-
-### Environment Requirements
-
-- python 3.8+
-
-## Testing
+You can install `pyfory` using pip:
 
 ```bash
-cd python
-pytest -v -s .
+pip install pyfory
 ```
 
-## Code Style
+## Quickstart
 
-```bash
-cd python
-pip install ruff
-ruff format python
+Here are a few examples of how to use `pyfory` for serialization.
+
+### Basic Serialization
+
+This example shows how to serialize and deserialize a simple Python object.
+
+```python
+from typing import Dict
+import pyfory
+
+class SomeClass:
+    f1: "SomeClass"
+    f2: Dict[str, str]
+    f3: Dict[str, str]
+
+fory = pyfory.Fory(ref_tracking=True)
+fory.register_type(SomeClass, typename="example.SomeClass")
+obj = SomeClass()
+obj.f2 = {"k1": "v1", "k2": "v2"}
+obj.f1, obj.f3 = obj, obj.f2
+data = fory.serialize(obj)
+# bytes can be data serialized by other languages.
+print(fory.deserialize(data))
 ```
 
-## Debug
+### Cross-language Serialization
 
-```bash
-cd python
-python setup.py develop
+Fory excels at cross-language serialization. You can serialize data in Python and deserialize it in another language like Java or Go, and vice-versa.
+
+Here's an example of how to serialize an object in Python and deserialize it in Java:
+
+**Python**
+
+```python
+from typing import Dict
+import pyfory
+
+class SomeClass:
+    f1: "SomeClass"
+    f2: Dict[str, str]
+    f3: Dict[str, str]
+
+fory = pyfory.Fory(ref_tracking=True)
+fory.register_type(SomeClass, typename="example.SomeClass")
+obj = SomeClass()
+obj.f2 = {"k1": "v1", "k2": "v2"}
+obj.f1, obj.f3 = obj, obj.f2
+data = fory.serialize(obj)
+# `data` can now be sent to a Java application
 ```
 
-- Use `cython --cplus -a  pyfory/_serialization.pyx` to produce an annotated HTML file of the source code. Then you can
-  analyze interaction between Python objects and Python's C API.
-- Read more: <https://cython.readthedocs.io/en/latest/src/userguide/debugging.html>
+**Java**
 
-```bash
-FORY_DEBUG=true python setup.py build_ext --inplace
-# For linux
-cygdb build
+```java
+import org.apache.fory.*;
+import org.apache.fory.config.*;
+import java.util.*;
+
+public class ReferenceExample {
+  public static class SomeClass {
+    SomeClass f1;
+    Map<String, String> f2;
+    Map<String, String> f3;
+  }
+
+  public static void main(String[] args) {
+    Fory fory = Fory.builder().withLanguage(Language.XLANG)
+      .withRefTracking(true).build();
+    fory.register(SomeClass.class, "example.SomeClass");
+    // `bytes` would be the data received from the Python application
+    byte[] bytes = ...
+    System.out.println(fory.deserialize(bytes));
+  }
+}
 ```
 
-## Debug with lldb
+## Useful Links
 
-```bash
-lldb
-(lldb) target create -- python
-(lldb) settings set -- target.run-args "-c" "from pyfory.tests.test_serializer import test_enum; test_enum()"
-(lldb) run
-(lldb) bt
-```
+- **[Project Website](https://fory.apache.org)**
+- **[Documentation](https://fory.apache.org/docs/latest/python_guide/)**
+- **[GitHub Repository](https://github.com/apache/fory)**
+- **[Issue Tracker](https://github.com/apache/fory/issues)**
+- **[Slack Channel](https://join.slack.com/t/fory-project/shared_invite/zt-36g0qouzm-kcQSvV_dtfbtBKHRwT5gsw)**


### PR DESCRIPTION
## What does this PR do?

The existing PyPI documentation for `pyfory` was a single line and uninformative. This change improves the documentation by:

1.  Creating a new `python/README.md` with a clear and concise description of the project, installation instructions, and usage examples. This file is used to generate the PyPI page description.
2.  Moving the developer-focused build and test instructions to a new `python/CONTRIBUTING.md` file.

This will provide a much better experience for Python developers who discover `pyfory` on PyPI, similar to the documentation for other popular libraries like `opendal` and `msgpack`.

## Related issues

Closes #2488 