### PR TITLE
fix(java): MemoryBuffer tests that equalTo works with size zero buffers

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -2568,9 +2568,12 @@ public final class MemoryBuffer {
    * @param offset1 Offset of this buffer to start equaling
    * @param offset2 Offset of buf2 to start equaling
    * @param len Length of the equaled memory region
-   * @return true if equal, false otherwise
+   * @return true if buffers equal or len zero, false otherwise
    */
   public boolean equalTo(MemoryBuffer buf2, int offset1, int offset2, int len) {
+    if (len == 0) {
+      return buf2 != null;
+    }
     final long pos1 = address + offset1;
     final long pos2 = buf2.address + offset2;
     checkArgument(pos1 < addressLimit);

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -219,6 +219,13 @@ public class MemoryBufferTest {
   }
 
   @Test
+  public void testEqualToZeroSize() {
+    MemoryBuffer buf1 = MemoryUtils.buffer(0);
+    MemoryBuffer buf2 = MemoryUtils.buffer(0);
+    Assert.assertTrue(buf1.equalTo(buf2, 0, 0, buf1.size()));
+  }
+
+  @Test
   public void testWritePrimitiveArrayWithSizeEmbedded() {
     MemoryBuffer buf = MemoryUtils.buffer(16);
     Random random = new Random(0);

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
@@ -145,8 +145,11 @@ public class ImplementInterfaceTest {
 
   public interface OptionalType {
     Optional<String> f1();
+
     OptionalInt f2();
+
     OptionalLong f3();
+
     OptionalDouble f4();
   }
 
@@ -163,17 +166,17 @@ public class ImplementInterfaceTest {
 
     @Override
     public OptionalInt f2() {
-        return f2;
+      return f2;
     }
 
     @Override
     public OptionalLong f3() {
-        return f3;
+      return f3;
     }
 
     @Override
     public OptionalDouble f4() {
-        return f4;
+      return f4;
     }
   }
 


### PR DESCRIPTION
Current implementation throws IAE for size zero buffers