### PR TITLE
refactor(go): Change codegen annotation from //fory:gen to //fory:generate

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -63,12 +63,12 @@ Ensure $GOBIN or $GOPATH/bin is on your PATH so that `fory` is discoverable by `
 
 ### Usage: annotate and generate
 
-1. Mark structs for generation with `//fory:gen`, and add a `go:generate` directive. File-based generation is recommended.
+1. Mark structs for generation with `//fory:generate`, and add a `go:generate` directive. File-based generation is recommended.
 
 ```go
 package yourpkg
 
-//fory:gen
+//fory:generate
 type User struct {
     ID   int64  `json:"id"`
     Name string `json:"name"`
@@ -97,7 +97,7 @@ Re-run generation whenever any of the following change for generated structs:
 
 - Field additions/removals/renames
 - Field type changes or tag changes
-- New structs annotated with `//fory:gen`
+- New structs annotated with `//fory:generate`
 
 Fory adds a compile-time guard in generated files to detect stale code. If you forget to re-generate, your build will fail with a clear message. The generator also includes a smart auto-retry: when invoked via `go generate`, it detects this situation, removes the stale generated file, and retries automatically. You can force this behavior manually with:
 

--- a/go/fory/cmd/fory/main.go
+++ b/go/fory/cmd/fory/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	typeFlag    = flag.String("type", "", "comma-separated list of types to generate code for (optional if using //fory:gen comments)")
+	typeFlag    = flag.String("type", "", "comma-separated list of types to generate code for (optional if using //fory:generate comments)")
 	pkgFlag     = flag.String("pkg", ".", "package directory to search for types (legacy mode)")
 	fileFlag    = flag.String("file", "", "source file to generate code for (new mode)")
 	forceFlag   = flag.Bool("force", false, "force regeneration by removing existing generated files first")
@@ -95,7 +95,7 @@ Options:
   -pkg string
         package directory to search for types (legacy mode) (default ".")
   -type string
-        comma-separated list of types to generate code for (optional if using //fory:gen comments)
+        comma-separated list of types to generate code for (optional if using //fory:generate comments)
   -force
         force regeneration by removing existing generated files first
   -help
@@ -104,7 +104,7 @@ Options:
         show version information
 
 Examples:
-  # Generate for specific file using //fory:gen comments
+  # Generate for specific file using //fory:generate comments
   fory -file structs.go
 
   # Generate for specific types in current package

--- a/go/fory/codegen/generator.go
+++ b/go/fory/codegen/generator.go
@@ -182,7 +182,7 @@ func processPackageFile(pkg *packages.Package, sourceFile string, typeList strin
 	if typeList != "" {
 		targetTypes = strings.Split(typeList, ",")
 	} else {
-		// Auto-discover types with //fory:gen comments
+		// Auto-discover types with //fory:generate comments
 		discoveredTypes, err := discoverTypesFromFile(pkg, absSourceFile)
 		if err != nil {
 			return fmt.Errorf("discovering types from file: %w", err)

--- a/go/fory/codegen/parser.go
+++ b/go/fory/codegen/parser.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// discoverTypesFromFile scans the source file for //fory:gen comments
+// discoverTypesFromFile scans the source file for //fory:generate comments
 func discoverTypesFromFile(pkg *packages.Package, sourceFile string) ([]string, error) {
 	var discoveredTypes []string
 
@@ -45,14 +45,14 @@ func discoverTypesFromFile(pkg *packages.Package, sourceFile string) ([]string, 
 			continue
 		}
 
-		// Scan for type declarations with //fory:gen comments
+		// Scan for type declarations with //fory:generate comments
 		for _, decl := range file.Decls {
 			if genDecl, ok := decl.(*ast.GenDecl); ok && genDecl.Tok == token.TYPE {
 				for _, spec := range genDecl.Specs {
 					if typeSpec, ok := spec.(*ast.TypeSpec); ok {
 						// Check if it's a struct type
 						if _, ok := typeSpec.Type.(*ast.StructType); ok {
-							// Look for //fory:gen comment
+							// Look for //fory:generate comment
 							if hasGenerateComment(genDecl.Doc) || hasGenerateComment(typeSpec.Doc) {
 								discoveredTypes = append(discoveredTypes, typeSpec.Name.Name)
 							}
@@ -66,14 +66,14 @@ func discoverTypesFromFile(pkg *packages.Package, sourceFile string) ([]string, 
 	return discoveredTypes, nil
 }
 
-// hasGenerateComment checks if comment group contains //fory:gen
+// hasGenerateComment checks if comment group contains //fory:generate
 func hasGenerateComment(commentGroup *ast.CommentGroup) bool {
 	if commentGroup == nil {
 		return false
 	}
 
 	for _, comment := range commentGroup.List {
-		if strings.Contains(comment.Text, "fory:gen") {
+		if strings.Contains(comment.Text, "fory:generate") {
 			return true
 		}
 	}

--- a/go/fory/tests/structs.go
+++ b/go/fory/tests/structs.go
@@ -20,7 +20,7 @@ package fory
 // ValidationDemo is a simple struct for testing code generation
 // Contains various basic types to validate comprehensive type support
 
-// fory:gen
+// fory:generate
 type ValidationDemo struct {
 	A int32   // int32 field
 	B string  // string field
@@ -32,7 +32,7 @@ type ValidationDemo struct {
 // SliceDemo is a struct for testing slice serialization
 // Contains various slice types
 
-// fory:gen
+// fory:generate
 type SliceDemo struct {
 	IntSlice    []int32   // slice of int32
 	StringSlice []string  // slice of string
@@ -41,13 +41,13 @@ type SliceDemo struct {
 }
 
 // DynamicSliceDemo is a struct for testing dynamic slice serialization
-// fory:gen
+// fory:generate
 type DynamicSliceDemo struct {
 	DynamicSlice []interface{} // slice of interface{}
 }
 
 // MapDemo demonstrates map field support
-// fory:gen
+// fory:generate
 type MapDemo struct {
 	StringMap map[string]string // map[string]string
 	IntMap    map[int]int       // map[int]int


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?
Updates the annotation marker used to identify structs for code generation, making it more explicit and consistent with Go's generate conventions.
<!-- Describe the purpose of this PR. -->

## What does this PR do?
- Changes the code generation annotation from `//fory:gen` to `//fory:generate` 
- Updates all related documentation and help text
<!-- Describe the details of this PR. -->

## Related issues
- #2227 
<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
