### PR TITLE
ci: Pass the GH token to actions/download-artifact

### DIFF
--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "pyfory-wheels-*"
           path: downloaded_wheels
           merge-multiple: true


### PR DESCRIPTION
## Why?

`actions/download-artifact` is [failing to find artifacts](https://github.com/apache/fory/actions/runs/17198889531/job/48785824375) despite [artifacts being created](https://github.com/apache/fory/actions/runs/17198794761).

## What does this PR do?

Pass the github token so the action can find artifacts from other workflow runs (ours are separate).