### PR TITLE
fix(java): row format buffer recycling leaves offset and size for null values

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/row/binary/writer/BinaryRowWriter.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/row/binary/writer/BinaryRowWriter.java
@@ -128,6 +128,12 @@ public class BinaryRowWriter extends BinaryWriter {
     writeDecimal(ordinal, value, (ArrowType.Decimal) schema.getFields().get(ordinal).getType());
   }
 
+  @Override
+  public void setNullAt(int ordinal) {
+    super.setNullAt(ordinal);
+    write(ordinal, 0L);
+  }
+
   public BinaryRow getRow() {
     BinaryRow row = new BinaryRow(schema);
     int size = size();

--- a/java/fory-format/src/main/java/org/apache/fory/format/row/binary/writer/BinaryWriter.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/row/binary/writer/BinaryWriter.java
@@ -121,10 +121,10 @@ public abstract class BinaryWriter {
   }
 
   /**
-   * Since writer is used for one-pass writer, same field won't be writer twice. There is no need to
-   * put zero into the corresponding field when set null.
+   * Writer might recycle buffers, so implementations should clear data from a previous not-null
+   * write when setting null to avoid information leaks.
    */
-  public final void setNullAt(int ordinal) {
+  public void setNullAt(int ordinal) {
     BitUtils.set(buffer, startIndex + bytesBeforeBitMap, ordinal);
   }
 

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/RowEncoderTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/RowEncoderTest.java
@@ -118,4 +118,21 @@ public class RowEncoderTest {
     Assert.assertEquals(s1.f1, s.f1);
     Assert.assertEquals(s1.f2, s.f2);
   }
+
+  @Test
+  public void testNullClearOffset() {
+    RowEncoder<Bar> encoder = Encoders.bean(Bar.class);
+    Bar bar = new Bar();
+    bar.f1 = 42;
+    bar.f2 = null;
+    byte[] nullBefore = encoder.encode(bar);
+
+    bar.f2 = "not null";
+    // write offset and size
+    encoder.encode(bar);
+
+    bar.f2 = null;
+    byte[] nullAfter = encoder.encode(bar);
+    Assert.assertEquals(nullAfter, nullBefore);
+  }
 }


### PR DESCRIPTION


## Why?

<!-- Describe the purpose of this PR. -->

## What does this PR do?

<!-- Describe the details of this PR. -->

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
