### PR TITLE
fix(ci): Install pyfory for golang xlang tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,9 @@ jobs:
       - name: Install bazel
         run: python ./ci/run_ci.py cpp --install-deps-only
       - name: Install python dependencies
-        run: pip install pyarrow==15.0.0 Cython wheel pytest setuptools -U
+        run: pip install pyarrow==15.0.0 cython wheel pytest setuptools -U
+      - name: Install pyfory
+        run: pip install -e python/
       - name: Run Golang CI
         run: python ./ci/run_ci.py go
 


### PR DESCRIPTION
## Why?

Golang xlang tests are failing because pyfory is not installed

## What does this PR do?

* Add step to install the pyfory package in the CI workflow.
* Ensure pyarrow, cython, wheel, pytest, and setuptools are up-to-date.

## Related issues

Fixes #2555 