### PR TITLE
feat(java): bean encoder implemented interfaces honor `@Ignore`

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Ignore.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Ignore.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Ignore fields just like transient. */
+/** Ignore properties just like transient. */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Ignore {}

--- a/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
@@ -462,7 +462,8 @@ public class Descriptor {
       for (Method method : clazz.getMethods()) {
         if (method.getParameterCount() == 0
             && method.getReturnType() != void.class
-            && !Modifier.isStatic(method.getModifiers())) {
+            && !Modifier.isStatic(method.getModifiers())
+            && !method.isAnnotationPresent(Ignore.class)) {
           descriptorMap.put(method, new Descriptor(method));
         }
       }

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/ImplementInterfaceTest.java
@@ -29,6 +29,7 @@ import java.util.TreeSet;
 import lombok.Data;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.fory.annotation.ForyField;
+import org.apache.fory.annotation.Ignore;
 import org.apache.fory.format.row.binary.BinaryArray;
 import org.apache.fory.format.row.binary.BinaryRow;
 import org.apache.fory.format.type.DataTypes;
@@ -438,5 +439,62 @@ public class ImplementInterfaceTest {
     final ListLazyElemOuter deserializedBean = encoder.fromRow(row);
     Assert.assertEquals(deserializedBean.f1().get(2).f1(), 42);
     Assert.assertEquals(deserializedBean.f1().get(3), null);
+  }
+
+  public interface IgnoredMethods {
+    int f1();
+
+    @Ignore
+    default int doubled() {
+      return doubled(f1());
+    }
+
+    IgnoredMethods withF1(int f1);
+
+    private int doubled(final int n) {
+      return n * 2;
+    }
+  }
+
+  static class IgnoredMethodsImpl implements IgnoredMethods {
+    private final int f1;
+
+    IgnoredMethodsImpl(final int f1) {
+      this.f1 = f1;
+    }
+
+    @Override
+    public int f1() {
+      return f1;
+    }
+
+    @Override
+    public int doubled() {
+      return f1() * 3;
+    }
+
+    @Override
+    public IgnoredMethods withF1(final int f1) {
+      return new IgnoredMethodsImpl(f1);
+    }
+  }
+
+  @Test
+  public void testIgnoredMethods() {
+    final IgnoredMethods bean1 = new IgnoredMethodsImpl(2112);
+    final RowEncoder<IgnoredMethods> encoder = Encoders.bean(IgnoredMethods.class);
+    Assert.assertEquals(encoder.schema().getFields().size(), 1);
+    final BinaryRow row = encoder.toRow(bean1);
+    final MemoryBuffer buffer = MemoryUtils.wrap(row.toBytes());
+    row.pointTo(buffer, 0, buffer.size());
+    final IgnoredMethods deserializedBean = encoder.fromRow(row);
+    Assert.assertEquals(deserializedBean.f1(), 2112);
+    Assert.assertEquals(deserializedBean.doubled(), 2112 * 2);
+
+    try {
+      deserializedBean.withF1(100);
+      Assert.fail();
+    } catch (final UnsupportedOperationException expected) {
+    }
   }
 }


### PR DESCRIPTION
this allows you to mark methods as not properties, for example if you have a computed value with a `default` method
