### PR TITLE
fix(java): Skip calculation of classVersionHash if checkClassVersion is false

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
@@ -103,7 +103,9 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
     DescriptorGrouper grouper = fory(f -> f.getClassResolver().createDescriptorGrouper(p, false));
     descriptors = grouper.getSortedDescriptors();
     classVersionHash =
-        new Literal(ObjectSerializer.computeStructHash(fory, descriptors), PRIMITIVE_INT_TYPE);
+        fory.checkClassVersion()
+            ? new Literal(ObjectSerializer.computeStructHash(fory, descriptors), PRIMITIVE_INT_TYPE)
+            : null;
     objectCodecOptimizer =
         new ObjectCodecOptimizer(beanClass, grouper, !fory.isBasicTypesRefIgnored(), ctx);
     if (isRecord) {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fory.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Fory has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

Calculating the `classVersionHash` can be quite expensive and can currently have side-effects. This PR implements a simple optimization that skips the calculation entirely if `fory.checkClassVersion() == false`.

See https://github.com/apache/fory/issues/2559

<!-- Describe the purpose of this PR. -->

## What does this PR do?

<!-- Describe the details of this PR. -->

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
