### PR TITLE
fix(java): array encoder seems to waste 8 bytes in encode(T)

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -411,7 +411,7 @@ public class Encoders {
         @Override
         public byte[] encode(T obj) {
           BinaryArray array = toArray(obj);
-          return writer.getBuffer().getBytes(0, 8 + array.getSizeInBytes());
+          return writer.getBuffer().getBytes(0, array.getSizeInBytes());
         }
 
         @Override

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ArrayEncoderTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ArrayEncoderTest.java
@@ -53,7 +53,7 @@ public class ArrayEncoderTest {
     byte[] bs = encoder.encode(bars);
     List<RowEncoderTest.Bar> bbars = encoder.decode(bs);
 
-    Assert.assertEquals(bs.length, 224);
+    Assert.assertEquals(bs.length, 216);
     Assert.assertEquals(bars, bbars);
 
     testStreamingEncode(encoder, bars);
@@ -87,7 +87,7 @@ public class ArrayEncoderTest {
     byte[] bs = encoder.encode(bars);
     List<List<List<RowEncoderTest.Bar>>> bbars = encoder.decode(bs);
 
-    Assert.assertEquals(bs.length, 1576);
+    Assert.assertEquals(bs.length, 1568);
     Assert.assertEquals(bars, bbars);
 
     testStreamingEncode(encoder, bars);
@@ -121,7 +121,7 @@ public class ArrayEncoderTest {
     byte[] bs = encoder.encode(lmap);
     List<List<Map<RowEncoderTest.Foo, List<RowEncoderTest.Bar>>>> blmap = encoder.decode(bs);
 
-    Assert.assertEquals(bs.length, 10824);
+    Assert.assertEquals(bs.length, 10816);
     Assert.assertEquals(lmap, blmap);
 
     testStreamingEncode(encoder, lmap);


### PR DESCRIPTION
the bytes at the end are always 0. are these bytes necessary?
