### PR TITLE
feat(java): Add getClassResolver to BaseFory

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/AbstractThreadSafeFory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/AbstractThreadSafeFory.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.fory.annotation.Internal;
 import org.apache.fory.resolver.ClassChecker;
+import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.SerializerFactory;
 
@@ -89,6 +90,11 @@ public abstract class AbstractThreadSafeFory implements ThreadSafeFory {
           fory.ensureSerializersCompiled();
           return null;
         });
+  }
+
+  @Override
+  public ClassResolver getClassResolver() {
+    return execute(fory -> fory.getClassResolver());
   }
 
   @Internal

--- a/java/fory-core/src/main/java/org/apache/fory/BaseFory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/BaseFory.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import org.apache.fory.io.ForyInputStream;
 import org.apache.fory.io.ForyReadableChannel;
 import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.serializer.BufferCallback;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.SerializerFactory;
@@ -222,4 +223,7 @@ public interface BaseFory {
 
   /** Deep copy the <code>obj</code>. */
   <T> T copy(T obj);
+
+  /** Return the class resolver used by this fory instance. */
+  ClassResolver getClassResolver();
 }


### PR DESCRIPTION
## Why?

So you can serialize private third-party classes like `kotlin.time.InstantSerializer` more easily.

## What does this PR do?

* Add `getClassResolver()` method to the `BaseFory` interface.
* Implement `getClassResolver()` in `AbstractThreadSafeFory` to return the
  class resolver.
* Import `ClassResolver` in both modified files.