### PR TITLE
refactor(Rust): Refactor compile-time code & fix named_enum & fix skip enum

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -459,11 +459,11 @@ public class RustXlangTest extends ForyTestBase {
     int f2;
     Item f3;
     String f4;
-    //    Color f5;
+    Color f5;
     List<String> f6;
     int f7;
-    //    Integer f8;
-    //    Integer last;
+    Integer f8;
+    Integer last;
   }
 
   private void testSimpleStruct(Language language, List<String> command)
@@ -488,11 +488,11 @@ public class RustXlangTest extends ForyTestBase {
     obj.f2 = 39;
     obj.f3 = item;
     obj.f4 = "f4";
-    //    obj.f5 = Color.White;
+    obj.f5 = Color.White;
     obj.f6 = Collections.singletonList("f6");
     obj.f7 = 40;
-    //    obj.f8 = 41;
-    //    obj.last = 42;
+    obj.f8 = 41;
+    obj.last = 42;
 
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     fory.serialize(buffer, obj);
@@ -527,11 +527,11 @@ public class RustXlangTest extends ForyTestBase {
     obj.f2 = 39;
     obj.f3 = item;
     obj.f4 = "f4";
-    //    obj.f5 = Color.White;
+    obj.f5 = Color.White;
     obj.f6 = Collections.singletonList("f6");
     obj.f7 = 40;
-    //    obj.f8 = 41;
-    //    obj.last = 42;
+    obj.f8 = 41;
+    obj.last = 42;
 
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     fory.serialize(buffer, obj);
@@ -659,13 +659,13 @@ public class RustXlangTest extends ForyTestBase {
     Assert.assertTrue(executeCommand(command, 30, env_workdir.getLeft(), env_workdir.getRight()));
 
     MemoryBuffer buffer2 = MemoryUtils.wrap(Files.readAllBytes(dataFile));
-    //        Item1 newItem1 = (Item1) fory.deserialize(buffer2);
-    //        Assert.assertEquals(newItem1.f1, 1);
-    //        Assert.assertEquals(newItem1.f2, 2);
-    //        Assert.assertEquals(newItem1.f3, 3);
-    //        Assert.assertEquals(newItem1.f4, 4);
-    //        Assert.assertEquals(newItem1.f5, 0);
-    //        Assert.assertNull(newItem1.f6);
+    Item1 newItem1 = (Item1) fory.deserialize(buffer2);
+    Assert.assertEquals(newItem1.f1, 1);
+    Assert.assertEquals(newItem1.f2, 2);
+    Assert.assertEquals(newItem1.f3, 3);
+    Assert.assertEquals(newItem1.f4, 4);
+    Assert.assertEquals(newItem1.f5, 0);
+    Assert.assertNull(newItem1.f6);
     Assert.assertEquals(fory.deserialize(buffer2), 1);
     Assert.assertEquals(fory.deserialize(buffer2), 2);
     Assert.assertEquals(fory.deserialize(buffer2), 3);

--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -494,7 +494,7 @@ impl TypeMeta {
         // global_binary_header:| hash:50bits | is_compressed:1bit | write_fields_meta:1bit | meta_size:12bits |
         let meta_size = layers_writer.len() as i64;
         let mut header: i64 = min(META_SIZE_MASK, meta_size);
-        let write_meta_fields_flag = self.get_field_infos().is_empty();
+        let write_meta_fields_flag = !self.get_field_infos().is_empty();
         if write_meta_fields_flag {
             header |= HAS_FIELDS_META_FLAG;
         }

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -162,31 +162,29 @@ impl TypeResolver {
         self.type_id_index[index] = type_info.type_id;
 
         if type_info.register_by_name {
+            let namespace = type_info.namespace.clone();
+            let type_name = type_info.type_name.clone();
             if self
                 .name_serialize_map
-                .contains_key(&(type_info.namespace.clone(), type_info.type_name.clone()))
+                .contains_key(&(namespace.clone(), type_name.clone()))
             {
                 panic!("TypeId {:?} already registered_by_name", type_info.type_id);
             }
-            let namespace_bytes = type_info.namespace.clone();
-            let type_name_bytes = type_info.type_name.clone();
-            self.type_name_map.insert(
-                rs_type_id,
-                (namespace_bytes.clone(), type_name_bytes.clone()),
-            );
+            self.type_name_map
+                .insert(rs_type_id, (namespace.clone(), type_name.clone()));
             self.name_serialize_map.insert(
-                (namespace_bytes, type_name_bytes),
+                (namespace, type_name),
                 Harness::new(serializer::<T>, deserializer::<T>),
             );
         } else {
-            if self.serialize_map.contains_key(&type_info.type_id) {
-                panic!("TypeId {:?} already registered_by_id", type_info.type_id);
+            let type_id = type_info.type_id;
+            if self.serialize_map.contains_key(&type_id) {
+                panic!("TypeId {:?} already registered_by_id", type_id);
             }
-            self.type_id_map.insert(rs_type_id, type_info.type_id);
-            self.serialize_map.insert(
-                type_info.type_id,
-                Harness::new(serializer::<T>, deserializer::<T>),
-            );
+
+            self.type_id_map.insert(rs_type_id, type_id);
+            self.serialize_map
+                .insert(type_id, Harness::new(serializer::<T>, deserializer::<T>));
         }
     }
 

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::Error;
+use crate::fory::Fory;
+use crate::meta::{
+    TypeMeta, NAMESPACE_ENCODER, NAMESPACE_ENCODINGS, TYPE_NAME_ENCODER, TYPE_NAME_ENCODINGS,
+};
+use crate::resolver::context::{ReadContext, WriteContext};
+use crate::serializer::Serializer;
+use crate::types::{Mode, RefFlag, TypeId};
+
+#[inline(always)]
+pub fn actual_type_id(type_id: u32, register_by_name: bool, _mode: &Mode) -> u32 {
+    if register_by_name {
+        TypeId::NAMED_ENUM as u32
+    } else {
+        (type_id << 8) + TypeId::ENUM as u32
+    }
+}
+
+#[inline(always)]
+pub fn type_def(
+    _fory: &Fory,
+    type_id: u32,
+    namespace: &str,
+    type_name: &str,
+    register_by_name: bool,
+) -> Vec<u8> {
+    let namespace_metastring = NAMESPACE_ENCODER
+        .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
+        .unwrap();
+    let type_name_metastring = TYPE_NAME_ENCODER
+        .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
+        .unwrap();
+    let meta = TypeMeta::from_fields(
+        type_id,
+        namespace_metastring,
+        type_name_metastring,
+        register_by_name,
+        vec![],
+    );
+    meta.to_bytes().unwrap()
+}
+
+#[inline(always)]
+pub fn write_type_info<T: Serializer>(context: &mut WriteContext, is_field: bool) {
+    if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
+        let type_id = T::get_type_id(context.get_fory());
+        context.writer.var_uint32(type_id);
+        if type_id & 0xff == TypeId::NAMED_ENUM as u32 {
+            let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
+            context.writer.var_uint32(meta_index);
+        }
+    }
+}
+
+#[inline(always)]
+pub fn read_type_info<T: Serializer>(context: &mut ReadContext, is_field: bool) {
+    if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
+        let local_type_id = T::get_type_id(context.get_fory());
+        let remote_type_id = context.reader.var_uint32();
+        assert_eq!(local_type_id, remote_type_id);
+        if local_type_id & 0xff == TypeId::NAMED_ENUM as u32 {
+            let _meta_index = context.reader.var_uint32();
+        }
+    }
+}
+
+#[inline(always)]
+pub fn read_compatible<T: Serializer>(context: &mut ReadContext) -> Result<T, Error> {
+    T::read_type_info(context, true);
+    T::read(context)
+}
+
+#[inline(always)]
+pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool) {
+    context.writer.i8(RefFlag::NotNullValue as i8);
+    T::write_type_info(context, is_field);
+    this.write(context, is_field);
+}
+
+#[inline(always)]
+pub fn deserialize<T: Serializer>(context: &mut ReadContext, is_field: bool) -> Result<T, Error> {
+    let ref_flag = context.reader.i8();
+    if ref_flag == RefFlag::Null as i8 {
+        Ok(T::default())
+    } else if ref_flag == (RefFlag::NotNullValue as i8) {
+        T::read_type_info(context, false);
+        T::read(context)
+    } else {
+        unimplemented!()
+    }
+}

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -95,7 +95,7 @@ pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, is_field: 
 }
 
 #[inline(always)]
-pub fn deserialize<T: Serializer>(context: &mut ReadContext, is_field: bool) -> Result<T, Error> {
+pub fn deserialize<T: Serializer>(context: &mut ReadContext, _is_field: bool) -> Result<T, Error> {
     let ref_flag = context.reader.i8();
     if ref_flag == RefFlag::Null as i8 {
         Ok(T::default())

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -24,6 +24,7 @@ mod any;
 mod bool;
 pub mod collection;
 mod datetime;
+pub mod enum_;
 mod list;
 pub mod map;
 mod number;
@@ -32,6 +33,7 @@ mod primitive_list;
 mod set;
 pub mod skip;
 mod string;
+pub mod struct_;
 
 pub fn write_data<T: Serializer + 'static>(
     record: &T,

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -136,21 +136,10 @@ pub fn skip_field_value(
                 }
                 Ok(())
             } else if type_id == TypeId::NAMED_ENUM {
-                let remote_type_id = context.reader.var_uint32();
-                assert_eq!(type_id_num, remote_type_id);
-                let meta_index = context.reader.var_uint32();
-                let type_def = context.get_meta(meta_index as usize);
-                let type_resolver = context.get_fory().get_type_resolver();
-                type_resolver
-                    .get_name_harness(
-                        &type_def.get_namespace().original,
-                        &type_def.get_type_name().original,
-                    )
-                    .unwrap()
-                    .get_deserializer()(context, true, true)?;
+                let _ordinal = context.reader.var_uint32();
                 Ok(())
             } else {
-                unreachable!();
+                unreachable!("unimplemented type: {:?}", type_id);
             }
         }
         Err(_) => {
@@ -171,13 +160,7 @@ pub fn skip_field_value(
                     skip_field_value(context, &nullable_field_type, read_ref_flag)?;
                 }
             } else if internal_id == ENUM_ID {
-                let remote_type_id = context.reader.var_uint32();
-                assert_eq!(type_id_num, remote_type_id);
-                let type_resolver = context.get_fory().get_type_resolver();
-                type_resolver
-                    .get_harness(type_id_num)
-                    .unwrap()
-                    .get_deserializer()(context, true, true)?;
+                let _ordinal = context.reader.var_uint32();
             } else {
                 unimplemented!()
             }

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::fory::Fory;
+use crate::meta::{
+    FieldInfo, TypeMeta, NAMESPACE_ENCODER, NAMESPACE_ENCODINGS, TYPE_NAME_ENCODER,
+    TYPE_NAME_ENCODINGS,
+};
+use crate::resolver::context::{ReadContext, WriteContext};
+use crate::serializer::{Serializer, StructSerializer};
+use crate::types::{Mode, RefFlag, TypeId};
+
+#[inline(always)]
+pub fn actual_type_id(type_id: u32, register_by_name: bool, mode: &Mode) -> u32 {
+    if mode == &Mode::Compatible {
+        if register_by_name {
+            TypeId::NAMED_COMPATIBLE_STRUCT as u32
+        } else {
+            (type_id << 8) + TypeId::COMPATIBLE_STRUCT as u32
+        }
+    } else if register_by_name {
+        TypeId::NAMED_STRUCT as u32
+    } else {
+        (type_id << 8) + TypeId::STRUCT as u32
+    }
+}
+
+#[inline(always)]
+pub fn type_def<T: Serializer + StructSerializer>(
+    fory: &Fory,
+    type_id: u32,
+    namespace: &str,
+    type_name: &str,
+    register_by_name: bool,
+    field_infos: &[FieldInfo],
+) -> Vec<u8> {
+    let sorted_field_names = T::get_sorted_field_names(fory);
+    let mut sorted_field_infos = Vec::with_capacity(field_infos.len());
+    for name in &sorted_field_names {
+        if let Some(info) = field_infos.iter().find(|f| &f.field_name == name) {
+            sorted_field_infos.push(info.clone());
+        } else {
+            panic!("Field {} not found in field_infos", name);
+        }
+    }
+    let namespace_metastring = NAMESPACE_ENCODER
+        .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
+        .unwrap();
+    let type_name_metastring = TYPE_NAME_ENCODER
+        .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
+        .unwrap();
+    let meta = TypeMeta::from_fields(
+        type_id,
+        namespace_metastring,
+        type_name_metastring,
+        register_by_name,
+        sorted_field_infos,
+    );
+    meta.to_bytes().unwrap()
+}
+
+#[inline(always)]
+pub fn write_type_info<T: Serializer>(context: &mut WriteContext, _is_field: bool) {
+    let type_id = T::get_type_id(context.get_fory());
+    context.writer.var_uint32(type_id);
+    if *context.get_fory().get_mode() == Mode::Compatible {
+        let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
+        context.writer.var_uint32(meta_index);
+    }
+}
+
+#[inline(always)]
+pub fn read_type_info<T: Serializer>(context: &mut ReadContext, _is_field: bool) {
+    let remote_type_id = context.reader.var_uint32();
+    assert_eq!(remote_type_id, T::get_type_id(context.get_fory()));
+    if *context.get_fory().get_mode() == Mode::Compatible {
+        let _meta_index = context.reader.var_uint32();
+    }
+}
+
+#[inline(always)]
+pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, _is_field: bool) {
+    match context.get_fory().get_mode() {
+        // currently same
+        Mode::SchemaConsistent => {
+            context.writer.i8(RefFlag::NotNullValue as i8);
+            T::write_type_info(context, false);
+            this.write(context, true);
+        }
+        Mode::Compatible => {
+            context.writer.i8(RefFlag::NotNullValue as i8);
+            T::write_type_info(context, false);
+            this.write(context, true);
+        }
+    }
+}

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -19,57 +19,46 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::DataEnum;
 
+pub fn gen_actual_type_id() -> TokenStream {
+    quote! {
+       fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, mode)
+    }
+}
+
 pub fn gen_type_def(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        let namespace_metastring = fory_core::meta::NAMESPACE_ENCODER.encode_with_encodings(namespace, fory_core::meta::NAMESPACE_ENCODINGS).unwrap();
-        let type_name_metastring = fory_core::meta::TYPE_NAME_ENCODER.encode_with_encodings(type_name, fory_core::meta::TYPE_NAME_ENCODINGS).unwrap();
-        let meta = fory_core::meta::TypeMeta::from_fields(
-            type_id,
-            namespace_metastring,
-            type_name_metastring,
-            register_by_name,
-            vec![],
-        );
-        meta.to_bytes().unwrap()
+        fory_core::serializer::enum_::type_def(fory, type_id, namespace, type_name, register_by_name)
+    }
+}
+
+pub fn gen_reserved_space() -> TokenStream {
+    quote! {
+       4
+    }
+}
+
+pub fn gen_write_type_info() -> TokenStream {
+    quote! {
+        fory_core::serializer::enum_::write_type_info::<Self>(context, is_field)
+    }
+}
+
+pub fn gen_read_type_info() -> TokenStream {
+    quote! {
+        fory_core::serializer::enum_::read_type_info::<Self>(context, is_field)
     }
 }
 
 pub fn gen_write(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
-
     quote! {
-        fn serialize(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
-            context.writer.i8(fory_core::types::RefFlag::NotNullValue as i8);
-            Self::write_type_info(context, is_field);
-            self.write(context, is_field);
-        }
-
-        fn write(&self, context: &mut fory_core::resolver::context::WriteContext, _is_field: bool) {
-            match self {
-                #(
-                    Self::#variant_idents => {
-                        context.writer.var_uint32(#variant_values);
-                    }
-                )*
-            }
-        }
-
-        fn write_type_info(context: &mut fory_core::resolver::context::WriteContext, is_field: bool){
-            if *context.get_fory().get_mode() == fory_core::types::Mode::Compatible {
-                let type_id = Self::get_type_id(context.get_fory());
-                context.writer.var_uint32(type_id);
-                if type_id & 0xff == fory_core::types::TypeId::NAMED_ENUM as u32 {
-                    let meta_index = context.push_meta(
-                        std::any::TypeId::of::<Self>()
-                    ) as u32;
-                    context.writer.var_uint32(meta_index);
+        match self {
+            #(
+                Self::#variant_idents => {
+                    context.writer.var_uint32(#variant_values);
                 }
-            }
-        }
-
-        fn reserved_space() -> usize {
-            4
+            )*
         }
     }
 }
@@ -77,60 +66,31 @@ pub fn gen_write(data_enum: &DataEnum) -> TokenStream {
 pub fn gen_read(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
-
     quote! {
-        fn deserialize(context: &mut fory_core::resolver::context::ReadContext, _is_field: bool) -> Result<Self, fory_core::error::Error> {
-            let ref_flag = context.reader.i8();
-            if ref_flag == fory_core::types::RefFlag::Null as i8 {
-                Ok(Self::default())
-            } else if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) {
-                Self::read_type_info(context, false);
-                Self::read(context)
-            } else {
-                unimplemented!()
-            }
-        }
-
-       fn read(
-           context: &mut fory_core::resolver::context::ReadContext,
-       ) -> Result<Self, fory_core::error::Error> {
-           let ordinal = context.reader.var_uint32();
-           match ordinal {
-               #(
-                   #variant_values => Ok(Self::#variant_idents),
-               )*
-               _ => panic!("unknown value"),
-           }
-       }
-
-       fn read_type_info(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) {
-            if *context.get_fory().get_mode() == fory_core::types::Mode::Compatible {
-                let local_type_id = Self::get_type_id(context.get_fory());
-                let remote_type_id = context.reader.var_uint32();
-                assert_eq!(local_type_id, remote_type_id);
-                if local_type_id & 0xff == fory_core::types::TypeId::NAMED_ENUM as u32 {
-                    let _meta_index = context.reader.var_uint32();
-                }
-            }
+        let ordinal = context.reader.var_uint32();
+        match ordinal {
+           #(
+               #variant_values => Ok(Self::#variant_idents),
+           )*
+           _ => panic!("unknown value"),
         }
     }
 }
 
-pub fn gen_actual_type_id() -> TokenStream {
+pub fn gen_read_compatible() -> TokenStream {
     quote! {
-        if register_by_name {
-            fory_core::types::TypeId::NAMED_ENUM as u32
-        } else {
-            (type_id << 8) + fory_core::types::TypeId::ENUM as u32
-        }
+        fory_core::serializer::enum_::read_compatible::<Self>(context)
     }
 }
 
-pub fn gen_read_compatible(_data_enum: &DataEnum) -> TokenStream {
+pub fn gen_serialize(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        fn read_compatible(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
-            <Self as fory_core::serializer::Serializer>::read_type_info(context, true);
-            <Self as fory_core::serializer::Serializer>::read(context)
-        }
+        fory_core::serializer::enum_::serialize::<Self>(self, context, is_field)
+    }
+}
+
+pub fn gen_deserialize(_data_enum: &DataEnum) -> TokenStream {
+    quote! {
+        fory_core::serializer::enum_::deserialize::<Self>(context, is_field)
     }
 }

--- a/rust/fory-derive/src/object/misc.rs
+++ b/rust/fory-derive/src/object/misc.rs
@@ -30,6 +30,7 @@ pub fn allocate_type_id() -> u32 {
     TYPE_ID_COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
+#[allow(dead_code)]
 fn hash(fields: &[&Field]) -> TokenStream {
     let props = fields.iter().map(|field| {
         let ty = &field.ty;

--- a/rust/fory-derive/src/object/misc.rs
+++ b/rust/fory-derive/src/object/misc.rs
@@ -54,85 +54,13 @@ fn hash(fields: &[&Field]) -> TokenStream {
     }
 }
 
-fn type_def(fields: &[&Field]) -> TokenStream {
-    let field_infos = fields.iter().map(|field| {
-        let ty = &field.ty;
-        let name = format!("{}", field.ident.as_ref().expect("should be field name"));
-        let generic_tree = parse_generic_tree(ty);
-        let generic_token = generic_tree_to_tokens(&generic_tree, false);
-        quote! {
-            fory_core::meta::FieldInfo::new(#name, #generic_token)
-        }
-    });
-    quote! {
-         let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::get_sorted_field_names(fory);
-        let field_infos: Vec<fory_core::meta::FieldInfo> = vec![#(#field_infos),*];
-        let mut sorted_field_infos = Vec::with_capacity(field_infos.len());
-        for name in &sorted_field_names {
-            if let Some(info) = field_infos.iter().find(|f| &f.field_name == name) {
-                sorted_field_infos.push(info.clone());
-            } else {
-                panic!("Field {} not found in field_infos", name);
-            }
-        }
-        let namespace_metastring = fory_core::meta::NAMESPACE_ENCODER.encode_with_encodings(namespace, fory_core::meta::NAMESPACE_ENCODINGS).unwrap();
-        let type_name_metastring = fory_core::meta::TYPE_NAME_ENCODER.encode_with_encodings(type_name, fory_core::meta::TYPE_NAME_ENCODINGS).unwrap();
-        let meta = fory_core::meta::TypeMeta::from_fields(
-            type_id,
-            namespace_metastring,
-            type_name_metastring,
-            register_by_name,
-            sorted_field_infos,
-        );
-        meta.to_bytes().unwrap()
-    }
-}
-
-pub fn gen_in_struct_impl(fields: &[&Field]) -> TokenStream {
-    let _hash_token_stream = hash(fields);
-    let type_def_token_stream = type_def(fields);
-
-    quote! {
-        #type_def_token_stream
-    }
-}
-
 pub fn gen_actual_type_id() -> TokenStream {
     quote! {
-        if mode == &fory_core::types::Mode::Compatible {
-            if register_by_name {
-                fory_core::types::TypeId::NAMED_COMPATIBLE_STRUCT as u32
-            } else {
-                (type_id << 8) + fory_core::types::TypeId::COMPATIBLE_STRUCT as u32
-            }
-        } else {
-            if register_by_name {
-                fory_core::types::TypeId::NAMED_STRUCT as u32
-            } else {
-                (type_id << 8) + fory_core::types::TypeId::STRUCT as u32
-            }
-        }
-
+        fory_core::serializer::struct_::actual_type_id(type_id, register_by_name, mode)
     }
 }
 
-pub fn gen(type_id: u32) -> TokenStream {
-    quote! {
-        fn get_type_id(fory: &fory_core::fory::Fory) -> u32 {
-            fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_id)
-        }
-    }
-}
-
-pub fn gen_type_index(type_id: u32) -> TokenStream {
-    quote! {
-        fn type_index() -> u32 {
-            #type_id
-        }
-    }
-}
-
-pub fn gen_sort_fields(fields: &[&Field]) -> TokenStream {
+pub fn gen_get_sorted_field_names(fields: &[&Field]) -> TokenStream {
     let create_sorted_field_names = get_sort_fields_ts(fields);
     quote! {
         let sorted_field_names = match fory.get_type_resolver().get_sorted_field_names::<Self>(std::any::TypeId::of::<Self>()) {
@@ -144,5 +72,21 @@ pub fn gen_sort_fields(fields: &[&Field]) -> TokenStream {
             }
         };
         sorted_field_names
+    }
+}
+
+pub fn gen_type_def(fields: &[&Field]) -> TokenStream {
+    let field_infos = fields.iter().map(|field| {
+        let ty = &field.ty;
+        let name = format!("{}", field.ident.as_ref().expect("should be field name"));
+        let generic_tree = parse_generic_tree(ty);
+        let generic_token = generic_tree_to_tokens(&generic_tree, false);
+        quote! {
+            fory_core::meta::FieldInfo::new(#name, #generic_token)
+        }
+    });
+    quote! {
+        let field_infos: Vec<fory_core::meta::FieldInfo> = vec![#(#field_infos),*];
+        fory_core::serializer::struct_::type_def::<Self>(fory, type_id, namespace, type_name, register_by_name, &field_infos)
     }
 }

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -29,7 +29,7 @@ fn create_deserialize_nullable_fn_name(field: &Field) -> Ident {
     format_ident!("_deserialize_nullable_{}", field.ident.as_ref().expect(""))
 }
 
-fn bind(fields: &[&Field]) -> Vec<TokenStream> {
+fn declare_var(fields: &[&Field]) -> Vec<TokenStream> {
     fields
         .iter()
         .map(|field| {
@@ -42,7 +42,7 @@ fn bind(fields: &[&Field]) -> Vec<TokenStream> {
         .collect()
 }
 
-fn create(fields: &[&Field]) -> Vec<TokenStream> {
+fn assign_value(fields: &[&Field]) -> Vec<TokenStream> {
     fields
         .iter()
         .map(|field| {
@@ -55,7 +55,14 @@ fn create(fields: &[&Field]) -> Vec<TokenStream> {
         .collect()
 }
 
-fn read(fields: &[&Field]) -> TokenStream {
+pub fn gen_read_type_info() -> TokenStream {
+    quote! {
+        fory_core::serializer::struct_::read_type_info::<Self>(context, is_field)
+    }
+}
+
+pub fn gen_read(fields: &[&Field]) -> TokenStream {
+    // read way before:
     // let assign_stmt = fields.iter().map(|field| {
     //     let ty = &field.ty;
     //     let name = &field.ident;
@@ -70,15 +77,16 @@ fn read(fields: &[&Field]) -> TokenStream {
     let sorted_deserialize = if fields.is_empty() {
         quote! {}
     } else {
-        let let_decls = fields
-            .iter()
-            .zip(private_idents.iter())
-            .map(|(field, private_ident)| {
-                let ty = &field.ty;
-                quote! {
-                    let mut #private_ident: #ty = Default::default();
-                }
-            });
+        let declare_var_ts =
+            fields
+                .iter()
+                .zip(private_idents.iter())
+                .map(|(field, private_ident)| {
+                    let ty = &field.ty;
+                    quote! {
+                        let mut #private_ident: #ty = Default::default();
+                    }
+                });
         let match_ts = fields.iter().zip(private_idents.iter()).map(|(field, private_ident)| {
             let ty = &field.ty;
             let name_str = field.ident.as_ref().unwrap().to_string();
@@ -90,7 +98,7 @@ fn read(fields: &[&Field]) -> TokenStream {
             }
         });
         quote! {
-             #(#let_decls)*
+             #(#declare_var_ts)*
             let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::get_sorted_field_names(context.get_fory());
             for field_name in sorted_field_names {
                 match field_name.as_str() {
@@ -110,31 +118,28 @@ fn read(fields: &[&Field]) -> TokenStream {
             }
         });
     quote! {
-        fn read(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
-            #sorted_deserialize
-            Ok(Self {
-                #(#field_idents),*
-            })
-            // Ok(Self {
-            //     #(#assign_stmt),*
-            // })
-        }
-
-        fn read_type_info(context: &mut fory_core::resolver::context::ReadContext, _is_field: bool) {
-            let remote_type_id = context.reader.var_uint32();
-            assert_eq!(remote_type_id, Self::get_type_id(context.get_fory()));
-            if *context.get_fory().get_mode() == fory_core::types::Mode::Compatible {
-                let _meta_index = context.reader.var_uint32();
-            }
-        }
+        #sorted_deserialize
+        Ok(Self {
+            #(#field_idents),*
+            // #(#assign_stmt),*
+        })
     }
 }
 
-fn deserialize_compatible(struct_ident: &Ident) -> TokenStream {
+pub fn gen_deserialize(struct_ident: &Ident) -> TokenStream {
     quote! {
         let ref_flag = context.reader.i8();
         if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::types::RefFlag::RefValue as i8) {
-            <#struct_ident as fory_core::serializer::StructSerializer>::read_compatible(context)
+            match context.get_fory().get_mode() {
+                fory_core::types::Mode::SchemaConsistent => {
+                    Self::read_type_info(context, false);
+                    Self::read(context)
+                },
+                fory_core::types::Mode::Compatible => {
+                    <#struct_ident as fory_core::serializer::StructSerializer>::read_compatible(context)
+                },
+                _ => unreachable!()
+            }
         } else if ref_flag == (fory_core::types::RefFlag::Null as i8) {
             Ok(Self::default())
             // Err(fory_core::error::AnyhowError::msg("Try to deserialize non-option type to null"))?
@@ -143,33 +148,6 @@ fn deserialize_compatible(struct_ident: &Ident) -> TokenStream {
         } else {
             Err(fory_core::error::AnyhowError::msg("Unknown ref flag, value:{ref_flag}"))?
         }
-    }
-}
-
-pub fn gen_deserialize_nullable(fields: &[&Field]) -> TokenStream {
-    let func_tokens: Vec<TokenStream> = fields
-        .iter()
-        .map(|field| {
-            let fn_name = create_deserialize_nullable_fn_name(field);
-            let ty = &field.ty;
-            let generic_tree = parse_generic_tree(ty);
-            let nullable_generic_tree = NullableTypeNode::from(generic_tree);
-            let deserialize_tokens = nullable_generic_tree.to_deserialize_tokens(&vec![], true);
-            quote! {
-                fn #fn_name(
-                    context: &mut fory_core::resolver::context::ReadContext,
-                    local_nullable_type: &fory_core::meta::NullableFieldType,
-                    remote_nullable_type: &fory_core::meta::NullableFieldType
-                ) -> Result<#ty, fory_core::error::Error> {
-                    // println!("remote:{:#?}", remote_nullable_type);
-                    // println!("local:{:#?}", local_nullable_type);
-                    #deserialize_tokens
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-    quote! {
-        #(#func_tokens)*
     }
 }
 
@@ -225,56 +203,54 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
             }
         }
     });
-    let bind: Vec<TokenStream> = bind(fields);
-    let create: Vec<TokenStream> = create(fields);
+    let declare_ts: Vec<TokenStream> = declare_var(fields);
+    let assign_ts: Vec<TokenStream> = assign_value(fields);
     quote! {
-        fn read_compatible(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
-            let remote_type_id = context.reader.var_uint32();
-            let meta_index = context.reader.var_uint32();
+        let remote_type_id = context.reader.var_uint32();
+        let meta_index = context.reader.var_uint32();
+        let meta = context.get_meta(meta_index as usize);
+        let fields = {
             let meta = context.get_meta(meta_index as usize);
-            let fields = {
-                let meta = context.get_meta(meta_index as usize);
-                meta.get_field_infos().clone()
-            };
-            #(#bind)*
-            for _field in fields.iter() {
-                #(#pattern_items else)* {
-                    println!("skip {:?}:{:?}", _field.field_name.as_str(), _field.field_type);
-                    let nullable_field_type = fory_core::meta::NullableFieldType::from(_field.field_type.clone());
-                    let read_ref_flag = fory_core::serializer::skip::get_read_ref_flag(&nullable_field_type);
-                    fory_core::serializer::skip::skip_field_value(context, &nullable_field_type, read_ref_flag).unwrap();
-                }
+            meta.get_field_infos().clone()
+        };
+        #(#declare_ts)*
+        for _field in fields.iter() {
+            #(#pattern_items else)* {
+                println!("skip {:?}:{:?}", _field.field_name.as_str(), _field.field_type);
+                let nullable_field_type = fory_core::meta::NullableFieldType::from(_field.field_type.clone());
+                let read_ref_flag = fory_core::serializer::skip::get_read_ref_flag(&nullable_field_type);
+                fory_core::serializer::skip::skip_field_value(context, &nullable_field_type, read_ref_flag).unwrap();
             }
-            Ok(Self {
-                #(#create),*
-            })
         }
+        Ok(Self {
+            #(#assign_ts),*
+        })
     }
 }
 
-pub fn gen(fields: &[&Field], struct_ident: &Ident) -> TokenStream {
-    let read_token_stream = read(fields);
-    let compatible_token_stream = deserialize_compatible(struct_ident);
-
-    quote! {
-        fn deserialize(context: &mut fory_core::resolver::context::ReadContext, _is_field: bool) -> Result<Self, fory_core::error::Error> {
-            match context.get_fory().get_mode() {
-                fory_core::types::Mode::SchemaConsistent => {
-                    let ref_flag = context.reader.i8();
-                    if ref_flag == fory_core::types::RefFlag::Null as i8 {
-                        Ok(Self::default())
-                    } else if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) {
-                        Self::read_type_info(context, false);
-                        Self::read(context)
-                    } else {
-                        unimplemented!()
-                    }
-                },
-                fory_core::types::Mode::Compatible => {
-                    #compatible_token_stream
+pub fn gen_deserialize_nullable(fields: &[&Field]) -> TokenStream {
+    let func_tokens: Vec<TokenStream> = fields
+        .iter()
+        .map(|field| {
+            let fn_name = create_deserialize_nullable_fn_name(field);
+            let ty = &field.ty;
+            let generic_tree = parse_generic_tree(ty);
+            let nullable_generic_tree = NullableTypeNode::from(generic_tree);
+            let deserialize_tokens = nullable_generic_tree.to_deserialize_tokens(&vec![], true);
+            quote! {
+                fn #fn_name(
+                    context: &mut fory_core::resolver::context::ReadContext,
+                    local_nullable_type: &fory_core::meta::NullableFieldType,
+                    remote_nullable_type: &fory_core::meta::NullableFieldType
+                ) -> Result<#ty, fory_core::error::Error> {
+                    // println!("remote:{:#?}", remote_nullable_type);
+                    // println!("local:{:#?}", local_nullable_type);
+                    #deserialize_tokens
                 }
             }
-        }
-        #read_token_stream
+        })
+        .collect::<Vec<_>>();
+    quote! {
+        #(#func_tokens)*
     }
 }

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -187,7 +187,7 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
                         fory_core::serializer::skip::skip_field_value(context, &remote_nullable_type, read_ref_flag).unwrap();
                         #var_name = Some(#base_ty::default());
                     } else {
-                        println!("Try to deserialize: {}", #field_name_str);
+                        println!("Try to deserialize_compatible: {}", #field_name_str);
                         #var_name = Some(
                             #struct_ident::#deserialize_nullable_fn_name(
                                 context,

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -22,38 +22,70 @@ use quote::quote;
 
 pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
+    // StructSerializer
+    let (actual_type_id_ts, get_sorted_field_names_ts, type_def_ts, read_compatible_ts) =
+        match &ast.data {
+            syn::Data::Struct(s) => {
+                let fields = sorted_fields(&s.fields);
+                (
+                    misc::gen_actual_type_id(),
+                    misc::gen_get_sorted_field_names(&fields),
+                    misc::gen_type_def(&fields),
+                    read::gen_read_compatible(&fields, name),
+                )
+            }
+            syn::Data::Enum(s) => (
+                derive_enum::gen_actual_type_id(),
+                quote! { unreachable!() },
+                derive_enum::gen_type_def(s),
+                derive_enum::gen_read_compatible(),
+            ),
+            syn::Data::Union(_) => {
+                panic!("Union is not supported")
+            }
+        };
+    // Serializer
     let (
-        type_def_token_stream,
-        actual_type_id_token_stream,
-        write_token_stream,
-        read_token_stream,
-        read_compatible_token_stream,
-        read_nullable_token_stream,
-        sort_fields_token_stream,
+        reserved_space_ts,
+        write_type_info_ts,
+        read_type_info_ts,
+        write_ts,
+        read_ts,
+        serialize_ts,
+        deserialize_ts,
     ) = match &ast.data {
         syn::Data::Struct(s) => {
             let fields = sorted_fields(&s.fields);
             (
-                misc::gen_in_struct_impl(&fields),
-                misc::gen_actual_type_id(),
-                write::gen(&fields),
-                read::gen(&fields, name),
-                read::gen_read_compatible(&fields, name),
-                read::gen_deserialize_nullable(&fields),
-                misc::gen_sort_fields(&fields),
+                write::gen_reserved_space(&fields),
+                write::gen_write_type_info(),
+                read::gen_read_type_info(),
+                write::gen_write(&fields),
+                read::gen_read(&fields),
+                write::gen_serialize(),
+                read::gen_deserialize(name),
             )
         }
-        syn::Data::Enum(s) => (
-            derive_enum::gen_type_def(s),
-            derive_enum::gen_actual_type_id(),
-            derive_enum::gen_write(s),
-            derive_enum::gen_read(s),
-            derive_enum::gen_read_compatible(s),
-            quote! {},
-            quote! {
-                unreachable!();
-            },
+        syn::Data::Enum(e) => (
+            derive_enum::gen_reserved_space(),
+            derive_enum::gen_write_type_info(),
+            derive_enum::gen_read_type_info(),
+            derive_enum::gen_write(e),
+            derive_enum::gen_read(e),
+            derive_enum::gen_serialize(e),
+            derive_enum::gen_deserialize(e),
         ),
+        syn::Data::Union(_) => {
+            panic!("Union is not supported")
+        }
+    };
+    // extra
+    let (deserialize_nullable_ts,) = match &ast.data {
+        syn::Data::Struct(s) => {
+            let fields = sorted_fields(&s.fields);
+            (read::gen_deserialize_nullable(&fields),)
+        }
+        syn::Data::Enum(s) => (quote! {},),
         syn::Data::Union(_) => {
             panic!("Union is not supported")
         }
@@ -61,31 +93,65 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
 
     // Allocate a unique type ID once and share it between both functions
     let type_id = misc::allocate_type_id();
-    let misc_token_stream = misc::gen(type_id);
-    let type_index_token_stream = misc::gen_type_index(type_id);
 
     let gen = quote! {
         impl fory_core::serializer::StructSerializer for #name {
-            fn type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: &str, type_name: &str, register_by_name: bool) -> Vec<u8> {
-                #type_def_token_stream
+            fn type_index() -> u32 {
+                #type_id
             }
+
             fn actual_type_id(type_id: u32, register_by_name: bool, mode: &fory_core::types::Mode) -> u32 {
-                #actual_type_id_token_stream
+                #actual_type_id_ts
             }
-            #type_index_token_stream
-            #read_compatible_token_stream
+
             fn get_sorted_field_names(fory: &fory_core::fory::Fory) -> Vec<String> {
-                #sort_fields_token_stream
+                #get_sorted_field_names_ts
+            }
+
+            fn type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: &str, type_name: &str, register_by_name: bool) -> Vec<u8> {
+                #type_def_ts
+            }
+
+            fn read_compatible(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
+                #read_compatible_ts
             }
         }
         impl fory_core::types::ForyGeneralList for #name {}
         impl fory_core::serializer::Serializer for #name {
-            #misc_token_stream
-            #write_token_stream
-            #read_token_stream
+            fn get_type_id(fory: &fory_core::fory::Fory) -> u32 {
+                fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_id)
+            }
+
+            fn reserved_space() -> usize {
+                #reserved_space_ts
+            }
+
+            fn write_type_info(context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+                #write_type_info_ts
+            }
+
+            fn read_type_info(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) {
+                #read_type_info_ts
+            }
+
+            fn write(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+                #write_ts
+            }
+
+            fn read(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
+                #read_ts
+            }
+
+            fn serialize(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+                #serialize_ts
+            }
+
+            fn deserialize(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) -> Result<Self, fory_core::error::Error> {
+                #deserialize_ts
+            }
         }
         impl #name {
-            #read_nullable_token_stream
+            #deserialize_nullable_ts
         }
     };
     gen.into()

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -85,19 +85,19 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
             let fields = sorted_fields(&s.fields);
             (read::gen_deserialize_nullable(&fields),)
         }
-        syn::Data::Enum(s) => (quote! {},),
+        syn::Data::Enum(_s) => (quote! {},),
         syn::Data::Union(_) => {
             panic!("Union is not supported")
         }
     };
 
     // Allocate a unique type ID once and share it between both functions
-    let type_id = misc::allocate_type_id();
+    let type_idx = misc::allocate_type_id();
 
     let gen = quote! {
         impl fory_core::serializer::StructSerializer for #name {
             fn type_index() -> u32 {
-                #type_id
+                #type_idx
             }
 
             fn actual_type_id(type_id: u32, register_by_name: bool, mode: &fory_core::types::Mode) -> u32 {
@@ -119,7 +119,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
         impl fory_core::types::ForyGeneralList for #name {}
         impl fory_core::serializer::Serializer for #name {
             fn get_type_id(fory: &fory_core::fory::Fory) -> u32 {
-                fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_id)
+                fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_idx)
             }
 
             fn reserved_space() -> usize {

--- a/rust/tests/tests/test_compatible.rs
+++ b/rust/tests/tests/test_compatible.rs
@@ -589,3 +589,8 @@ fn boxed() {
     let item2_f6: Option<i32> = fory2.deserialize(&bytes).unwrap();
     assert_eq!(item2.f6, item2_f6);
 }
+
+#[test]
+fn skip_custom_type() {
+
+}

--- a/rust/tests/tests/test_compatible.rs
+++ b/rust/tests/tests/test_compatible.rs
@@ -591,6 +591,7 @@ fn boxed() {
 }
 
 #[test]
+#[ignore]
 fn skip_custom_type() {
-
+    todo!()
 }

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -52,11 +52,11 @@ struct SimpleStruct {
     f2: i32,
     f3: Item,
     f4: Option<String>,
-    // f5: Color,
+    f5: Color,
     f6: Vec<Option<String>>,
     f7: i32,
-    // f8: i32,
-    // last: i32,
+    f8: i32,
+    last: i32,
 }
 
 #[test]
@@ -360,11 +360,11 @@ fn test_simple_struct() {
             name: Some("item".to_string()),
         },
         f4: Some("f4".to_string()),
-        // f5: Color::White,
+        f5: Color::White,
         f6: vec![Some("f6".to_string())],
         f7: 40,
-        // f8: 41,
-        // last: 42,
+        f8: 41,
+        last: 42,
     };
     let remote_obj: SimpleStruct = fory.deserialize(&bytes).unwrap();
     assert_eq!(remote_obj, local_obj);
@@ -391,11 +391,11 @@ fn test_simple_named_struct() {
             name: Some("item".to_string()),
         },
         f4: Some("f4".to_string()),
-        // f5: Color::White,
+        f5: Color::White,
         f6: vec![Some("f6".to_string())],
         f7: 40,
-        // f8: 41,
-        // last: 42,
+        f8: 41,
+        last: 42,
     };
     let remote_obj: SimpleStruct = fory.deserialize(&bytes).unwrap();
     assert_eq!(remote_obj, local_obj);
@@ -579,7 +579,7 @@ fn test_integer() {
 
     let mut writer = Writer::default();
     let mut context = WriteContext::new(&fory, &mut writer);
-    // fory.serialize_with_context(&remote_item2, &mut context);
+    fory.serialize_with_context(&remote_item2, &mut context);
     fory.serialize_with_context(&remote_f1, &mut context);
     fory.serialize_with_context(&remote_f2, &mut context);
     fory.serialize_with_context(&remote_f3, &mut context);


### PR DESCRIPTION
## What does this PR do?
1. Extract part of the compile-time code out and mark them with `#[inline(always)]` for inlining, which makes IDE hints and debugging quite convenient and avoid performance loss.
2. Fix logic of named_enum && skip enum.
3. Enable some java <-> rust unit tests. Thanks to #2654 && #2655

## Related issues
Fixes #2653 