### PR TITLE
feat(python): meta share mode for pyfory compatible serialization

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -125,11 +125,11 @@ format_files() {
 
 format_all_scripts() {
     echo "$(date)" "Ruff format...."
-    git ls-files -- '*.py' '*.pyx' '*.pxd' '*.pxi' "${GIT_LS_EXCLUDES[@]}" | xargs -P 10 \
+    git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs -P 10 \
       ruff format
 
     echo "$(date)" "Ruff check...."
-    git ls-files -- '*.py' '*.pyx' '*.pxd' '*.pxi' "${GIT_LS_EXCLUDES[@]}" | xargs \
+    git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs \
       ruff check --fix
 }
 
@@ -193,10 +193,10 @@ format_changed() {
     # exist on both branches.
     MERGEBASE="$(git merge-base origin/main HEAD)"
 
-    if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.py' '*.pyx' '*.pxd' '*.pxi' &>/dev/null; then
-        git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' '*.pyx' '*.pxd' '*.pxi' | xargs -P 5 \
+    if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.py' &>/dev/null; then
+        git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' | xargs -P 5 \
             ruff format
-        git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' '*.pyx' '*.pxd' '*.pxi' | xargs -P 5 \
+        git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.py' | xargs -P 5 \
             ruff check --fix
     fi
 

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -98,7 +98,7 @@ class Fory:
     __slots__ = (
         "language",
         "is_py",
-        "compatbile",
+        "compatible",
         "ref_tracking",
         "ref_resolver",
         "type_resolver",
@@ -120,7 +120,7 @@ class Fory:
         language=Language.PYTHON,
         ref_tracking: bool = False,
         require_type_registration: bool = True,
-        compatbile: bool = False,
+        compatible: bool = False,
     ):
         """
         :param require_type_registration:
@@ -131,14 +131,14 @@ class Fory:
           Do not disable type registration if you can't ensure your environment are
           *indeed secure*. We are not responsible for security risks if
           you disable this option.
-        :param compatbile:
-         Whether to enable compatbile mode for cross-language serialization.
+        :param compatible:
+         Whether to enable compatible mode for cross-language serialization.
          When enabled, type forward/backward compatibility for struct fields will be enabled.
         """
         self.language = language
         self.is_py = language == Language.PYTHON
         self.require_type_registration = _ENABLE_TYPE_REGISTRATION_FORCIBLY or require_type_registration
-        self.compatbile = compatbile
+        self.compatible = compatible
         self.ref_tracking = ref_tracking
         if self.ref_tracking:
             self.ref_resolver = MapRefResolver()
@@ -148,11 +148,11 @@ class Fory:
         from pyfory._registry import TypeResolver
 
         self.metastring_resolver = MetaStringResolver()
-        self.type_resolver = TypeResolver(self, meta_share=compatbile)
+        self.type_resolver = TypeResolver(self, meta_share=compatible)
         self.type_resolver.initialize()
         from pyfory._serialization import SerializationContext
 
-        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatbile)
+        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatible)
         self.buffer = Buffer.allocate(32)
         if not require_type_registration:
             warnings.warn(

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -98,6 +98,7 @@ class Fory:
     __slots__ = (
         "language",
         "is_py",
+        "compatbile",
         "ref_tracking",
         "ref_resolver",
         "type_resolver",
@@ -113,14 +114,13 @@ class Fory:
         "_unsupported_objects",
         "_peer_language",
     )
-    serialization_context: "SerializationContext"
 
     def __init__(
         self,
         language=Language.PYTHON,
         ref_tracking: bool = False,
         require_type_registration: bool = True,
-        meta_share: bool = False,
+        compatbile: bool = False,
     ):
         """
         :param require_type_registration:
@@ -131,14 +131,14 @@ class Fory:
           Do not disable type registration if you can't ensure your environment are
           *indeed secure*. We are not responsible for security risks if
           you disable this option.
-        :param meta_share:
-         Whether to enable meta share mode for cross-language serialization.
-         When enabled, type definitions will be shared between serialization calls
-         to reduce overhead for repeated types.
+        :param compatbile:
+         Whether to enable compatbile mode for cross-language serialization.
+         When enabled, type forward/backward compatibility for struct fields will be enabled.
         """
         self.language = language
         self.is_py = language == Language.PYTHON
         self.require_type_registration = _ENABLE_TYPE_REGISTRATION_FORCIBLY or require_type_registration
+        self.compatbile = compatbile
         self.ref_tracking = ref_tracking
         if self.ref_tracking:
             self.ref_resolver = MapRefResolver()
@@ -148,10 +148,10 @@ class Fory:
         from pyfory._registry import TypeResolver
 
         self.metastring_resolver = MetaStringResolver()
-        self.type_resolver = TypeResolver(self, meta_share=meta_share)
+        self.type_resolver = TypeResolver(self, meta_share=compatbile)
         self.type_resolver.initialize()
         from pyfory._serialization import SerializationContext
-        self.serialization_context = SerializationContext(scoped_meta_share_enabled=meta_share)
+        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatbile)
         self.buffer = Buffer.allocate(32)
         if not require_type_registration:
             warnings.warn(

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -148,7 +148,7 @@ class Fory:
         from pyfory._registry import TypeResolver
 
         self.metastring_resolver = MetaStringResolver()
-        self.type_resolver = TypeResolver(self)
+        self.type_resolver = TypeResolver(self, meta_share=meta_share)
         self.type_resolver.initialize()
         from pyfory._serialization import SerializationContext
         self.serialization_context = SerializationContext(scoped_meta_share_enabled=meta_share)

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -151,6 +151,7 @@ class Fory:
         self.type_resolver = TypeResolver(self, meta_share=compatbile)
         self.type_resolver.initialize()
         from pyfory._serialization import SerializationContext
+
         self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatbile)
         self.buffer = Buffer.allocate(32)
         if not require_type_registration:
@@ -266,12 +267,12 @@ class Fory:
         if self.serialization_context.scoped_meta_share_enabled:
             type_defs_offset_pos = buffer.writer_index
             buffer.write_int32(-1)  # Reserve 4 bytes for type definitions offset
-        
+
         if self.language == Language.PYTHON:
             self.serialize_ref(buffer, obj)
         else:
             self.xserialize_ref(buffer, obj)
-        
+
         # Write type definitions at the end, similar to Java implementation
         if self.serialization_context.scoped_meta_share_enabled:
             meta_context = self.serialization_context.meta_context
@@ -280,7 +281,7 @@ class Fory:
                 current_pos = buffer.writer_index
                 buffer.put_int32(type_defs_offset_pos, current_pos - type_defs_offset_pos - 4)
                 self.type_resolver.write_type_defs(buffer)
-        
+
         self.reset_write()
         if buffer is not self.buffer:
             return buffer
@@ -391,7 +392,7 @@ class Fory:
             self._buffers = iter(buffers)
         else:
             assert buffers is None, "buffers should be null when the serialized stream is produced with buffer_callback null."
-        
+
         # Read type definitions at the start, similar to Java implementation
         if self.serialization_context.scoped_meta_share_enabled:
             relative_type_defs_offset = buffer.read_int32()
@@ -404,7 +405,7 @@ class Fory:
                 self.type_resolver.read_type_defs(buffer)
                 # Jump back to continue with object deserialization
                 buffer.reader_index = current_reader_index
-        
+
         if is_target_x_lang:
             obj = self.xdeserialize_ref(buffer)
         else:
@@ -524,8 +525,6 @@ class Fory:
     def reset(self):
         self.reset_write()
         self.reset_read()
-
-
 
 
 _ENABLE_TYPE_REGISTRATION_FORCIBLY = os.getenv("ENABLE_TYPE_REGISTRATION_FORCIBLY", "0") in {

--- a/python/pyfory/_fory.py
+++ b/python/pyfory/_fory.py
@@ -274,7 +274,7 @@ class Fory:
         
         # Write type definitions at the end, similar to Java implementation
         if self.serialization_context.scoped_meta_share_enabled:
-            meta_context = self.serialization_context.get_meta_context()
+            meta_context = self.serialization_context.meta_context
             if meta_context is not None and len(meta_context.get_writing_type_defs()) > 0:
                 # Update the offset to point to current position
                 current_pos = buffer.writer_index

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -649,12 +649,12 @@ class TypeResolver:
 
     def write_shared_type_meta(self, buffer, typeinfo):
         """Write shared type meta information."""
-        meta_context = self.fory.serialization_context.get_meta_context()
+        meta_context = self.fory.serialization_context.meta_context
         meta_context.write_typeinfo(buffer, typeinfo)
 
     def read_shared_type_meta(self, buffer):
         """Read shared type meta information."""
-        meta_context = self.fory.serialization_context.get_meta_context()
+        meta_context = self.fory.serialization_context.meta_context
         assert meta_context is not None, "Meta context must be set when meta share is enabled"
         type_id = buffer.read_varuint32()
         typeinfo = meta_context.get_read_type_info(type_id)
@@ -663,7 +663,7 @@ class TypeResolver:
 
     def write_type_defs(self, buffer):
         """Write all type definitions that need to be sent."""
-        meta_context = self.fory.serialization_context.get_meta_context()
+        meta_context = self.fory.serialization_context.meta_context
         if meta_context is None:
             return
         writing_type_defs = meta_context.get_writing_type_defs()
@@ -674,7 +674,7 @@ class TypeResolver:
         
     def read_type_defs(self, buffer):
         """Read all type definitions from the buffer."""
-        meta_context = self.fory.serialization_context.get_meta_context()
+        meta_context = self.fory.serialization_context.meta_context
         if meta_context is None:
             return
         

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -549,7 +549,7 @@ class TypeResolver:
             else:
                 serializer = PickleSerializer(self.fory, cls)
         return serializer
-    
+
     def _set_struct_typeinfo(self, typeinfo):
         assert self.meta_share, "Meta share must be enabled"
         type_def = encode_typedef(self, typeinfo.cls)
@@ -561,7 +561,7 @@ class TypeResolver:
         if typeinfo is None:
             return False
         return TypeId.is_namespaced_type(typeinfo.type_id & 0xFF)
-    
+
     def is_registered_by_id(self, cls):
         typeinfo = self._types_info.get(cls)
         if typeinfo is None:
@@ -577,7 +577,7 @@ class TypeResolver:
         typeinfo = self._types_info.get(cls)
         assert typeinfo is not None, f"{cls} not registered"
         return typeinfo.type_id
-    
+
     def _load_metabytes_to_typeinfo(self, ns_metabytes, type_metabytes):
         typeinfo = self._ns_type_to_typeinfo.get((ns_metabytes, type_metabytes))
         if typeinfo is not None:
@@ -599,12 +599,12 @@ class TypeResolver:
             return
         type_id = typeinfo.type_id
         internal_type_id = type_id & 0xFF
-        
+
         # Check if meta share is enabled first
         if self.meta_share:
             self.write_shared_type_meta(buffer, typeinfo)
             return
-            
+
         buffer.write_varuint32(type_id)
         if TypeId.is_namespaced_type(internal_type_id):
             self.metastring_resolver.write_meta_string_bytes(buffer, typeinfo.namespace_bytes)
@@ -614,7 +614,7 @@ class TypeResolver:
         # Check if meta share is enabled first
         if self.meta_share:
             return self.read_shared_type_meta(buffer)
-            
+
         type_id = buffer.read_varuint32()
         internal_type_id = type_id & 0xFF
         if TypeId.is_namespaced_type(internal_type_id):
@@ -671,13 +671,13 @@ class TypeResolver:
         for type_def in writing_type_defs:
             # Just copy the encoded bytes directly
             buffer.write_bytes(type_def.encoded)
-        
+
     def read_type_defs(self, buffer):
         """Read all type definitions from the buffer."""
         meta_context = self.fory.serialization_context.meta_context
         if meta_context is None:
             return
-        
+
         num_type_defs = buffer.read_varuint32()
         for i in range(num_type_defs):
             # Read the header (first 8 bytes) to get the type ID
@@ -696,7 +696,7 @@ class TypeResolver:
             meta_context.add_read_type_info(type_info)
 
     def _build_type_info_from_typedef(self, type_def):
-        """Build TypeInfo from TypeDef using TypeDef's create_serializer method."""        
+        """Build TypeInfo from TypeDef using TypeDef's create_serializer method."""
         # Create serializer using TypeDef's create_serializer method
         serializer = type_def.create_serializer(self)
         ns_metastr = self.namespace_encoder.encode(type_def.namespace or "")

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -480,6 +480,8 @@ class TypeResolver:
             raise TypeUnregisteredError(f"{cls} not registered")
         logger.info("Type %s not registered", cls)
         serializer = self._create_serializer(cls)
+        if serializer is None:
+            serializer = DataClassSerializer(self.fory, cls, xlang=not self.fory.is_py)
         type_id = None
         if self.language == Language.PYTHON:
             if isinstance(serializer, EnumSerializer):

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -86,7 +86,6 @@ from pyfory._fory import (
 from pyfory.meta.typedef import TypeDef
 from pyfory.meta.typedef_decoder import decode_typedef, skip_typedef
 from pyfory.meta.typedef_encoder import encode_typedef
-from pyfory.type import TypeId
 
 try:
     import numpy as np

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -672,8 +672,7 @@ class TypeResolver:
         buffer.write_varuint32(len(writing_type_defs))
         
         for type_def in writing_type_defs:
-            # Write type definition header (ID and size)
-            buffer.write_int64(type_def.id if hasattr(type_def, 'id') else 0)
+            # Just copy the encoded bytes directly
             buffer.write_bytes(type_def.encoded)
         
         meta_context.clear_writing_type_defs()
@@ -686,9 +685,7 @@ class TypeResolver:
         
         num_type_defs = buffer.read_varuint32()
         for i in range(num_type_defs):
-            # Read type definition header
-            type_def_id = buffer.read_int64()
-            # Read the encoded type definition
+            # Read the encoded type definition directly
             from pyfory.meta.typedef_decoder import decode_typedef
             type_def = decode_typedef(buffer, self)
             meta_context.add_read_type_def(type_def)

--- a/python/pyfory/_registry.py
+++ b/python/pyfory/_registry.py
@@ -505,7 +505,7 @@ class TypeResolver:
         )
 
     def _set_typeinfo(self, typeinfo):
-        type_id = typeinfo.type_id & 0xff
+        type_id = typeinfo.type_id & 0xFF
         if is_struct_type(type_id):
             if self.meta_share:
                 type_def = encode_typedef(self, typeinfo.cls)
@@ -515,7 +515,7 @@ class TypeResolver:
                 typeinfo.serializer = DataClassSerializer(self.fory, typeinfo.cls, xlang=not self.fory.is_py)
         else:
             typeinfo.serializer = self._create_serializer(typeinfo.cls)
-            
+
         return typeinfo
 
     def _create_serializer(self, cls):

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -768,6 +768,7 @@ cdef class Fory:
     cdef readonly c_bool ref_tracking
     cdef readonly c_bool require_type_registration
     cdef readonly c_bool is_py
+    cdef readonly c_bool compatbile
     cdef readonly MapRefResolver ref_resolver
     cdef readonly TypeResolver type_resolver
     cdef readonly MetaStringResolver metastring_resolver
@@ -786,7 +787,7 @@ cdef class Fory:
             language=Language.PYTHON,
             ref_tracking: bool = False,
             require_type_registration: bool = True,
-            meta_share: bool = False,
+            compatbile: bool = False,
     ):
         """
        :param require_type_registration:
@@ -797,23 +798,23 @@ cdef class Fory:
           Do not disable type registration if you can't ensure your environment are
           *indeed secure*. We are not responsible for security risks if
           you disable this option.
-       :param meta_share:
-        Whether to enable meta share mode for cross-language serialization.
-         When enabled, type definitions are shared across multiple serialization calls
-         to reduce overhead for repeated types.
+       :param compatbile:
+        Whether to enable compatbile mode for cross-language serialization.
+         When enabled, type forward/backward compatibility for struct fields will be enabled.
         """
         self.language = language
         if _ENABLE_TYPE_REGISTRATION_FORCIBLY or require_type_registration:
             self.require_type_registration = True
         else:
             self.require_type_registration = False
+        self.compatbile = compatbile
         self.ref_tracking = ref_tracking
         self.ref_resolver = MapRefResolver(ref_tracking)
         self.is_py = self.language == Language.PYTHON
         self.metastring_resolver = MetaStringResolver()
         self.type_resolver = TypeResolver(self)
         self.type_resolver.initialize()
-        self.serialization_context = SerializationContext(scoped_meta_share_enabled=meta_share)
+        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatbile)
         self.buffer = Buffer.allocate(32)
         if not require_type_registration:
             warnings.warn(

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -757,7 +757,7 @@ cdef class Fory:
     cdef readonly c_bool ref_tracking
     cdef readonly c_bool require_type_registration
     cdef readonly c_bool is_py
-    cdef readonly c_bool compatbile
+    cdef readonly c_bool compatible
     cdef readonly MapRefResolver ref_resolver
     cdef readonly TypeResolver type_resolver
     cdef readonly MetaStringResolver metastring_resolver
@@ -776,7 +776,7 @@ cdef class Fory:
             language=Language.PYTHON,
             ref_tracking: bool = False,
             require_type_registration: bool = True,
-            compatbile: bool = False,
+            compatible: bool = False,
     ):
         """
        :param require_type_registration:
@@ -787,8 +787,8 @@ cdef class Fory:
           Do not disable type registration if you can't ensure your environment are
           *indeed secure*. We are not responsible for security risks if
           you disable this option.
-       :param compatbile:
-        Whether to enable compatbile mode for cross-language serialization.
+       :param compatible:
+        Whether to enable compatible mode for cross-language serialization.
          When enabled, type forward/backward compatibility for struct fields will be enabled.
         """
         self.language = language
@@ -796,13 +796,13 @@ cdef class Fory:
             self.require_type_registration = True
         else:
             self.require_type_registration = False
-        self.compatbile = compatbile
+        self.compatible = compatible
         self.ref_tracking = ref_tracking
         self.ref_resolver = MapRefResolver(ref_tracking)
         self.is_py = self.language == Language.PYTHON
         self.metastring_resolver = MetaStringResolver()
-        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatbile)
-        self.type_resolver = TypeResolver(self, meta_share=compatbile)
+        self.serialization_context = SerializationContext(scoped_meta_share_enabled=compatible)
+        self.type_resolver = TypeResolver(self, meta_share=compatible)
         self.type_resolver.initialize()
         self.buffer = Buffer.allocate(32)
         if not require_type_registration:

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -525,7 +525,7 @@ cdef class TypeResolver:
             if type_info.serializer is not None:
                 return type_info
             else:
-                type_info.serializer = self._resolver._create_serializer(cls)
+                type_info.serializer = self._resolver.get_typeinfo(cls).serializer
                 return type_info
         elif not create:
             return None

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -996,11 +996,27 @@ cdef class Fory:
             set_bit(buffer, mask_index, 3)
         else:
             clear_bit(buffer, mask_index, 3)
+        # Reserve space for type definitions offset, similar to Java implementation
+        cdef int32_t type_defs_offset_pos = -1
+        if self.serialization_context.scoped_meta_share_enabled:
+            type_defs_offset_pos = buffer.writer_index
+            buffer.write_int32(-1)  # Reserve 4 bytes for type definitions offset
+        
         cdef int32_t start_offset
         if self.language == Language.PYTHON:
             self.serialize_ref(buffer, obj)
         else:
             self.xserialize_ref(buffer, obj)
+        
+        # Write type definitions at the end, similar to Java implementation
+        if self.serialization_context.scoped_meta_share_enabled:
+            meta_context = self.serialization_context.get_meta_context()
+            if meta_context is not None and len(meta_context.get_writing_type_defs()) > 0:
+                # Update the offset to point to current position
+                current_pos = buffer.writer_index
+                buffer.put_int32(type_defs_offset_pos, current_pos - type_defs_offset_pos - 4)
+                self.type_resolver.write_type_defs(buffer)
+        
         if buffer is not self.buffer:
             return buffer
         else:
@@ -1131,6 +1147,20 @@ cdef class Fory:
                 "buffers should be null when the serialized stream is "
                 "produced with buffer_callback null."
             )
+        
+        # Read type definitions at the start, similar to Java implementation
+        if self.serialization_context.scoped_meta_share_enabled:
+            relative_type_defs_offset = buffer.read_int32()
+            if relative_type_defs_offset != -1:
+                # Save current reader position
+                current_reader_index = buffer.reader_index
+                # Jump to type definitions
+                buffer.reader_index = current_reader_index + relative_type_defs_offset
+                # Read type definitions
+                self.type_resolver.read_type_defs(buffer)
+                # Jump back to continue with object deserialization
+                buffer.reader_index = current_reader_index
+        
         if not is_target_x_lang:
             return self.deserialize_ref(buffer)
         return self.xdeserialize_ref(buffer)

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -633,8 +633,7 @@ cdef class TypeResolver:
         buffer.write_varuint32(len(writing_type_defs))
         
         for type_def in writing_type_defs:
-            # Write type definition header (ID and size)
-            buffer.write_int64(type_def.id if hasattr(type_def, 'id') else 0)
+            # Just copy the encoded bytes directly
             buffer.write_bytes(type_def.encoded)
         
         meta_context.clear_writing_type_defs()
@@ -647,9 +646,7 @@ cdef class TypeResolver:
         
         num_type_defs = buffer.read_varuint32()
         for i in range(num_type_defs):
-            # Read type definition header
-            type_def_id = buffer.read_int64()
-            # Read the encoded type definition
+            # Read the encoded type definition directly
             from pyfory.meta.typedef_decoder import decode_typedef
             type_def = decode_typedef(buffer, self._resolver)
             meta_context.add_read_type_def(type_def)

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -620,8 +620,6 @@ cdef class TypeResolver:
         else:
             # New type, write ID and add to writing queue
             buffer.write_varuint32(type_id)
-            # Store the typeinfo in the read cache for immediate deserialization
-            meta_context.set_read_type_info(type_id, typeinfo)
             type_def = self._resolver._build_type_def(typeinfo)
             meta_context.add_writing_type_def(type_def)
 

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -399,6 +399,7 @@ cdef class TypeInfo:
     cdef public MetaStringBytes namespace_bytes
     cdef public MetaStringBytes typename_bytes
     cdef public c_bool dynamic_type
+    cdef public object type_def
 
     def __init__(
             self,
@@ -408,6 +409,7 @@ cdef class TypeInfo:
             namespace_bytes: MetaStringBytes = None,
             typename_bytes: MetaStringBytes = None,
             dynamic_type: bool = False,
+            type_def: object = None
     ):
         self.cls = cls
         self.type_id = type_id
@@ -415,6 +417,7 @@ cdef class TypeInfo:
         self.namespace_bytes = namespace_bytes
         self.typename_bytes = typename_bytes
         self.dynamic_type = dynamic_type
+        self.type_def = type_def
 
     def __repr__(self):
         return f"TypeInfo(cls={self.cls}, type_id={self.type_id}, " \
@@ -527,6 +530,18 @@ cdef class TypeResolver:
             self._c_types_info[<uintptr_t> <PyObject *> cls] = <PyObject *> type_info
             self._populate_typeinfo(type_info)
             return type_info
+    
+    def is_registered_by_name(self, cls):
+        return self._resolver.is_registered_by_name(cls)
+    
+    def is_registered_by_id(self, cls):
+        return self._resolver.is_registered_by_id(cls)
+
+    def get_registered_name(self, cls):
+        return self._resolver.get_registered_name(cls)
+
+    def get_registered_id(self, cls):
+        return self._resolver.get_registered_id(cls)
 
     cdef inline TypeInfo _load_bytes_to_typeinfo(
             self, int32_t type_id, MetaStringBytes ns_metabytes, MetaStringBytes type_metabytes):

--- a/python/pyfory/_serialization.pyx
+++ b/python/pyfory/_serialization.pyx
@@ -447,11 +447,11 @@ cdef class TypeResolver:
         flat_hash_map[pair[int64_t, int64_t], PyObject *] _c_meta_hash_to_typeinfo
         MetaStringResolver meta_string_resolver
 
-    def __init__(self, fory):
+    def __init__(self, fory, meta_share=False):
         self.fory = fory
         self.metastring_resolver = fory.metastring_resolver
         from pyfory._registry import TypeResolver
-        self._resolver = TypeResolver(fory)
+        self._resolver = TypeResolver(fory, meta_share=meta_share)
 
     def initialize(self):
         self._resolver.initialize()
@@ -655,16 +655,7 @@ cdef class TypeResolver:
 
     cpdef read_type_defs(self, Buffer buffer):
         """Read all type definitions from the buffer."""
-        meta_context = self._resolver.fory.serialization_context.get_meta_context()
-        if meta_context is None:
-            return
-        
-        num_type_defs = buffer.read_varuint32()
-        for i in range(num_type_defs):
-            # Read the encoded type definition directly
-            from pyfory.meta.typedef_decoder import decode_typedef
-            type_def = decode_typedef(buffer, self._resolver)
-            meta_context.add_read_type_def(type_def)
+        self._resolver.read_type_defs(buffer)
 
     def _read_type_info_with_meta_share(self, meta_context, type_id):
         """Read type info with meta share support."""

--- a/python/pyfory/_serializer.py
+++ b/python/pyfory/_serializer.py
@@ -53,15 +53,11 @@ KV_NULL = KEY_HAS_NULL | VALUE_HAS_NULL
 # Key is null, value type is declared type, and ref tracking for value is disabled.
 NULL_KEY_VALUE_DECL_TYPE = KEY_HAS_NULL | VALUE_DECL_TYPE
 # Key is null, value type is declared type, and ref tracking for value is enabled.
-NULL_KEY_VALUE_DECL_TYPE_TRACKING_REF = (
-    KEY_HAS_NULL | VALUE_DECL_TYPE | TRACKING_VALUE_REF
-)
+NULL_KEY_VALUE_DECL_TYPE_TRACKING_REF = KEY_HAS_NULL | VALUE_DECL_TYPE | TRACKING_VALUE_REF
 # Value is null, key type is declared type, and ref tracking for key is disabled.
 NULL_VALUE_KEY_DECL_TYPE = VALUE_HAS_NULL | KEY_DECL_TYPE
 # Value is null, key type is declared type, and ref tracking for key is enabled.
-NULL_VALUE_KEY_DECL_TYPE_TRACKING_REF = (
-    VALUE_HAS_NULL | KEY_DECL_TYPE | TRACKING_VALUE_REF
-)
+NULL_VALUE_KEY_DECL_TYPE_TRACKING_REF = VALUE_HAS_NULL | KEY_DECL_TYPE | TRACKING_VALUE_REF
 
 
 class Serializer(ABC):
@@ -182,11 +178,7 @@ _base_date = datetime.date(1970, 1, 1)
 class DateSerializer(CrossLanguageCompatibleSerializer):
     def write(self, buffer, value: datetime.date):
         if not isinstance(value, datetime.date):
-            raise TypeError(
-                "{} should be {} instead of {}".format(
-                    value, datetime.date, type(value)
-                )
-            )
+            raise TypeError("{} should be {} instead of {}".format(value, datetime.date, type(value)))
         days = (value - _base_date).days
         buffer.write_int32(days)
 
@@ -208,9 +200,7 @@ class TimestampSerializer(CrossLanguageCompatibleSerializer):
 
     def write(self, buffer, value: datetime.datetime):
         if not isinstance(value, datetime.datetime):
-            raise TypeError(
-                "{} should be {} instead of {}".format(value, datetime, type(value))
-            )
+            raise TypeError("{} should be {} instead of {}".format(value, datetime, type(value)))
         # TimestampType represent micro seconds
         buffer.write_int64(self._get_timestamp(value))
 
@@ -287,10 +277,7 @@ class CollectionSerializer(Serializer):
                     collect_flag |= COLLECTION_TRACKING_REF
         buffer.write_varuint32(len(value))
         buffer.write_int8(collect_flag)
-        if (
-            not has_different_type
-            and (collect_flag & COLLECTION_NOT_DECL_ELEMENT_TYPE) != 0
-        ):
+        if not has_different_type and (collect_flag & COLLECTION_NOT_DECL_ELEMENT_TYPE) != 0:
             self.type_resolver.write_typeinfo(buffer, elem_typeinfo)
         return collect_flag, elem_typeinfo
 
@@ -385,9 +372,7 @@ class CollectionSerializer(Serializer):
         for _ in range(len_):
             self._add_element(
                 collection_,
-                get_next_element(
-                    buffer, self.ref_resolver, self.type_resolver, self.is_py
-                ),
+                get_next_element(buffer, self.ref_resolver, self.type_resolver, self.is_py),
             )
 
     def xwrite(self, buffer, value):
@@ -532,12 +517,8 @@ class MapSerializer(Serializer):
                 type_resolver.write_typeinfo(buffer, value_typeinfo)
                 value_serializer = value_typeinfo.serializer
 
-            key_write_ref = (
-                key_serializer.need_to_write_ref if key_serializer else False
-            )
-            value_write_ref = (
-                value_serializer.need_to_write_ref if value_serializer else False
-            )
+            key_write_ref = key_serializer.need_to_write_ref if key_serializer else False
+            value_write_ref = value_serializer.need_to_write_ref if value_serializer else False
             if key_write_ref:
                 chunk_header |= TRACKING_KEY_REF
             if value_write_ref:
@@ -547,18 +528,11 @@ class MapSerializer(Serializer):
             chunk_size = 0
 
             while chunk_size < MAX_CHUNK_SIZE:
-                if (
-                    key is None
-                    or value is None
-                    or type(key) is not key_cls
-                    or type(value) is not value_cls
-                ):
+                if key is None or value is None or type(key) is not key_cls or type(value) is not value_cls:
                     break
                 if not key_write_ref or not ref_resolver.write_ref_or_null(buffer, key):
                     self._write_obj(key_serializer, buffer, key)
-                if not value_write_ref or not ref_resolver.write_ref_or_null(
-                    buffer, value
-                ):
+                if not value_write_ref or not ref_resolver.write_ref_or_null(buffer, value):
                     value_serializer.write(buffer, value)
 
                 chunk_size += 1
@@ -583,9 +557,7 @@ class MapSerializer(Serializer):
         if size != 0:
             chunk_header = buffer.read_uint8()
         key_serializer, value_serializer = self.key_serializer, self.value_serializer
-        deserialize_ref = (
-            fory.deserialize_ref if self.fory.is_py else fory.xdeserialize_ref
-        )
+        deserialize_ref = fory.deserialize_ref if self.fory.is_py else fory.xdeserialize_ref
         while size > 0:
             while True:
                 key_has_null = (chunk_header & KEY_HAS_NULL) != 0

--- a/python/pyfory/_struct.py
+++ b/python/pyfory/_struct.py
@@ -243,7 +243,8 @@ class StructTypeIdVisitor(TypeVisitor):
         return TypeId.MAP, key_ids, value_ids
 
     def visit_customized(self, field_name, type_, types_path=None):
-        return None, None
+        typeinfo = self.fory.type_resolver.get_typeinfo(type_)
+        return [typeinfo.type_id]
 
     def visit_other(self, field_name, type_, types_path=None):
         from pyfory.serializer import PickleSerializer  # Local import

--- a/python/pyfory/format/__init__.py
+++ b/python/pyfory/format/__init__.py
@@ -41,8 +41,7 @@ try:
     )
 except (ImportError, AttributeError) as e:
     warnings.warn(
-        f"Fory format initialization failed, please ensure pyarrow is installed "
-        f"with version which fory is compiled with: {e}",
+        f"Fory format initialization failed, please ensure pyarrow is installed with version which fory is compiled with: {e}",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/python/pyfory/format/tests/test_encoder.py
+++ b/python/pyfory/format/tests/test_encoder.py
@@ -63,9 +63,7 @@ def test_encoder_with_schema():
 @require_pyarrow
 def test_dict():
     dict_ = {"f1": 1, "f2": "str"}
-    encoder = pyfory.create_row_encoder(
-        pa.schema([("f1", pa.int32()), ("f2", pa.utf8())])
-    )
+    encoder = pyfory.create_row_encoder(pa.schema([("f1", pa.int32()), ("f2", pa.utf8())]))
     row = encoder.to_row(dict_)
     new_obj = encoder.from_row(row)
     assert new_obj.f1 == dict_["f1"]
@@ -74,9 +72,7 @@ def test_dict():
 
 @require_pyarrow
 def test_ints():
-    cls = pyfory.record_class_factory(
-        "TestNumeric", ["f" + str(i) for i in range(1, 9)]
-    )
+    cls = pyfory.record_class_factory("TestNumeric", ["f" + str(i) for i in range(1, 9)])
     schema = pa.schema(
         [
             ("f1", pa.int64()),

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -41,7 +41,9 @@ FIELD_NAME_ENCODINGS = [Encoding.UTF_8, Encoding.LOWER_UPPER_DIGIT_SPECIAL, Enco
 
 
 class TypeDef:
-    def __init__(self, namespace: str, typename: str, cls: type, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False):
+    def __init__(
+        self, namespace: str, typename: str, cls: type, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False
+    ):
         self.namespace = namespace
         self.typename = typename
         self.cls = cls
@@ -59,9 +61,12 @@ class TypeDef:
 
     def create_serializer(self, resolver):
         from pyfory.serializer import DataClassSerializer
+
         fory = resolver.fory
-        return DataClassSerializer(fory, self.cls, xlang=not fory.is_py, field_names=self.get_field_names(), serializers=self.create_fields_serializer(resolver))
-    
+        return DataClassSerializer(
+            fory, self.cls, xlang=not fory.is_py, field_names=self.get_field_names(), serializers=self.create_fields_serializer(resolver)
+        )
+
     def __repr__(self):
         return f"TypeDef(namespace={self.namespace}, typename={self.typename}, cls={self.cls}, type_id={self.type_id}, fields={self.fields}, is_compressed={self.is_compressed})"
 

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -43,8 +43,9 @@ FIELD_NAME_ENCODINGS = [Encoding.UTF_8, Encoding.LOWER_UPPER_DIGIT_SPECIAL, Enco
 
 
 class TypeDef:
-    def __init__(self, name: str, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False):
+    def __init__(self, name: str, cls: type, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False):
         self.name = name
+        self.cls = cls
         self.type_id = type_id
         self.fields = fields
         self.encoded = encoded
@@ -54,8 +55,16 @@ class TypeDef:
         serializers = [field_info.field_type.create_serializer(resolver) for field_info in self.fields]
         return serializers
 
+    def get_field_names(self):
+        return [field_info.name for field_info in self.fields]
+
+    def create_serializer(self, resolver):
+        from pyfory.serializer import DataClassSerializer
+        fory = resolver.fory
+        return DataClassSerializer(fory, self.cls, xlang=not fory.is_py, field_names=self.get_field_names(), serializers=self.create_fields_serializer(resolver))
+
     def __repr__(self):
-        return f"TypeDef(name={self.name}, type_id={self.type_id}, fields={self.fields}, is_compressed={self.is_compressed})"
+        return f"TypeDef(name={self.name}, cls={self.cls}, type_id={self.type_id}, fields={self.fields}, is_compressed={self.is_compressed})"
 
 
 class FieldInfo:

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -134,7 +134,10 @@ class FieldType:
         elif xtype_id == TypeId.UNKNOWN:
             return DynamicFieldType(xtype_id, False, is_nullable, is_tracking_ref)
         else:
-            return FieldType(xtype_id, False, is_nullable, is_tracking_ref)
+            # For primitive types, determine if they are monomorphic based on the type
+            from pyfory.type import is_polymorphic_type
+            is_monomorphic = not is_polymorphic_type(xtype_id)
+            return FieldType(xtype_id, is_monomorphic, is_nullable, is_tracking_ref)
 
     def create_serializer(self, resolver):
         if self.type_id in [TypeId.EXT, TypeId.STRUCT, TypeId.NAMED_STRUCT, TypeId.COMPATIBLE_STRUCT, TypeId.NAMED_COMPATIBLE_STRUCT, TypeId.UNKNOWN]:

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -19,7 +19,7 @@ from typing import List
 import typing
 from pyfory.type import TypeId
 from pyfory._util import Buffer
-from pyfory.type import TypeId, infer_field, is_primitive_type, is_polymorphic_type, is_struct_type
+from pyfory.type import infer_field, is_primitive_type, is_polymorphic_type, is_struct_type
 from pyfory.meta.metastring import Encoding
 
 

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -43,8 +43,9 @@ FIELD_NAME_ENCODINGS = [Encoding.UTF_8, Encoding.LOWER_UPPER_DIGIT_SPECIAL, Enco
 
 
 class TypeDef:
-    def __init__(self, name: str, cls: type, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False):
-        self.name = name
+    def __init__(self, namespace: str, typename: str, cls: type, type_id: int, fields: List["FieldInfo"], encoded: bytes = None, is_compressed: bool = False):
+        self.namespace = namespace
+        self.typename = typename
         self.cls = cls
         self.type_id = type_id
         self.fields = fields
@@ -62,9 +63,9 @@ class TypeDef:
         from pyfory.serializer import DataClassSerializer
         fory = resolver.fory
         return DataClassSerializer(fory, self.cls, xlang=not fory.is_py, field_names=self.get_field_names(), serializers=self.create_fields_serializer(resolver))
-
+    
     def __repr__(self):
-        return f"TypeDef(name={self.name}, cls={self.cls}, type_id={self.type_id}, fields={self.fields}, is_compressed={self.is_compressed})"
+        return f"TypeDef(namespace={self.namespace}, typename={self.typename}, cls={self.cls}, type_id={self.type_id}, fields={self.fields}, is_compressed={self.is_compressed})"
 
 
 class FieldInfo:

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -19,8 +19,6 @@ from typing import List
 import typing
 from pyfory.type import TypeId
 from pyfory._util import Buffer
-from pyfory.serializer import MapSerializer, ListSerializer, SetSerializer
-from pyfory._struct import _sort_fields, StructTypeIdVisitor, get_field_names
 from pyfory.type import TypeId, infer_field, is_primitive_type, is_polymorphic_type
 from pyfory.meta.metastring import Encoding
 
@@ -155,6 +153,8 @@ class CollectionFieldType(FieldType):
         self.element_type = element_type
 
     def create_serializer(self, resolver):
+        from pyfory.serializer import ListSerializer, SetSerializer
+
         if self.type_id == TypeId.LIST:
             return ListSerializer(resolver.fory, list, self.element_type.create_serializer(resolver))
         elif self.type_id == TypeId.SET:
@@ -180,6 +180,8 @@ class MapFieldType(FieldType):
     def create_serializer(self, resolver):
         key_serializer = self.key_type.create_serializer(resolver)
         value_serializer = self.value_type.create_serializer(resolver)
+        from pyfory.serializer import MapSerializer
+
         return MapSerializer(resolver.fory, dict, key_serializer, value_serializer)
 
     def __repr__(self):
@@ -202,6 +204,8 @@ class DynamicFieldType(FieldType):
 
 def build_field_infos(type_resolver, cls):
     """Build field information for the class."""
+    from pyfory._struct import _sort_fields, StructTypeIdVisitor, get_field_names
+
     field_names = get_field_names(cls)
     type_hints = typing.get_type_hints(cls)
 
@@ -215,6 +219,7 @@ def build_field_infos(type_resolver, cls):
         field_infos.append(field_info)
 
     serializers = [field_info.field_type.create_serializer(type_resolver) for field_info in field_infos]
+
     field_names, serializers = _sort_fields(type_resolver, field_names, serializers)
     field_infos_map = {field_info.name: field_info for field_info in field_infos}
     new_field_infos = []

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -136,6 +136,7 @@ class FieldType:
         else:
             # For primitive types, determine if they are monomorphic based on the type
             from pyfory.type import is_polymorphic_type
+
             is_monomorphic = not is_polymorphic_type(xtype_id)
             return FieldType(xtype_id, is_monomorphic, is_nullable, is_tracking_ref)
 
@@ -240,7 +241,7 @@ def build_field_infos(type_resolver, cls):
 def build_field_type(type_resolver, field_name: str, type_hint, visitor):
     """Build field type from type hint."""
     type_ids = infer_field(field_name, type_hint, visitor)
-    print(f"=??????????=> {field_name, type_hint, visitor,type_ids}")
+    print(f"=??????????=> {field_name, type_hint, visitor, type_ids}")
     return build_field_type_from_type_ids(type_resolver, field_name, type_ids, visitor)
 
 
@@ -248,7 +249,7 @@ def build_field_type_from_type_ids(type_resolver, field_name: str, type_ids, vis
     tracking_ref = type_resolver.fory.ref_tracking
     type_id = type_ids[0]
     if type_id is not None and type_id >= 0:
-        type_id = type_id & 0xff
+        type_id = type_id & 0xFF
     morphic = not is_polymorphic_type(type_id)
     if type_id in [TypeId.SET, TypeId.LIST]:
         elem_type = build_field_type_from_type_ids(type_resolver, field_name, type_ids[1], visitor)

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -46,7 +46,21 @@ TYPENAME_DECODER = MetaStringDecoder("$", "_")
 FIELD_NAME_DECODER = MetaStringDecoder("$", "_")
 
 
-def decode_typedef(buffer: Buffer, resolver) -> TypeDef:
+def skip_typedef(buffer: Buffer, header) -> None:
+    """
+    Skip a TypeDef from the buffer.
+    """
+    header = buffer.read_int64()    
+    # Extract components from header
+    meta_size = header & META_SIZE_MASKS
+    # If meta size is at maximum, read additional size
+    if meta_size == META_SIZE_MASKS:
+        meta_size += buffer.read_varuint32()
+    # Read meta data
+    buffer.read_bytes(meta_size)
+
+
+def decode_typedef(buffer: Buffer, resolver, header=None) -> TypeDef:
     """
     Decode a TypeDef from the buffer.
 
@@ -58,7 +72,8 @@ def decode_typedef(buffer: Buffer, resolver) -> TypeDef:
         The decoded TypeDef.
     """
     # Read global binary header
-    header = buffer.read_int64()
+    if header is None:
+        header = buffer.read_int64()
 
     # Extract components from header
     meta_size = header & META_SIZE_MASKS

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -196,7 +196,7 @@ def read_field_info(buffer: Buffer, resolver, defined_class: str) -> FieldInfo:
     field_name_size += 1
     encoding = FIELD_NAME_ENCODINGS[field_name_encoding]
     is_nullable = (header & 0b10) != 0
-    is_tracking_ref = header & 0b1
+    is_tracking_ref = (header & 0b1) != 0
 
     # Read field type info (without flags since they're in the header)
     xtype_id = buffer.read_varuint32()

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -50,7 +50,6 @@ def skip_typedef(buffer: Buffer, header) -> None:
     """
     Skip a TypeDef from the buffer.
     """
-    header = buffer.read_int64()    
     # Extract components from header
     meta_size = header & META_SIZE_MASKS
     # If meta size is at maximum, read additional size

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -95,7 +95,6 @@ def decode_typedef(buffer: Buffer, resolver) -> TypeDef:
     if is_registered_by_name:
         namespace = read_namespace(meta_buffer)
         typename = read_typename(meta_buffer)
-        name = namespace + "." + typename if namespace else typename
         # Look up the type_id from namespace and typename
         type_info = resolver.get_typeinfo_by_name(namespace, typename)
         if type_info:
@@ -108,9 +107,12 @@ def decode_typedef(buffer: Buffer, resolver) -> TypeDef:
         type_info = resolver.get_typeinfo_by_id(type_id)
         if type_info is not None:
             type_cls = type_info.cls
-            name = type_info.cls.__name__
+            namespace = type_info.decode_namespace()
+            typename = type_info.decode_typename()
         else:
-            name = f"fory.Nonexistent{type_id}"
+            namespace = "fory"
+            typename = f"Nonexistent{type_id}"
+    name = namespace + "." + typename if namespace else typename
     # Read fields info if present
     field_infos = []
     if has_fields_meta:
@@ -119,7 +121,7 @@ def decode_typedef(buffer: Buffer, resolver) -> TypeDef:
         type_cls = record_class_factory(name, [field_info.name for field_info in field_infos])
 
     # Create TypeDef object
-    return TypeDef(name, type_cls, type_id, field_infos, meta_data, is_compressed)
+    return TypeDef(namespace, typename, type_cls, type_id, field_infos, meta_data, is_compressed)
 
 
 def read_namespace(buffer: Buffer) -> str:

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -25,15 +25,12 @@ from typing import List
 from pyfory._util import Buffer
 from pyfory.meta.typedef import TypeDef, FieldInfo, FieldType
 from pyfory.meta.typedef import (
-    FieldInfo,
-    TypeDef,
     SMALL_NUM_FIELDS_THRESHOLD,
     REGISTER_BY_NAME_FLAG,
     FIELD_NAME_SIZE_THRESHOLD,
     COMPRESS_META_FLAG,
     HAS_FIELDS_META_FLAG,
     META_SIZE_MASKS,
-    NUM_HASH_BITS,
     FIELD_NAME_ENCODINGS,
 )
 from pyfory.type import TypeId, record_class_factory

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -80,7 +80,8 @@ def encode_typedef(type_resolver, cls):
         namespace, typename = type_resolver.get_registered_name(cls)
         write_namespace(buffer, namespace)
         write_typename(buffer, typename)
-        type_id = TypeId.NAMED_COMPATIBLE_STRUCT
+        # Use the actual type_id from the resolver, not a generic one
+        type_id = type_resolver.get_registered_id(cls)
     else:
         assert type_resolver.is_registered_by_id(cls), "Class must be registered by name or id"
         type_id = type_resolver.get_registered_id(cls)

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -33,7 +33,6 @@ from pyfory.meta.typedef import (
 from pyfory.meta.metastring import MetaStringEncoder
 
 from pyfory._util import Buffer
-from pyfory.type import TypeId
 from pyfory.lib.mmh3 import hash_buffer
 
 

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -101,7 +101,15 @@ def encode_typedef(type_resolver, cls):
         binary = compressed_binary
     # Prepend header
     binary = prepend_header(binary, is_compressed, len(field_infos) > 0)    
-    return TypeDef(cls.__name__, cls, type_id, field_infos, binary, is_compressed)
+    # Extract namespace and typename
+    if type_resolver.is_registered_by_name(cls):
+        namespace, typename = type_resolver.get_registered_name(cls)
+    else:
+        splits = cls.__name__.rsplit(".", 1)
+        if len(splits) == 1:
+            splits.insert(0, "")
+        namespace, typename = splits
+    return TypeDef(namespace, typename, cls, type_id, field_infos, binary, is_compressed)
 
 
 def prepend_header(buffer: bytes, is_compressed: bool, has_fields_meta: bool):

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -100,7 +100,7 @@ def encode_typedef(type_resolver, cls):
     if is_compressed:
         binary = compressed_binary
     # Prepend header
-    binary = prepend_header(binary, is_compressed, len(field_infos) > 0)    
+    binary = prepend_header(binary, is_compressed, len(field_infos) > 0)
     # Extract namespace and typename
     if type_resolver.is_registered_by_name(cls):
         namespace, typename = type_resolver.get_registered_name(cls)

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -80,10 +80,11 @@ def encode_typedef(type_resolver, cls):
         namespace, typename = type_resolver.get_registered_name(cls)
         write_namespace(buffer, namespace)
         write_typename(buffer, typename)
+        type_id = TypeId.NAMED_COMPATIBLE_STRUCT
     else:
         assert type_resolver.is_registered_by_id(cls), "Class must be registered by name or id"
-        buffer.write_varuint32(type_resolver.get_registered_id(cls))
-
+        type_id = type_resolver.get_registered_id(cls)
+        buffer.write_varuint32(type_id)
     # Update header byte
     buffer.put_uint8(0, header)
 
@@ -99,8 +100,8 @@ def encode_typedef(type_resolver, cls):
     if is_compressed:
         binary = compressed_binary
     # Prepend header
-    binary = prepend_header(binary, is_compressed, len(field_infos) > 0)
-    return TypeDef(cls.__name__, type_info.type_id, field_infos, binary, is_compressed)
+    binary = prepend_header(binary, is_compressed, len(field_infos) > 0)    
+    return TypeDef(cls.__name__, cls, type_id, field_infos, binary, is_compressed)
 
 
 def prepend_header(buffer: bytes, is_compressed: bool, has_fields_meta: bool):

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -75,17 +75,14 @@ def encode_typedef(type_resolver, cls):
         buffer.write_varuint32(len(field_infos) - SMALL_NUM_FIELDS_THRESHOLD)
 
     # Write type info
-    type_info = type_resolver.get_typeinfo(cls)
-    assert type_info.type_id > 0
-
-    if not TypeId.is_namespaced_type(type_info.type_id):
-        buffer.write_varuint32(type_info.type_id)
-    else:
+    if type_resolver.is_registered_by_name(cls):
         header |= REGISTER_BY_NAME_FLAG
-        namespace = type_info.decode_namespace()
-        typename = type_info.decode_typename()
+        namespace, typename = type_resolver.get_registered_name(cls)
         write_namespace(buffer, namespace)
         write_typename(buffer, typename)
+    else:
+        assert type_resolver.is_registered_by_id(cls), "Class must be registered by name or id"
+        buffer.write_varuint32(type_resolver.get_registered_id(cls))
 
     # Update header byte
     buffer.put_uint8(0, header)

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -125,7 +125,7 @@ def prepend_header(buffer: bytes, is_compressed: bool, has_fields_meta: bool):
         result.write_varuint32(meta_size - META_SIZE_MASKS)
 
     result.write_bytes(buffer)
-    return result
+    return result.to_bytes()
 
 
 def write_namespace(buffer: Buffer, namespace: str):

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -490,9 +490,7 @@ class DataClassSerializer(Serializer):
         context["_field_names"] = self._field_names
         context["_type_hints"] = self._type_hints
         context["_serializers"] = self._serializers
-
         current_class_field_names = set(self._get_field_names(self.type_))
-        
         stmts = [
             f'"""xread method for {self.type_}"""',
         ]

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -448,7 +448,7 @@ class DataClassSerializer(Serializer):
         stmts = [
             f'"""xwrite method for {self.type_}"""',
         ]
-        if not self.fory.compatbile:
+        if not self.fory.compatible:
             # Compute hash at generation time since we're in xlang mode
             if self._hash == 0:
                 self._hash = _get_hash(self.fory, self._field_names, self._type_hints)
@@ -494,7 +494,7 @@ class DataClassSerializer(Serializer):
         stmts = [
             f'"""xread method for {self.type_}"""',
         ]
-        if not self.fory.compatbile:
+        if not self.fory.compatible:
             # Compute hash at generation time since we're in xlang mode
             if self._hash == 0:
                 self._hash = _get_hash(self.fory, self._field_names, self._type_hints)

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -24,7 +24,7 @@ import os
 import pickle
 import types
 import typing
-from typing_extensions import List
+from typing import List
 import warnings
 from weakref import WeakValueDictionary
 

--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -449,7 +449,7 @@ class DataClassSerializer(Serializer):
             f'"""xwrite method for {self.type_}"""',
         ]
         if not self.fory.compatbile:
-             # Compute hash at generation time since we're in xlang mode
+            # Compute hash at generation time since we're in xlang mode
             if self._hash == 0:
                 self._hash = _get_hash(self.fory, self._field_names, self._type_hints)
             stmts.append(f"{buffer}.write_int32({self._hash})")
@@ -498,16 +498,20 @@ class DataClassSerializer(Serializer):
             # Compute hash at generation time since we're in xlang mode
             if self._hash == 0:
                 self._hash = _get_hash(self.fory, self._field_names, self._type_hints)
-            stmts.extend([
-                f"read_hash = {buffer}.read_int32()",
-                f"if read_hash != {self._hash}:",
-                f"""   raise TypeNotCompatibleError(
+            stmts.extend(
+                [
+                    f"read_hash = {buffer}.read_int32()",
+                    f"if read_hash != {self._hash}:",
+                    f"""   raise TypeNotCompatibleError(
                 f"Hash {{read_hash}} is not consistent with {self._hash} for type {self.type_}")""",
-            ])
-        stmts.extend([
-            f"{obj} = {obj_class}.__new__({obj_class})",
-            f"{ref_resolver}.reference({obj})",
-        ])
+                ]
+            )
+        stmts.extend(
+            [
+                f"{obj} = {obj_class}.__new__({obj_class})",
+                f"{ref_resolver}.reference({obj})",
+            ]
+        )
 
         if not self._has_slots:
             stmts.append(f"{obj_dict} = {obj}.__dict__")

--- a/python/pyfory/tests/benchmark.py
+++ b/python/pyfory/tests/benchmark.py
@@ -33,13 +33,9 @@ def test_encode():
     assert foo == encoder.from_row(row)
 
     t1 = timeit.timeit(lambda: encoder.to_row(foo), number=iter_nums)
-    print(
-        "encoder take {0} for {1} times, avg: {2}".format(t1, iter_nums, t1 / iter_nums)
-    )
+    print("encoder take {0} for {1} times, avg: {2}".format(t1, iter_nums, t1 / iter_nums))
     t2 = timeit.timeit(lambda: pickle.dumps(foo), number=iter_nums)
-    print(
-        "pickle take {0} for {1} times, avg: {2}".format(t2, iter_nums, t2 / iter_nums)
-    )
+    print("pickle take {0} for {1} times, avg: {2}".format(t2, iter_nums, t2 / iter_nums))
 
 
 @pytest.mark.skip(reason="take too long")
@@ -51,18 +47,10 @@ def test_decode():
     row = encoder.to_row(foo)
     assert foo == encoder.from_row(row)
     t1 = timeit.timeit(lambda: encoder.from_row(row), number=iter_nums)
-    print(
-        "encoder take {0} for {1} times, avg: {2}, size {3}".format(
-            t1, iter_nums, t1 / iter_nums, row.size_bytes()
-        )
-    )
+    print("encoder take {0} for {1} times, avg: {2}, size {3}".format(t1, iter_nums, t1 / iter_nums, row.size_bytes()))
     pickled_data = pickle.dumps(foo)
     t2 = timeit.timeit(lambda: pickle.loads(pickled_data), number=iter_nums)
-    print(
-        "pickle take {0} for {1} times, avg: {2}, size {3}".format(
-            t2, iter_nums, t2 / iter_nums, len(pickled_data)
-        )
-    )
+    print("pickle take {0} for {1} times, avg: {2}, size {3}".format(t2, iter_nums, t2 / iter_nums, len(pickled_data)))
 
 
 if __name__ == "__main__":

--- a/python/pyfory/tests/record.py
+++ b/python/pyfory/tests/record.py
@@ -117,9 +117,7 @@ def foo_schema():
             ("f4", pa.map_(pa.string(), pa.int32())),
             ("f5", pa.list_(pa.int32())),
             ("f6", pa.int32()),
-            pa.field(
-                "f7", bar_struct, metadata={"cls": fory.get_qualified_classname(Bar)}
-            ),
+            pa.field("f7", bar_struct, metadata={"cls": fory.get_qualified_classname(Bar)}),
         ],
         metadata={"cls": fory.get_qualified_classname(Foo)},
     )

--- a/python/pyfory/tests/test_buffer.py
+++ b/python/pyfory/tests/test_buffer.py
@@ -217,10 +217,7 @@ def check_varuint64(buf: Buffer, value: int, bytes_written: int):
     assert buf.writer_index == buf.reader_index
     assert value == varint
     # test slow read branch in `read_varint64`
-    assert (
-        buf.slice(reader_index, buf.reader_index - reader_index).read_varuint64()
-        == value
-    )
+    assert buf.slice(reader_index, buf.reader_index - reader_index).read_varuint64() == value
 
 
 def test_write_buffer():

--- a/python/pyfory/tests/test_codegen.py
+++ b/python/pyfory/tests/test_codegen.py
@@ -43,8 +43,6 @@ def test_debug_compiled():
 
 
 def test_compile_function():
-    code, func = codegen.compile_function(
-        "test_compile_function", ["x"], ["print(1)", "print(2)", "return x"], {}
-    )
+    code, func = codegen.compile_function("test_compile_function", ["x"], ["print(1)", "print(2)", "return x"], {})
     print(code)
     assert func(100) == 100

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -50,11 +50,10 @@ class ReducedDataClass:
 
 
 class TestMetaShareMode:
-    
     def setup_method(self):
         """Setup method to register dataclasses for each test."""
         pass
-    
+
     def test_meta_share_enabled(self):
         """Test that meta share mode can be enabled."""
         fory = Fory(language=Language.XLANG, compatbile=True)
@@ -70,13 +69,13 @@ class TestMetaShareMode:
     def test_simple_dataclass_serialization(self):
         """Test serialization of simple dataclass with meta share."""
         fory = Fory(language=Language.XLANG, compatbile=True)
-        
+
         # Register the dataclass
         fory.register_type(SimpleDataClass)
-        
+
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory.serialize(obj)
-        
+
         # Deserialize
         deserialized = fory.deserialize(buffer)
         assert deserialized.name == obj.name
@@ -86,27 +85,27 @@ class TestMetaShareMode:
     def test_multiple_objects_same_type(self):
         """Test that multiple objects of same type reuse type definition."""
         fory = Fory(language=Language.XLANG, compatbile=True)
-        
+
         # Register the dataclass
         fory.register_type(SimpleDataClass)
-        
+
         obj1 = SimpleDataClass(name="test1", age=25, active=True)
         obj2 = SimpleDataClass(name="test2", age=30, active=False)
-        
+
         # Serialize both objects
         buffer1 = fory.serialize(obj1)
         buffer2 = fory.serialize(obj2)
-        
+
         # Create a new fory instance with the same meta context for deserialization
         fory2 = Fory(language=Language.XLANG, compatbile=True)
         fory2.register_type(SimpleDataClass)
         # Copy the meta context from the first fory instance
         fory2.serialization_context.meta_context = fory.serialization_context.meta_context
-        
+
         # Deserialize both
         deserialized1 = fory2.deserialize(buffer1)
         deserialized2 = fory2.deserialize(buffer2)
-        
+
         assert deserialized1.name == obj1.name
         assert deserialized2.name == obj2.name
         assert deserialized1.age == obj1.age
@@ -115,29 +114,29 @@ class TestMetaShareMode:
     def test_simple_nested_dataclass_serialization(self):
         """Test serialization of simple nested dataclass with meta share."""
         fory = Fory(language=Language.XLANG, compatbile=True)
-        
+
         # Register the dataclass
         fory.register_type(SimpleNestedDataClass)
-        
+
         obj = SimpleNestedDataClass(value=42, name="test")
-        
+
         buffer = fory.serialize(obj)
         deserialized = fory.deserialize(buffer)
-        
+
         assert deserialized.value == obj.value
         assert deserialized.name == obj.name
 
     def test_serialization_without_meta_share(self):
         """Test that serialization works without meta share mode."""
         fory = Fory(language=Language.XLANG, compatbile=False)
-        
+
         # Register the dataclass
         fory.register_type(SimpleDataClass)
-        
+
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory.serialize(obj)
         deserialized = fory.deserialize(buffer)
-        
+
         assert deserialized.name == obj.name
         assert deserialized.age == obj.age
         assert deserialized.active == obj.active
@@ -146,22 +145,21 @@ class TestMetaShareMode:
         # Serialize with original schema
         fory1 = Fory(language=Language.XLANG, compatbile=True)
         fory1.register_type(SimpleDataClass)
-        
+
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory1.serialize(obj)
-        
+
         # Deserialize with extended schema (more fields)
         fory2 = Fory(language=Language.XLANG, compatbile=True)
         fory2.register_type(ExtendedDataClass)
         deserialized = fory2.deserialize(buffer)
-        
+
         # Current behavior: deserialized object is of the new registered type
         assert isinstance(deserialized, ExtendedDataClass)
         assert deserialized.name == obj.name
         assert deserialized.age == obj.age
         assert deserialized.active == obj.active
-        assert not hasattr(deserialized, 'email')
-  
+        assert not hasattr(deserialized, "email")
 
     def test_schema_evolution_fewer_fields(self):
         # Serialize with original schema
@@ -169,15 +167,14 @@ class TestMetaShareMode:
         fory1.register_type(SimpleDataClass)
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory1.serialize(obj)
-        
+
         # Deserialize with reduced schema (fewer fields)
         fory2 = Fory(language=Language.XLANG, compatbile=True)
-        fory2.register_type(ReducedDataClass)        
+        fory2.register_type(ReducedDataClass)
         deserialized = fory2.deserialize(buffer)
-        
+
         assert isinstance(deserialized, ReducedDataClass)
         assert deserialized.name == obj.name
         assert deserialized.age == obj.age
         # The missing field should not be present
-        assert not hasattr(deserialized, 'active')
-
+        assert not hasattr(deserialized, "active")

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -18,8 +18,6 @@
 import dataclasses
 from typing import List, Dict
 from pyfory import Fory, Language
-from pyfory.buffer import Buffer
-from pyfory.type import TypeId
 import pyfory
 
 

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -228,10 +228,7 @@ class TestMetaShareMode:
         fory1.register_type(NestedStructClass)
         fory1.register_type(SimpleNestedDataClass)
 
-        obj = NestedStructClass(
-            name="test",
-            nested=SimpleNestedDataClass(value=42, name="nested_test")
-        )
+        obj = NestedStructClass(name="test", nested=SimpleNestedDataClass(value=42, name="nested_test"))
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (different nested type)
@@ -252,11 +249,7 @@ class TestMetaShareMode:
         fory1 = Fory(language=Language.XLANG, compatbile=True)
         fory1.register_type(ListFieldsClass)
 
-        obj = ListFieldsClass(
-            name="test",
-            int_list=[1, 2, 3],
-            str_list=["a", "b", "c"]
-        )
+        obj = ListFieldsClass(name="test", int_list=[1, 2, 3], str_list=["a", "b", "c"])
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (swapped List types)
@@ -277,11 +270,7 @@ class TestMetaShareMode:
         fory1 = Fory(language=Language.XLANG, compatbile=True)
         fory1.register_type(DictFieldsClass)
 
-        obj = DictFieldsClass(
-            name="test",
-            int_dict={"key1": 1, "key2": 2},
-            str_dict={"key1": "value1", "key2": "value2"}
-        )
+        obj = DictFieldsClass(name="test", int_dict={"key1": 1, "key2": 2}, str_dict={"key1": "value1", "key2": "value2"})
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (swapped Dict value types)

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -96,19 +96,19 @@ class TestMetaShareMode:
 
     def test_meta_share_enabled(self):
         """Test that meta share mode can be enabled."""
-        fory = Fory(language=Language.XLANG, compatbile=True)
+        fory = Fory(language=Language.XLANG, compatible=True)
         assert fory.serialization_context.scoped_meta_share_enabled
         assert fory.serialization_context.meta_context is not None
 
     def test_meta_share_disabled(self):
         """Test that meta share mode can be disabled."""
-        fory = Fory(language=Language.XLANG, compatbile=False)
+        fory = Fory(language=Language.XLANG, compatible=False)
         assert not fory.serialization_context.scoped_meta_share_enabled
         assert fory.serialization_context.meta_context is None
 
     def test_simple_dataclass_serialization(self):
         """Test serialization of simple dataclass with meta share."""
-        fory = Fory(language=Language.XLANG, compatbile=True)
+        fory = Fory(language=Language.XLANG, compatible=True)
 
         # Register the dataclass
         fory.register_type(SimpleDataClass)
@@ -124,7 +124,7 @@ class TestMetaShareMode:
 
     def test_multiple_objects_same_type(self):
         """Test that multiple objects of same type reuse type definition."""
-        fory = Fory(language=Language.XLANG, compatbile=True)
+        fory = Fory(language=Language.XLANG, compatible=True)
 
         # Register the dataclass
         fory.register_type(SimpleDataClass)
@@ -137,7 +137,7 @@ class TestMetaShareMode:
         buffer2 = fory.serialize(obj2)
 
         # Create a new fory instance with the same meta context for deserialization
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(SimpleDataClass)
         # Copy the meta context from the first fory instance
         fory2.serialization_context.meta_context = fory.serialization_context.meta_context
@@ -153,7 +153,7 @@ class TestMetaShareMode:
 
     def test_simple_nested_dataclass_serialization(self):
         """Test serialization of simple nested dataclass with meta share."""
-        fory = Fory(language=Language.XLANG, compatbile=True)
+        fory = Fory(language=Language.XLANG, compatible=True)
 
         # Register the dataclass
         fory.register_type(SimpleNestedDataClass)
@@ -168,7 +168,7 @@ class TestMetaShareMode:
 
     def test_serialization_without_meta_share(self):
         """Test that serialization works without meta share mode."""
-        fory = Fory(language=Language.XLANG, compatbile=False)
+        fory = Fory(language=Language.XLANG, compatible=False)
 
         # Register the dataclass
         fory.register_type(SimpleDataClass)
@@ -183,14 +183,14 @@ class TestMetaShareMode:
 
     def test_schema_evolution_more_fields(self):
         # Serialize with original schema
-        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1 = Fory(language=Language.XLANG, compatible=True)
         fory1.register_type(SimpleDataClass)
 
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory1.serialize(obj)
 
         # Deserialize with extended schema (more fields)
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(ExtendedDataClass)
         deserialized = fory2.deserialize(buffer)
 
@@ -203,13 +203,13 @@ class TestMetaShareMode:
 
     def test_schema_evolution_fewer_fields(self):
         # Serialize with original schema
-        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1 = Fory(language=Language.XLANG, compatible=True)
         fory1.register_type(SimpleDataClass)
         obj = SimpleDataClass(name="test", age=25, active=True)
         buffer = fory1.serialize(obj)
 
         # Deserialize with reduced schema (fewer fields)
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(ReducedDataClass)
         deserialized = fory2.deserialize(buffer)
 
@@ -222,7 +222,7 @@ class TestMetaShareMode:
     def test_schema_inconsistent_nested_struct(self):
         """Test schema inconsistency with nested struct types."""
         # Serialize with original schema
-        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1 = Fory(language=Language.XLANG, compatible=True)
         fory1.register_type(NestedStructClass)
         fory1.register_type(SimpleNestedDataClass)
 
@@ -230,7 +230,7 @@ class TestMetaShareMode:
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (different nested type)
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(NestedStructClassInconsistent)
         fory2.register_type(ExtendedDataClass)
 
@@ -244,14 +244,14 @@ class TestMetaShareMode:
     def test_schema_inconsistent_list_fields(self):
         """Test schema inconsistency with List field types."""
         # Serialize with original schema
-        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1 = Fory(language=Language.XLANG, compatible=True)
         fory1.register_type(ListFieldsClass)
 
         obj = ListFieldsClass(name="test", int_list=[1, 2, 3], str_list=["a", "b", "c"])
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (swapped List types)
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(ListFieldsClassInconsistent)
 
         # This should handle the schema inconsistency gracefully
@@ -265,14 +265,14 @@ class TestMetaShareMode:
     def test_schema_inconsistent_dict_fields(self):
         """Test schema inconsistency with Dict field types."""
         # Serialize with original schema
-        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1 = Fory(language=Language.XLANG, compatible=True)
         fory1.register_type(DictFieldsClass)
 
         obj = DictFieldsClass(name="test", int_dict={"key1": 1, "key2": 2}, str_dict={"key1": "value1", "key2": "value2"})
         buffer = fory1.serialize(obj)
 
         # Deserialize with inconsistent schema (swapped Dict value types)
-        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2 = Fory(language=Language.XLANG, compatible=True)
         fory2.register_type(DictFieldsClassInconsistent)
 
         # This should handle the schema inconsistency gracefully

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -16,9 +16,11 @@
 # under the License.
 
 import dataclasses
+from typing import List, Dict
 from pyfory import Fory, Language
 from pyfory.buffer import Buffer
 from pyfory.type import TypeId
+import pyfory
 
 
 @dataclasses.dataclass
@@ -47,6 +49,46 @@ class ReducedDataClass:
     name: str
     age: int
     # Missing 'active' field
+
+
+@dataclasses.dataclass
+class NestedStructClass:
+    name: str
+    nested: SimpleNestedDataClass
+
+
+@dataclasses.dataclass
+class NestedStructClassInconsistent:
+    name: str
+    nested: ExtendedDataClass  # Different nested type
+
+
+@dataclasses.dataclass
+class ListFieldsClass:
+    name: str
+    int_list: List[pyfory.Int32Type]
+    str_list: List[str]
+
+
+@dataclasses.dataclass
+class ListFieldsClassInconsistent:
+    name: str
+    int_list: List[str]  # Changed from Int32Type to str
+    str_list: List[pyfory.Int32Type]  # Changed from str to Int32Type
+
+
+@dataclasses.dataclass
+class DictFieldsClass:
+    name: str
+    int_dict: Dict[str, pyfory.Int32Type]
+    str_dict: Dict[str, str]
+
+
+@dataclasses.dataclass
+class DictFieldsClassInconsistent:
+    name: str
+    int_dict: Dict[str, str]  # Changed from Int32Type to str
+    str_dict: Dict[str, pyfory.Int32Type]  # Changed from str to Int32Type
 
 
 class TestMetaShareMode:
@@ -178,3 +220,78 @@ class TestMetaShareMode:
         assert deserialized.age == obj.age
         # The missing field should not be present
         assert not hasattr(deserialized, "active")
+
+    def test_schema_inconsistent_nested_struct(self):
+        """Test schema inconsistency with nested struct types."""
+        # Serialize with original schema
+        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1.register_type(NestedStructClass)
+        fory1.register_type(SimpleNestedDataClass)
+
+        obj = NestedStructClass(
+            name="test",
+            nested=SimpleNestedDataClass(value=42, name="nested_test")
+        )
+        buffer = fory1.serialize(obj)
+
+        # Deserialize with inconsistent schema (different nested type)
+        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2.register_type(NestedStructClassInconsistent)
+        fory2.register_type(ExtendedDataClass)
+
+        # This should handle the schema inconsistency gracefully
+        deserialized = fory2.deserialize(buffer)
+        assert isinstance(deserialized, NestedStructClassInconsistent)
+        assert deserialized.name == obj.name
+        # The nested field type has changed, so we expect different behavior
+        assert hasattr(deserialized, "nested")
+
+    def test_schema_inconsistent_list_fields(self):
+        """Test schema inconsistency with List field types."""
+        # Serialize with original schema
+        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1.register_type(ListFieldsClass)
+
+        obj = ListFieldsClass(
+            name="test",
+            int_list=[1, 2, 3],
+            str_list=["a", "b", "c"]
+        )
+        buffer = fory1.serialize(obj)
+
+        # Deserialize with inconsistent schema (swapped List types)
+        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2.register_type(ListFieldsClassInconsistent)
+
+        # This should handle the schema inconsistency gracefully
+        deserialized = fory2.deserialize(buffer)
+        assert isinstance(deserialized, ListFieldsClassInconsistent)
+        assert deserialized.name == obj.name
+        # The field types have been swapped, so we expect different behavior
+        assert hasattr(deserialized, "int_list")
+        assert hasattr(deserialized, "str_list")
+
+    def test_schema_inconsistent_dict_fields(self):
+        """Test schema inconsistency with Dict field types."""
+        # Serialize with original schema
+        fory1 = Fory(language=Language.XLANG, compatbile=True)
+        fory1.register_type(DictFieldsClass)
+
+        obj = DictFieldsClass(
+            name="test",
+            int_dict={"key1": 1, "key2": 2},
+            str_dict={"key1": "value1", "key2": "value2"}
+        )
+        buffer = fory1.serialize(obj)
+
+        # Deserialize with inconsistent schema (swapped Dict value types)
+        fory2 = Fory(language=Language.XLANG, compatbile=True)
+        fory2.register_type(DictFieldsClassInconsistent)
+
+        # This should handle the schema inconsistency gracefully
+        deserialized = fory2.deserialize(buffer)
+        assert isinstance(deserialized, DictFieldsClassInconsistent)
+        assert deserialized.name == obj.name
+        # The field value types have been swapped, so we expect different behavior
+        assert hasattr(deserialized, "int_dict")
+        assert hasattr(deserialized, "str_dict")

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import dataclasses
+from pyfory import Fory, Language
+from pyfory.buffer import Buffer
+from pyfory.type import TypeId
+
+
+@dataclasses.dataclass
+class SimpleDataClass:
+    name: str
+    age: int
+    active: bool
+
+
+@dataclasses.dataclass
+class SimpleNestedDataClass:
+    value: int
+    name: str
+
+
+class TestMetaShareMode:
+    
+    def setup_method(self):
+        """Setup method to register dataclasses for each test."""
+        pass
+    
+    def test_meta_share_enabled(self):
+        """Test that meta share mode can be enabled."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        assert fory.serialization_context.scoped_meta_share_enabled
+        assert fory.serialization_context.meta_context is not None
+
+    def test_meta_share_disabled(self):
+        """Test that meta share mode can be disabled."""
+        fory = Fory(language=Language.XLANG, meta_share=False)
+        assert not fory.serialization_context.scoped_meta_share_enabled
+        assert fory.serialization_context.meta_context is None
+
+    def test_simple_dataclass_serialization(self):
+        """Test serialization of simple dataclass with meta share."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        
+        # Register the dataclass
+        fory.register_type(SimpleDataClass)
+        
+        obj = SimpleDataClass(name="test", age=25, active=True)
+        buffer = fory.serialize(obj)
+        
+        # Deserialize
+        deserialized = fory.deserialize(buffer)
+        assert deserialized.name == obj.name
+        assert deserialized.age == obj.age
+        assert deserialized.active == obj.active
+
+    def test_multiple_objects_same_type(self):
+        """Test that multiple objects of same type reuse type definition."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        
+        # Register the dataclass
+        fory.register_type(SimpleDataClass)
+        
+        obj1 = SimpleDataClass(name="test1", age=25, active=True)
+        obj2 = SimpleDataClass(name="test2", age=30, active=False)
+        
+        # Serialize both objects
+        buffer1 = fory.serialize(obj1)
+        buffer2 = fory.serialize(obj2)
+        
+        # Create a new fory instance with the same meta context for deserialization
+        fory2 = Fory(language=Language.XLANG, meta_share=True)
+        fory2.register_type(SimpleDataClass)
+        # Copy the meta context from the first fory instance
+        fory2.serialization_context.meta_context = fory.serialization_context.meta_context
+        
+        # Deserialize both
+        deserialized1 = fory2.deserialize(buffer1)
+        deserialized2 = fory2.deserialize(buffer2)
+        
+        assert deserialized1.name == obj1.name
+        assert deserialized2.name == obj2.name
+        assert deserialized1.age == obj1.age
+        assert deserialized2.age == obj2.age
+
+    def test_simple_nested_dataclass_serialization(self):
+        """Test serialization of simple nested dataclass with meta share."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        
+        # Register the dataclass
+        fory.register_type(SimpleNestedDataClass)
+        
+        obj = SimpleNestedDataClass(value=42, name="test")
+        
+        buffer = fory.serialize(obj)
+        deserialized = fory.deserialize(buffer)
+        
+        assert deserialized.value == obj.value
+        assert deserialized.name == obj.name
+
+    def test_meta_context_type_mapping(self):
+        """Test that meta context properly maps types to IDs."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        meta_context = fory.serialization_context.meta_context
+        
+        # Register the dataclass
+        fory.register_type(SimpleDataClass)
+        
+        obj = SimpleDataClass(name="test", age=25, active=True)
+        buffer = fory.serialize(obj)
+        
+        # Check that type was added to meta context
+        type_id = meta_context.get_type_id(SimpleDataClass)
+        assert type_id is not None
+        assert type_id >= 0
+
+    def test_serialization_without_meta_share(self):
+        """Test that serialization works without meta share mode."""
+        fory = Fory(language=Language.XLANG, meta_share=False)
+        
+        # Register the dataclass
+        fory.register_type(SimpleDataClass)
+        
+        obj = SimpleDataClass(name="test", age=25, active=True)
+        buffer = fory.serialize(obj)
+        deserialized = fory.deserialize(buffer)
+        
+        assert deserialized.name == obj.name
+        assert deserialized.age == obj.age
+        assert deserialized.active == obj.active
+
+    def test_meta_context_reset(self):
+        """Test that meta context is properly reset."""
+        fory = Fory(language=Language.XLANG, meta_share=True)
+        meta_context = fory.serialization_context.meta_context
+        
+        # Register the dataclass
+        fory.register_type(SimpleDataClass)
+        
+        obj = SimpleDataClass(name="test", age=25, active=True)
+        fory.serialize(obj)
+        
+        # Check that type was added
+        type_id = meta_context.get_type_id(SimpleDataClass)
+        assert type_id is not None
+        
+        # Reset and check that type mapping is preserved (meta share behavior)
+        fory.reset_write()
+        type_id_after_reset = meta_context.get_type_id(SimpleDataClass)
+        assert type_id_after_reset is not None  # Should be preserved in meta share mode

--- a/python/pyfory/tests/test_meta_share.py
+++ b/python/pyfory/tests/test_meta_share.py
@@ -113,22 +113,6 @@ class TestMetaShareMode:
         assert deserialized.value == obj.value
         assert deserialized.name == obj.name
 
-    def test_meta_context_type_mapping(self):
-        """Test that meta context properly maps types to IDs."""
-        fory = Fory(language=Language.XLANG, meta_share=True)
-        meta_context = fory.serialization_context.meta_context
-        
-        # Register the dataclass
-        fory.register_type(SimpleDataClass)
-        
-        obj = SimpleDataClass(name="test", age=25, active=True)
-        buffer = fory.serialize(obj)
-        
-        # Check that type was added to meta context
-        type_id = meta_context.get_type_id(SimpleDataClass)
-        assert type_id is not None
-        assert type_id >= 0
-
     def test_serialization_without_meta_share(self):
         """Test that serialization works without meta share mode."""
         fory = Fory(language=Language.XLANG, meta_share=False)
@@ -144,22 +128,3 @@ class TestMetaShareMode:
         assert deserialized.age == obj.age
         assert deserialized.active == obj.active
 
-    def test_meta_context_reset(self):
-        """Test that meta context is properly reset."""
-        fory = Fory(language=Language.XLANG, meta_share=True)
-        meta_context = fory.serialization_context.meta_context
-        
-        # Register the dataclass
-        fory.register_type(SimpleDataClass)
-        
-        obj = SimpleDataClass(name="test", age=25, active=True)
-        fory.serialize(obj)
-        
-        # Check that type was added
-        type_id = meta_context.get_type_id(SimpleDataClass)
-        assert type_id is not None
-        
-        # Reset and check that type mapping is preserved (meta share behavior)
-        fory.reset_write()
-        type_id_after_reset = meta_context.get_type_id(SimpleDataClass)
-        assert type_id_after_reset is not None  # Should be preserved in meta share mode

--- a/python/pyfory/tests/test_metastring.py
+++ b/python/pyfory/tests/test_metastring.py
@@ -196,7 +196,5 @@ def test_non_ascii_encoding_and_non_utf8():
 
     non_ascii_string = "こんにちは"  # Non-ASCII string
 
-    with pytest.raises(
-        ValueError, match="Unsupported character for LOWER_SPECIAL encoding: こ"
-    ):
+    with pytest.raises(ValueError, match="Unsupported character for LOWER_SPECIAL encoding: こ"):
         encoder.encode_with_encoding(non_ascii_string, Encoding.LOWER_SPECIAL)

--- a/python/pyfory/tests/test_typedef_encoding.py
+++ b/python/pyfory/tests/test_typedef_encoding.py
@@ -75,7 +75,7 @@ def test_typedef_creation():
         FieldInfo("age", FieldType(TypeId.INT32, True, True, False), "TestTypeDef"),
     ]
 
-    typedef = TypeDef("TestTypeDef", TypeId.STRUCT, fields, b"encoded_data", False)
+    typedef = TypeDef("", "TestTypeDef", TypeId.STRUCT, fields, b"encoded_data", False)
 
     assert typedef.namespace == ""
     assert typedef.typename == "TestTypeDef"

--- a/python/pyfory/tests/test_typedef_encoding.py
+++ b/python/pyfory/tests/test_typedef_encoding.py
@@ -77,7 +77,8 @@ def test_typedef_creation():
 
     typedef = TypeDef("TestTypeDef", TypeId.STRUCT, fields, b"encoded_data", False)
 
-    assert typedef.name == "TestTypeDef"
+    assert typedef.namespace == ""
+    assert typedef.typename == "TestTypeDef"
     assert typedef.type_id == TypeId.STRUCT
     assert len(typedef.fields) == 2
     assert typedef.encoded == b"encoded_data"

--- a/python/pyfory/tests/test_typedef_encoding.py
+++ b/python/pyfory/tests/test_typedef_encoding.py
@@ -75,7 +75,7 @@ def test_typedef_creation():
         FieldInfo("age", FieldType(TypeId.INT32, True, True, False), "TestTypeDef"),
     ]
 
-    typedef = TypeDef("", "TestTypeDef", TypeId.STRUCT, fields, b"encoded_data", False)
+    typedef = TypeDef("", "TestTypeDef", None, TypeId.STRUCT, fields, b"encoded_data", False)
 
     assert typedef.namespace == ""
     assert typedef.typename == "TestTypeDef"

--- a/python/pyfory/type.py
+++ b/python/pyfory/type.py
@@ -369,10 +369,19 @@ _polymorphic_type_ids = {
     TypeId.UNKNOWN,
 }
 
+_struct_type_ids = {
+    TypeId.STRUCT,
+    TypeId.COMPATIBLE_STRUCT,
+    TypeId.NAMED_STRUCT,
+    TypeId.NAMED_COMPATIBLE_STRUCT,
+}
 
 def is_polymorphic_type(type_id: int) -> bool:
     return type_id in _polymorphic_type_ids
 
+
+def is_struct_type(type_id: int) -> bool:
+    return type_id in _struct_type_ids
 
 def is_subclass(from_type, to_type):
     try:

--- a/python/pyfory/type.py
+++ b/python/pyfory/type.py
@@ -129,6 +129,7 @@ class TypeId:
     Fory type for cross-language serialization.
     See `org.apache.fory.types.Type`
     """
+
     UNKNOWN = -1
     # null value
     NA = 0
@@ -356,7 +357,7 @@ def is_map_type(type_):
         return issubclass(type_, typing.Dict)
     except TypeError:
         return False
-    
+
 
 _polymorphic_type_ids = {
     TypeId.STRUCT,
@@ -401,30 +402,18 @@ class TypeVisitor(ABC):
 def infer_field(field_name, type_, visitor: TypeVisitor, types_path=None):
     types_path = list(types_path or [])
     types_path.append(type_)
-    origin = (
-        typing.get_origin(type_)
-        if hasattr(typing, "get_origin")
-        else getattr(type_, "__origin__", type_)
-    )
+    origin = typing.get_origin(type_) if hasattr(typing, "get_origin") else getattr(type_, "__origin__", type_)
     origin = origin or type_
-    args = (
-        typing.get_args(type_)
-        if hasattr(typing, "get_args")
-        else getattr(type_, "__args__", ())
-    )
+    args = typing.get_args(type_) if hasattr(typing, "get_args") else getattr(type_, "__args__", ())
     if args:
         if origin is list or origin == typing.List:
             elem_type = args[0]
             return visitor.visit_list(field_name, elem_type, types_path=types_path)
         elif origin is dict or origin == typing.Dict:
             key_type, value_type = args
-            return visitor.visit_dict(
-                field_name, key_type, value_type, types_path=types_path
-            )
+            return visitor.visit_dict(field_name, key_type, value_type, types_path=types_path)
         else:
-            raise TypeError(
-                f"Collection types should be {list, dict} instead of {type_}"
-            )
+            raise TypeError(f"Collection types should be {list, dict} instead of {type_}")
     else:
         if is_function(origin) or not hasattr(origin, "__annotations__"):
             return visitor.visit_other(field_name, type_, types_path=types_path)

--- a/python/pyfory/type.py
+++ b/python/pyfory/type.py
@@ -376,12 +376,14 @@ _struct_type_ids = {
     TypeId.NAMED_COMPATIBLE_STRUCT,
 }
 
+
 def is_polymorphic_type(type_id: int) -> bool:
     return type_id in _polymorphic_type_ids
 
 
 def is_struct_type(type_id: int) -> bool:
     return type_id in _struct_type_ids
+
 
 def is_subclass(from_type, to_type):
     try:


### PR DESCRIPTION


## Why?

implement meta share mode for pyfory, so the struct can add/delete fields and have inconsistent schema bettween serialization and deserialization

## What does this PR do?

<!-- Describe the details of this PR. -->

## Related issues

#2509
https://github.com/apache/fory/issues/1938
https://github.com/apache/fory/issues/2160
https://github.com/apache/fory/pull/2278 

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
