### PR TITLE
feat(go): Add slice support to fory-go codegen serialization

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -2,7 +2,28 @@
 
 Fory is a blazingly fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
 
-Currently, Fory Go is implemented using reflection. We have also implemented a static code generator to generate serializer code ahead of time to speed up serialization.
+Fory Go provides two serialization paths: a high-performance code generation path and a reflection-based path. The code generation path is recommended for production use as it offers better performance and broader type support.
+
+## Supported Types
+
+Fory Go supports the following types for both reflection-based serialization and code generation:
+
+### Basic Data Types
+
+- `bool`
+- `int8`, `int16`, `int32`, `int64`, `int`
+- `uint8` (byte)
+- `float32`, `float64`
+- `string`
+
+### Collection Types
+
+- `[]bool`, `[]int16`, `[]int32`, `[]int64`
+- `[]float32`, `[]float64`
+- `[]string`
+- `[]byte` (optimized binary serialization)
+- `[]interface{}` (dynamic slice)
+- `map[interface{}]interface{}` (dynamic map)
 
 ## Fory Go Codegen (optional)
 
@@ -27,7 +48,7 @@ The generator binary is `fory`.
 go install github.com/apache/fory/go/fory/cmd/fory@latest
 ```
 
-- Go 1.13+
+- Go 1.13+:
 
 ```bash
 # Inside a module-enabled environment

--- a/go/fory/codegen/decoder.go
+++ b/go/fory/codegen/decoder.go
@@ -116,9 +116,15 @@ func generateFieldReadTyped(buf *bytes.Buffer, field *FieldInfo) error {
 		case types.Int16:
 			fmt.Fprintf(buf, "\t%s = buf.ReadInt16()\n", fieldAccess)
 		case types.Int32:
-			fmt.Fprintf(buf, "\t%s = buf.ReadInt32()\n", fieldAccess)
+			fmt.Fprintf(buf, "\tif flag := buf.ReadInt8(); flag != -1 {\n")
+			fmt.Fprintf(buf, "\t\treturn fmt.Errorf(\"expected NotNullValueFlag for field %s, got %%d\", flag)\n", field.GoName)
+			fmt.Fprintf(buf, "\t}\n")
+			fmt.Fprintf(buf, "\t%s = buf.ReadVarint32()\n", fieldAccess)
 		case types.Int, types.Int64:
-			fmt.Fprintf(buf, "\t%s = buf.ReadInt64()\n", fieldAccess)
+			fmt.Fprintf(buf, "\tif flag := buf.ReadInt8(); flag != -1 {\n")
+			fmt.Fprintf(buf, "\t\treturn fmt.Errorf(\"expected NotNullValueFlag for field %s, got %%d\", flag)\n", field.GoName)
+			fmt.Fprintf(buf, "\t}\n")
+			fmt.Fprintf(buf, "\t%s = buf.ReadVarint64()\n", fieldAccess)
 		case types.Uint8:
 			fmt.Fprintf(buf, "\t%s = buf.ReadByte_()\n", fieldAccess)
 		case types.Uint16:
@@ -132,6 +138,9 @@ func generateFieldReadTyped(buf *bytes.Buffer, field *FieldInfo) error {
 		case types.Float64:
 			fmt.Fprintf(buf, "\t%s = buf.ReadFloat64()\n", fieldAccess)
 		case types.String:
+			fmt.Fprintf(buf, "\tif flag := buf.ReadInt8(); flag != 0 {\n")
+			fmt.Fprintf(buf, "\t\treturn fmt.Errorf(\"expected RefValueFlag for field %s, got %%d\", flag)\n", field.GoName)
+			fmt.Fprintf(buf, "\t}\n")
 			fmt.Fprintf(buf, "\t%s = fory.ReadString(buf)\n", fieldAccess)
 		default:
 			fmt.Fprintf(buf, "\t// TODO: unsupported basic type %s\n", basic.String())

--- a/go/fory/codegen/decoder.go
+++ b/go/fory/codegen/decoder.go
@@ -293,9 +293,9 @@ func generateSliceElementRead(buf *bytes.Buffer, elemType types.Type, elemAccess
 func generateSliceReadInline(buf *bytes.Buffer, sliceType *types.Slice, fieldAccess string) error {
 	elemType := sliceType.Elem()
 
-	// Read NotNullValueFlag first (matching encoder behavior)
-	fmt.Fprintf(buf, "\tif flag := buf.ReadInt8(); flag != -1 {\n")
-	fmt.Fprintf(buf, "\t\treturn fmt.Errorf(\"expected NotNullValueFlag for slice field, got %%d\", flag)\n")
+	// Read RefValueFlag first (slice is referencable)
+	fmt.Fprintf(buf, "\tif flag := buf.ReadInt8(); flag != 0 {\n")
+	fmt.Fprintf(buf, "\t\treturn fmt.Errorf(\"expected RefValueFlag for slice field, got %%d\", flag)\n")
 	fmt.Fprintf(buf, "\t}\n")
 
 	// Read slice length - use block scope to avoid variable name conflicts
@@ -307,8 +307,8 @@ func generateSliceReadInline(buf *bytes.Buffer, sliceType *types.Slice, fieldAcc
 
 	// Read collection header
 	fmt.Fprintf(buf, "\t\t\tcollectFlag := buf.ReadInt8()\n")
-	fmt.Fprintf(buf, "\t\t\t// We expect CollectionNotDeclElementType + CollectionNotSameType = 12\n")
-	fmt.Fprintf(buf, "\t\t\tif collectFlag != 12 {\n")
+	fmt.Fprintf(buf, "\t\t\t// We expect 12 (no ref tracking) or 13 (with ref tracking)\n")
+	fmt.Fprintf(buf, "\t\t\tif collectFlag != 12 && collectFlag != 13 {\n")
 	fmt.Fprintf(buf, "\t\t\t\treturn fmt.Errorf(\"unexpected collection flag: %%d\", collectFlag)\n")
 	fmt.Fprintf(buf, "\t\t\t}\n")
 

--- a/go/fory/codegen/encoder.go
+++ b/go/fory/codegen/encoder.go
@@ -108,9 +108,11 @@ func generateFieldWriteTyped(buf *bytes.Buffer, field *FieldInfo) error {
 		case types.Int16:
 			fmt.Fprintf(buf, "\tbuf.WriteInt16(%s)\n", fieldAccess)
 		case types.Int32:
-			fmt.Fprintf(buf, "\tbuf.WriteInt32(%s)\n", fieldAccess)
+			fmt.Fprintf(buf, "\tbuf.WriteInt8(-1) // NotNullValueFlag\n")
+			fmt.Fprintf(buf, "\tbuf.WriteVarint32(%s)\n", fieldAccess)
 		case types.Int, types.Int64:
-			fmt.Fprintf(buf, "\tbuf.WriteInt64(%s)\n", fieldAccess)
+			fmt.Fprintf(buf, "\tbuf.WriteInt8(-1) // NotNullValueFlag\n")
+			fmt.Fprintf(buf, "\tbuf.WriteVarint64(%s)\n", fieldAccess)
 		case types.Uint8:
 			fmt.Fprintf(buf, "\tbuf.WriteByte_(%s)\n", fieldAccess)
 		case types.Uint16:
@@ -124,6 +126,7 @@ func generateFieldWriteTyped(buf *bytes.Buffer, field *FieldInfo) error {
 		case types.Float64:
 			fmt.Fprintf(buf, "\tbuf.WriteFloat64(%s)\n", fieldAccess)
 		case types.String:
+			fmt.Fprintf(buf, "\tbuf.WriteInt8(0) // RefValueFlag\n")
 			fmt.Fprintf(buf, "\tfory.WriteString(buf, %s)\n", fieldAccess)
 		default:
 			fmt.Fprintf(buf, "\t// TODO: unsupported basic type %s\n", basic.String())

--- a/go/fory/codegen/guard.go
+++ b/go/fory/codegen/guard.go
@@ -53,14 +53,15 @@ func generateStructGuard(buf *bytes.Buffer, structInfo StructInfo) {
 	buf.WriteString(fmt.Sprintf("// Snapshot of %s's underlying type at generation time.\n", typeName))
 	buf.WriteString(fmt.Sprintf("type %s struct {\n", expectedTypeName))
 
-	// Sort fields to ensure consistent ordering (using pointers)
-	fields := make([]*FieldInfo, len(structInfo.Fields))
-	copy(fields, structInfo.Fields)
-	sort.Slice(fields, func(i, j int) bool {
-		return fields[i].GoName < fields[j].GoName
+	// Sort fields by their original index to match the struct definition
+	// This is important for the compile-time guard to work correctly
+	originalFields := make([]*FieldInfo, len(structInfo.Fields))
+	copy(originalFields, structInfo.Fields)
+	sort.Slice(originalFields, func(i, j int) bool {
+		return originalFields[i].Index < originalFields[j].Index
 	})
 
-	for _, field := range fields {
+	for _, field := range originalFields {
 		buf.WriteString(fmt.Sprintf("\t%s %s", field.GoName, formatFieldType(*field)))
 
 		// Add struct tag if present (we'll extract it from the original struct)

--- a/go/fory/codegen/utils.go
+++ b/go/fory/codegen/utils.go
@@ -61,6 +61,12 @@ func isSupportedFieldType(t types.Type) bool {
 		t = ptr.Elem()
 	}
 
+	// Check slice types
+	if slice, ok := t.(*types.Slice); ok {
+		// Check if element type is supported
+		return isSupportedFieldType(slice.Elem())
+	}
+
 	// Check named types
 	if named, ok := t.(*types.Named); ok {
 		typeStr := named.String()
@@ -115,6 +121,11 @@ func getTypeID(t types.Type) string {
 	// Handle pointer types
 	if ptr, ok := t.(*types.Pointer); ok {
 		t = ptr.Elem()
+	}
+
+	// Check slice types
+	if _, ok := t.(*types.Slice); ok {
+		return "LIST"
 	}
 
 	// Check named types first
@@ -210,6 +221,7 @@ func getTypeIDValue(typeID string) int {
 		"TIMESTAMP":    20,  // TIMESTAMP = 20
 		"LOCAL_DATE":   21,  // LOCAL_DATE = 21
 		"NAMED_STRUCT": 17,  // NAMED_STRUCT = 17 (Note: not 30!)
+		"LIST":         21,  // LIST = 21
 	}
 
 	if val, ok := typeIDMap[typeID]; ok {
@@ -327,6 +339,8 @@ func getFieldHashID(field *FieldInfo) int32 {
 		tid = 21 // LOCAL_DATE
 	case "NAMED_STRUCT":
 		tid = 17 // NAMED_STRUCT
+	case "LIST":
+		tid = 21 // LIST
 	default:
 		tid = 0 // Unknown type
 	}

--- a/go/fory/struct.go
+++ b/go/fory/struct.go
@@ -26,11 +26,12 @@ import (
 )
 
 type structSerializer struct {
-	typeTag    string
-	type_      reflect.Type
-	fieldsInfo structFieldsInfo
-	structHash int32
-	fieldDefs  []FieldDef // defs obtained during reading
+	typeTag         string
+	type_           reflect.Type
+	fieldsInfo      structFieldsInfo
+	structHash      int32
+	fieldDefs       []FieldDef // defs obtained during reading
+	codegenDelegate Serializer // Optional codegen serializer for performance (like Python's approach)
 }
 
 var UNKNOWN_TYPE_ID = int16(-1)
@@ -44,6 +45,12 @@ func (s *structSerializer) NeedWriteRef() bool {
 }
 
 func (s *structSerializer) Write(f *Fory, buf *ByteBuffer, value reflect.Value) error {
+	// If we have a codegen delegate, use it for optimal performance
+	if s.codegenDelegate != nil {
+		return s.codegenDelegate.Write(f, buf, value)
+	}
+
+	// Fall back to reflection-based serialization
 	// TODO support fields back and forward compatible. need to serialize fields name too.
 	if s.fieldsInfo == nil {
 		if fieldsInfo, err := createStructFieldInfos(f, s.type_); err != nil {
@@ -78,6 +85,12 @@ func (s *structSerializer) Write(f *Fory, buf *ByteBuffer, value reflect.Value) 
 }
 
 func (s *structSerializer) Read(f *Fory, buf *ByteBuffer, type_ reflect.Type, value reflect.Value) error {
+	// If we have a codegen delegate, use it for optimal performance
+	if s.codegenDelegate != nil {
+		return s.codegenDelegate.Read(f, buf, type_, value)
+	}
+
+	// Fall back to reflection-based deserialization
 	// struct value may be a value type if it's not a pointer, so we don't invoke `refResolver.Reference` here,
 	// but invoke it in `ptrToStructSerializer` instead.
 	if value.Kind() == reflect.Ptr {
@@ -381,6 +394,7 @@ func (x structFieldsInfo) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 type ptrToStructSerializer struct {
 	type_ reflect.Type
 	structSerializer
+	codegenDelegate Serializer // Optional codegen serializer for performance (like Python's approach)
 }
 
 func (s *ptrToStructSerializer) TypeId() TypeId {
@@ -392,10 +406,22 @@ func (s *ptrToStructSerializer) NeedWriteRef() bool {
 }
 
 func (s *ptrToStructSerializer) Write(f *Fory, buf *ByteBuffer, value reflect.Value) error {
+	// If we have a codegen delegate, use it for optimal performance (Python-style approach)
+	if s.codegenDelegate != nil {
+		return s.codegenDelegate.Write(f, buf, value)
+	}
+
+	// Fall back to reflection-based serialization
 	return s.structSerializer.Write(f, buf, value.Elem())
 }
 
 func (s *ptrToStructSerializer) Read(f *Fory, buf *ByteBuffer, type_ reflect.Type, value reflect.Value) error {
+	// If we have a codegen delegate, use it for optimal performance
+	if s.codegenDelegate != nil {
+		return s.codegenDelegate.Read(f, buf, type_, value)
+	}
+
+	// Fall back to reflection-based deserialization
 	newValue := reflect.New(type_.Elem())
 	value.Set(newValue)
 	elem := newValue.Elem()

--- a/go/fory/tests/generator_test.go
+++ b/go/fory/tests/generator_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:generate fory -file structs.go
+//go:generate go run ../cmd/fory/main.go --force -file structs.go
 
 func TestValidationDemo(t *testing.T) {
 	// 1. Create test instance

--- a/go/fory/tests/generator_test.go
+++ b/go/fory/tests/generator_test.go
@@ -60,6 +60,11 @@ func TestValidationDemo(t *testing.T) {
 
 	// 5. Validate data integrity
 	assert.EqualValues(t, original, result, "Complete struct should match after round-trip")
+
+	// 6. Assert that serializer is the generated serializer
+	validationSerializer := NewSerializerFor_ValidationDemo()
+	_, ok := validationSerializer.(ValidationDemo_ForyGenSerializer)
+	assert.True(t, ok, "Serializer should be the generated ValidationDemo_ForyGenSerializer")
 }
 
 func TestSliceDemo(t *testing.T) {
@@ -71,15 +76,11 @@ func TestSliceDemo(t *testing.T) {
 		BoolSlice:   []bool{true, false, true, false},
 	}
 
-	// Validate original data structure
-	assert.Equal(t, 5, len(original.IntSlice), "IntSlice should have 5 elements")
-	assert.Equal(t, []int32{10, 20, 30, 40, 50}, original.IntSlice, "IntSlice values should match")
-	assert.Equal(t, 4, len(original.StringSlice), "StringSlice should have 4 elements")
-	assert.Equal(t, []string{"hello", "world", "fory", "slice"}, original.StringSlice, "StringSlice values should match")
-	assert.Equal(t, 5, len(original.FloatSlice), "FloatSlice should have 5 elements")
-	assert.Equal(t, []float64{1.1, 2.2, 3.3, 4.4, 5.5}, original.FloatSlice, "FloatSlice values should match")
-	assert.Equal(t, 4, len(original.BoolSlice), "BoolSlice should have 4 elements")
-	assert.Equal(t, []bool{true, false, true, false}, original.BoolSlice, "BoolSlice values should match")
+	// Validate original data structure (quick sanity check)
+	assert.NotEmpty(t, original.IntSlice, "IntSlice should not be empty")
+	assert.NotEmpty(t, original.StringSlice, "StringSlice should not be empty")
+	assert.NotEmpty(t, original.FloatSlice, "FloatSlice should not be empty")
+	assert.NotEmpty(t, original.BoolSlice, "BoolSlice should not be empty")
 
 	// 2. Serialize using generated code
 	f := fory.NewFory(true)
@@ -94,19 +95,11 @@ func TestSliceDemo(t *testing.T) {
 	require.NoError(t, err, "Deserialization should not fail")
 	require.NotNil(t, result, "Deserialized result should not be nil")
 
-	// 4. Validate round-trip serialization - detailed field checks
-	assert.Equal(t, len(original.IntSlice), len(result.IntSlice), "IntSlice length should match after round-trip")
-	assert.Equal(t, original.IntSlice, result.IntSlice, "IntSlice should match after round-trip")
-
-	assert.Equal(t, len(original.StringSlice), len(result.StringSlice), "StringSlice length should match after round-trip")
-	assert.Equal(t, original.StringSlice, result.StringSlice, "StringSlice should match after round-trip")
-
-	assert.Equal(t, len(original.FloatSlice), len(result.FloatSlice), "FloatSlice length should match after round-trip")
-	assert.Equal(t, original.FloatSlice, result.FloatSlice, "FloatSlice should match after round-trip")
-
-	assert.Equal(t, len(original.BoolSlice), len(result.BoolSlice), "BoolSlice length should match after round-trip")
-	assert.Equal(t, original.BoolSlice, result.BoolSlice, "BoolSlice should match after round-trip")
-
-	// 5. Validate data integrity
+	// 4. Validate round-trip serialization
 	assert.EqualValues(t, original, result, "Complete struct should match after round-trip")
+
+	// 5. Assert that serializer is the generated serializer
+	sliceSerializer := NewSerializerFor_SliceDemo()
+	_, ok := sliceSerializer.(SliceDemo_ForyGenSerializer)
+	assert.True(t, ok, "Serializer should be the generated SliceDemo_ForyGenSerializer")
 }

--- a/go/fory/tests/generator_test.go
+++ b/go/fory/tests/generator_test.go
@@ -61,3 +61,52 @@ func TestValidationDemo(t *testing.T) {
 	// 5. Validate data integrity
 	assert.EqualValues(t, original, result, "Complete struct should match after round-trip")
 }
+
+func TestSliceDemo(t *testing.T) {
+	// 1. Create test instance with various slice types
+	original := &SliceDemo{
+		IntSlice:    []int32{10, 20, 30, 40, 50},
+		StringSlice: []string{"hello", "world", "fory", "slice"},
+		FloatSlice:  []float64{1.1, 2.2, 3.3, 4.4, 5.5},
+		BoolSlice:   []bool{true, false, true, false},
+	}
+
+	// Validate original data structure
+	assert.Equal(t, 5, len(original.IntSlice), "IntSlice should have 5 elements")
+	assert.Equal(t, []int32{10, 20, 30, 40, 50}, original.IntSlice, "IntSlice values should match")
+	assert.Equal(t, 4, len(original.StringSlice), "StringSlice should have 4 elements")
+	assert.Equal(t, []string{"hello", "world", "fory", "slice"}, original.StringSlice, "StringSlice values should match")
+	assert.Equal(t, 5, len(original.FloatSlice), "FloatSlice should have 5 elements")
+	assert.Equal(t, []float64{1.1, 2.2, 3.3, 4.4, 5.5}, original.FloatSlice, "FloatSlice values should match")
+	assert.Equal(t, 4, len(original.BoolSlice), "BoolSlice should have 4 elements")
+	assert.Equal(t, []bool{true, false, true, false}, original.BoolSlice, "BoolSlice values should match")
+
+	// 2. Serialize using generated code
+	f := fory.NewFory(true)
+	data, err := f.Marshal(original)
+	require.NoError(t, err, "Serialization should not fail")
+	require.NotEmpty(t, data, "Serialized data should not be empty")
+	assert.Greater(t, len(data), 0, "Serialized data should have positive length")
+
+	// 3. Deserialize using generated code
+	var result *SliceDemo
+	err = f.Unmarshal(data, &result)
+	require.NoError(t, err, "Deserialization should not fail")
+	require.NotNil(t, result, "Deserialized result should not be nil")
+
+	// 4. Validate round-trip serialization - detailed field checks
+	assert.Equal(t, len(original.IntSlice), len(result.IntSlice), "IntSlice length should match after round-trip")
+	assert.Equal(t, original.IntSlice, result.IntSlice, "IntSlice should match after round-trip")
+
+	assert.Equal(t, len(original.StringSlice), len(result.StringSlice), "StringSlice length should match after round-trip")
+	assert.Equal(t, original.StringSlice, result.StringSlice, "StringSlice should match after round-trip")
+
+	assert.Equal(t, len(original.FloatSlice), len(result.FloatSlice), "FloatSlice length should match after round-trip")
+	assert.Equal(t, original.FloatSlice, result.FloatSlice, "FloatSlice should match after round-trip")
+
+	assert.Equal(t, len(original.BoolSlice), len(result.BoolSlice), "BoolSlice length should match after round-trip")
+	assert.Equal(t, original.BoolSlice, result.BoolSlice, "BoolSlice should match after round-trip")
+
+	// 5. Validate data integrity
+	assert.EqualValues(t, original, result, "Complete struct should match after round-trip")
+}

--- a/go/fory/tests/generator_xlang_test.go
+++ b/go/fory/tests/generator_xlang_test.go
@@ -117,3 +117,152 @@ func TestActualCodegenName(t *testing.T) {
 		fmt.Printf("❌ 用codegen反序列化reflect数据失败: %v\n", err)
 	}
 }
+
+// TestSliceDemoXlang - 测试SliceDemo的跨语言兼容性
+func TestSliceDemoXlang(t *testing.T) {
+	fmt.Println("=== SliceDemo跨语言兼容性测试 ===")
+
+	// 获取SliceDemo的类型信息
+	sliceDemoType := reflect.TypeOf(SliceDemo{})
+	pkgPath := sliceDemoType.PkgPath()
+	typeName := sliceDemoType.Name()
+	expectedTypeTag := pkgPath + "." + typeName
+
+	fmt.Printf("SliceDemo 类型分析：\n")
+	fmt.Printf("  包路径: %s\n", pkgPath)
+	fmt.Printf("  类型名: %s\n", typeName)
+	fmt.Printf("  实际typeTag: %s\n", expectedTypeTag)
+
+	// 创建测试数据
+	codegenInstance := &SliceDemo{
+		IntSlice:    []int32{1, 2, 3, 4, 5},
+		StringSlice: []string{"hello", "world", "fory"},
+		FloatSlice:  []float64{1.1, 2.2, 3.3},
+		BoolSlice:   []bool{true, false, true},
+	}
+
+	// 使用反射定义等价结构
+	type ReflectSliceStruct struct {
+		IntSlice    []int32   `json:"int_slice"`
+		StringSlice []string  `json:"string_slice"`
+		FloatSlice  []float64 `json:"float_slice"`
+		BoolSlice   []bool    `json:"bool_slice"`
+	}
+
+	reflectInstance := &ReflectSliceStruct{
+		IntSlice:    []int32{1, 2, 3, 4, 5},
+		StringSlice: []string{"hello", "world", "fory"},
+		FloatSlice:  []float64{1.1, 2.2, 3.3},
+		BoolSlice:   []bool{true, false, true},
+	}
+
+	// Codegen 模式 - 关闭reference tracking以避免复杂性
+	foryForCodegen := forygo.NewFory(false)
+
+	// Reflect 模式 - 关闭reference tracking以避免复杂性
+	foryForReflect := forygo.NewFory(false)
+	err := foryForReflect.RegisterTagType(expectedTypeTag, ReflectSliceStruct{})
+	require.NoError(t, err, "应该能够用完整名称注册ReflectSliceStruct")
+
+	fmt.Printf("✅ 成功使用完整名称注册: %s\n", expectedTypeTag)
+
+	// 序列化测试
+	codegenData, err := foryForCodegen.Marshal(codegenInstance)
+	require.NoError(t, err, "Codegen序列化不应失败")
+
+	reflectData, err := foryForReflect.Marshal(reflectInstance)
+	require.NoError(t, err, "Reflect序列化不应失败")
+
+	fmt.Printf("\n序列化结果：\n")
+	fmt.Printf("  Codegen数据长度: %d bytes\n", len(codegenData))
+	fmt.Printf("  Reflect数据长度: %d bytes\n", len(reflectData))
+	fmt.Printf("  数据是否相同: %t\n", reflect.DeepEqual(codegenData, reflectData))
+
+	// 详细分析序列化数据差异
+	fmt.Println("\n=== 详细序列化数据分析 ===")
+	fmt.Printf("Codegen完整数据: %x\n", codegenData)
+	fmt.Printf("Reflect完整数据: %x\n", reflectData)
+
+	// 逐字节比较
+	fmt.Println("\n=== 逐字节差异分析 ===")
+	minLen := len(codegenData)
+	if len(reflectData) < minLen {
+		minLen = len(reflectData)
+	}
+
+	differentBytes := 0
+	for i := 0; i < minLen; i++ {
+		if codegenData[i] != reflectData[i] {
+			if differentBytes < 10 { // 只显示前10个差异
+				fmt.Printf("  位置%d: Codegen=0x%02x, Reflect=0x%02x\n", i, codegenData[i], reflectData[i])
+			}
+			differentBytes++
+		}
+	}
+
+	if len(codegenData) != len(reflectData) {
+		fmt.Printf("  长度差异: Codegen=%d, Reflect=%d (差异=%d bytes)\n",
+			len(codegenData), len(reflectData), len(reflectData)-len(codegenData))
+	}
+
+	if differentBytes == 0 && len(codegenData) == len(reflectData) {
+		fmt.Println("🎉 SUCCESS: 序列化结果完全相同！")
+
+		// 验证跨序列化
+		fmt.Println("\n=== 跨序列化测试 ===")
+
+		// 用reflect反序列化codegen数据
+		var reflectResult *ReflectSliceStruct
+		err = foryForReflect.Unmarshal(codegenData, &reflectResult)
+		if err == nil && reflectResult != nil {
+			fmt.Printf("✅ 成功用reflect反序列化codegen数据:\n")
+			fmt.Printf("   IntSlice: %v\n", reflectResult.IntSlice)
+			fmt.Printf("   StringSlice: %v\n", reflectResult.StringSlice)
+			fmt.Printf("   FloatSlice: %v\n", reflectResult.FloatSlice)
+			fmt.Printf("   BoolSlice: %v\n", reflectResult.BoolSlice)
+
+			// 验证数据是否匹配
+			intMatch := reflect.DeepEqual(codegenInstance.IntSlice, reflectResult.IntSlice)
+			stringMatch := reflect.DeepEqual(codegenInstance.StringSlice, reflectResult.StringSlice)
+			floatMatch := reflect.DeepEqual(codegenInstance.FloatSlice, reflectResult.FloatSlice)
+			boolMatch := reflect.DeepEqual(codegenInstance.BoolSlice, reflectResult.BoolSlice)
+
+			fmt.Printf("   数据匹配检查: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
+				intMatch, stringMatch, floatMatch, boolMatch)
+
+			if intMatch && stringMatch && floatMatch && boolMatch {
+				fmt.Println("🎉 所有slice字段数据完全匹配！")
+			}
+		} else {
+			fmt.Printf("❌ 用reflect反序列化codegen数据失败: %v\n", err)
+		}
+
+		// 用codegen反序列化reflect数据
+		var codegenResult *SliceDemo
+		err = foryForCodegen.Unmarshal(reflectData, &codegenResult)
+		if err == nil && codegenResult != nil {
+			fmt.Printf("✅ 成功用codegen反序列化reflect数据:\n")
+			fmt.Printf("   IntSlice: %v\n", codegenResult.IntSlice)
+			fmt.Printf("   StringSlice: %v\n", codegenResult.StringSlice)
+			fmt.Printf("   FloatSlice: %v\n", codegenResult.FloatSlice)
+			fmt.Printf("   BoolSlice: %v\n", codegenResult.BoolSlice)
+
+			// 验证数据是否匹配
+			intMatch := reflect.DeepEqual(reflectInstance.IntSlice, codegenResult.IntSlice)
+			stringMatch := reflect.DeepEqual(reflectInstance.StringSlice, codegenResult.StringSlice)
+			floatMatch := reflect.DeepEqual(reflectInstance.FloatSlice, codegenResult.FloatSlice)
+			boolMatch := reflect.DeepEqual(reflectInstance.BoolSlice, codegenResult.BoolSlice)
+
+			fmt.Printf("   数据匹配检查: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
+				intMatch, stringMatch, floatMatch, boolMatch)
+
+			if intMatch && stringMatch && floatMatch && boolMatch {
+				fmt.Println("🎉 完全兼容！Codegen可以正确反序列化reflect数据！")
+			}
+		} else {
+			fmt.Printf("❌ 用codegen反序列化reflect数据失败: %v\n", err)
+		}
+	} else {
+		fmt.Printf("❌ 发现%d个字节差异\n", differentBytes)
+	}
+}

--- a/go/fory/tests/generator_xlang_test.go
+++ b/go/fory/tests/generator_xlang_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestActualCodegenName - 分析codegen实际使用的名称
+// TestActualCodegenName - Analyze actual type names used by codegen
 func TestActualCodegenName(t *testing.T) {
-	fmt.Println("=== 分析Codegen实际使用的名称 ===")
+	fmt.Println("=== Analyzing Actual Codegen Type Names ===")
 
-	// 从源码分析得出：
-	// RegisterSerializerFactory 会计算：
+	// From source code analysis:
+	// RegisterSerializerFactory calculates:
 	// typeTag := pkgPath + "." + typeName
 
 	validationDemoType := reflect.TypeOf(ValidationDemo{})
@@ -39,15 +39,15 @@ func TestActualCodegenName(t *testing.T) {
 	typeName := validationDemoType.Name()
 	expectedTypeTag := pkgPath + "." + typeName
 
-	fmt.Printf("ValidationDemo 类型分析：\n")
-	fmt.Printf("  包路径: %s\n", pkgPath)
-	fmt.Printf("  类型名: %s\n", typeName)
-	fmt.Printf("  实际typeTag: %s\n", expectedTypeTag)
+	fmt.Printf("ValidationDemo type analysis:\n")
+	fmt.Printf("  Package path: %s\n", pkgPath)
+	fmt.Printf("  Type name: %s\n", typeName)
+	fmt.Printf("  Actual typeTag: %s\n", expectedTypeTag)
 
-	// 现在使用正确的完整名称进行测试
-	fmt.Println("\n=== 使用正确的完整名称测试 ===")
+	// Test with correct full type name
+	fmt.Println("\n=== Testing with Correct Full Type Name ===")
 
-	// 创建测试数据
+	// Create test data
 	codegenInstance := &ValidationDemo{
 		A: 100,
 		B: "test_data",
@@ -66,74 +66,74 @@ func TestActualCodegenName(t *testing.T) {
 		C: 200,
 	}
 
-	// Codegen 模式 (自动使用完整名称)
+	// Codegen mode (automatically uses full name)
 	foryForCodegen := forygo.NewFory(true)
 
-	// Reflect 模式 (使用完整名称注册)
+	// Reflect mode (register with full name)
 	foryForReflect := forygo.NewFory(true)
 	err := foryForReflect.RegisterTagType(expectedTypeTag, ReflectStruct{})
-	require.NoError(t, err, "应该能够用完整名称注册ReflectStruct")
+	require.NoError(t, err, "Should be able to register ReflectStruct with full name")
 
-	fmt.Printf("✅ 成功使用完整名称注册: %s\n", expectedTypeTag)
+	fmt.Printf("✅ Successfully registered with full name: %s\n", expectedTypeTag)
 
-	// 序列化测试
+	// Serialization test
 	codegenData, err := foryForCodegen.Marshal(codegenInstance)
-	require.NoError(t, err, "Codegen序列化不应失败")
+	require.NoError(t, err, "Codegen serialization should not fail")
 
 	reflectData, err := foryForReflect.Marshal(reflectInstance)
-	require.NoError(t, err, "Reflect序列化不应失败")
+	require.NoError(t, err, "Reflect serialization should not fail")
 
-	fmt.Printf("\n序列化结果：\n")
-	fmt.Printf("  Codegen数据长度: %d bytes\n", len(codegenData))
-	fmt.Printf("  Reflect数据长度: %d bytes\n", len(reflectData))
-	fmt.Printf("  数据是否相同: %t\n", reflect.DeepEqual(codegenData, reflectData))
+	fmt.Printf("\nSerialization results:\n")
+	fmt.Printf("  Codegen data length: %d bytes\n", len(codegenData))
+	fmt.Printf("  Reflect data length: %d bytes\n", len(reflectData))
+	fmt.Printf("  Data identical: %t\n", reflect.DeepEqual(codegenData, reflectData))
 
 	if reflect.DeepEqual(codegenData, reflectData) {
-		fmt.Println("🎉 SUCCESS: 使用完整包路径名称后，两个struct成功映射到相同名称！")
+		fmt.Println("🎉 SUCCESS: Using full package path, both structs successfully map to the same name!")
 	} else {
-		fmt.Println("❌ 仍然不同，可能还有其他因素")
+		fmt.Println("❌ Still different, may have other factors")
 		fmt.Printf("  Codegen hex: %x\n", codegenData)
 		fmt.Printf("  Reflect hex: %x\n", reflectData)
 	}
 
-	// 验证跨序列化
-	fmt.Println("\n=== 跨序列化测试 ===")
+	// Verify cross serialization
+	fmt.Println("\n=== Cross Serialization Test ===")
 
-	// 用reflect fory反序列化codegen数据
+	// Use reflect to deserialize codegen data
 	var reflectResult *ReflectStruct
 	err = foryForReflect.Unmarshal(codegenData, &reflectResult)
 	if err == nil && reflectResult != nil {
-		fmt.Printf("✅ 成功用reflect反序列化codegen数据: %+v\n", reflectResult)
+		fmt.Printf("✅ Successfully used reflect to deserialize codegen data: %+v\n", reflectResult)
 	} else {
-		fmt.Printf("❌ 用reflect反序列化codegen数据失败: %v\n", err)
+		fmt.Printf("❌ Failed to use reflect to deserialize codegen data: %v\n", err)
 	}
 
-	// 用codegen fory反序列化reflect数据
+	// Use codegen to deserialize reflect data
 	var codegenResult *ValidationDemo
 	err = foryForCodegen.Unmarshal(reflectData, &codegenResult)
 	if err == nil && codegenResult != nil {
-		fmt.Printf("✅ 成功用codegen反序列化reflect数据: %+v\n", codegenResult)
+		fmt.Printf("✅ Successfully used codegen to deserialize reflect data: %+v\n", codegenResult)
 	} else {
-		fmt.Printf("❌ 用codegen反序列化reflect数据失败: %v\n", err)
+		fmt.Printf("❌ Failed to use codegen to deserialize reflect data: %v\n", err)
 	}
 }
 
-// TestSliceDemoXlang - 测试SliceDemo的跨语言兼容性
+// TestSliceDemoXlang - Test cross-language compatibility of SliceDemo
 func TestSliceDemoXlang(t *testing.T) {
-	fmt.Println("=== SliceDemo跨语言兼容性测试 ===")
+	fmt.Println("=== SliceDemo Cross-Language Compatibility Test ===")
 
-	// 获取SliceDemo的类型信息
+	// Get SliceDemo type information
 	sliceDemoType := reflect.TypeOf(SliceDemo{})
 	pkgPath := sliceDemoType.PkgPath()
 	typeName := sliceDemoType.Name()
 	expectedTypeTag := pkgPath + "." + typeName
 
-	fmt.Printf("SliceDemo 类型分析：\n")
-	fmt.Printf("  包路径: %s\n", pkgPath)
-	fmt.Printf("  类型名: %s\n", typeName)
-	fmt.Printf("  实际typeTag: %s\n", expectedTypeTag)
+	fmt.Printf("SliceDemo type analysis:\n")
+	fmt.Printf("  Package path: %s\n", pkgPath)
+	fmt.Printf("  Type name: %s\n", typeName)
+	fmt.Printf("  Actual typeTag: %s\n", expectedTypeTag)
 
-	// 创建测试数据
+	// Create test data
 	codegenInstance := &SliceDemo{
 		IntSlice:    []int32{1, 2, 3, 4, 5},
 		StringSlice: []string{"hello", "world", "fory"},
@@ -141,7 +141,7 @@ func TestSliceDemoXlang(t *testing.T) {
 		BoolSlice:   []bool{true, false, true},
 	}
 
-	// 使用反射定义等价结构
+	// Define equivalent struct using reflection
 	type ReflectSliceStruct struct {
 		IntSlice    []int32   `json:"int_slice"`
 		StringSlice []string  `json:"string_slice"`
@@ -156,35 +156,35 @@ func TestSliceDemoXlang(t *testing.T) {
 		BoolSlice:   []bool{true, false, true},
 	}
 
-	// Codegen 模式 - 关闭reference tracking以避免复杂性
-	foryForCodegen := forygo.NewFory(false)
+	// Codegen mode - enable reference tracking
+	foryForCodegen := forygo.NewFory(true)
 
-	// Reflect 模式 - 关闭reference tracking以避免复杂性
-	foryForReflect := forygo.NewFory(false)
+	// Reflect mode - enable reference tracking
+	foryForReflect := forygo.NewFory(true)
 	err := foryForReflect.RegisterTagType(expectedTypeTag, ReflectSliceStruct{})
-	require.NoError(t, err, "应该能够用完整名称注册ReflectSliceStruct")
+	require.NoError(t, err, "Should be able to register ReflectSliceStruct with full name")
 
-	fmt.Printf("✅ 成功使用完整名称注册: %s\n", expectedTypeTag)
+	fmt.Printf("✅ Successfully registered with full name: %s\n", expectedTypeTag)
 
-	// 序列化测试
+	// Serialization test
 	codegenData, err := foryForCodegen.Marshal(codegenInstance)
-	require.NoError(t, err, "Codegen序列化不应失败")
+	require.NoError(t, err, "Codegen serialization should not fail")
 
 	reflectData, err := foryForReflect.Marshal(reflectInstance)
-	require.NoError(t, err, "Reflect序列化不应失败")
+	require.NoError(t, err, "Reflect serialization should not fail")
 
-	fmt.Printf("\n序列化结果：\n")
-	fmt.Printf("  Codegen数据长度: %d bytes\n", len(codegenData))
-	fmt.Printf("  Reflect数据长度: %d bytes\n", len(reflectData))
-	fmt.Printf("  数据是否相同: %t\n", reflect.DeepEqual(codegenData, reflectData))
+	fmt.Printf("\nSerialization results:\n")
+	fmt.Printf("  Codegen data length: %d bytes\n", len(codegenData))
+	fmt.Printf("  Reflect data length: %d bytes\n", len(reflectData))
+	fmt.Printf("  Data identical: %t\n", reflect.DeepEqual(codegenData, reflectData))
 
-	// 详细分析序列化数据差异
-	fmt.Println("\n=== 详细序列化数据分析 ===")
-	fmt.Printf("Codegen完整数据: %x\n", codegenData)
-	fmt.Printf("Reflect完整数据: %x\n", reflectData)
+	// Detailed serialization data analysis
+	fmt.Println("\n=== Detailed Serialization Data Analysis ===")
+	fmt.Printf("Codegen complete data: %x\n", codegenData)
+	fmt.Printf("Reflect complete data: %x\n", reflectData)
 
-	// 逐字节比较
-	fmt.Println("\n=== 逐字节差异分析 ===")
+	// Byte-by-byte comparison
+	fmt.Println("\n=== Byte-by-Byte Difference Analysis ===")
 	minLen := len(codegenData)
 	if len(reflectData) < minLen {
 		minLen = len(reflectData)
@@ -193,76 +193,76 @@ func TestSliceDemoXlang(t *testing.T) {
 	differentBytes := 0
 	for i := 0; i < minLen; i++ {
 		if codegenData[i] != reflectData[i] {
-			if differentBytes < 10 { // 只显示前10个差异
-				fmt.Printf("  位置%d: Codegen=0x%02x, Reflect=0x%02x\n", i, codegenData[i], reflectData[i])
+			if differentBytes < 10 { // Only show first 10 differences
+				fmt.Printf("  Position %d: Codegen=0x%02x, Reflect=0x%02x\n", i, codegenData[i], reflectData[i])
 			}
 			differentBytes++
 		}
 	}
 
 	if len(codegenData) != len(reflectData) {
-		fmt.Printf("  长度差异: Codegen=%d, Reflect=%d (差异=%d bytes)\n",
+		fmt.Printf("  Length difference: Codegen=%d, Reflect=%d (difference=%d bytes)\n",
 			len(codegenData), len(reflectData), len(reflectData)-len(codegenData))
 	}
 
 	if differentBytes == 0 && len(codegenData) == len(reflectData) {
-		fmt.Println("🎉 SUCCESS: 序列化结果完全相同！")
+		fmt.Println("🎉 SUCCESS: Serialization results are completely identical!")
 
-		// 验证跨序列化
-		fmt.Println("\n=== 跨序列化测试 ===")
+		// Verify cross serialization
+		fmt.Println("\n=== Cross Serialization Test ===")
 
-		// 用reflect反序列化codegen数据
+		// Use reflect to deserialize codegen data
 		var reflectResult *ReflectSliceStruct
 		err = foryForReflect.Unmarshal(codegenData, &reflectResult)
 		if err == nil && reflectResult != nil {
-			fmt.Printf("✅ 成功用reflect反序列化codegen数据:\n")
+			fmt.Printf("✅ Successfully used reflect to deserialize codegen data:\n")
 			fmt.Printf("   IntSlice: %v\n", reflectResult.IntSlice)
 			fmt.Printf("   StringSlice: %v\n", reflectResult.StringSlice)
 			fmt.Printf("   FloatSlice: %v\n", reflectResult.FloatSlice)
 			fmt.Printf("   BoolSlice: %v\n", reflectResult.BoolSlice)
 
-			// 验证数据是否匹配
+			// Verify data matching
 			intMatch := reflect.DeepEqual(codegenInstance.IntSlice, reflectResult.IntSlice)
 			stringMatch := reflect.DeepEqual(codegenInstance.StringSlice, reflectResult.StringSlice)
 			floatMatch := reflect.DeepEqual(codegenInstance.FloatSlice, reflectResult.FloatSlice)
 			boolMatch := reflect.DeepEqual(codegenInstance.BoolSlice, reflectResult.BoolSlice)
 
-			fmt.Printf("   数据匹配检查: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
+			fmt.Printf("   Data match check: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
 				intMatch, stringMatch, floatMatch, boolMatch)
 
 			if intMatch && stringMatch && floatMatch && boolMatch {
-				fmt.Println("🎉 所有slice字段数据完全匹配！")
+				fmt.Println("🎉 All slice field data matches completely!")
 			}
 		} else {
-			fmt.Printf("❌ 用reflect反序列化codegen数据失败: %v\n", err)
+			fmt.Printf("❌ Failed to use reflect to deserialize codegen data: %v\n", err)
 		}
 
-		// 用codegen反序列化reflect数据
+		// Use codegen to deserialize reflect data
 		var codegenResult *SliceDemo
 		err = foryForCodegen.Unmarshal(reflectData, &codegenResult)
 		if err == nil && codegenResult != nil {
-			fmt.Printf("✅ 成功用codegen反序列化reflect数据:\n")
+			fmt.Printf("✅ Successfully used codegen to deserialize reflect data:\n")
 			fmt.Printf("   IntSlice: %v\n", codegenResult.IntSlice)
 			fmt.Printf("   StringSlice: %v\n", codegenResult.StringSlice)
 			fmt.Printf("   FloatSlice: %v\n", codegenResult.FloatSlice)
 			fmt.Printf("   BoolSlice: %v\n", codegenResult.BoolSlice)
 
-			// 验证数据是否匹配
+			// Verify data matching
 			intMatch := reflect.DeepEqual(reflectInstance.IntSlice, codegenResult.IntSlice)
 			stringMatch := reflect.DeepEqual(reflectInstance.StringSlice, codegenResult.StringSlice)
 			floatMatch := reflect.DeepEqual(reflectInstance.FloatSlice, codegenResult.FloatSlice)
 			boolMatch := reflect.DeepEqual(reflectInstance.BoolSlice, codegenResult.BoolSlice)
 
-			fmt.Printf("   数据匹配检查: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
+			fmt.Printf("   Data match check: IntSlice=%v, StringSlice=%v, FloatSlice=%v, BoolSlice=%v\n",
 				intMatch, stringMatch, floatMatch, boolMatch)
 
 			if intMatch && stringMatch && floatMatch && boolMatch {
-				fmt.Println("🎉 完全兼容！Codegen可以正确反序列化reflect数据！")
+				fmt.Println("🎉 Fully compatible! Codegen can correctly deserialize reflect data!")
 			}
 		} else {
-			fmt.Printf("❌ 用codegen反序列化reflect数据失败: %v\n", err)
+			fmt.Printf("❌ Failed to use codegen to deserialize reflect data: %v\n", err)
 		}
 	} else {
-		fmt.Printf("❌ 发现%d个字节差异\n", differentBytes)
+		fmt.Printf("❌ Found %d byte differences\n", differentBytes)
 	}
 }

--- a/go/fory/tests/generator_xlang_test.go
+++ b/go/fory/tests/generator_xlang_test.go
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fory
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	forygo "github.com/apache/fory/go/fory"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActualCodegenName - 分析codegen实际使用的名称
+func TestActualCodegenName(t *testing.T) {
+	fmt.Println("=== 分析Codegen实际使用的名称 ===")
+
+	// 从源码分析得出：
+	// RegisterSerializerFactory 会计算：
+	// typeTag := pkgPath + "." + typeName
+
+	validationDemoType := reflect.TypeOf(ValidationDemo{})
+	pkgPath := validationDemoType.PkgPath()
+	typeName := validationDemoType.Name()
+	expectedTypeTag := pkgPath + "." + typeName
+
+	fmt.Printf("ValidationDemo 类型分析：\n")
+	fmt.Printf("  包路径: %s\n", pkgPath)
+	fmt.Printf("  类型名: %s\n", typeName)
+	fmt.Printf("  实际typeTag: %s\n", expectedTypeTag)
+
+	// 现在使用正确的完整名称进行测试
+	fmt.Println("\n=== 使用正确的完整名称测试 ===")
+
+	// 创建测试数据
+	codegenInstance := &ValidationDemo{
+		A: 100,
+		B: "test_data",
+		C: 200,
+	}
+
+	type ReflectStruct struct {
+		A int32  `json:"a"`
+		B string `json:"b"`
+		C int64  `json:"c"`
+	}
+
+	reflectInstance := &ReflectStruct{
+		A: 100,
+		B: "test_data",
+		C: 200,
+	}
+
+	// Codegen 模式 (自动使用完整名称)
+	foryForCodegen := forygo.NewFory(true)
+
+	// Reflect 模式 (使用完整名称注册)
+	foryForReflect := forygo.NewFory(true)
+	err := foryForReflect.RegisterTagType(expectedTypeTag, ReflectStruct{})
+	require.NoError(t, err, "应该能够用完整名称注册ReflectStruct")
+
+	fmt.Printf("✅ 成功使用完整名称注册: %s\n", expectedTypeTag)
+
+	// 序列化测试
+	codegenData, err := foryForCodegen.Marshal(codegenInstance)
+	require.NoError(t, err, "Codegen序列化不应失败")
+
+	reflectData, err := foryForReflect.Marshal(reflectInstance)
+	require.NoError(t, err, "Reflect序列化不应失败")
+
+	fmt.Printf("\n序列化结果：\n")
+	fmt.Printf("  Codegen数据长度: %d bytes\n", len(codegenData))
+	fmt.Printf("  Reflect数据长度: %d bytes\n", len(reflectData))
+	fmt.Printf("  数据是否相同: %t\n", reflect.DeepEqual(codegenData, reflectData))
+
+	if reflect.DeepEqual(codegenData, reflectData) {
+		fmt.Println("🎉 SUCCESS: 使用完整包路径名称后，两个struct成功映射到相同名称！")
+	} else {
+		fmt.Println("❌ 仍然不同，可能还有其他因素")
+		fmt.Printf("  Codegen hex: %x\n", codegenData)
+		fmt.Printf("  Reflect hex: %x\n", reflectData)
+	}
+
+	// 验证跨序列化
+	fmt.Println("\n=== 跨序列化测试 ===")
+
+	// 用reflect fory反序列化codegen数据
+	var reflectResult *ReflectStruct
+	err = foryForReflect.Unmarshal(codegenData, &reflectResult)
+	if err == nil && reflectResult != nil {
+		fmt.Printf("✅ 成功用reflect反序列化codegen数据: %+v\n", reflectResult)
+	} else {
+		fmt.Printf("❌ 用reflect反序列化codegen数据失败: %v\n", err)
+	}
+
+	// 用codegen fory反序列化reflect数据
+	var codegenResult *ValidationDemo
+	err = foryForCodegen.Unmarshal(reflectData, &codegenResult)
+	if err == nil && codegenResult != nil {
+		fmt.Printf("✅ 成功用codegen反序列化reflect数据: %+v\n", codegenResult)
+	} else {
+		fmt.Printf("❌ 用codegen反序列化reflect数据失败: %v\n", err)
+	}
+}

--- a/go/fory/tests/structs.go
+++ b/go/fory/tests/structs.go
@@ -26,3 +26,20 @@ type ValidationDemo struct {
 	B string `json:"b"` // string field
 	C int64  `json:"c"` // int64 field (instead of array, as arrays are not supported yet)
 }
+
+// SliceDemo is a struct for testing slice serialization
+// Contains various slice types
+
+// fory:gen
+type SliceDemo struct {
+	IntSlice    []int32   `json:"int_slice"`    // slice of int32
+	StringSlice []string  `json:"string_slice"` // slice of string
+	FloatSlice  []float64 `json:"float_slice"`  // slice of float64
+	BoolSlice   []bool    `json:"bool_slice"`   // slice of bool
+}
+
+// SimpleSliceDemo is a struct for testing slice serialization with single field
+// fory:gen
+type SimpleSliceDemo struct {
+	IntSlice []int32 `json:"int_slice"` // slice of int32
+}

--- a/go/fory/tests/structs.go
+++ b/go/fory/tests/structs.go
@@ -37,9 +37,3 @@ type SliceDemo struct {
 	FloatSlice  []float64 `json:"float_slice"`  // slice of float64
 	BoolSlice   []bool    `json:"bool_slice"`   // slice of bool
 }
-
-// SimpleSliceDemo is a struct for testing slice serialization with single field
-// fory:gen
-type SimpleSliceDemo struct {
-	IntSlice []int32 `json:"int_slice"` // slice of int32
-}

--- a/go/fory/tests/structs.go
+++ b/go/fory/tests/structs.go
@@ -22,9 +22,9 @@ package fory
 
 // fory:gen
 type ValidationDemo struct {
-	A int32  `json:"a"` // int32 field
-	B string `json:"b"` // string field
-	C int64  `json:"c"` // int64 field (instead of array, as arrays are not supported yet)
+	A int32  // int32 field
+	B string // string field
+	C int64  // int64 field
 }
 
 // SliceDemo is a struct for testing slice serialization
@@ -32,8 +32,8 @@ type ValidationDemo struct {
 
 // fory:gen
 type SliceDemo struct {
-	IntSlice    []int32   `json:"int_slice"`    // slice of int32
-	StringSlice []string  `json:"string_slice"` // slice of string
-	FloatSlice  []float64 `json:"float_slice"`  // slice of float64
-	BoolSlice   []bool    `json:"bool_slice"`   // slice of bool
+	IntSlice    []int32   // slice of int32
+	StringSlice []string  // slice of string
+	FloatSlice  []float64 // slice of float64
+	BoolSlice   []bool    // slice of bool
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->



## What does this PR do?

This PR extends the ahead-of-time code generation to support serialization and deserialization of slice types, implementing a complete slice handling system that maintains full compatibility with the existing reflection-based approach.

## TODO
- Extend the code generation to handle `map` types (planned for the next PR).

## Related issues
- #2227 
<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
