### PR TITLE
fix: Fix the issue of addListener not releasing the lock

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
@@ -237,8 +237,9 @@ public class AllowListChecker implements ClassChecker {
   public void addListener(ClassResolver classResolver) {
     try {
       lock.writeLock().lock();
-    } finally {
       listeners.put(classResolver, true);
+    } finally {
+        lock.writeLock().unlock();
     }
   }
 


### PR DESCRIPTION
addListener doesn't  release the lock, which cause it hang for serialization