### PR TITLE
ci: Fix Windows wheel creation

### DIFF
--- a/.github/workflows/build-native-release.yml
+++ b/.github/workflows/build-native-release.yml
@@ -42,6 +42,7 @@ jobs:
         run: ./ci/run_ci.sh install_bazel_windows
         shell: bash
       - name: Build wheel
+        shell: bash
         run: ./ci/deploy.sh build_pyfory
       - name: Install and verify wheel
         shell: bash

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  actions: read  # for accessing workflow run artifacts
 
 jobs:
   publish-wheels:
@@ -35,7 +36,10 @@ jobs:
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v5
         with:
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: "pyfory-wheels-*"
           path: downloaded_wheels
+          merge-multiple: true
 
       - name: Move wheels to a single directory
         shell: bash


### PR DESCRIPTION
## Why?

* Wheels were not created on Windows because it does not use bash by default
* Once that works, downloading them will fail because `actions/download-artifact` requires the `run-id` to access artifacts from different workflows.

## What does this PR do?

* Add `actions: read` permission to release workflow.
* Configure `download-artifact` action to use `run-id` and `pattern` for downloading wheels from a previous workflow run.
* Enable `merge-multiple` for downloading artifacts.
* Add `shell: bash` to build step in native release workflow.


## Related issues

#2506 