### PR TITLE
refactor(Rust): Refine api name

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/XtypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/XtypeResolver.java
@@ -338,17 +338,25 @@ public class XtypeResolver extends TypeResolver {
   }
 
   public <T> void registerSerializer(Class<T> type, Class<? extends Serializer> serializerClass) {
-    ClassInfo classInfo = checkClassRegistration(type);
-    if (!serializerClass.getPackage().getName().startsWith("org.apache.fory")) {
-      SerializationUtils.validate(type, serializerClass);
-    }
-    classInfo.serializer = Serializers.newSerializer(fory, type, serializerClass);
+    registerSerializer(type, Serializers.newSerializer(fory, type, serializerClass));
   }
 
   public void registerSerializer(Class<?> type, Serializer<?> serializer) {
     ClassInfo classInfo = checkClassRegistration(type);
     if (!serializer.getClass().getPackage().getName().startsWith("org.apache.fory")) {
       SerializationUtils.validate(type, serializer.getClass());
+    }
+    int xtypeId = classInfo.xtypeId;
+    int foryId = xtypeId & 0xff;
+    if (foryId != Types.EXT && foryId != Types.NAMED_EXT) {
+      if (foryId == Types.STRUCT || foryId == Types.COMPATIBLE_STRUCT) {
+        classInfo.xtypeId = (xtypeId & 0xffffff00) | Types.EXT;
+      } else if (foryId == Types.NAMED_STRUCT || foryId == Types.NAMED_COMPATIBLE_STRUCT) {
+        classInfo.xtypeId = (xtypeId & 0xffffff00) | Types.NAMED_EXT;
+      } else {
+        throw new IllegalArgumentException(
+            String.format("Can't register serializer for type %s with id %s", type, xtypeId));
+      }
     }
     classInfo.serializer = serializer;
   }

--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -78,7 +78,7 @@ public class RustXlangTest extends ForyTestBase {
 
   private static final int RUST_TESTCASE_INDEX = 4;
 
-//  @BeforeClass
+  @BeforeClass
   public void isRustJavaCIEnabled() {
     String enabled = System.getenv("FORY_RUST_JAVA_CI");
     if (enabled == null || !enabled.equals("1")) {

--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -106,22 +106,22 @@ public class RustXlangTest extends ForyTestBase {
     testBuffer(Language.RUST, command);
     command.set(RUST_TESTCASE_INDEX, "test_buffer_var");
     testBufferVar(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_murmurhash3");
-    testMurmurHash3(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_string_serializer");
-    testStringSerializer(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_cross_language_serializer");
-    testCrossLanguageSerializer(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_simple_struct");
-    testSimpleStruct(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_simple_named_struct");
-    testSimpleNamedStruct(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_list");
-    testList(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_map");
-    testMap(Language.RUST, command);
-    command.set(RUST_TESTCASE_INDEX, "test_integer");
-    testInteger(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_murmurhash3");
+//    testMurmurHash3(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_string_serializer");
+//    testStringSerializer(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_cross_language_serializer");
+//    testCrossLanguageSerializer(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_simple_struct");
+//    testSimpleStruct(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_simple_named_struct");
+//    testSimpleNamedStruct(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_list");
+//    testList(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_map");
+//    testMap(Language.RUST, command);
+//    command.set(RUST_TESTCASE_INDEX, "test_integer");
+//    testInteger(Language.RUST, command);
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -78,7 +78,7 @@ public class RustXlangTest extends ForyTestBase {
 
   private static final int RUST_TESTCASE_INDEX = 4;
 
-  @BeforeClass
+//  @BeforeClass
   public void isRustJavaCIEnabled() {
     String enabled = System.getenv("FORY_RUST_JAVA_CI");
     if (enabled == null || !enabled.equals("1")) {

--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -106,22 +106,22 @@ public class RustXlangTest extends ForyTestBase {
     testBuffer(Language.RUST, command);
     command.set(RUST_TESTCASE_INDEX, "test_buffer_var");
     testBufferVar(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_murmurhash3");
-//    testMurmurHash3(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_string_serializer");
-//    testStringSerializer(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_cross_language_serializer");
-//    testCrossLanguageSerializer(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_simple_struct");
-//    testSimpleStruct(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_simple_named_struct");
-//    testSimpleNamedStruct(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_list");
-//    testList(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_map");
-//    testMap(Language.RUST, command);
-//    command.set(RUST_TESTCASE_INDEX, "test_integer");
-//    testInteger(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_murmurhash3");
+    testMurmurHash3(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_string_serializer");
+    testStringSerializer(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_cross_language_serializer");
+    testCrossLanguageSerializer(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_simple_struct");
+    testSimpleStruct(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_simple_named_struct");
+    testSimpleNamedStruct(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_list");
+    testList(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_map");
+    testMap(Language.RUST, command);
+    command.set(RUST_TESTCASE_INDEX, "test_integer");
+    testInteger(Language.RUST, command);
   }
 
   @Test

--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -43,81 +43,96 @@ impl Writer {
         }
     }
 
-    pub fn u8(&mut self, value: u8) {
-        self.bf.write_u8(value).unwrap();
-    }
-
-    pub fn i8(&mut self, value: i8) {
-        self.bf.write_i8(value).unwrap();
-    }
-
-    pub fn u16(&mut self, value: u16) {
-        self.bf.write_u16::<LittleEndian>(value).unwrap();
-    }
-
-    pub fn i16(&mut self, value: i16) {
-        self.bf.write_i16::<LittleEndian>(value).unwrap();
-    }
-
-    pub fn u32(&mut self, value: u32) {
-        self.bf.write_u32::<LittleEndian>(value).unwrap();
-    }
-
     pub fn skip(&mut self, len: usize) {
         self.bf.resize(self.bf.len() + len, 0);
     }
 
-    pub fn i32(&mut self, value: i32) {
+    pub fn set_bytes(&mut self, offset: usize, data: &[u8]) {
+        self.bf
+            .get_mut(offset..offset + data.len())
+            .expect("//todo")
+            .copy_from_slice(data);
+    }
+
+    pub fn write_bytes(&mut self, v: &[u8]) -> usize {
+        self.reserve(v.len());
+        self.bf.extend_from_slice(v);
+        v.len()
+    }
+
+    pub fn write_u8(&mut self, value: u8) {
+        self.bf.write_u8(value).unwrap();
+    }
+
+    pub fn write_i8(&mut self, value: i8) {
+        self.bf.write_i8(value).unwrap();
+    }
+
+    pub fn write_u16(&mut self, value: u16) {
+        self.bf.write_u16::<LittleEndian>(value).unwrap();
+    }
+
+    pub fn write_i16(&mut self, value: i16) {
+        self.bf.write_i16::<LittleEndian>(value).unwrap();
+    }
+
+    pub fn write_u32(&mut self, value: u32) {
+        self.bf.write_u32::<LittleEndian>(value).unwrap();
+    }
+
+    pub fn write_i32(&mut self, value: i32) {
         self.bf.write_i32::<LittleEndian>(value).unwrap();
     }
 
-    pub fn f32(&mut self, value: f32) {
+    pub fn write_f32(&mut self, value: f32) {
         self.bf.write_f32::<LittleEndian>(value).unwrap();
     }
 
-    pub fn i64(&mut self, value: i64) {
+    pub fn write_i64(&mut self, value: i64) {
         self.bf.write_i64::<LittleEndian>(value).unwrap();
     }
 
-    pub fn f64(&mut self, value: f64) {
+    pub fn write_f64(&mut self, value: f64) {
         self.bf.write_f64::<LittleEndian>(value).unwrap();
     }
 
-    pub fn u64(&mut self, value: u64) {
+    pub fn write_u64(&mut self, value: u64) {
         self.bf.write_u64::<LittleEndian>(value).unwrap();
     }
 
-    pub fn var_int32(&mut self, value: i32) {
+    pub fn write_var_int32(&mut self, value: i32) {
         let zigzag = ((value as i64) << 1) ^ ((value as i64) >> 31);
-        self.internal_var_uint32(zigzag as u32)
+        self._write_var_uint32(zigzag as u32)
     }
 
-    pub fn var_uint32(&mut self, value: u32) {
-        self.internal_var_uint32(value)
+    pub fn write_var_uint32(&mut self, value: u32) {
+        self._write_var_uint32(value)
     }
 
-    fn internal_var_uint32(&mut self, value: u32) {
+    fn _write_var_uint32(&mut self, value: u32) {
         if value < 0x80 {
-            self.u8(value as u8);
+            self.write_u8(value as u8);
         } else if value < 0x4000 {
             // 2 bytes
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (value >> 7) as u8;
-            self.u16(((u2 as u16) << 8) | u1 as u16);
+            self.write_u16(((u2 as u16) << 8) | u1 as u16);
         } else if value < 0x200000 {
             // 3 bytes
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
             let u3 = (value >> 14) as u8;
-            self.u16(((u2 as u16) << 8) | u1 as u16);
-            self.u8(u3);
+            self.write_u16(((u2 as u16) << 8) | u1 as u16);
+            self.write_u8(u3);
         } else if value < 0x10000000 {
             // 4 bytes
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
             let u3 = (((value >> 14) as u8) & 0x7F) | 0x80;
             let u4 = (value >> 21) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
         } else {
             // 5 bytes
             let u1 = ((value as u8) & 0x7F) | 0x80;
@@ -125,47 +140,53 @@ impl Writer {
             let u3 = (((value >> 14) as u8) & 0x7F) | 0x80;
             let u4 = (((value >> 21) as u8) & 0x7F) | 0x80;
             let u5 = (value >> 28) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
-            self.u8(u5);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
+            self.write_u8(u5);
         }
     }
 
-    pub fn var_int64(&mut self, value: i64) {
+    pub fn write_var_int64(&mut self, value: i64) {
         let zigzag = ((value << 1) ^ (value >> 63)) as u64;
-        self.internal_var_uint64(zigzag)
+        self._write_var_uint64(zigzag)
     }
 
-    pub fn var_uint64(&mut self, value: u64) {
-        self.internal_var_uint64(value)
+    pub fn write_var_uint64(&mut self, value: u64) {
+        self._write_var_uint64(value)
     }
 
-    fn internal_var_uint64(&mut self, value: u64) {
+    fn _write_var_uint64(&mut self, value: u64) {
         if value < 0x80 {
-            self.u8(value as u8);
+            self.write_u8(value as u8);
         } else if value < 0x4000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (value >> 7) as u8;
-            self.u16(((u2 as u16) << 8) | u1 as u16);
+            self.write_u16(((u2 as u16) << 8) | u1 as u16);
         } else if value < 0x200000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
             let u3 = (value >> 14) as u8;
-            self.u16(((u2 as u16) << 8) | u1 as u16);
-            self.u8(u3);
+            self.write_u16(((u2 as u16) << 8) | u1 as u16);
+            self.write_u8(u3);
         } else if value < 0x10000000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
             let u3 = (((value >> 14) as u8) & 0x7F) | 0x80;
             let u4 = (value >> 21) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
         } else if value < 0x800000000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
             let u3 = (((value >> 14) as u8) & 0x7F) | 0x80;
             let u4 = (((value >> 21) as u8) & 0x7F) | 0x80;
             let u5 = (value >> 28) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
-            self.u8(u5);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
+            self.write_u8(u5);
         } else if value < 0x40000000000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
@@ -173,8 +194,10 @@ impl Writer {
             let u4 = (((value >> 21) as u8) & 0x7F) | 0x80;
             let u5 = (((value >> 28) as u8) & 0x7F) | 0x80;
             let u6 = (value >> 35) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
-            self.u16(((u6 as u16) << 8) | u5 as u16);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
+            self.write_u16(((u6 as u16) << 8) | u5 as u16);
         } else if value < 0x2000000000000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
@@ -183,9 +206,11 @@ impl Writer {
             let u5 = (((value >> 28) as u8) & 0x7F) | 0x80;
             let u6 = (((value >> 35) as u8) & 0x7F) | 0x80;
             let u7 = (value >> 42) as u8;
-            self.u32(((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32);
-            self.u16(((u6 as u16) << 8) | u5 as u16);
-            self.u8(u7);
+            self.write_u32(
+                ((u4 as u32) << 24) | ((u3 as u32) << 16) | ((u2 as u32) << 8) | u1 as u32,
+            );
+            self.write_u16(((u6 as u16) << 8) | u5 as u16);
+            self.write_u8(u7);
         } else if value < 0x100000000000000 {
             let u1 = ((value as u8) & 0x7F) | 0x80;
             let u2 = (((value >> 7) as u8) & 0x7F) | 0x80;
@@ -195,7 +220,7 @@ impl Writer {
             let u6 = (((value >> 35) as u8) & 0x7F) | 0x80;
             let u7 = (((value >> 42) as u8) & 0x7F) | 0x80;
             let u8 = (value >> 49) as u8;
-            self.u64(
+            self.write_u64(
                 (u8 as u64) << 56
                     | (u7 as u64) << 48
                     | (u6 as u64) << 40
@@ -215,7 +240,7 @@ impl Writer {
             let u7 = (((value >> 42) as u8) & 0x7F) | 0x80;
             let u8 = (((value >> 49) as u8) & 0x7F) | 0x80;
             let u9 = (value >> 56) as u8;
-            self.u64(
+            self.write_u64(
                 (u8 as u64) << 56
                     | (u7 as u64) << 48
                     | (u6 as u64) << 40
@@ -225,32 +250,32 @@ impl Writer {
                     | (u2 as u64) << 8
                     | (u1 as u64),
             );
-            self.u8(u9);
+            self.write_u8(u9);
         }
     }
 
-    pub fn var_uint36_small(&mut self, value: u64) {
+    pub fn write_var_uint36_small(&mut self, value: u64) {
         assert!(value < (1u64 << 36), "value too large for 36-bit varint");
         if value < 0x80 {
-            self.u8(value as u8);
+            self.write_u8(value as u8);
         } else if value < 0x4000 {
             let b0 = ((value & 0x7F) as u8) | 0x80;
             let b1 = (value >> 7) as u8;
             let combined = ((b1 as u16) << 8) | (b0 as u16);
-            self.u16(combined);
+            self.write_u16(combined);
         } else if value < 0x200000 {
             let b0 = (value & 0x7F) | 0x80;
             let b1 = ((value >> 7) & 0x7F) | 0x80;
             let b2 = value >> 14;
             let combined = b0 | (b1 << 8) | (b2 << 16);
-            self.u32(combined as u32);
+            self.write_u32(combined as u32);
         } else if value < 0x10000000 {
             let b0 = (value & 0x7F) | 0x80;
             let b1 = ((value >> 7) & 0x7F) | 0x80;
             let b2 = ((value >> 14) & 0x7F) | 0x80;
             let b3 = value >> 21;
             let combined = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
-            self.u32(combined as u32);
+            self.write_u32(combined as u32);
         } else {
             let b0 = (value & 0x7F) | 0x80;
             let b1 = ((value >> 7) & 0x7F) | 0x80;
@@ -258,38 +283,25 @@ impl Writer {
             let b3 = ((value >> 21) & 0x7F) | 0x80;
             let b4 = value >> 28;
             let combined = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24) | (b4 << 32);
-            self.u64(combined);
+            self.write_u64(combined);
         }
     }
 
     // TODO: simd
-    pub fn latin1_string(&mut self, s: &str) {
+    pub fn write_latin1_string(&mut self, s: &str) {
         for c in s.chars() {
             let b = c as u32;
             assert!(b <= 0xFF, "Non-Latin1 character found");
-            self.u8(b as u8);
+            self.write_u8(b as u8);
         }
     }
 
     // TODO: simd
-    pub fn utf8_string(&mut self, s: &str) {
+    pub fn write_utf8_string(&mut self, s: &str) {
         let bytes = s.as_bytes();
         for &b in bytes {
-            self.u8(b);
+            self.write_u8(b);
         }
-    }
-
-    pub fn bytes(&mut self, v: &[u8]) -> usize {
-        self.reserve(v.len());
-        self.bf.extend_from_slice(v);
-        v.len()
-    }
-
-    pub fn set_bytes(&mut self, offset: usize, data: &[u8]) {
-        self.bf
-            .get_mut(offset..offset + data.len())
-            .expect("//todo")
-            .copy_from_slice(data);
     }
 }
 
@@ -315,67 +327,67 @@ impl<'bf> Reader<'bf> {
         self.cursor
     }
 
-    pub fn u8(&mut self) -> u8 {
+    pub fn read_u8(&mut self) -> u8 {
         let result = self.bf[self.cursor];
         self.move_next(1);
         result
     }
 
-    pub fn i8(&mut self) -> i8 {
+    pub fn read_i8(&mut self) -> i8 {
         let result = self.bf[self.cursor];
         self.move_next(1);
         result as i8
     }
 
-    pub fn u16(&mut self) -> u16 {
+    pub fn read_u16(&mut self) -> u16 {
         let result = LittleEndian::read_u16(self.slice_after_cursor());
         self.move_next(2);
         result
     }
 
-    pub fn i16(&mut self) -> i16 {
+    pub fn read_i16(&mut self) -> i16 {
         let result = LittleEndian::read_i16(self.slice_after_cursor());
         self.move_next(2);
         result
     }
 
-    pub fn u32(&mut self) -> u32 {
+    pub fn read_u32(&mut self) -> u32 {
         let result = LittleEndian::read_u32(self.slice_after_cursor());
         self.move_next(4);
         result
     }
 
-    pub fn i32(&mut self) -> i32 {
+    pub fn read_i32(&mut self) -> i32 {
         let result = LittleEndian::read_i32(self.slice_after_cursor());
         self.move_next(4);
         result
     }
 
-    pub fn u64(&mut self) -> u64 {
+    pub fn read_u64(&mut self) -> u64 {
         let result = LittleEndian::read_u64(self.slice_after_cursor());
         self.move_next(8);
         result
     }
 
-    pub fn i64(&mut self) -> i64 {
+    pub fn read_i64(&mut self) -> i64 {
         let result = LittleEndian::read_i64(self.slice_after_cursor());
         self.move_next(8);
         result
     }
 
-    pub fn f32(&mut self) -> f32 {
+    pub fn read_f32(&mut self) -> f32 {
         let result = LittleEndian::read_f32(self.slice_after_cursor());
         self.move_next(4);
         result
     }
 
-    pub fn f64(&mut self) -> f64 {
+    pub fn read_f64(&mut self) -> f64 {
         let result = LittleEndian::read_f64(self.slice_after_cursor());
         self.move_next(8);
         result
     }
 
-    pub fn var_uint32(&mut self) -> u32 {
+    pub fn read_var_uint32(&mut self) -> u32 {
         let start = self.cursor;
         let b0 = self.bf[start] as u32;
         if b0 < 0x80 {
@@ -411,12 +423,12 @@ impl<'bf> Reader<'bf> {
         encoded
     }
 
-    pub fn var_int32(&mut self) -> i32 {
-        let encoded = self.var_uint32();
+    pub fn read_var_int32(&mut self) -> i32 {
+        let encoded = self.read_var_uint32();
         ((encoded >> 1) as i32) ^ -((encoded & 1) as i32)
     }
 
-    pub fn var_uint64(&mut self) -> u64 {
+    pub fn read_var_uint64(&mut self) -> u64 {
         let start = self.cursor;
         let b0 = self.bf[start] as u64;
         if b0 < 0x80 {
@@ -480,25 +492,25 @@ impl<'bf> Reader<'bf> {
         var64
     }
 
-    pub fn var_int64(&mut self) -> i64 {
-        let encoded = self.var_uint64();
+    pub fn read_var_int64(&mut self) -> i64 {
+        let encoded = self.read_var_uint64();
         ((encoded >> 1) as i64) ^ -((encoded & 1) as i64)
     }
 
-    pub fn latin1_string(&mut self, len: usize) -> String {
+    pub fn read_latin1_string(&mut self, len: usize) -> String {
         let slice = &self.bf[self.cursor..self.cursor + len];
         let result: String = slice.iter().map(|&b| b as char).collect();
         self.move_next(len);
         result
     }
 
-    pub fn utf8_string(&mut self, len: usize) -> String {
+    pub fn read_utf8_string(&mut self, len: usize) -> String {
         let result = String::from_utf8_lossy(&self.bf[self.cursor..self.cursor + len]).to_string();
         self.move_next(len);
         result
     }
 
-    pub fn utf16_string(&mut self, len: usize) -> String {
+    pub fn read_utf16_string(&mut self, len: usize) -> String {
         assert!(len % 2 == 0, "UTF-16 length must be even");
         let slice = &self.bf[self.cursor..self.cursor + len];
         let units: Vec<u16> = slice
@@ -517,7 +529,7 @@ impl<'bf> Reader<'bf> {
         let start = self.cursor;
         // fast path
         if self.slice_after_cursor().len() >= 8 {
-            let bulk = self.u64();
+            let bulk = self.read_u64();
             let mut result = bulk & 0x7F;
             let mut read_idx = start;
 
@@ -544,7 +556,7 @@ impl<'bf> Reader<'bf> {
         let mut result = 0u64;
         let mut shift = 0;
         while self.cursor < self.bf.len() {
-            let b = self.u8();
+            let b = self.read_u8();
             result |= ((b & 0x7F) as u64) << shift;
             if (b & 0x80) == 0 {
                 break;
@@ -558,11 +570,11 @@ impl<'bf> Reader<'bf> {
         self.move_next(len as usize);
     }
 
-    pub fn slice(&self) -> &[u8] {
+    pub fn get_slice(&self) -> &[u8] {
         self.bf
     }
 
-    pub fn bytes(&mut self, len: usize) -> &'bf [u8] {
+    pub fn read_bytes(&mut self, len: usize) -> &'bf [u8] {
         let result = &self.bf[self.cursor..self.cursor + len];
         self.move_next(len);
         result

--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -100,16 +100,16 @@ impl Writer {
         self.bf.write_u64::<LittleEndian>(value).unwrap();
     }
 
-    pub fn write_var_int32(&mut self, value: i32) {
+    pub fn write_varint32(&mut self, value: i32) {
         let zigzag = ((value as i64) << 1) ^ ((value as i64) >> 31);
-        self._write_var_uint32(zigzag as u32)
+        self._write_varuint32(zigzag as u32)
     }
 
-    pub fn write_var_uint32(&mut self, value: u32) {
-        self._write_var_uint32(value)
+    pub fn write_varuint32(&mut self, value: u32) {
+        self._write_varuint32(value)
     }
 
-    fn _write_var_uint32(&mut self, value: u32) {
+    fn _write_varuint32(&mut self, value: u32) {
         if value < 0x80 {
             self.write_u8(value as u8);
         } else if value < 0x4000 {
@@ -147,16 +147,16 @@ impl Writer {
         }
     }
 
-    pub fn write_var_int64(&mut self, value: i64) {
+    pub fn write_varint64(&mut self, value: i64) {
         let zigzag = ((value << 1) ^ (value >> 63)) as u64;
-        self._write_var_uint64(zigzag)
+        self._write_varuint64(zigzag)
     }
 
-    pub fn write_var_uint64(&mut self, value: u64) {
-        self._write_var_uint64(value)
+    pub fn write_varuint64(&mut self, value: u64) {
+        self._write_varuint64(value)
     }
 
-    fn _write_var_uint64(&mut self, value: u64) {
+    fn _write_varuint64(&mut self, value: u64) {
         if value < 0x80 {
             self.write_u8(value as u8);
         } else if value < 0x4000 {
@@ -254,7 +254,7 @@ impl Writer {
         }
     }
 
-    pub fn write_var_uint36_small(&mut self, value: u64) {
+    pub fn write_varuint36_small(&mut self, value: u64) {
         assert!(value < (1u64 << 36), "value too large for 36-bit varint");
         if value < 0x80 {
             self.write_u8(value as u8);
@@ -387,7 +387,7 @@ impl<'bf> Reader<'bf> {
         result
     }
 
-    pub fn read_var_uint32(&mut self) -> u32 {
+    pub fn read_varuint32(&mut self) -> u32 {
         let start = self.cursor;
         let b0 = self.bf[start] as u32;
         if b0 < 0x80 {
@@ -423,12 +423,12 @@ impl<'bf> Reader<'bf> {
         encoded
     }
 
-    pub fn read_var_int32(&mut self) -> i32 {
-        let encoded = self.read_var_uint32();
+    pub fn read_varint32(&mut self) -> i32 {
+        let encoded = self.read_varuint32();
         ((encoded >> 1) as i32) ^ -((encoded & 1) as i32)
     }
 
-    pub fn read_var_uint64(&mut self) -> u64 {
+    pub fn read_varuint64(&mut self) -> u64 {
         let start = self.cursor;
         let b0 = self.bf[start] as u64;
         if b0 < 0x80 {
@@ -492,8 +492,8 @@ impl<'bf> Reader<'bf> {
         var64
     }
 
-    pub fn read_var_int64(&mut self) -> i64 {
-        let encoded = self.read_var_uint64();
+    pub fn read_varint64(&mut self) -> i64 {
+        let encoded = self.read_varuint64();
         ((encoded >> 1) as i64) ^ -((encoded & 1) as i64)
     }
 
@@ -525,7 +525,7 @@ impl<'bf> Reader<'bf> {
         result
     }
 
-    pub fn var_uint36_small(&mut self) -> u64 {
+    pub fn read_varuint36small(&mut self) -> u64 {
         let start = self.cursor;
         // fast path
         if self.slice_after_cursor().len() >= 8 {

--- a/rust/fory-core/src/fory.rs
+++ b/rust/fory-core/src/fory.rs
@@ -73,7 +73,7 @@ impl Fory {
 
     pub fn write_head<T: Serializer>(&self, is_none: bool, writer: &mut Writer) {
         const HEAD_SIZE: usize = 10;
-        writer.reserve(<T as Serializer>::reserved_space() + SIZE_OF_REF_AND_TYPE + HEAD_SIZE);
+        writer.reserve(<T as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE + HEAD_SIZE);
         if self.xlang {
             writer.write_u16(MAGIC_NUMBER);
         }
@@ -153,7 +153,7 @@ impl Fory {
                 bytes_to_skip = context.load_meta(meta_offset as usize);
             }
         }
-        let result = <T as Serializer>::deserialize(context, false);
+        let result = <T as Serializer>::fory_deserialize(context, false);
         if bytes_to_skip > 0 {
             context.reader.skip(bytes_to_skip as u32);
         }
@@ -171,14 +171,14 @@ impl Fory {
         record: &T,
         context: &mut WriteContext,
     ) -> Vec<u8> {
-        let is_none = record.is_none();
+        let is_none = record.fory_is_none();
         self.write_head::<T>(is_none, context.writer);
         let meta_start_offset = context.writer.len();
         if !is_none {
             if self.mode == Mode::Compatible {
                 context.writer.write_i32(-1);
             };
-            <T as Serializer>::serialize(record, context, false);
+            <T as Serializer>::fory_serialize(record, context, false);
             if self.mode == Mode::Compatible && !context.empty() {
                 context.write_meta(meta_start_offset);
             }
@@ -191,7 +191,7 @@ impl Fory {
     }
 
     pub fn register<T: 'static + StructSerializer>(&mut self, id: u32) {
-        let actual_type_id = T::actual_type_id(id, false, &self.mode);
+        let actual_type_id = T::fory_actual_type_id(id, false, &self.mode);
         let empty_string = String::new();
         let type_info =
             TypeInfo::new::<T>(self, actual_type_id, &empty_string, &empty_string, false);
@@ -203,7 +203,7 @@ impl Fory {
         namespace: &str,
         type_name: &str,
     ) {
-        let actual_type_id = T::actual_type_id(0, true, &self.mode);
+        let actual_type_id = T::fory_actual_type_id(0, true, &self.mode);
         let type_info = TypeInfo::new::<T>(self, actual_type_id, namespace, type_name, true);
         self.type_resolver.register::<T>(&type_info);
     }

--- a/rust/fory-core/src/fory.rs
+++ b/rust/fory-core/src/fory.rs
@@ -27,11 +27,15 @@ use crate::types::{
     config_flags::{IS_CROSS_LANGUAGE_FLAG, IS_LITTLE_ENDIAN_FLAG},
     Language, Mode, MAGIC_NUMBER, SIZE_OF_REF_AND_TYPE,
 };
+use crate::util::get_ext_actual_type_id;
 use anyhow::anyhow;
+
+static EMPTY_STRING: String = String::new();
 
 pub struct Fory {
     mode: Mode,
     xlang: bool,
+    share_meta: bool,
     type_resolver: TypeResolver,
     compress_string: bool,
 }
@@ -41,6 +45,7 @@ impl Default for Fory {
         Fory {
             mode: Mode::SchemaConsistent,
             xlang: true,
+            share_meta: false,
             type_resolver: TypeResolver::default(),
             compress_string: false,
         }
@@ -49,6 +54,8 @@ impl Default for Fory {
 
 impl Fory {
     pub fn mode(mut self, mode: Mode) -> Self {
+        // Setting share_meta individually is not supported currently
+        self.share_meta = mode != Mode::SchemaConsistent;
         self.mode = mode;
         self
     }
@@ -71,9 +78,13 @@ impl Fory {
         self.compress_string
     }
 
+    pub fn is_share_meta(&self) -> bool {
+        self.share_meta
+    }
+
     pub fn write_head<T: Serializer>(&self, is_none: bool, writer: &mut Writer) {
         const HEAD_SIZE: usize = 10;
-        writer.reserve(<T as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE + HEAD_SIZE);
+        writer.reserve(T::fory_reserved_space() + SIZE_OF_REF_AND_TYPE + HEAD_SIZE);
         if self.xlang {
             writer.write_u16(MAGIC_NUMBER);
         }
@@ -190,15 +201,14 @@ impl Fory {
         &self.type_resolver
     }
 
-    pub fn register<T: 'static + StructSerializer>(&mut self, id: u32) {
+    pub fn register<T: 'static + StructSerializer + Serializer>(&mut self, id: u32) {
         let actual_type_id = T::fory_actual_type_id(id, false, &self.mode);
-        let empty_string = String::new();
         let type_info =
-            TypeInfo::new::<T>(self, actual_type_id, &empty_string, &empty_string, false);
+            TypeInfo::new::<T>(self, actual_type_id, &EMPTY_STRING, &EMPTY_STRING, false);
         self.type_resolver.register::<T>(&type_info);
     }
 
-    pub fn register_by_namespace<T: 'static + StructSerializer>(
+    pub fn register_by_namespace<T: 'static + StructSerializer + Serializer>(
         &mut self,
         namespace: &str,
         type_name: &str,
@@ -208,7 +218,37 @@ impl Fory {
         self.type_resolver.register::<T>(&type_info);
     }
 
-    pub fn register_by_name<T: 'static + StructSerializer>(&mut self, type_name: &str) {
+    pub fn register_by_name<T: 'static + StructSerializer + Serializer>(
+        &mut self,
+        type_name: &str,
+    ) {
         self.register_by_namespace::<T>("", type_name);
     }
+
+    pub fn register_serializer<T: Serializer>(&mut self, id: u32) {
+        let actual_type_id = get_ext_actual_type_id(id, false);
+        let type_info = TypeInfo::new_with_empty_def::<T>(
+            self,
+            actual_type_id,
+            &EMPTY_STRING,
+            &EMPTY_STRING,
+            false,
+        );
+        self.type_resolver.register_serializer::<T>(&type_info);
+    }
+
+    pub fn register_serializer_by_name<T: Serializer>(&mut self, type_name: &str, namespace: &str) {
+        let actual_type_id = get_ext_actual_type_id(0, false);
+        let type_info =
+            TypeInfo::new_with_empty_def::<T>(self, actual_type_id, namespace, type_name, true);
+        self.type_resolver.register_serializer::<T>(&type_info);
+    }
+}
+
+pub fn write<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool) {
+    T::fory_write(this, context, is_field);
+}
+
+pub fn read<T: Serializer>(context: &mut ReadContext, is_field: bool) -> Result<T, Error> {
+    T::fory_read(context, is_field)
 }

--- a/rust/fory-core/src/fory.rs
+++ b/rust/fory-core/src/fory.rs
@@ -153,7 +153,7 @@ impl Fory {
                 bytes_to_skip = context.load_meta(meta_offset as usize);
             }
         }
-        let result = <T as Serializer>::fory_deserialize(context, false);
+        let result = <T as Serializer>::fory_read(context, false);
         if bytes_to_skip > 0 {
             context.reader.skip(bytes_to_skip as u32);
         }
@@ -178,7 +178,7 @@ impl Fory {
             if self.mode == Mode::Compatible {
                 context.writer.write_i32(-1);
             };
-            <T as Serializer>::fory_serialize(record, context, false);
+            <T as Serializer>::fory_write(record, context, false);
             if self.mode == Mode::Compatible && !context.empty() {
                 context.write_meta(meta_start_offset);
             }

--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -301,12 +301,12 @@ impl TypeMetaLayer {
         self.type_id
     }
 
-    pub fn get_type_name(&self) -> MetaString {
-        self.type_name.clone()
+    pub fn get_type_name(&self) -> &MetaString {
+        &self.type_name
     }
 
-    pub fn get_namespace(&self) -> MetaString {
-        self.namespace.clone()
+    pub fn get_namespace(&self) -> &MetaString {
+        &self.namespace
     }
 
     pub fn get_field_infos(&self) -> &Vec<FieldInfo> {
@@ -438,11 +438,11 @@ impl TypeMeta {
     }
 
     pub fn get_type_name(&self) -> MetaString {
-        self.layers.first().unwrap().get_type_name()
+        self.layers.first().unwrap().get_type_name().clone()
     }
 
     pub fn get_namespace(&self) -> MetaString {
-        self.layers.first().unwrap().get_namespace()
+        self.layers.first().unwrap().get_namespace().clone()
     }
 
     pub fn from_fields(

--- a/rust/fory-core/src/resolver/context.rs
+++ b/rust/fory-core/src/resolver/context.rs
@@ -68,14 +68,14 @@ impl<'se> WriteContext<'se> {
         let mayby_idx = self.tags.iter().position(|x| *x == tag);
         match mayby_idx {
             Some(idx) => {
-                self.writer.u8(USESTRINGID);
-                self.writer.i16(idx as i16);
+                self.writer.write_u8(USESTRINGID);
+                self.writer.write_i16(idx as i16);
             }
             None => {
-                self.writer.u8(USESTRINGVALUE);
+                self.writer.write_u8(USESTRINGVALUE);
                 self.writer.skip(8); // todo tag hash
-                self.writer.i16(tag.len() as i16);
-                self.writer.bytes(tag.as_bytes());
+                self.writer.write_i16(tag.len() as i16);
+                self.writer.write_bytes(tag.as_bytes());
             }
         };
     }
@@ -115,14 +115,14 @@ impl<'de, 'bf: 'de> ReadContext<'de, 'bf> {
     pub fn read_tag(&mut self) -> Result<&str, Error> {
         const USESTRINGVALUE: u8 = 0;
         const USESTRINGID: u8 = 1;
-        let tag_type = self.reader.u8();
+        let tag_type = self.reader.read_u8();
         if tag_type == USESTRINGID {
-            Ok(self.tags[self.reader.i16() as usize])
+            Ok(self.tags[self.reader.read_i16() as usize])
         } else if tag_type == USESTRINGVALUE {
             self.reader.skip(8); // todo tag hash
-            let len = self.reader.i16();
+            let len = self.reader.read_i16();
             let tag: &str =
-                unsafe { std::str::from_utf8_unchecked(self.reader.bytes(len as usize)) };
+                unsafe { std::str::from_utf8_unchecked(self.reader.read_bytes(len as usize)) };
             self.tags.push(tag);
             Ok(tag)
         } else {

--- a/rust/fory-core/src/resolver/meta_resolver.rs
+++ b/rust/fory-core/src/resolver/meta_resolver.rs
@@ -33,7 +33,7 @@ impl MetaReaderResolver {
     }
 
     pub fn load(&mut self, reader: &mut Reader) -> usize {
-        let meta_size = reader.read_var_uint32();
+        let meta_size = reader.read_varuint32();
         // self.reading_type_defs.reserve(meta_size as usize);
         for _ in 0..meta_size {
             self.reading_type_defs
@@ -68,7 +68,7 @@ impl<'a> MetaWriterResolver<'a> {
     }
 
     pub fn to_bytes(&self, writer: &mut Writer) -> Result<(), Error> {
-        writer.write_var_uint32(self.type_defs.len() as u32);
+        writer.write_varuint32(self.type_defs.len() as u32);
         for item in &self.type_defs {
             writer.write_bytes(item);
         }

--- a/rust/fory-core/src/resolver/meta_resolver.rs
+++ b/rust/fory-core/src/resolver/meta_resolver.rs
@@ -33,7 +33,7 @@ impl MetaReaderResolver {
     }
 
     pub fn load(&mut self, reader: &mut Reader) -> usize {
-        let meta_size = reader.var_uint32();
+        let meta_size = reader.read_var_uint32();
         // self.reading_type_defs.reserve(meta_size as usize);
         for _ in 0..meta_size {
             self.reading_type_defs
@@ -68,9 +68,9 @@ impl<'a> MetaWriterResolver<'a> {
     }
 
     pub fn to_bytes(&self, writer: &mut Writer) -> Result<(), Error> {
-        writer.var_uint32(self.type_defs.len() as u32);
+        writer.write_var_uint32(self.type_defs.len() as u32);
         for item in &self.type_defs {
-            writer.bytes(item);
+            writer.write_bytes(item);
         }
         Ok(())
     }

--- a/rust/fory-core/src/resolver/metastring_resolver.rs
+++ b/rust/fory-core/src/resolver/metastring_resolver.rs
@@ -36,7 +36,7 @@ impl MetaStringResolver {
         }
         let metastring_bytes = MetaStringBytes::from(str);
         self.metastring_to_bytes_map
-            .insert((*str).clone(), metastring_bytes.clone());
+            .insert(str.clone(), metastring_bytes.clone());
         metastring_bytes
     }
 }

--- a/rust/fory-core/src/resolver/ref_resolver.rs
+++ b/rust/fory-core/src/resolver/ref_resolver.rs
@@ -81,15 +81,15 @@ impl RefWriter {
 
         if let Some(&ref_id) = self.refs.get(&ptr_addr) {
             // This object has been seen before, write a reference
-            writer.i8(RefFlag::Ref as i8);
-            writer.u32(ref_id);
+            writer.write_i8(RefFlag::Ref as i8);
+            writer.write_u32(ref_id);
             true
         } else {
             // First time seeing this object, register it and return false
             let ref_id = self.next_ref_id;
             self.next_ref_id += 1;
             self.refs.insert(ptr_addr, ref_id);
-            writer.i8(RefFlag::RefValue as i8);
+            writer.write_i8(RefFlag::RefValue as i8);
             false
         }
     }
@@ -114,15 +114,15 @@ impl RefWriter {
 
         if let Some(&ref_id) = self.refs.get(&ptr_addr) {
             // This object has been seen before, write a reference
-            writer.i8(RefFlag::Ref as i8);
-            writer.u32(ref_id);
+            writer.write_i8(RefFlag::Ref as i8);
+            writer.write_u32(ref_id);
             true
         } else {
             // First time seeing this object, register it and return false
             let ref_id = self.next_ref_id;
             self.next_ref_id += 1;
             self.refs.insert(ptr_addr, ref_id);
-            writer.i8(RefFlag::RefValue as i8);
+            writer.write_i8(RefFlag::RefValue as i8);
             false
         }
     }
@@ -245,7 +245,7 @@ impl RefReader {
     ///
     /// Panics if an invalid reference flag value is encountered
     pub fn read_ref_flag(&self, reader: &mut Reader) -> RefFlag {
-        let flag_value = reader.i8();
+        let flag_value = reader.read_i8();
         match flag_value {
             -3 => RefFlag::Null,
             -2 => RefFlag::Ref,
@@ -265,7 +265,7 @@ impl RefReader {
     ///
     /// The reference ID as a u32
     pub fn read_ref_id(&self, reader: &mut Reader) -> u32 {
-        reader.u32()
+        reader.read_u32()
     }
 
     /// Clear all stored references.
@@ -308,15 +308,15 @@ impl RefResolver {
 
         if let Some(&ref_id) = self.write_refs.get(&ptr_addr) {
             // This object has been seen before, write a reference
-            writer.i8(RefFlag::Ref as i8);
-            writer.u32(ref_id);
+            writer.write_i8(RefFlag::Ref as i8);
+            writer.write_u32(ref_id);
             true
         } else {
             // First time seeing this object, register it and return false
             let ref_id = self.next_ref_id;
             self.next_ref_id += 1;
             self.write_refs.insert(ptr_addr, ref_id);
-            writer.i8(RefFlag::RefValue as i8);
+            writer.write_i8(RefFlag::RefValue as i8);
             false
         }
     }
@@ -328,15 +328,15 @@ impl RefResolver {
 
         if let Some(&ref_id) = self.write_refs.get(&ptr_addr) {
             // This object has been seen before, write a reference
-            writer.i8(RefFlag::Ref as i8);
-            writer.u32(ref_id);
+            writer.write_i8(RefFlag::Ref as i8);
+            writer.write_u32(ref_id);
             true
         } else {
             // First time seeing this object, register it and return false
             let ref_id = self.next_ref_id;
             self.next_ref_id += 1;
             self.write_refs.insert(ptr_addr, ref_id);
-            writer.i8(RefFlag::RefValue as i8);
+            writer.write_i8(RefFlag::RefValue as i8);
             false
         }
     }
@@ -369,7 +369,7 @@ impl RefResolver {
 
     /// Read a reference flag and determine what action to take
     pub fn read_ref_flag(&self, reader: &mut Reader) -> RefFlag {
-        let flag_value = reader.i8();
+        let flag_value = reader.read_i8();
         match flag_value {
             -3 => RefFlag::Null,
             -2 => RefFlag::Ref,
@@ -381,7 +381,7 @@ impl RefResolver {
 
     /// Read a reference ID
     pub fn read_ref_id(&self, reader: &mut Reader) -> u32 {
-        reader.u32()
+        reader.read_u32()
     }
 
     /// Clear all stored references (useful for reusing the resolver)

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -18,13 +18,20 @@
 use super::context::{ReadContext, WriteContext};
 use crate::error::Error;
 use crate::fory::Fory;
-use crate::serializer::StructSerializer;
+use crate::meta::{
+    MetaString, NAMESPACE_ENCODER, NAMESPACE_ENCODINGS, TYPE_NAME_ENCODER, TYPE_NAME_ENCODINGS,
+};
+use crate::serializer::{Serializer, StructSerializer};
 use std::cell::RefCell;
+use std::sync::Arc;
 use std::{any::Any, collections::HashMap};
 
 type SerializerFn = fn(&dyn Any, &mut WriteContext, is_field: bool);
 type DeserializerFn =
     fn(&mut ReadContext, is_field: bool, skip_ref_flag: bool) -> Result<Box<dyn Any>, Error>;
+
+pub type ExtWriteFn = dyn Fn(&dyn Any, &mut WriteContext, bool) + Send + Sync;
+pub type ExtReadFn = dyn Fn(&mut ReadContext, bool) -> Result<Box<dyn Any>, Error> + Send + Sync;
 
 pub struct Harness {
     serializer: SerializerFn,
@@ -39,7 +46,7 @@ impl Harness {
         }
     }
 
-    pub fn get_serializer(&self) -> fn(&dyn Any, &mut WriteContext, is_field: bool) {
+    pub fn get_serializer(&self) -> SerializerFn {
         self.serializer
     }
 
@@ -48,12 +55,42 @@ impl Harness {
     }
 }
 
+pub struct ExtHarness {
+    write_fn: Arc<ExtWriteFn>,
+    read_fn: Arc<ExtReadFn>,
+}
+
+impl ExtHarness {
+    pub fn new<T, W, R>(write_fn: W, read_fn: R) -> ExtHarness
+    where
+        T: 'static,
+        W: Fn(&T, &mut WriteContext, bool) + Send + Sync + 'static,
+        R: Fn(&mut ReadContext, bool) -> Result<T, Error> + Send + Sync + 'static,
+    {
+        Self {
+            write_fn: Arc::new(move |obj, ctx, is_field| {
+                let obj = obj.downcast_ref::<T>().unwrap();
+                write_fn(obj, ctx, is_field);
+            }),
+            read_fn: Arc::new(move |ctx, is_field| Ok(Box::new(read_fn(ctx, is_field)?))),
+        }
+    }
+
+    pub fn get_write_fn(&self) -> Arc<ExtWriteFn> {
+        Arc::clone(&self.write_fn)
+    }
+
+    pub fn get_read_fn(&self) -> Arc<ExtReadFn> {
+        Arc::clone(&self.read_fn)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct TypeInfo {
     type_def: Vec<u8>,
     type_id: u32,
-    namespace: String,
-    type_name: String,
+    namespace: MetaString,
+    type_name: MetaString,
     register_by_name: bool,
 }
 
@@ -65,17 +102,59 @@ impl TypeInfo {
         type_name: &str,
         register_by_name: bool,
     ) -> TypeInfo {
+        let namespace_metastring = NAMESPACE_ENCODER
+            .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
+            .unwrap();
+        let type_name_metastring = TYPE_NAME_ENCODER
+            .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
+            .unwrap();
         TypeInfo {
-            type_def: T::fory_type_def(fory, type_id, namespace, type_name, register_by_name),
+            type_def: T::fory_type_def(
+                fory,
+                type_id,
+                namespace_metastring.clone(),
+                type_name_metastring.clone(),
+                register_by_name,
+            ),
             type_id,
-            namespace: namespace.to_owned(),
-            type_name: type_name.to_owned(),
+            namespace: namespace_metastring,
+            type_name: type_name_metastring,
+            register_by_name,
+        }
+    }
+
+    pub fn new_with_empty_def<T: Serializer>(
+        _fory: &Fory,
+        type_id: u32,
+        namespace: &str,
+        type_name: &str,
+        register_by_name: bool,
+    ) -> TypeInfo {
+        let namespace_metastring = NAMESPACE_ENCODER
+            .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
+            .unwrap();
+        let type_name_metastring = TYPE_NAME_ENCODER
+            .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
+            .unwrap();
+        TypeInfo {
+            type_def: vec![],
+            type_id,
+            namespace: namespace_metastring,
+            type_name: type_name_metastring,
             register_by_name,
         }
     }
 
     pub fn get_type_id(&self) -> u32 {
         self.type_id
+    }
+
+    pub fn get_namespace(&self) -> &MetaString {
+        &self.namespace
+    }
+
+    pub fn get_type_name(&self) -> &MetaString {
+        &self.type_name
     }
 
     pub fn get_type_def(&self) -> &Vec<u8> {
@@ -85,11 +164,13 @@ impl TypeInfo {
 
 #[derive(Default)]
 pub struct TypeResolver {
-    serialize_map: HashMap<u32, Harness>,
-    name_serialize_map: HashMap<(String, String), Harness>,
+    serializer_map: HashMap<u32, Harness>,
+    name_serializer_map: HashMap<(MetaString, MetaString), Harness>,
+    ext_serializer_map: HashMap<u32, ExtHarness>,
+    ext_name_serializer_map: HashMap<(MetaString, MetaString), ExtHarness>,
     type_id_map: HashMap<std::any::TypeId, u32>,
-    type_name_map: HashMap<std::any::TypeId, (String, String)>,
-    type_info_map: HashMap<std::any::TypeId, TypeInfo>,
+    type_name_map: HashMap<std::any::TypeId, (MetaString, MetaString)>,
+    type_info_cache: HashMap<std::any::TypeId, TypeInfo>,
     // Fast lookup by numeric ID for common types
     type_id_index: Vec<u32>,
     sorted_field_names_map: RefCell<HashMap<std::any::TypeId, Vec<String>>>,
@@ -99,7 +180,7 @@ const NO_TYPE_ID: u32 = 1000000000;
 
 impl TypeResolver {
     pub fn get_type_info(&self, type_id: std::any::TypeId) -> &TypeInfo {
-        self.type_info_map.get(&type_id).unwrap_or_else(|| {
+        self.type_info_cache.get(&type_id).unwrap_or_else(|| {
             panic!(
                 "TypeId {:?} not found in type_info_map, maybe you forgot to register some types",
                 type_id
@@ -122,8 +203,8 @@ impl TypeResolver {
         )
     }
 
-    pub fn register<T: StructSerializer>(&mut self, type_info: &TypeInfo) {
-        fn serializer<T2: 'static + StructSerializer>(
+    pub fn register<T: StructSerializer + Serializer>(&mut self, type_info: &TypeInfo) {
+        fn serializer<T2: 'static + Serializer>(
             this: &dyn Any,
             context: &mut WriteContext,
             is_field: bool,
@@ -133,58 +214,101 @@ impl TypeResolver {
                 Some(v) => {
                     let skip_ref_flag =
                         crate::serializer::get_skip_ref_flag::<T2>(context.get_fory());
-                    crate::serializer::write_info_data(v, context, is_field, skip_ref_flag, true);
+                    crate::serializer::write_ref_info_data(
+                        v,
+                        context,
+                        is_field,
+                        skip_ref_flag,
+                        true,
+                    );
                 }
                 None => todo!(),
             }
         }
 
-        fn deserializer<T2: 'static + StructSerializer>(
+        fn deserializer<T2: 'static + Serializer>(
             context: &mut ReadContext,
             is_field: bool,
             skip_ref_flag: bool,
         ) -> Result<Box<dyn Any>, Error> {
-            match crate::serializer::read_info_data::<T2>(context, is_field, skip_ref_flag, true) {
+            match crate::serializer::read_ref_info_data::<T2>(
+                context,
+                is_field,
+                skip_ref_flag,
+                true,
+            ) {
                 Ok(v) => Ok(Box::new(v)),
                 Err(e) => Err(e),
             }
         }
-        let rs_type_id = std::any::TypeId::of::<T>();
-        if self.type_info_map.contains_key(&rs_type_id) {
-            panic!("rs_struct:{:?} already registered", type_info.type_id);
-        }
-        self.type_info_map.insert(rs_type_id, type_info.clone());
 
+        let rs_type_id = std::any::TypeId::of::<T>();
+        if self.type_info_cache.contains_key(&rs_type_id) {
+            panic!("rs_struct:{:?} already registered", rs_type_id);
+        }
+        self.type_info_cache.insert(rs_type_id, type_info.clone());
         let index = T::fory_type_index() as usize;
         if index >= self.type_id_index.len() {
             self.type_id_index.resize(index + 1, NO_TYPE_ID);
+        } else if self.type_id_index.get(index).unwrap() != &NO_TYPE_ID {
+            panic!("please:{:?} already registered", type_info.type_id);
         }
         self.type_id_index[index] = type_info.type_id;
 
         if type_info.register_by_name {
             let namespace = &type_info.namespace;
             let type_name = &type_info.type_name;
-            if self
-                .name_serialize_map
-                .contains_key(&(namespace.to_string(), type_name.to_string()))
-            {
-                panic!("TypeId {:?} already registered_by_name", type_info.type_id);
+            let key = (namespace.clone(), type_name.clone());
+            if self.name_serializer_map.contains_key(&key) {
+                panic!(
+                    "Namespace:{:?} Name:{:?} already registered_by_name",
+                    namespace, type_name
+                );
             }
-            self.type_name_map
-                .insert(rs_type_id, (namespace.to_string(), type_name.to_string()));
-            self.name_serialize_map.insert(
-                (namespace.to_string(), type_name.to_string()),
-                Harness::new(serializer::<T>, deserializer::<T>),
-            );
+            self.type_name_map.insert(rs_type_id, key.clone());
+            self.name_serializer_map
+                .insert(key, Harness::new(serializer::<T>, deserializer::<T>));
         } else {
             let type_id = type_info.type_id;
-            if self.serialize_map.contains_key(&type_id) {
+            if self.serializer_map.contains_key(&type_id) {
                 panic!("TypeId {:?} already registered_by_id", type_id);
             }
-
             self.type_id_map.insert(rs_type_id, type_id);
-            self.serialize_map
+            self.serializer_map
                 .insert(type_id, Harness::new(serializer::<T>, deserializer::<T>));
+        }
+    }
+
+    pub fn register_serializer<T: Serializer>(&mut self, type_info: &TypeInfo) {
+        let rs_type_id = std::any::TypeId::of::<T>();
+        if self.type_info_cache.contains_key(&rs_type_id) {
+            panic!("rs_struct:{:?} already registered", rs_type_id);
+        }
+        self.type_info_cache.insert(rs_type_id, type_info.clone());
+
+        let write_fn: fn(&T, &mut WriteContext, bool) = T::fory_write;
+        let read_fn: fn(&mut ReadContext, bool) -> Result<T, Error> = T::fory_read;
+        if type_info.register_by_name {
+            let namespace = &type_info.namespace;
+            let type_name = &type_info.type_name;
+            let key = (namespace.clone(), type_name.clone());
+            if self.ext_name_serializer_map.contains_key(&key) {
+                panic!(
+                    "Namespace:{:?} Name:{:?} already registered_by_name",
+                    namespace, type_name
+                );
+            }
+            self.type_name_map.insert(rs_type_id, key.clone());
+            let harness = ExtHarness::new(write_fn, read_fn);
+            self.ext_name_serializer_map.insert(key, harness);
+        } else {
+            let type_id = type_info.type_id;
+            if self.ext_serializer_map.contains_key(&type_id) {
+                panic!("TypeId {:?} already registered_by_id", type_id);
+            }
+            self.type_id_map.insert(rs_type_id, type_id);
+            let harness = ExtHarness::new(write_fn, read_fn);
+            self.ext_serializer_map.insert(type_id, harness);
         }
     }
 
@@ -193,12 +317,29 @@ impl TypeResolver {
     }
 
     pub fn get_harness(&self, id: u32) -> Option<&Harness> {
-        self.serialize_map.get(&id)
+        self.serializer_map.get(&id)
     }
 
-    pub fn get_name_harness(&self, namespace: &str, type_name: &str) -> Option<&Harness> {
-        self.name_serialize_map
-            .get(&(namespace.to_owned(), type_name.to_owned()))
+    pub fn get_name_harness(
+        &self,
+        namespace: &MetaString,
+        type_name: &MetaString,
+    ) -> Option<&Harness> {
+        let key = (namespace.clone(), type_name.clone());
+        self.name_serializer_map.get(&key)
+    }
+
+    pub fn get_ext_harness(&self, id: u32) -> Option<&ExtHarness> {
+        self.ext_serializer_map.get(&id)
+    }
+
+    pub fn get_ext_name_harness(
+        &self,
+        namespace: &MetaString,
+        type_name: &MetaString,
+    ) -> Option<&ExtHarness> {
+        let key = (namespace.clone(), type_name.clone());
+        self.ext_name_serializer_map.get(&key)
     }
 
     pub fn get_sorted_field_names<T: StructSerializer>(

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -133,7 +133,7 @@ impl TypeResolver {
                 Some(v) => {
                     let skip_ref_flag =
                         crate::serializer::get_skip_ref_flag::<T2>(context.get_fory());
-                    crate::serializer::write_data(v, context, is_field, skip_ref_flag, true);
+                    crate::serializer::write_info_data(v, context, is_field, skip_ref_flag, true);
                 }
                 None => todo!(),
             }
@@ -144,7 +144,7 @@ impl TypeResolver {
             is_field: bool,
             skip_ref_flag: bool,
         ) -> Result<Box<dyn Any>, Error> {
-            match crate::serializer::read_data::<T2>(context, is_field, skip_ref_flag, true) {
+            match crate::serializer::read_info_data::<T2>(context, is_field, skip_ref_flag, true) {
                 Ok(v) => Ok(Box::new(v)),
                 Err(e) => Err(e),
             }

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -153,7 +153,7 @@ impl TypeResolver {
         if self.type_info_map.contains_key(&rs_type_id) {
             panic!("rs_struct:{:?} already registered", type_info.type_id);
         }
-        self.type_info_map.insert(rs_type_id, (*type_info).clone());
+        self.type_info_map.insert(rs_type_id, type_info.clone());
 
         let index = T::fory_type_index() as usize;
         if index >= self.type_id_index.len() {
@@ -162,18 +162,18 @@ impl TypeResolver {
         self.type_id_index[index] = type_info.type_id;
 
         if type_info.register_by_name {
-            let namespace = type_info.namespace.clone();
-            let type_name = type_info.type_name.clone();
+            let namespace = &type_info.namespace;
+            let type_name = &type_info.type_name;
             if self
                 .name_serialize_map
-                .contains_key(&(namespace.clone(), type_name.clone()))
+                .contains_key(&(namespace.to_string(), type_name.to_string()))
             {
                 panic!("TypeId {:?} already registered_by_name", type_info.type_id);
             }
             self.type_name_map
-                .insert(rs_type_id, (namespace.clone(), type_name.clone()));
+                .insert(rs_type_id, (namespace.to_string(), type_name.to_string()));
             self.name_serialize_map.insert(
-                (namespace, type_name),
+                (namespace.to_string(), type_name.to_string()),
                 Harness::new(serializer::<T>, deserializer::<T>),
             );
         } else {

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -66,7 +66,7 @@ impl TypeInfo {
         register_by_name: bool,
     ) -> TypeInfo {
         TypeInfo {
-            type_def: T::type_def(fory, type_id, namespace, type_name, register_by_name),
+            type_def: T::fory_type_def(fory, type_id, namespace, type_name, register_by_name),
             type_id,
             namespace: namespace.to_owned(),
             type_name: type_name.to_owned(),
@@ -155,7 +155,7 @@ impl TypeResolver {
         }
         self.type_info_map.insert(rs_type_id, (*type_info).clone());
 
-        let index = T::type_index() as usize;
+        let index = T::fory_type_index() as usize;
         if index >= self.type_id_index.len() {
             self.type_id_index.resize(index + 1, NO_TYPE_ID);
         }

--- a/rust/fory-core/src/row/row.rs
+++ b/rust/fory-core/src/row/row.rs
@@ -55,18 +55,18 @@ macro_rules! impl_row_for_number {
         }
     };
 }
-impl_row_for_number!(i8, Writer::i8, read_i8_from_bytes);
-impl_row_for_number!(i16, Writer::i16, LittleEndian::read_i16);
-impl_row_for_number!(i32, Writer::i32, LittleEndian::read_i32);
-impl_row_for_number!(i64, Writer::i64, LittleEndian::read_i64);
-impl_row_for_number!(f32, Writer::f32, LittleEndian::read_f32);
-impl_row_for_number!(f64, Writer::f64, LittleEndian::read_f64);
+impl_row_for_number!(i8, Writer::write_i8, read_i8_from_bytes);
+impl_row_for_number!(i16, Writer::write_i16, LittleEndian::read_i16);
+impl_row_for_number!(i32, Writer::write_i32, LittleEndian::read_i32);
+impl_row_for_number!(i64, Writer::write_i64, LittleEndian::read_i64);
+impl_row_for_number!(f32, Writer::write_f32, LittleEndian::read_f32);
+impl_row_for_number!(f64, Writer::write_f64, LittleEndian::read_f64);
 
 impl<'a> Row<'a> for String {
     type ReadResult = &'a str;
 
     fn write(v: &Self, writer: &mut Writer) {
-        writer.bytes(v.as_bytes());
+        writer.write_bytes(v.as_bytes());
     }
 
     fn cast(bytes: &'a [u8]) -> Self::ReadResult {
@@ -78,7 +78,7 @@ impl Row<'_> for bool {
     type ReadResult = Self;
 
     fn write(v: &Self, writer: &mut Writer) {
-        writer.u8(if *v { 1 } else { 0 });
+        writer.write_u8(if *v { 1 } else { 0 });
     }
 
     fn cast(bytes: &[u8]) -> Self::ReadResult {
@@ -91,7 +91,7 @@ impl Row<'_> for NaiveDate {
 
     fn write(v: &Self, writer: &mut Writer) {
         let days_since_epoch = v.signed_duration_since(EPOCH).num_days();
-        writer.u32(days_since_epoch as u32);
+        writer.write_u32(days_since_epoch as u32);
     }
 
     fn cast(bytes: &[u8]) -> Self::ReadResult {
@@ -108,7 +108,7 @@ impl Row<'_> for NaiveDateTime {
     type ReadResult = Result<NaiveDateTime, Error>;
 
     fn write(v: &Self, writer: &mut Writer) {
-        writer.i64(v.and_utc().timestamp_millis());
+        writer.write_i64(v.and_utc().timestamp_millis());
     }
 
     fn cast(bytes: &[u8]) -> Self::ReadResult {
@@ -125,7 +125,7 @@ impl<'a> Row<'a> for Vec<u8> {
     type ReadResult = &'a [u8];
 
     fn write(v: &Self, writer: &mut Writer) {
-        writer.bytes(v);
+        writer.write_bytes(v);
     }
 
     fn cast(bytes: &'a [u8]) -> Self::ReadResult {

--- a/rust/fory-core/src/row/writer.rs
+++ b/rust/fory-core/src/row/writer.rs
@@ -125,7 +125,7 @@ impl ArrayWriter<'_> {
         array_writer
             .field_writer_helper
             .writer
-            .u64(num_fields as u64);
+            .write_u64(num_fields as u64);
         array_writer.field_writer_helper.writer.skip(fixed_size - 8);
         array_writer
     }

--- a/rust/fory-core/src/serializer/bool.rs
+++ b/rust/fory-core/src/serializer/bool.rs
@@ -24,32 +24,32 @@ use crate::types::{Mode, TypeId};
 use std::mem;
 
 impl Serializer for bool {
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<i32>()
     }
 
-    fn write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
         context.writer.write_u8(if *self { 1 } else { 0 });
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             context.writer.write_var_uint32(TypeId::BOOL as u32);
         }
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         Ok(context.reader.read_u8() == 1)
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::BOOL as u32);
         }
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::BOOL as u32
     }
 }

--- a/rust/fory-core/src/serializer/bool.rs
+++ b/rust/fory-core/src/serializer/bool.rs
@@ -28,7 +28,7 @@ impl Serializer for bool {
         mem::size_of::<i32>()
     }
 
-    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         context.writer.write_u8(if *self { 1 } else { 0 });
     }
 
@@ -38,7 +38,7 @@ impl Serializer for bool {
         }
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         Ok(context.reader.read_u8() == 1)
     }
 

--- a/rust/fory-core/src/serializer/bool.rs
+++ b/rust/fory-core/src/serializer/bool.rs
@@ -20,33 +20,20 @@ use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::{Mode, TypeId};
+use crate::types::TypeId;
 use std::mem;
 
 impl Serializer for bool {
-    fn fory_reserved_space() -> usize {
-        mem::size_of::<i32>()
-    }
-
     fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         context.writer.write_u8(if *self { 1 } else { 0 });
     }
 
-    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.write_var_uint32(TypeId::BOOL as u32);
-        }
-    }
-
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
         Ok(context.reader.read_u8() == 1)
     }
 
-    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.read_var_uint32();
-            assert_eq!(remote_type_id, TypeId::BOOL as u32);
-        }
+    fn fory_reserved_space() -> usize {
+        mem::size_of::<i32>()
     }
 
     fn fory_get_type_id(_fory: &Fory) -> u32 {

--- a/rust/fory-core/src/serializer/bool.rs
+++ b/rust/fory-core/src/serializer/bool.rs
@@ -29,22 +29,22 @@ impl Serializer for bool {
     }
 
     fn write(&self, context: &mut WriteContext, _is_field: bool) {
-        context.writer.u8(if *self { 1 } else { 0 });
+        context.writer.write_u8(if *self { 1 } else { 0 });
     }
 
     fn write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.var_uint32(TypeId::BOOL as u32);
+            context.writer.write_var_uint32(TypeId::BOOL as u32);
         }
     }
 
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        Ok(context.reader.u8() == 1)
+        Ok(context.reader.read_u8() == 1)
     }
 
     fn read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.var_uint32();
+            let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::BOOL as u32);
         }
     }

--- a/rust/fory-core/src/serializer/box_.rs
+++ b/rust/fory-core/src/serializer/box_.rs
@@ -20,40 +20,29 @@ use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::ForyGeneralList;
 
 impl<T: Serializer> Serializer for Box<T> {
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        Ok(Box::new(T::read(context)?))
+    fn fory_read_data(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
+        Ok(Box::new(T::fory_read_data(context, is_field)?))
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
-        T::read_type_info(context, is_field);
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
+        T::fory_read_type_info(context, is_field);
     }
 
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
-        T::write(self.as_ref(), context, is_field)
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
+        T::fory_write_data(self.as_ref(), context, is_field)
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
-        T::write_type_info(context, is_field);
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
+        T::fory_write_type_info(context, is_field);
     }
 
-    fn reserved_space() -> usize {
-        T::reserved_space()
+    fn fory_reserved_space() -> usize {
+        T::fory_reserved_space()
     }
 
-    fn get_type_id(fory: &Fory) -> u32 {
-        T::get_type_id(fory)
-    }
-
-    fn is_option() -> bool {
-        false
-    }
-
-    fn is_none(&self) -> bool {
-        false
+    fn fory_get_type_id(fory: &Fory) -> u32 {
+        T::fory_get_type_id(fory)
     }
 }
-
-impl<T: Serializer> ForyGeneralList for Box<T> {}

--- a/rust/fory-core/src/serializer/collection.rs
+++ b/rust/fory-core/src/serializer/collection.rs
@@ -37,7 +37,7 @@ pub fn write_collection_type_info(
     collection_type_id: u32,
 ) {
     if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        context.writer.write_var_uint32(collection_type_id);
+        context.writer.write_varuint32(collection_type_id);
     }
 }
 
@@ -48,7 +48,7 @@ pub fn write_collection<'a, T: Serializer + 'a, I: IntoIterator<Item = &'a T>>(
 ) {
     let items: Vec<&T> = iter.into_iter().collect();
     let len = items.len();
-    context.writer.write_var_uint32(len as u32);
+    context.writer.write_varuint32(len as u32);
     if len == 0 {
         return;
     }
@@ -78,7 +78,7 @@ pub fn write_collection<'a, T: Serializer + 'a, I: IntoIterator<Item = &'a T>>(
     for item in &items {
         // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<T>(context.get_fory());
         let skip_ref_flag = is_same_type && !has_null;
-        crate::serializer::write_info_data(*item, context, is_field, skip_ref_flag, true);
+        crate::serializer::write_ref_info_data(*item, context, is_field, skip_ref_flag, true);
     }
 }
 
@@ -88,7 +88,7 @@ pub fn read_collection_type_info(
     collection_type_id: u32,
 ) {
     if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        let remote_collection_type_id = context.reader.read_var_uint32();
+        let remote_collection_type_id = context.reader.read_varuint32();
         assert_eq!(remote_collection_type_id, collection_type_id);
     }
 }
@@ -98,7 +98,7 @@ where
     T: Serializer,
     C: FromIterator<T>,
 {
-    let len = context.reader.read_var_uint32();
+    let len = context.reader.read_varuint32();
     if len == 0 {
         return Ok(C::from_iter(std::iter::empty()));
     }
@@ -110,6 +110,6 @@ where
     let skip_ref_flag = is_same_type && !has_null;
     // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<T>(context.get_fory());
     (0..len)
-        .map(|_| crate::serializer::read_info_data(context, declared, skip_ref_flag, true))
+        .map(|_| crate::serializer::read_ref_info_data(context, declared, skip_ref_flag, true))
         .collect::<Result<C, Error>>()
 }

--- a/rust/fory-core/src/serializer/collection.rs
+++ b/rust/fory-core/src/serializer/collection.rs
@@ -54,9 +54,9 @@ pub fn write_collection<'a, T: Serializer + 'a, I: IntoIterator<Item = &'a T>>(
     }
     let mut header = 0;
     let mut has_null = false;
-    if T::is_option() {
+    if T::fory_is_option() {
         for item in &items {
-            if item.is_none() {
+            if item.fory_is_none() {
                 has_null = true;
                 break;
             }
@@ -73,7 +73,7 @@ pub fn write_collection<'a, T: Serializer + 'a, I: IntoIterator<Item = &'a T>>(
         header |= IS_SAME_TYPE;
     }
     context.writer.write_u8(header);
-    T::write_type_info(context, is_field);
+    T::fory_write_type_info(context, is_field);
     // context.writer.reserve((T::reserved_space() + SIZE_OF_REF_AND_TYPE) * len);
     for item in &items {
         // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<T>(context.get_fory());
@@ -104,7 +104,7 @@ where
     }
     let header = context.reader.read_u8();
     let declared = (header & DECL_ELEMENT_TYPE) != 0;
-    T::read_type_info(context, declared);
+    T::fory_read_type_info(context, declared);
     let has_null = (header & HAS_NULL) != 0;
     let is_same_type = (header & IS_SAME_TYPE) != 0;
     let skip_ref_flag = is_same_type && !has_null;

--- a/rust/fory-core/src/serializer/collection.rs
+++ b/rust/fory-core/src/serializer/collection.rs
@@ -78,7 +78,7 @@ pub fn write_collection<'a, T: Serializer + 'a, I: IntoIterator<Item = &'a T>>(
     for item in &items {
         // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<T>(context.get_fory());
         let skip_ref_flag = is_same_type && !has_null;
-        crate::serializer::write_data(*item, context, is_field, skip_ref_flag, true);
+        crate::serializer::write_info_data(*item, context, is_field, skip_ref_flag, true);
     }
 }
 
@@ -110,6 +110,6 @@ where
     let skip_ref_flag = is_same_type && !has_null;
     // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<T>(context.get_fory());
     (0..len)
-        .map(|_| crate::serializer::read_data(context, declared, skip_ref_flag, true))
+        .map(|_| crate::serializer::read_info_data(context, declared, skip_ref_flag, true))
         .collect::<Result<C, Error>>()
 }

--- a/rust/fory-core/src/serializer/datetime.rs
+++ b/rust/fory-core/src/serializer/datetime.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Days, NaiveDate, NaiveDateTime};
 use std::mem;
 
 impl Serializer for NaiveDateTime {
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         let micros = context.reader.read_i64();
         let seconds = micros / 1_000_000;
         let subsec_micros = (micros % 1_000_000) as u32;
@@ -46,7 +46,7 @@ impl Serializer for NaiveDateTime {
         }
     }
 
-    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         let dt = self.and_utc();
         let micros = dt.timestamp() * 1_000_000 + dt.timestamp_subsec_micros() as i64;
         context.writer.write_i64(micros);
@@ -70,7 +70,7 @@ impl Serializer for NaiveDateTime {
 impl ForyGeneralList for NaiveDateTime {}
 
 impl Serializer for NaiveDate {
-    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         let days_since_epoch = self.signed_duration_since(EPOCH).num_days();
         context.writer.write_i32(days_since_epoch as i32);
     }
@@ -85,7 +85,7 @@ impl Serializer for NaiveDate {
         mem::size_of::<i32>()
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         let days = context.reader.read_i32();
         EPOCH
             .checked_add_days(Days::new(days as u64))

--- a/rust/fory-core/src/serializer/datetime.rs
+++ b/rust/fory-core/src/serializer/datetime.rs
@@ -28,7 +28,7 @@ use std::mem;
 
 impl Serializer for NaiveDateTime {
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        let micros = context.reader.i64();
+        let micros = context.reader.read_i64();
         let seconds = micros / 1_000_000;
         let subsec_micros = (micros % 1_000_000) as u32;
         let nanos = subsec_micros * 1_000;
@@ -41,7 +41,7 @@ impl Serializer for NaiveDateTime {
 
     fn read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.var_uint32();
+            let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::TIMESTAMP as u32);
         }
     }
@@ -49,12 +49,12 @@ impl Serializer for NaiveDateTime {
     fn write(&self, context: &mut WriteContext, _is_field: bool) {
         let dt = self.and_utc();
         let micros = dt.timestamp() * 1_000_000 + dt.timestamp_subsec_micros() as i64;
-        context.writer.i64(micros);
+        context.writer.write_i64(micros);
     }
 
     fn write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.var_uint32(TypeId::TIMESTAMP as u32);
+            context.writer.write_var_uint32(TypeId::TIMESTAMP as u32);
         }
     }
 
@@ -72,12 +72,12 @@ impl ForyGeneralList for NaiveDateTime {}
 impl Serializer for NaiveDate {
     fn write(&self, context: &mut WriteContext, _is_field: bool) {
         let days_since_epoch = self.signed_duration_since(EPOCH).num_days();
-        context.writer.i32(days_since_epoch as i32);
+        context.writer.write_i32(days_since_epoch as i32);
     }
 
     fn write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.var_uint32(TypeId::LOCAL_DATE as u32);
+            context.writer.write_var_uint32(TypeId::LOCAL_DATE as u32);
         }
     }
 
@@ -86,7 +86,7 @@ impl Serializer for NaiveDate {
     }
 
     fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        let days = context.reader.i32();
+        let days = context.reader.read_i32();
         EPOCH
             .checked_add_days(Days::new(days as u64))
             .ok_or(Error::from(anyhow!(
@@ -96,7 +96,7 @@ impl Serializer for NaiveDate {
 
     fn read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.var_uint32();
+            let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::LOCAL_DATE as u32);
         }
     }

--- a/rust/fory-core/src/serializer/datetime.rs
+++ b/rust/fory-core/src/serializer/datetime.rs
@@ -20,14 +20,20 @@ use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, Mode, TypeId};
+use crate::types::TypeId;
 use crate::util::EPOCH;
 use anyhow::anyhow;
 use chrono::{DateTime, Days, NaiveDate, NaiveDateTime};
 use std::mem;
 
 impl Serializer for NaiveDateTime {
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
+        let dt = self.and_utc();
+        let micros = dt.timestamp() * 1_000_000 + dt.timestamp_subsec_micros() as i64;
+        context.writer.write_i64(micros);
+    }
+
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
         let micros = context.reader.read_i64();
         let seconds = micros / 1_000_000;
         let subsec_micros = (micros % 1_000_000) as u32;
@@ -39,25 +45,6 @@ impl Serializer for NaiveDateTime {
             )))
     }
 
-    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.read_var_uint32();
-            assert_eq!(remote_type_id, TypeId::TIMESTAMP as u32);
-        }
-    }
-
-    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
-        let dt = self.and_utc();
-        let micros = dt.timestamp() * 1_000_000 + dt.timestamp_subsec_micros() as i64;
-        context.writer.write_i64(micros);
-    }
-
-    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.write_var_uint32(TypeId::TIMESTAMP as u32);
-        }
-    }
-
     fn fory_reserved_space() -> usize {
         mem::size_of::<u64>()
     }
@@ -67,25 +54,13 @@ impl Serializer for NaiveDateTime {
     }
 }
 
-impl ForyGeneralList for NaiveDateTime {}
-
 impl Serializer for NaiveDate {
     fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         let days_since_epoch = self.signed_duration_since(EPOCH).num_days();
         context.writer.write_i32(days_since_epoch as i32);
     }
 
-    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.write_var_uint32(TypeId::LOCAL_DATE as u32);
-        }
-    }
-
-    fn fory_reserved_space() -> usize {
-        mem::size_of::<i32>()
-    }
-
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
         let days = context.reader.read_i32();
         EPOCH
             .checked_add_days(Days::new(days as u64))
@@ -94,16 +69,11 @@ impl Serializer for NaiveDate {
             )))
     }
 
-    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.read_var_uint32();
-            assert_eq!(remote_type_id, TypeId::LOCAL_DATE as u32);
-        }
+    fn fory_reserved_space() -> usize {
+        mem::size_of::<i32>()
     }
 
     fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::LOCAL_DATE as u32
     }
 }
-
-impl ForyGeneralList for NaiveDate {}

--- a/rust/fory-core/src/serializer/datetime.rs
+++ b/rust/fory-core/src/serializer/datetime.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Days, NaiveDate, NaiveDateTime};
 use std::mem;
 
 impl Serializer for NaiveDateTime {
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         let micros = context.reader.read_i64();
         let seconds = micros / 1_000_000;
         let subsec_micros = (micros % 1_000_000) as u32;
@@ -39,30 +39,30 @@ impl Serializer for NaiveDateTime {
             )))
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::TIMESTAMP as u32);
         }
     }
 
-    fn write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
         let dt = self.and_utc();
         let micros = dt.timestamp() * 1_000_000 + dt.timestamp_subsec_micros() as i64;
         context.writer.write_i64(micros);
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             context.writer.write_var_uint32(TypeId::TIMESTAMP as u32);
         }
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<u64>()
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::TIMESTAMP as u32
     }
 }
@@ -70,22 +70,22 @@ impl Serializer for NaiveDateTime {
 impl ForyGeneralList for NaiveDateTime {}
 
 impl Serializer for NaiveDate {
-    fn write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
         let days_since_epoch = self.signed_duration_since(EPOCH).num_days();
         context.writer.write_i32(days_since_epoch as i32);
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             context.writer.write_var_uint32(TypeId::LOCAL_DATE as u32);
         }
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<i32>()
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         let days = context.reader.read_i32();
         EPOCH
             .checked_add_days(Days::new(days as u64))
@@ -94,14 +94,14 @@ impl Serializer for NaiveDate {
             )))
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::LOCAL_DATE as u32);
         }
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::LOCAL_DATE as u32
     }
 }

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -17,9 +17,7 @@
 
 use crate::error::Error;
 use crate::fory::Fory;
-use crate::meta::{
-    TypeMeta, NAMESPACE_ENCODER, NAMESPACE_ENCODINGS, TYPE_NAME_ENCODER, TYPE_NAME_ENCODINGS,
-};
+use crate::meta::{MetaString, TypeMeta};
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
 use crate::types::{Mode, RefFlag, TypeId};
@@ -37,54 +35,63 @@ pub fn actual_type_id(type_id: u32, register_by_name: bool, _mode: &Mode) -> u32
 pub fn type_def(
     _fory: &Fory,
     type_id: u32,
-    namespace: &str,
-    type_name: &str,
+    namespace: MetaString,
+    type_name: MetaString,
     register_by_name: bool,
 ) -> Vec<u8> {
-    let namespace_metastring = NAMESPACE_ENCODER
-        .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
-        .unwrap();
-    let type_name_metastring = TYPE_NAME_ENCODER
-        .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
-        .unwrap();
-    let meta = TypeMeta::from_fields(
-        type_id,
-        namespace_metastring,
-        type_name_metastring,
-        register_by_name,
-        vec![],
-    );
+    let meta = TypeMeta::from_fields(type_id, namespace, type_name, register_by_name, vec![]);
     meta.to_bytes().unwrap()
 }
 
 #[inline(always)]
 pub fn write_type_info<T: Serializer>(context: &mut WriteContext, is_field: bool) {
-    if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        let type_id = T::fory_get_type_id(context.get_fory());
-        context.writer.write_var_uint32(type_id);
-        if type_id & 0xff == TypeId::NAMED_ENUM as u32 {
-            let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
-            context.writer.write_var_uint32(meta_index);
-        }
+    if is_field {
+        return;
+    }
+    let type_id = T::fory_get_type_id(context.get_fory());
+    context.writer.write_varuint32(type_id);
+    let is_named_enum = type_id & 0xff == TypeId::NAMED_ENUM as u32;
+    if !is_named_enum {
+        return;
+    }
+    let rs_type_id = std::any::TypeId::of::<T>();
+    if context.get_fory().is_share_meta() {
+        let meta_index = context.push_meta(rs_type_id) as u32;
+        context.writer.write_varuint32(meta_index);
+    } else {
+        let resolver = context.get_fory().get_type_resolver();
+        let type_info = resolver.get_type_info(rs_type_id);
+        let _namespace = type_info.get_namespace().to_owned();
+        let _type_name = type_info.get_type_name().to_owned();
+        unimplemented!("unimplement NamedEnum::write_type_info when non-share_meta")
+        // context.writer.write_bytes(namespace.bytes.as_slice());
+        // context.writer.write_bytes(type_name.bytes.as_slice());
     }
 }
 
 #[inline(always)]
 pub fn read_type_info<T: Serializer>(context: &mut ReadContext, is_field: bool) {
-    if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        let local_type_id = T::fory_get_type_id(context.get_fory());
-        let remote_type_id = context.reader.read_var_uint32();
-        assert_eq!(local_type_id, remote_type_id);
-        if local_type_id & 0xff == TypeId::NAMED_ENUM as u32 {
-            let _meta_index = context.reader.read_var_uint32();
-        }
+    if is_field {
+        return;
+    }
+    let local_type_id = T::fory_get_type_id(context.get_fory());
+    let remote_type_id = context.reader.read_varuint32();
+    assert_eq!(local_type_id, remote_type_id);
+    let is_named_enum = local_type_id & 0xff == TypeId::NAMED_ENUM as u32;
+    if !is_named_enum {
+        return;
+    }
+    if context.get_fory().is_share_meta() {
+        let _meta_index = context.reader.read_varuint32();
+    } else {
+        unimplemented!("unimplement NamedEnum::read_type_info when non-share_meta")
     }
 }
 
 #[inline(always)]
 pub fn read_compatible<T: Serializer>(context: &mut ReadContext) -> Result<T, Error> {
     T::fory_read_type_info(context, true);
-    T::fory_read_data(context)
+    T::fory_read_data(context, true)
 }
 
 #[inline(always)]
@@ -95,13 +102,13 @@ pub fn write<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool
 }
 
 #[inline(always)]
-pub fn read<T: Serializer>(context: &mut ReadContext, _is_field: bool) -> Result<T, Error> {
+pub fn read<T: Serializer>(context: &mut ReadContext, is_field: bool) -> Result<T, Error> {
     let ref_flag = context.reader.read_i8();
     if ref_flag == RefFlag::Null as i8 {
         Ok(T::default())
     } else if ref_flag == (RefFlag::NotNullValue as i8) {
         T::fory_read_type_info(context, false);
-        T::fory_read_data(context)
+        T::fory_read_data(context, is_field)
     } else {
         unimplemented!()
     }

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -60,7 +60,7 @@ pub fn type_def(
 #[inline(always)]
 pub fn write_type_info<T: Serializer>(context: &mut WriteContext, is_field: bool) {
     if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        let type_id = T::get_type_id(context.get_fory());
+        let type_id = T::fory_get_type_id(context.get_fory());
         context.writer.write_var_uint32(type_id);
         if type_id & 0xff == TypeId::NAMED_ENUM as u32 {
             let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
@@ -72,7 +72,7 @@ pub fn write_type_info<T: Serializer>(context: &mut WriteContext, is_field: bool
 #[inline(always)]
 pub fn read_type_info<T: Serializer>(context: &mut ReadContext, is_field: bool) {
     if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-        let local_type_id = T::get_type_id(context.get_fory());
+        let local_type_id = T::fory_get_type_id(context.get_fory());
         let remote_type_id = context.reader.read_var_uint32();
         assert_eq!(local_type_id, remote_type_id);
         if local_type_id & 0xff == TypeId::NAMED_ENUM as u32 {
@@ -83,15 +83,15 @@ pub fn read_type_info<T: Serializer>(context: &mut ReadContext, is_field: bool) 
 
 #[inline(always)]
 pub fn read_compatible<T: Serializer>(context: &mut ReadContext) -> Result<T, Error> {
-    T::read_type_info(context, true);
-    T::read(context)
+    T::fory_read_type_info(context, true);
+    T::fory_read(context)
 }
 
 #[inline(always)]
 pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool) {
     context.writer.write_i8(RefFlag::NotNullValue as i8);
-    T::write_type_info(context, is_field);
-    this.write(context, is_field);
+    T::fory_write_type_info(context, is_field);
+    this.fory_write(context, is_field);
 }
 
 #[inline(always)]
@@ -100,8 +100,8 @@ pub fn deserialize<T: Serializer>(context: &mut ReadContext, _is_field: bool) ->
     if ref_flag == RefFlag::Null as i8 {
         Ok(T::default())
     } else if ref_flag == (RefFlag::NotNullValue as i8) {
-        T::read_type_info(context, false);
-        T::read(context)
+        T::fory_read_type_info(context, false);
+        T::fory_read(context)
     } else {
         unimplemented!()
     }

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -84,24 +84,24 @@ pub fn read_type_info<T: Serializer>(context: &mut ReadContext, is_field: bool) 
 #[inline(always)]
 pub fn read_compatible<T: Serializer>(context: &mut ReadContext) -> Result<T, Error> {
     T::fory_read_type_info(context, true);
-    T::fory_read(context)
+    T::fory_read_data(context)
 }
 
 #[inline(always)]
-pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool) {
+pub fn write<T: Serializer>(this: &T, context: &mut WriteContext, is_field: bool) {
     context.writer.write_i8(RefFlag::NotNullValue as i8);
     T::fory_write_type_info(context, is_field);
-    this.fory_write(context, is_field);
+    this.fory_write_data(context, is_field);
 }
 
 #[inline(always)]
-pub fn deserialize<T: Serializer>(context: &mut ReadContext, _is_field: bool) -> Result<T, Error> {
+pub fn read<T: Serializer>(context: &mut ReadContext, _is_field: bool) -> Result<T, Error> {
     let ref_flag = context.reader.read_i8();
     if ref_flag == RefFlag::Null as i8 {
         Ok(T::default())
     } else if ref_flag == (RefFlag::NotNullValue as i8) {
         T::fory_read_type_info(context, false);
-        T::fory_read(context)
+        T::fory_read_data(context)
     } else {
         unimplemented!()
     }

--- a/rust/fory-core/src/serializer/list.rs
+++ b/rust/fory-core/src/serializer/list.rs
@@ -31,7 +31,7 @@ impl<T> Serializer for Vec<T>
 where
     T: Serializer + ForyGeneralList,
 {
-    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
         write_collection(self, context, is_field);
     }
 
@@ -39,7 +39,7 @@ where
         write_collection_type_info(context, is_field, TypeId::LIST as u32);
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         read_collection(context)
     }
 

--- a/rust/fory-core/src/serializer/list.rs
+++ b/rust/fory-core/src/serializer/list.rs
@@ -19,42 +19,80 @@ use crate::error::Error;
 use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
+use crate::serializer::primitive_list;
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, TypeId};
+use crate::types::TypeId;
+use std::any::TypeId as RsTypeId;
 use std::mem;
 
 use super::collection::{
     read_collection, read_collection_type_info, write_collection, write_collection_type_info,
 };
 
-impl<T> Serializer for Vec<T>
-where
-    T: Serializer + ForyGeneralList,
-{
+fn check_primitive<T: 'static>() -> Option<TypeId> {
+    Some(match RsTypeId::of::<T>() {
+        id if id == RsTypeId::of::<bool>() => TypeId::BOOL_ARRAY,
+        id if id == RsTypeId::of::<i8>() => TypeId::INT8_ARRAY,
+        id if id == RsTypeId::of::<i16>() => TypeId::INT16_ARRAY,
+        id if id == RsTypeId::of::<i32>() => TypeId::INT32_ARRAY,
+        id if id == RsTypeId::of::<i64>() => TypeId::INT64_ARRAY,
+        id if id == RsTypeId::of::<f32>() => TypeId::FLOAT32_ARRAY,
+        id if id == RsTypeId::of::<f64>() => TypeId::FLOAT64_ARRAY,
+        _ => return None,
+    })
+}
+
+impl<T: Serializer> Serializer for Vec<T> {
     fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
-        write_collection(self, context, is_field);
+        match check_primitive::<T>() {
+            Some(_) => {
+                primitive_list::fory_write_data(self, context);
+            }
+            None => {
+                write_collection(self, context, is_field);
+            }
+        }
     }
 
     fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        write_collection_type_info(context, is_field, TypeId::LIST as u32);
+        match check_primitive::<T>() {
+            Some(type_id) => {
+                primitive_list::fory_write_type_info(context, is_field, type_id);
+            }
+            None => {
+                write_collection_type_info(context, is_field, TypeId::LIST as u32);
+            }
+        }
     }
 
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
-        read_collection(context)
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
+        match check_primitive::<T>() {
+            Some(_) => primitive_list::fory_read_data(context),
+            None => read_collection(context),
+        }
     }
 
     fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        read_collection_type_info(context, is_field, TypeId::LIST as u32)
+        match check_primitive::<T>() {
+            Some(type_id) => primitive_list::fory_read_type_info(context, is_field, type_id),
+            None => read_collection_type_info(context, is_field, TypeId::LIST as u32),
+        }
     }
 
     fn fory_reserved_space() -> usize {
-        // size of the vec
-        mem::size_of::<u32>()
+        match check_primitive::<T>() {
+            Some(_) => primitive_list::fory_reserved_space::<T>(),
+            None => {
+                // size of the vec
+                mem::size_of::<u32>()
+            }
+        }
     }
 
     fn fory_get_type_id(_fory: &Fory) -> u32 {
-        TypeId::LIST as u32
+        match check_primitive::<T>() {
+            Some(type_id) => type_id as u32,
+            None => TypeId::LIST as u32,
+        }
     }
 }
-
-impl<T> ForyGeneralList for Vec<T> where T: Serializer {}

--- a/rust/fory-core/src/serializer/list.rs
+++ b/rust/fory-core/src/serializer/list.rs
@@ -31,28 +31,28 @@ impl<T> Serializer for Vec<T>
 where
     T: Serializer + ForyGeneralList,
 {
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
         write_collection(self, context, is_field);
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         write_collection_type_info(context, is_field, TypeId::LIST as u32);
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         read_collection(context)
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         read_collection_type_info(context, is_field, TypeId::LIST as u32)
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         // size of the vec
         mem::size_of::<u32>()
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::LIST as u32
     }
 }

--- a/rust/fory-core/src/serializer/map.rs
+++ b/rust/fory-core/src/serializer/map.rs
@@ -19,8 +19,8 @@ use crate::error::Error;
 use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
-use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, Mode, TypeId, SIZE_OF_REF_AND_TYPE};
+use crate::serializer::{read_ref_info_data, write_ref_info_data, Serializer};
+use crate::types::{TypeId, SIZE_OF_REF_AND_TYPE};
 use std::collections::HashMap;
 use std::mem;
 
@@ -55,7 +55,7 @@ fn check_and_write_null<K: Serializer + Eq + std::hash::Hash, V: Serializer>(
         }
         context.writer.write_u8(chunk_header);
 
-        crate::serializer::write_info_data(value, context, is_field, skip_ref_flag, false);
+        write_ref_info_data(value, context, is_field, skip_ref_flag, false);
         return true;
     }
     if value.fory_is_none() {
@@ -70,7 +70,7 @@ fn check_and_write_null<K: Serializer + Eq + std::hash::Hash, V: Serializer>(
             chunk_header |= TRACKING_KEY_REF;
         }
         context.writer.write_u8(chunk_header);
-        crate::serializer::write_info_data(key, context, is_field, skip_ref_flag, false);
+        write_ref_info_data(key, context, is_field, skip_ref_flag, false);
         return true;
     }
     false
@@ -83,13 +83,12 @@ fn write_chunk_size(context: &mut WriteContext, header_offset: usize, size: u8) 
 impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap<K, V> {
     fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
         let length = self.len();
-        context.writer.write_var_uint32(length as u32);
+        context.writer.write_varuint32(length as u32);
         if length == 0 {
             return;
         }
-        let reserved_space = (<K as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE)
-            * self.len()
-            + (<V as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE) * self.len();
+        let reserved_space = (K::fory_reserved_space() + SIZE_OF_REF_AND_TYPE) * self.len()
+            + (V::fory_reserved_space() + SIZE_OF_REF_AND_TYPE) * self.len();
         context.writer.reserve(reserved_space);
 
         let mut header_offset = 0;
@@ -133,8 +132,8 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 check_and_write_null(context, is_field, key, value);
                 continue;
             }
-            crate::serializer::write_info_data(key, context, is_field, skip_key_ref_flag, true);
-            crate::serializer::write_info_data(value, context, is_field, skip_val_ref_flag, true);
+            write_ref_info_data(key, context, is_field, skip_key_ref_flag, true);
+            write_ref_info_data(value, context, is_field, skip_val_ref_flag, true);
             pair_counter += 1;
             if pair_counter == MAX_CHUNK_SIZE {
                 write_chunk_size(context, header_offset, pair_counter);
@@ -147,8 +146,8 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
         }
     }
 
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
-        let len = context.reader.read_var_uint32();
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
+        let len = context.reader.read_varuint32();
         let mut map = HashMap::<K, V>::with_capacity(len as usize);
         if len == 0 {
             return Ok(map);
@@ -175,12 +174,7 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 } else {
                     false
                 };
-                let value = crate::serializer::read_info_data(
-                    context,
-                    value_declared,
-                    skip_ref_flag,
-                    false,
-                )?;
+                let value = read_ref_info_data(context, value_declared, skip_ref_flag, false)?;
                 map.insert(K::default(), value);
                 len_counter += 1;
                 continue;
@@ -192,8 +186,7 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 } else {
                     false
                 };
-                let key =
-                    crate::serializer::read_info_data(context, key_declared, skip_ref_flag, false)?;
+                let key = read_ref_info_data(context, key_declared, skip_ref_flag, false)?;
                 map.insert(key, V::default());
                 len_counter += 1;
                 continue;
@@ -204,27 +197,14 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
             assert!(len_counter + chunk_size as u32 <= len);
             for _ in (0..chunk_size).enumerate() {
                 // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<K>(context.get_fory());
-                let key = crate::serializer::read_info_data(context, key_declared, true, true)?;
+                let key = read_ref_info_data(context, key_declared, true, true)?;
                 // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<V>(context.get_fory());
-                let value = crate::serializer::read_info_data(context, value_declared, true, true)?;
+                let value = read_ref_info_data(context, value_declared, true, true)?;
                 map.insert(key, value);
             }
             len_counter += chunk_size as u32;
         }
         Ok(map)
-    }
-
-    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.write_var_uint32(TypeId::MAP as u32);
-        }
-    }
-
-    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_collection_type_id = context.reader.read_var_uint32();
-            assert_eq!(remote_collection_type_id, TypeId::MAP as u32);
-        }
     }
 
     fn fory_reserved_space() -> usize {
@@ -235,5 +215,3 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
         TypeId::MAP as u32
     }
 }
-
-impl<T1: Serializer + Eq + std::hash::Hash, T2: Serializer> ForyGeneralList for HashMap<T1, T2> {}

--- a/rust/fory-core/src/serializer/map.rs
+++ b/rust/fory-core/src/serializer/map.rs
@@ -39,11 +39,11 @@ fn check_and_write_null<K: Serializer + Eq + std::hash::Hash, V: Serializer>(
     key: &K,
     value: &V,
 ) -> bool {
-    if key.is_none() && value.is_none() {
+    if key.fory_is_none() && value.fory_is_none() {
         context.writer.write_u8(KEY_NULL | VALUE_NULL);
         return true;
     }
-    if key.is_none() {
+    if key.fory_is_none() {
         let mut chunk_header = KEY_NULL;
         let skip_ref_flag;
         if is_field {
@@ -58,7 +58,7 @@ fn check_and_write_null<K: Serializer + Eq + std::hash::Hash, V: Serializer>(
         crate::serializer::write_data(value, context, is_field, skip_ref_flag, false);
         return true;
     }
-    if value.is_none() {
+    if value.fory_is_none() {
         let mut chunk_header = VALUE_NULL;
         let skip_ref_flag;
         if is_field {
@@ -81,15 +81,15 @@ fn write_chunk_size(context: &mut WriteContext, header_offset: usize, size: u8) 
 }
 
 impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap<K, V> {
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
         let length = self.len();
         context.writer.write_var_uint32(length as u32);
         if length == 0 {
             return;
         }
-        let reserved_space = (<K as Serializer>::reserved_space() + SIZE_OF_REF_AND_TYPE)
+        let reserved_space = (<K as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE)
             * self.len()
-            + (<V as Serializer>::reserved_space() + SIZE_OF_REF_AND_TYPE) * self.len();
+            + (<V as Serializer>::fory_reserved_space() + SIZE_OF_REF_AND_TYPE) * self.len();
         context.writer.reserve(reserved_space);
 
         let mut header_offset = 0;
@@ -121,12 +121,12 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 if !skip_val_ref_flag {
                     chunk_header |= TRACKING_VALUE_REF;
                 }
-                K::write_type_info(context, is_field);
-                V::write_type_info(context, is_field);
+                K::fory_write_type_info(context, is_field);
+                V::fory_write_type_info(context, is_field);
                 context.writer.set_bytes(header_offset, &[chunk_header]);
                 need_write_header = false;
             }
-            if key.is_none() || value.is_none() {
+            if key.fory_is_none() || value.fory_is_none() {
                 write_chunk_size(context, header_offset, pair_counter);
                 pair_counter = 0;
                 need_write_header = true;
@@ -147,7 +147,7 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
         }
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         let len = context.reader.read_var_uint32();
         let mut map = HashMap::<K, V>::with_capacity(len as usize);
         if len == 0 {
@@ -195,8 +195,8 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 continue;
             }
             let chunk_size = context.reader.read_u8();
-            K::read_type_info(context, key_declared);
-            V::read_type_info(context, value_declared);
+            K::fory_read_type_info(context, key_declared);
+            V::fory_read_type_info(context, value_declared);
             assert!(len_counter + chunk_size as u32 <= len);
             for _ in (0..chunk_size).enumerate() {
                 // let skip_ref_flag = crate::serializer::get_skip_ref_flag::<K>(context.get_fory());
@@ -210,24 +210,24 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
         Ok(map)
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             context.writer.write_var_uint32(TypeId::MAP as u32);
         }
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             let remote_collection_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_collection_type_id, TypeId::MAP as u32);
         }
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<i32>()
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::MAP as u32
     }
 }

--- a/rust/fory-core/src/serializer/map.rs
+++ b/rust/fory-core/src/serializer/map.rs
@@ -175,8 +175,12 @@ impl<K: Serializer + Eq + std::hash::Hash, V: Serializer> Serializer for HashMap
                 } else {
                     false
                 };
-                let value =
-                    crate::serializer::read_info_data(context, value_declared, skip_ref_flag, false)?;
+                let value = crate::serializer::read_info_data(
+                    context,
+                    value_declared,
+                    skip_ref_flag,
+                    false,
+                )?;
                 map.insert(K::default(), value);
                 len_counter += 1;
                 continue;

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -42,16 +42,16 @@ pub fn write_data<T: Serializer + 'static>(
     skip_ref_flag: bool,
     skip_type_info: bool,
 ) {
-    if record.is_none() {
+    if record.fory_is_none() {
         context.writer.write_i8(RefFlag::Null as i8);
     } else {
         if !skip_ref_flag {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
         }
         if !skip_type_info {
-            T::write_type_info(context, is_field);
+            T::fory_write_type_info(context, is_field);
         }
-        record.write(context, is_field);
+        record.fory_write(context, is_field);
     }
 }
 
@@ -67,23 +67,23 @@ pub fn read_data<T: Serializer + Default>(
             Ok(T::default())
         } else if ref_flag == (RefFlag::NotNullValue as i8) {
             if !skip_type_info {
-                T::read_type_info(context, is_field);
+                T::fory_read_type_info(context, is_field);
             }
-            T::read(context)
+            T::fory_read(context)
         } else {
             unimplemented!()
         }
     } else {
         if !skip_type_info {
-            T::read_type_info(context, is_field);
+            T::fory_read_type_info(context, is_field);
         }
-        T::read(context)
+        T::fory_read(context)
     }
 }
 
 pub fn get_skip_ref_flag<T: Serializer>(fory: &Fory) -> bool {
-    let elem_type_id = T::get_type_id(fory);
-    !T::is_option() && PRIMITIVE_TYPES.contains(&elem_type_id)
+    let elem_type_id = T::fory_get_type_id(fory);
+    !T::fory_is_option() && PRIMITIVE_TYPES.contains(&elem_type_id)
 }
 
 pub trait Serializer
@@ -92,42 +92,42 @@ where
 {
     /// The possible max memory size of the type.
     /// Used to reserve the buffer space to avoid reallocation, which may hurt performance.
-    fn reserved_space() -> usize;
+    fn fory_reserved_space() -> usize;
 
     /// Write the data into the buffer.
-    fn write(&self, context: &mut WriteContext, is_field: bool);
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool);
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool);
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool);
 
     /// Entry point of the serialization.
     ///
     /// Step 1: write the type flag and type flag into the buffer.
     /// Step 2: invoke the write function to write the Rust object.
-    fn serialize(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_serialize(&self, context: &mut WriteContext, is_field: bool) {
         write_data(self, context, is_field, false, false);
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error>;
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error>;
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool);
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool);
 
-    fn deserialize(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
+    fn fory_deserialize(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
         read_data(context, is_field, false, false)
     }
 
-    fn get_type_id(_fory: &Fory) -> u32;
+    fn fory_get_type_id(_fory: &Fory) -> u32;
 
-    fn is_option() -> bool {
+    fn fory_is_option() -> bool {
         false
     }
 
-    fn is_none(&self) -> bool {
+    fn fory_is_none(&self) -> bool {
         false
     }
 }
 
 pub trait StructSerializer: Serializer + 'static {
-    fn type_def(
+    fn fory_type_def(
         fory: &Fory,
         type_id: u32,
         namespace: &str,
@@ -135,10 +135,10 @@ pub trait StructSerializer: Serializer + 'static {
         register_by_name: bool,
     ) -> Vec<u8>;
 
-    fn type_index() -> u32;
-    fn actual_type_id(type_id: u32, register_by_name: bool, mode: &Mode) -> u32;
+    fn fory_type_index() -> u32;
+    fn fory_actual_type_id(type_id: u32, register_by_name: bool, mode: &Mode) -> u32;
 
-    fn read_compatible(context: &mut ReadContext) -> Result<Self, Error>;
+    fn fory_read_compatible(context: &mut ReadContext) -> Result<Self, Error>;
 
-    fn get_sorted_field_names(fory: &Fory) -> Vec<String>;
+    fn fory_get_sorted_field_names(fory: &Fory) -> Vec<String>;
 }

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -77,7 +77,7 @@ pub fn read_ref_info_data<T: Serializer + Default>(
         } else if ref_flag == (RefFlag::RefValue as i8) {
             // First time seeing this referenceable object
             if !skip_type_info {
-                T::read_type_info(context, is_field);
+                T::fory_read_type_info(context, is_field);
             }
             T::fory_read_data(context, is_field)
         } else if ref_flag == (RefFlag::Ref as i8) {

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -43,10 +43,10 @@ pub fn write_data<T: Serializer + 'static>(
     skip_type_info: bool,
 ) {
     if record.is_none() {
-        context.writer.i8(RefFlag::Null as i8);
+        context.writer.write_i8(RefFlag::Null as i8);
     } else {
         if !skip_ref_flag {
-            context.writer.i8(RefFlag::NotNullValue as i8);
+            context.writer.write_i8(RefFlag::NotNullValue as i8);
         }
         if !skip_type_info {
             T::write_type_info(context, is_field);
@@ -62,7 +62,7 @@ pub fn read_data<T: Serializer + Default>(
     skip_type_info: bool,
 ) -> Result<T, Error> {
     if !skip_ref_flag {
-        let ref_flag = context.reader.i8();
+        let ref_flag = context.reader.read_i8();
         if ref_flag == RefFlag::Null as i8 {
             Ok(T::default())
         } else if ref_flag == (RefFlag::NotNullValue as i8) {

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -35,7 +35,7 @@ pub mod skip;
 mod string;
 pub mod struct_;
 
-pub fn write_data<T: Serializer + 'static>(
+pub fn write_info_data<T: Serializer + 'static>(
     record: &T,
     context: &mut WriteContext,
     is_field: bool,
@@ -51,11 +51,11 @@ pub fn write_data<T: Serializer + 'static>(
         if !skip_type_info {
             T::fory_write_type_info(context, is_field);
         }
-        record.fory_write(context, is_field);
+        record.fory_write_data(context, is_field);
     }
 }
 
-pub fn read_data<T: Serializer + Default>(
+pub fn read_info_data<T: Serializer + Default>(
     context: &mut ReadContext,
     is_field: bool,
     skip_ref_flag: bool,
@@ -69,7 +69,7 @@ pub fn read_data<T: Serializer + Default>(
             if !skip_type_info {
                 T::fory_read_type_info(context, is_field);
             }
-            T::fory_read(context)
+            T::fory_read_data(context)
         } else {
             unimplemented!()
         }
@@ -77,7 +77,7 @@ pub fn read_data<T: Serializer + Default>(
         if !skip_type_info {
             T::fory_read_type_info(context, is_field);
         }
-        T::fory_read(context)
+        T::fory_read_data(context)
     }
 }
 
@@ -95,7 +95,7 @@ where
     fn fory_reserved_space() -> usize;
 
     /// Write the data into the buffer.
-    fn fory_write(&self, context: &mut WriteContext, is_field: bool);
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool);
 
     fn fory_write_type_info(context: &mut WriteContext, is_field: bool);
 
@@ -103,16 +103,16 @@ where
     ///
     /// Step 1: write the type flag and type flag into the buffer.
     /// Step 2: invoke the write function to write the Rust object.
-    fn fory_serialize(&self, context: &mut WriteContext, is_field: bool) {
-        write_data(self, context, is_field, false, false);
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
+        write_info_data(self, context, is_field, false, false);
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error>;
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error>;
 
     fn fory_read_type_info(context: &mut ReadContext, is_field: bool);
 
-    fn fory_deserialize(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
-        read_data(context, is_field, false, false)
+    fn fory_read(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
+        read_info_data(context, is_field, false, false)
     }
 
     fn fory_get_type_id(_fory: &Fory) -> u32;

--- a/rust/fory-core/src/serializer/number.rs
+++ b/rust/fory-core/src/serializer/number.rs
@@ -26,7 +26,7 @@ use crate::types::{ForyGeneralList, TypeId};
 macro_rules! impl_num_serializer {
     ($ty:ty, $writer:expr, $reader:expr, $field_type:expr) => {
         impl Serializer for $ty {
-            fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+            fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
                 $writer(&mut context.writer, *self);
             }
 
@@ -36,7 +36,7 @@ macro_rules! impl_num_serializer {
                 }
             }
 
-            fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+            fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
                 Ok($reader(&mut context.reader))
             }
 

--- a/rust/fory-core/src/serializer/number.rs
+++ b/rust/fory-core/src/serializer/number.rs
@@ -26,32 +26,32 @@ use crate::types::{ForyGeneralList, TypeId};
 macro_rules! impl_num_serializer {
     ($ty:ty, $writer:expr, $reader:expr, $field_type:expr) => {
         impl Serializer for $ty {
-            fn write(&self, context: &mut WriteContext, _is_field: bool) {
+            fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
                 $writer(&mut context.writer, *self);
             }
 
-            fn write_type_info(context: &mut WriteContext, is_field: bool) {
+            fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
                 if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
                     context.writer.write_var_uint32($field_type as u32);
                 }
             }
 
-            fn read(context: &mut ReadContext) -> Result<Self, Error> {
+            fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
                 Ok($reader(&mut context.reader))
             }
 
-            fn read_type_info(context: &mut ReadContext, is_field: bool) {
+            fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
                 if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
                     let remote_type_id = context.reader.read_var_uint32();
                     assert_eq!(remote_type_id, $field_type as u32);
                 }
             }
 
-            fn reserved_space() -> usize {
+            fn fory_reserved_space() -> usize {
                 std::mem::size_of::<$ty>()
             }
 
-            fn get_type_id(_fory: &Fory) -> u32 {
+            fn fory_get_type_id(_fory: &Fory) -> u32 {
                 $field_type as u32
             }
         }

--- a/rust/fory-core/src/serializer/number.rs
+++ b/rust/fory-core/src/serializer/number.rs
@@ -21,7 +21,7 @@ use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, TypeId};
+use crate::types::TypeId;
 
 macro_rules! impl_num_serializer {
     ($ty:ty, $writer:expr, $reader:expr, $field_type:expr) => {
@@ -30,21 +30,8 @@ macro_rules! impl_num_serializer {
                 $writer(&mut context.writer, *self);
             }
 
-            fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-                if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
-                    context.writer.write_var_uint32($field_type as u32);
-                }
-            }
-
-            fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+            fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
                 Ok($reader(&mut context.reader))
-            }
-
-            fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-                if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
-                    let remote_type_id = context.reader.read_var_uint32();
-                    assert_eq!(remote_type_id, $field_type as u32);
-                }
             }
 
             fn fory_reserved_space() -> usize {
@@ -58,22 +45,18 @@ macro_rules! impl_num_serializer {
     };
 }
 
-impl ForyGeneralList for u16 {}
-impl ForyGeneralList for u32 {}
-impl ForyGeneralList for u64 {}
-
 impl_num_serializer!(i8, Writer::write_i8, Reader::read_i8, TypeId::INT8);
 impl_num_serializer!(i16, Writer::write_i16, Reader::read_i16, TypeId::INT16);
 impl_num_serializer!(
     i32,
-    Writer::write_var_int32,
-    Reader::read_var_int32,
+    Writer::write_varint32,
+    Reader::read_varint32,
     TypeId::INT32
 );
 impl_num_serializer!(
     i64,
-    Writer::write_var_int64,
-    Reader::read_var_int64,
+    Writer::write_varint64,
+    Reader::read_varint64,
     TypeId::INT64
 );
 impl_num_serializer!(f32, Writer::write_f32, Reader::read_f32, TypeId::FLOAT32);

--- a/rust/fory-core/src/serializer/option.rs
+++ b/rust/fory-core/src/serializer/option.rs
@@ -23,17 +23,17 @@ use crate::serializer::Serializer;
 use crate::types::ForyGeneralList;
 
 impl<T: Serializer> Serializer for Option<T> {
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
-        Ok(Some(T::fory_read(context)?))
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+        Ok(Some(T::fory_read_data(context)?))
     }
 
     fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         T::fory_read_type_info(context, is_field);
     }
 
-    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
         if let Some(v) = self {
-            T::fory_write(v, context, is_field)
+            T::fory_write_data(v, context, is_field)
         } else {
             unreachable!("write should be call by serialize")
         }

--- a/rust/fory-core/src/serializer/option.rs
+++ b/rust/fory-core/src/serializer/option.rs
@@ -23,39 +23,39 @@ use crate::serializer::Serializer;
 use crate::types::ForyGeneralList;
 
 impl<T: Serializer> Serializer for Option<T> {
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
-        Ok(Some(T::read(context)?))
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+        Ok(Some(T::fory_read(context)?))
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
-        T::read_type_info(context, is_field);
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
+        T::fory_read_type_info(context, is_field);
     }
 
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
         if let Some(v) = self {
-            T::write(v, context, is_field)
+            T::fory_write(v, context, is_field)
         } else {
             unreachable!("write should be call by serialize")
         }
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
-        T::write_type_info(context, is_field);
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
+        T::fory_write_type_info(context, is_field);
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         std::mem::size_of::<T>()
     }
 
-    fn get_type_id(fory: &Fory) -> u32 {
-        T::get_type_id(fory)
+    fn fory_get_type_id(fory: &Fory) -> u32 {
+        T::fory_get_type_id(fory)
     }
 
-    fn is_option() -> bool {
+    fn fory_is_option() -> bool {
         true
     }
 
-    fn is_none(&self) -> bool {
+    fn fory_is_none(&self) -> bool {
         self.is_none()
     }
 }

--- a/rust/fory-core/src/serializer/option.rs
+++ b/rust/fory-core/src/serializer/option.rs
@@ -20,11 +20,10 @@ use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::ForyGeneralList;
 
 impl<T: Serializer> Serializer for Option<T> {
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
-        Ok(Some(T::fory_read_data(context)?))
+    fn fory_read_data(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
+        Ok(Some(T::fory_read_data(context, is_field)?))
     }
 
     fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
@@ -59,5 +58,3 @@ impl<T: Serializer> Serializer for Option<T> {
         self.is_none()
     }
 }
-
-impl<T: Serializer> ForyGeneralList for Option<T> {}

--- a/rust/fory-core/src/serializer/primitive_list.rs
+++ b/rust/fory-core/src/serializer/primitive_list.rs
@@ -25,7 +25,7 @@ use crate::types::TypeId;
 macro_rules! impl_primitive_vec {
     ($name:ident, $ty:ty, $field_type:expr) => {
         impl Serializer for Vec<$ty> {
-            fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+            fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
                 let len_bytes = self.len() * std::mem::size_of::<$ty>();
                 context.writer.write_var_uint32(len_bytes as u32);
                 context.writer.reserve(len_bytes);
@@ -45,7 +45,7 @@ macro_rules! impl_primitive_vec {
                 }
             }
 
-            fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+            fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
                 let size_bytes = context.reader.read_var_uint32() as usize;
                 if size_bytes % std::mem::size_of::<$ty>() != 0 {
                     panic!("Invalid data length");

--- a/rust/fory-core/src/serializer/primitive_list.rs
+++ b/rust/fory-core/src/serializer/primitive_list.rs
@@ -16,74 +16,53 @@
 // under the License.
 
 use crate::error::Error;
-use crate::fory::Fory;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
-use crate::serializer::Serializer;
 use crate::types::TypeId;
 
-macro_rules! impl_primitive_vec {
-    ($name:ident, $ty:ty, $field_type:expr) => {
-        impl Serializer for Vec<$ty> {
-            fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
-                let len_bytes = self.len() * std::mem::size_of::<$ty>();
-                context.writer.write_var_uint32(len_bytes as u32);
-                context.writer.reserve(len_bytes);
+pub fn fory_write_data<T>(this: &[T], context: &mut WriteContext) {
+    let len_bytes = std::mem::size_of_val(this);
+    context.writer.write_varuint32(len_bytes as u32);
+    context.writer.reserve(len_bytes);
 
-                if !self.is_empty() {
-                    unsafe {
-                        let ptr = self.as_ptr() as *const u8;
-                        let slice = std::slice::from_raw_parts(ptr, len_bytes);
-                        context.writer.write_bytes(slice);
-                    }
-                }
-            }
-
-            fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-                if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
-                    context.writer.write_var_uint32($field_type as u32);
-                }
-            }
-
-            fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
-                let size_bytes = context.reader.read_var_uint32() as usize;
-                if size_bytes % std::mem::size_of::<$ty>() != 0 {
-                    panic!("Invalid data length");
-                }
-                let len = size_bytes / std::mem::size_of::<$ty>();
-                let mut vec: Vec<$ty> = Vec::with_capacity(len);
-                unsafe {
-                    let dst_ptr = vec.as_mut_ptr() as *mut u8;
-                    let src = context.reader.read_bytes(size_bytes);
-                    std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, size_bytes);
-                    vec.set_len(len);
-                }
-                Ok(vec)
-            }
-
-            fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-                if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
-                    let remote_type_id = context.reader.read_var_uint32();
-                    assert_eq!(remote_type_id, $field_type as u32);
-                }
-            }
-
-            fn fory_reserved_space() -> usize {
-                std::mem::size_of::<$ty>()
-            }
-
-            fn fory_get_type_id(_fory: &Fory) -> u32 {
-                $field_type as u32
-            }
+    if !this.is_empty() {
+        unsafe {
+            let ptr = this.as_ptr() as *const u8;
+            let slice = std::slice::from_raw_parts(ptr, len_bytes);
+            context.writer.write_bytes(slice);
         }
-    };
+    }
 }
 
-impl_primitive_vec!(bool, bool, TypeId::BOOL_ARRAY);
-impl_primitive_vec!(u8, u8, TypeId::BINARY);
-impl_primitive_vec!(i8, i8, TypeId::INT8_ARRAY);
-impl_primitive_vec!(i16, i16, TypeId::INT16_ARRAY);
-impl_primitive_vec!(i32, i32, TypeId::INT32_ARRAY);
-impl_primitive_vec!(i64, i64, TypeId::INT64_ARRAY);
-impl_primitive_vec!(f32, f32, TypeId::FLOAT32_ARRAY);
-impl_primitive_vec!(f64, f64, TypeId::FLOAT64_ARRAY);
+pub fn fory_write_type_info(context: &mut WriteContext, is_field: bool, type_id: TypeId) {
+    if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
+        context.writer.write_varuint32(type_id as u32);
+    }
+}
+
+pub fn fory_read_data<T>(context: &mut ReadContext) -> Result<Vec<T>, Error> {
+    let size_bytes = context.reader.read_varuint32() as usize;
+    if size_bytes % std::mem::size_of::<T>() != 0 {
+        panic!("Invalid data length");
+    }
+    let len = size_bytes / std::mem::size_of::<T>();
+    let mut vec: Vec<T> = Vec::with_capacity(len);
+    unsafe {
+        let dst_ptr = vec.as_mut_ptr() as *mut u8;
+        let src = context.reader.read_bytes(size_bytes);
+        std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, size_bytes);
+        vec.set_len(len);
+    }
+    Ok(vec)
+}
+
+pub fn fory_read_type_info(context: &mut ReadContext, is_field: bool, type_id: TypeId) {
+    if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
+        let remote_type_id = context.reader.read_varuint32();
+        assert_eq!(remote_type_id, type_id as u32);
+    }
+}
+
+pub fn fory_reserved_space<T>() -> usize {
+    std::mem::size_of::<T>()
+}

--- a/rust/fory-core/src/serializer/primitive_list.rs
+++ b/rust/fory-core/src/serializer/primitive_list.rs
@@ -25,7 +25,7 @@ use crate::types::TypeId;
 macro_rules! impl_primitive_vec {
     ($name:ident, $ty:ty, $field_type:expr) => {
         impl Serializer for Vec<$ty> {
-            fn write(&self, context: &mut WriteContext, _is_field: bool) {
+            fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
                 let len_bytes = self.len() * std::mem::size_of::<$ty>();
                 context.writer.write_var_uint32(len_bytes as u32);
                 context.writer.reserve(len_bytes);
@@ -39,13 +39,13 @@ macro_rules! impl_primitive_vec {
                 }
             }
 
-            fn write_type_info(context: &mut WriteContext, is_field: bool) {
+            fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
                 if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
                     context.writer.write_var_uint32($field_type as u32);
                 }
             }
 
-            fn read(context: &mut ReadContext) -> Result<Self, Error> {
+            fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
                 let size_bytes = context.reader.read_var_uint32() as usize;
                 if size_bytes % std::mem::size_of::<$ty>() != 0 {
                     panic!("Invalid data length");
@@ -61,18 +61,18 @@ macro_rules! impl_primitive_vec {
                 Ok(vec)
             }
 
-            fn read_type_info(context: &mut ReadContext, is_field: bool) {
+            fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
                 if *context.get_fory().get_mode() == crate::types::Mode::Compatible && !is_field {
                     let remote_type_id = context.reader.read_var_uint32();
                     assert_eq!(remote_type_id, $field_type as u32);
                 }
             }
 
-            fn reserved_space() -> usize {
+            fn fory_reserved_space() -> usize {
                 std::mem::size_of::<$ty>()
             }
 
-            fn get_type_id(_fory: &Fory) -> u32 {
+            fn fory_get_type_id(_fory: &Fory) -> u32 {
                 $field_type as u32
             }
         }

--- a/rust/fory-core/src/serializer/rc.rs
+++ b/rust/fory-core/src/serializer/rc.rs
@@ -19,12 +19,12 @@ use crate::error::Error;
 use crate::fory::Fory;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, RefFlag};
+use crate::types::RefFlag;
 use anyhow::anyhow;
 use std::rc::Rc;
 
 impl<T: Serializer + 'static> Serializer for Rc<T> {
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
         let ref_flag = context.ref_reader.read_ref_flag(&mut context.reader);
 
         match ref_flag {
@@ -37,11 +37,11 @@ impl<T: Serializer + 'static> Serializer for Rc<T> {
                     .ok_or_else(|| anyhow!("Rc reference {} not found", ref_id).into())
             }
             RefFlag::NotNullValue => {
-                let inner = T::read(context)?;
+                let inner = T::fory_read_data(context, is_field)?;
                 Ok(Rc::new(inner))
             }
             RefFlag::RefValue => {
-                let inner = T::read(context)?;
+                let inner = T::fory_read_data(context, is_field)?;
                 let rc = Rc::new(inner);
                 context.ref_reader.store_rc_ref(rc.clone());
                 Ok(rc)
@@ -49,35 +49,25 @@ impl<T: Serializer + 'static> Serializer for Rc<T> {
         }
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
-        T::read_type_info(context, is_field);
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
+        T::fory_read_type_info(context, is_field);
     }
 
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
         if !context.ref_writer.try_write_rc_ref(context.writer, self) {
-            T::write(self.as_ref(), context, is_field);
+            T::fory_write_data(self.as_ref(), context, is_field);
         }
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
-        T::write_type_info(context, is_field);
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
+        T::fory_write_type_info(context, is_field);
     }
 
-    fn reserved_space() -> usize {
-        T::reserved_space()
+    fn fory_reserved_space() -> usize {
+        T::fory_reserved_space()
     }
 
-    fn get_type_id(fory: &Fory) -> u32 {
-        T::get_type_id(fory)
-    }
-
-    fn is_option() -> bool {
-        false
-    }
-
-    fn is_none(&self) -> bool {
-        false
+    fn fory_get_type_id(fory: &Fory) -> u32 {
+        T::fory_get_type_id(fory)
     }
 }
-
-impl<T: Serializer> ForyGeneralList for Rc<T> {}

--- a/rust/fory-core/src/serializer/set.rs
+++ b/rust/fory-core/src/serializer/set.rs
@@ -28,27 +28,27 @@ use std::collections::HashSet;
 use std::mem;
 
 impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
-    fn write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
         write_collection(self, context, is_field);
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         write_collection_type_info(context, is_field, TypeId::SET as u32);
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         read_collection(context)
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         read_collection_type_info(context, is_field, TypeId::SET as u32)
     }
 
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<i32>()
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::SET as u32
     }
 }

--- a/rust/fory-core/src/serializer/set.rs
+++ b/rust/fory-core/src/serializer/set.rs
@@ -28,7 +28,7 @@ use std::collections::HashSet;
 use std::mem;
 
 impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
-    fn fory_write(&self, context: &mut WriteContext, is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
         write_collection(self, context, is_field);
     }
 
@@ -36,7 +36,7 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
         write_collection_type_info(context, is_field, TypeId::SET as u32);
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         read_collection(context)
     }
 

--- a/rust/fory-core/src/serializer/set.rs
+++ b/rust/fory-core/src/serializer/set.rs
@@ -23,7 +23,7 @@ use crate::serializer::collection::{
     read_collection, read_collection_type_info, write_collection, write_collection_type_info,
 };
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, TypeId};
+use crate::types::TypeId;
 use std::collections::HashSet;
 use std::mem;
 
@@ -36,7 +36,7 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
         write_collection_type_info(context, is_field, TypeId::SET as u32);
     }
 
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
         read_collection(context)
     }
 
@@ -52,5 +52,3 @@ impl<T: Serializer + Eq + std::hash::Hash> Serializer for HashSet<T> {
         TypeId::SET as u32
     }
 }
-
-impl<T: Serializer + Eq + std::hash::Hash> ForyGeneralList for HashSet<T> {}

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -33,7 +33,7 @@ macro_rules! basic_type_deserialize {
         $(
             if $tid == TypeId::$id {
                 <$ty>::fory_read_type_info($context, true);
-                <$ty>::fory_read($context)?;
+                <$ty>::fory_read_data($context)?;
                 return Ok(());
             }
         )+else {

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -32,8 +32,8 @@ macro_rules! basic_type_deserialize {
     ($tid:expr, $context:expr; $(($ty:ty, $id:ident)),+ $(,)?) => {
         $(
             if $tid == TypeId::$id {
-                <$ty>::read_type_info($context, true);
-                <$ty>::read($context)?;
+                <$ty>::fory_read_type_info($context, true);
+                <$ty>::fory_read($context)?;
                 return Ok(());
             }
         )+else {

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -32,8 +32,8 @@ macro_rules! basic_type_deserialize {
     ($tid:expr, $context:expr; $(($ty:ty, $id:ident)),+ $(,)?) => {
         $(
             if $tid == TypeId::$id {
-                <$ty>::fory_read_type_info($context, true);
-                <$ty>::fory_read_data($context)?;
+                <$ty as Serializer>::fory_read_type_info($context, true);
+                <$ty as Serializer>::fory_read_data($context, true)?;
                 return Ok(());
             }
         )+else {
@@ -70,7 +70,6 @@ pub fn skip_field_value(
                     (String, STRING),
                     (NaiveDate, LOCAL_DATE),
                     (NaiveDateTime, TIMESTAMP),
-                    (Vec<u8> , BINARY),
                     (Vec<bool> , BOOL_ARRAY),
                     (Vec<i8> , INT8_ARRAY),
                     (Vec<i16> , INT16_ARRAY),
@@ -81,7 +80,7 @@ pub fn skip_field_value(
                 );
             } else if CONTAINER_TYPES.contains(&type_id) {
                 if type_id == TypeId::LIST || type_id == TypeId::SET {
-                    let length = context.reader.read_var_uint32() as usize;
+                    let length = context.reader.read_varuint32() as usize;
                     if length == 0 {
                         return Ok(());
                     }
@@ -94,7 +93,7 @@ pub fn skip_field_value(
                         skip_field_value(context, elem_type, !skip_ref_flag)?;
                     }
                 } else if type_id == TypeId::MAP {
-                    let length = context.reader.read_var_uint32();
+                    let length = context.reader.read_varuint32();
                     if length == 0 {
                         return Ok(());
                     }
@@ -136,7 +135,7 @@ pub fn skip_field_value(
                 }
                 Ok(())
             } else if type_id == TypeId::NAMED_ENUM {
-                let _ordinal = context.reader.read_var_uint32();
+                let _ordinal = context.reader.read_varuint32();
                 Ok(())
             } else {
                 unreachable!("unimplemented type: {:?}", type_id);
@@ -146,10 +145,12 @@ pub fn skip_field_value(
             let internal_id = type_id_num & 0xff;
             const COMPATIBLE_STRUCT_ID: u32 = TypeId::COMPATIBLE_STRUCT as u32;
             const NAMED_COMPATIBLE_STRUCT_ID: u32 = TypeId::NAMED_COMPATIBLE_STRUCT as u32;
+            const EXT_ID: u32 = TypeId::EXT as u32;
+            const NAMED_EXT_ID: u32 = TypeId::NAMED_EXT as u32;
             const ENUM_ID: u32 = TypeId::ENUM as u32;
             if internal_id == COMPATIBLE_STRUCT_ID || internal_id == NAMED_COMPATIBLE_STRUCT_ID {
-                let remote_type_id = context.reader.read_var_uint32();
-                let meta_index = context.reader.read_var_uint32();
+                let remote_type_id = context.reader.read_varuint32();
+                let meta_index = context.reader.read_varuint32();
                 let type_def = context.get_meta(meta_index as usize);
                 assert_eq!(remote_type_id, type_def.get_type_id());
                 let field_infos = type_def.get_field_infos().to_vec();
@@ -160,9 +161,18 @@ pub fn skip_field_value(
                     skip_field_value(context, &nullable_field_type, read_ref_flag)?;
                 }
             } else if internal_id == ENUM_ID {
-                let _ordinal = context.reader.read_var_uint32();
-            } else {
-                unimplemented!()
+                let _ordinal = context.reader.read_varuint32();
+            } else if internal_id == EXT_ID {
+                let type_resolver = context.get_fory().get_type_resolver();
+                type_resolver
+                    .get_ext_harness(type_id_num)
+                    .unwrap()
+                    .get_read_fn()(context, true)
+                .unwrap();
+            } else if internal_id == NAMED_EXT_ID {
+                unimplemented!("NAMED_EXT_ID");
+                // let type_resolver = context.get_fory().get_type_resolver();
+                // type_resolver.get_ext_name_harness(type_id_num).unwrap().get_read_fn()(context, true).unwrap();
             }
             Ok(())
         }

--- a/rust/fory-core/src/serializer/string.rs
+++ b/rust/fory-core/src/serializer/string.rs
@@ -21,7 +21,7 @@ use crate::meta::get_latin1_length;
 use crate::resolver::context::ReadContext;
 use crate::resolver::context::WriteContext;
 use crate::serializer::Serializer;
-use crate::types::{ForyGeneralList, Mode, TypeId};
+use crate::types::TypeId;
 use std::mem;
 
 enum StrEncoding {
@@ -31,26 +31,22 @@ enum StrEncoding {
 }
 
 impl Serializer for String {
-    fn fory_reserved_space() -> usize {
-        mem::size_of::<i32>()
-    }
-
     fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         let mut len = get_latin1_length(self);
         if len >= 0 {
             let bitor = (len as u64) << 2 | StrEncoding::Latin1 as u64;
-            context.writer.write_var_uint36_small(bitor);
+            context.writer.write_varuint36_small(bitor);
             context.writer.write_latin1_string(self);
         } else if context.get_fory().is_compress_string() {
             // todo: support `writeNumUtf16BytesForUtf8Encoding` like in java
             len = self.len() as i32;
             let bitor = (len as u64) << 2 | StrEncoding::Utf8 as u64;
-            context.writer.write_var_uint36_small(bitor);
+            context.writer.write_varuint36_small(bitor);
             context.writer.write_utf8_string(self);
         } else {
             let utf16: Vec<u16> = self.encode_utf16().collect();
             let bitor = (utf16.len() as u64 * 2) << 2 | StrEncoding::Utf16 as u64;
-            context.writer.write_var_uint36_small(bitor);
+            context.writer.write_varuint36_small(bitor);
             for unit in utf16 {
                 #[cfg(target_endian = "little")]
                 {
@@ -64,14 +60,8 @@ impl Serializer for String {
         }
     }
 
-    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            context.writer.write_var_uint32(TypeId::STRING as u32);
-        }
-    }
-
-    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
-        let bitor = context.reader.var_uint36_small();
+    fn fory_read_data(context: &mut ReadContext, _is_field: bool) -> Result<Self, Error> {
+        let bitor = context.reader.read_varuint36small();
         let len = bitor >> 2;
         let encoding = bitor & 0b11;
         let encoding = match encoding {
@@ -90,16 +80,11 @@ impl Serializer for String {
         Ok(s)
     }
 
-    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
-        if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
-            let remote_type_id = context.reader.read_var_uint32();
-            assert_eq!(remote_type_id, TypeId::STRING as u32);
-        }
+    fn fory_reserved_space() -> usize {
+        mem::size_of::<i32>()
     }
 
     fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::STRING as u32
     }
 }
-
-impl ForyGeneralList for String {}

--- a/rust/fory-core/src/serializer/string.rs
+++ b/rust/fory-core/src/serializer/string.rs
@@ -31,11 +31,11 @@ enum StrEncoding {
 }
 
 impl Serializer for String {
-    fn reserved_space() -> usize {
+    fn fory_reserved_space() -> usize {
         mem::size_of::<i32>()
     }
 
-    fn write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
         let mut len = get_latin1_length(self);
         if len >= 0 {
             let bitor = (len as u64) << 2 | StrEncoding::Latin1 as u64;
@@ -64,13 +64,13 @@ impl Serializer for String {
         }
     }
 
-    fn write_type_info(context: &mut WriteContext, is_field: bool) {
+    fn fory_write_type_info(context: &mut WriteContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             context.writer.write_var_uint32(TypeId::STRING as u32);
         }
     }
 
-    fn read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
         let bitor = context.reader.var_uint36_small();
         let len = bitor >> 2;
         let encoding = bitor & 0b11;
@@ -90,14 +90,14 @@ impl Serializer for String {
         Ok(s)
     }
 
-    fn read_type_info(context: &mut ReadContext, is_field: bool) {
+    fn fory_read_type_info(context: &mut ReadContext, is_field: bool) {
         if *context.get_fory().get_mode() == Mode::Compatible && !is_field {
             let remote_type_id = context.reader.read_var_uint32();
             assert_eq!(remote_type_id, TypeId::STRING as u32);
         }
     }
 
-    fn get_type_id(_fory: &Fory) -> u32 {
+    fn fory_get_type_id(_fory: &Fory) -> u32 {
         TypeId::STRING as u32
     }
 }

--- a/rust/fory-core/src/serializer/string.rs
+++ b/rust/fory-core/src/serializer/string.rs
@@ -35,7 +35,7 @@ impl Serializer for String {
         mem::size_of::<i32>()
     }
 
-    fn fory_write(&self, context: &mut WriteContext, _is_field: bool) {
+    fn fory_write_data(&self, context: &mut WriteContext, _is_field: bool) {
         let mut len = get_latin1_length(self);
         if len >= 0 {
             let bitor = (len as u64) << 2 | StrEncoding::Latin1 as u64;
@@ -70,7 +70,7 @@ impl Serializer for String {
         }
     }
 
-    fn fory_read(context: &mut ReadContext) -> Result<Self, Error> {
+    fn fory_read_data(context: &mut ReadContext) -> Result<Self, Error> {
         let bitor = context.reader.var_uint36_small();
         let len = bitor >> 2;
         let encoding = bitor & 0b11;

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -93,18 +93,18 @@ pub fn read_type_info<T: Serializer>(context: &mut ReadContext, _is_field: bool)
 }
 
 #[inline(always)]
-pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, _is_field: bool) {
+pub fn write<T: Serializer>(this: &T, context: &mut WriteContext, _is_field: bool) {
     match context.get_fory().get_mode() {
         // currently same
         Mode::SchemaConsistent => {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
             T::fory_write_type_info(context, false);
-            this.fory_write(context, true);
+            this.fory_write_data(context, true);
         }
         Mode::Compatible => {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
             T::fory_write_type_info(context, false);
-            this.fory_write(context, true);
+            this.fory_write_data(context, true);
         }
     }
 }

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -48,7 +48,7 @@ pub fn type_def<T: Serializer + StructSerializer>(
     register_by_name: bool,
     field_infos: &[FieldInfo],
 ) -> Vec<u8> {
-    let sorted_field_names = T::get_sorted_field_names(fory);
+    let sorted_field_names = T::fory_get_sorted_field_names(fory);
     let mut sorted_field_infos = Vec::with_capacity(field_infos.len());
     for name in &sorted_field_names {
         if let Some(info) = field_infos.iter().find(|f| &f.field_name == name) {
@@ -75,7 +75,7 @@ pub fn type_def<T: Serializer + StructSerializer>(
 
 #[inline(always)]
 pub fn write_type_info<T: Serializer>(context: &mut WriteContext, _is_field: bool) {
-    let type_id = T::get_type_id(context.get_fory());
+    let type_id = T::fory_get_type_id(context.get_fory());
     context.writer.write_var_uint32(type_id);
     if *context.get_fory().get_mode() == Mode::Compatible {
         let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
@@ -86,7 +86,7 @@ pub fn write_type_info<T: Serializer>(context: &mut WriteContext, _is_field: boo
 #[inline(always)]
 pub fn read_type_info<T: Serializer>(context: &mut ReadContext, _is_field: bool) {
     let remote_type_id = context.reader.read_var_uint32();
-    assert_eq!(remote_type_id, T::get_type_id(context.get_fory()));
+    assert_eq!(remote_type_id, T::fory_get_type_id(context.get_fory()));
     if *context.get_fory().get_mode() == Mode::Compatible {
         let _meta_index = context.reader.read_var_uint32();
     }
@@ -98,13 +98,13 @@ pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, _is_field:
         // currently same
         Mode::SchemaConsistent => {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
-            T::write_type_info(context, false);
-            this.write(context, true);
+            T::fory_write_type_info(context, false);
+            this.fory_write(context, true);
         }
         Mode::Compatible => {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
-            T::write_type_info(context, false);
-            this.write(context, true);
+            T::fory_write_type_info(context, false);
+            this.fory_write(context, true);
         }
     }
 }

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -76,19 +76,19 @@ pub fn type_def<T: Serializer + StructSerializer>(
 #[inline(always)]
 pub fn write_type_info<T: Serializer>(context: &mut WriteContext, _is_field: bool) {
     let type_id = T::get_type_id(context.get_fory());
-    context.writer.var_uint32(type_id);
+    context.writer.write_var_uint32(type_id);
     if *context.get_fory().get_mode() == Mode::Compatible {
         let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
-        context.writer.var_uint32(meta_index);
+        context.writer.write_var_uint32(meta_index);
     }
 }
 
 #[inline(always)]
 pub fn read_type_info<T: Serializer>(context: &mut ReadContext, _is_field: bool) {
-    let remote_type_id = context.reader.var_uint32();
+    let remote_type_id = context.reader.read_var_uint32();
     assert_eq!(remote_type_id, T::get_type_id(context.get_fory()));
     if *context.get_fory().get_mode() == Mode::Compatible {
-        let _meta_index = context.reader.var_uint32();
+        let _meta_index = context.reader.read_var_uint32();
     }
 }
 
@@ -97,12 +97,12 @@ pub fn serialize<T: Serializer>(this: &T, context: &mut WriteContext, _is_field:
     match context.get_fory().get_mode() {
         // currently same
         Mode::SchemaConsistent => {
-            context.writer.i8(RefFlag::NotNullValue as i8);
+            context.writer.write_i8(RefFlag::NotNullValue as i8);
             T::write_type_info(context, false);
             this.write(context, true);
         }
         Mode::Compatible => {
-            context.writer.i8(RefFlag::NotNullValue as i8);
+            context.writer.write_i8(RefFlag::NotNullValue as i8);
             T::write_type_info(context, false);
             this.write(context, true);
         }

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -16,10 +16,7 @@
 // under the License.
 
 use crate::fory::Fory;
-use crate::meta::{
-    FieldInfo, TypeMeta, NAMESPACE_ENCODER, NAMESPACE_ENCODINGS, TYPE_NAME_ENCODER,
-    TYPE_NAME_ENCODINGS,
-};
+use crate::meta::{FieldInfo, MetaString, TypeMeta};
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::{Serializer, StructSerializer};
 use crate::types::{Mode, RefFlag, TypeId};
@@ -43,8 +40,8 @@ pub fn actual_type_id(type_id: u32, register_by_name: bool, mode: &Mode) -> u32 
 pub fn type_def<T: Serializer + StructSerializer>(
     fory: &Fory,
     type_id: u32,
-    namespace: &str,
-    type_name: &str,
+    namespace: MetaString,
+    type_name: MetaString,
     register_by_name: bool,
     field_infos: &[FieldInfo],
 ) -> Vec<u8> {
@@ -57,16 +54,10 @@ pub fn type_def<T: Serializer + StructSerializer>(
             panic!("Field {} not found in field_infos", name);
         }
     }
-    let namespace_metastring = NAMESPACE_ENCODER
-        .encode_with_encodings(namespace, NAMESPACE_ENCODINGS)
-        .unwrap();
-    let type_name_metastring = TYPE_NAME_ENCODER
-        .encode_with_encodings(type_name, TYPE_NAME_ENCODINGS)
-        .unwrap();
     let meta = TypeMeta::from_fields(
         type_id,
-        namespace_metastring,
-        type_name_metastring,
+        namespace,
+        type_name,
         register_by_name,
         sorted_field_infos,
     );
@@ -76,19 +67,46 @@ pub fn type_def<T: Serializer + StructSerializer>(
 #[inline(always)]
 pub fn write_type_info<T: Serializer>(context: &mut WriteContext, _is_field: bool) {
     let type_id = T::fory_get_type_id(context.get_fory());
-    context.writer.write_var_uint32(type_id);
-    if *context.get_fory().get_mode() == Mode::Compatible {
-        let meta_index = context.push_meta(std::any::TypeId::of::<T>()) as u32;
-        context.writer.write_var_uint32(meta_index);
+    context.writer.write_varuint32(type_id);
+    let rs_type_id = std::any::TypeId::of::<T>();
+
+    if type_id & 0xff == TypeId::NAMED_STRUCT as u32 {
+        if context.get_fory().is_share_meta() {
+            let meta_index = context.push_meta(rs_type_id) as u32;
+            context.writer.write_varuint32(meta_index);
+        } else {
+            let type_info = context
+                .get_fory()
+                .get_type_resolver()
+                .get_type_info(rs_type_id);
+            let _namespace = type_info.get_namespace();
+            let _type_name = type_info.get_type_name();
+            unimplemented!("unimplement NamedStruct::write_type_info in consistent_mode")
+        }
+    } else if type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
+        || type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32
+    {
+        let meta_index = context.push_meta(rs_type_id) as u32;
+        context.writer.write_varuint32(meta_index);
     }
 }
 
 #[inline(always)]
 pub fn read_type_info<T: Serializer>(context: &mut ReadContext, _is_field: bool) {
-    let remote_type_id = context.reader.read_var_uint32();
-    assert_eq!(remote_type_id, T::fory_get_type_id(context.get_fory()));
-    if *context.get_fory().get_mode() == Mode::Compatible {
-        let _meta_index = context.reader.read_var_uint32();
+    let remote_type_id = context.reader.read_varuint32();
+    let local_type_id = T::fory_get_type_id(context.get_fory());
+    assert_eq!(remote_type_id, local_type_id);
+
+    if local_type_id & 0xff == TypeId::NAMED_STRUCT as u32 {
+        if context.get_fory().is_share_meta() {
+            let _meta_index = context.reader.read_varuint32();
+        } else {
+            unimplemented!("unimplement NamedStruct::read_type_info when non-share_meta")
+        }
+    } else if local_type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
+        || local_type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32
+    {
+        let _meta_index = context.reader.read_varuint32();
     }
 }
 

--- a/rust/fory-core/src/types.rs
+++ b/rust/fory-core/src/types.rs
@@ -88,8 +88,6 @@ pub enum TypeId {
     ForyNullable = 265,
 }
 
-pub trait ForyGeneralList {}
-
 const MAX_UNT32: u64 = (1 << 31) - 1;
 
 // todo: struct hash

--- a/rust/fory-core/src/util.rs
+++ b/rust/fory-core/src/util.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::types::TypeId;
 use chrono::NaiveDate;
 use std::ptr;
 
@@ -118,4 +119,13 @@ pub fn to_utf8(utf16: &[u16], is_little_endian: bool) -> Result<Vec<u8>, String>
         utf8_bytes.set_len(offset);
     }
     Ok(utf8_bytes)
+}
+
+pub fn get_ext_actual_type_id(type_id: u32, register_by_name: bool) -> u32 {
+    (type_id << 8)
+        + if register_by_name {
+            TypeId::NAMED_EXT as u32
+        } else {
+            TypeId::EXT as u32
+        }
 }

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -56,7 +56,7 @@ pub fn gen_write(data_enum: &DataEnum) -> TokenStream {
         match self {
             #(
                 Self::#variant_idents => {
-                    context.writer.var_uint32(#variant_values);
+                    context.writer.write_var_uint32(#variant_values);
                 }
             )*
         }
@@ -67,7 +67,7 @@ pub fn gen_read(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
     quote! {
-        let ordinal = context.reader.var_uint32();
+        let ordinal = context.reader.read_var_uint32();
         match ordinal {
            #(
                #variant_values => Ok(Self::#variant_idents),

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -56,7 +56,7 @@ pub fn gen_write_data(data_enum: &DataEnum) -> TokenStream {
         match self {
             #(
                 Self::#variant_idents => {
-                    context.writer.write_var_uint32(#variant_values);
+                    context.writer.write_varuint32(#variant_values);
                 }
             )*
         }
@@ -67,7 +67,7 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
     quote! {
-        let ordinal = context.reader.read_var_uint32();
+        let ordinal = context.reader.read_varuint32();
         match ordinal {
            #(
                #variant_values => Ok(Self::#variant_idents),

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -49,7 +49,7 @@ pub fn gen_read_type_info() -> TokenStream {
     }
 }
 
-pub fn gen_write(data_enum: &DataEnum) -> TokenStream {
+pub fn gen_write_data(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
     quote! {
@@ -63,7 +63,7 @@ pub fn gen_write(data_enum: &DataEnum) -> TokenStream {
     }
 }
 
-pub fn gen_read(data_enum: &DataEnum) -> TokenStream {
+pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
     let variant_idents: Vec<_> = data_enum.variants.iter().map(|v| &v.ident).collect();
     let variant_values: Vec<_> = (0..variant_idents.len()).map(|v| v as u32).collect();
     quote! {
@@ -83,14 +83,14 @@ pub fn gen_read_compatible() -> TokenStream {
     }
 }
 
-pub fn gen_serialize(_data_enum: &DataEnum) -> TokenStream {
+pub fn gen_write(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::serialize::<Self>(self, context, is_field)
+        fory_core::serializer::enum_::write::<Self>(self, context, is_field)
     }
 }
 
-pub fn gen_deserialize(_data_enum: &DataEnum) -> TokenStream {
+pub fn gen_read(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::deserialize::<Self>(context, is_field)
+        fory_core::serializer::enum_::read::<Self>(context, is_field)
     }
 }

--- a/rust/fory-derive/src/object/misc.rs
+++ b/rust/fory-derive/src/object/misc.rs
@@ -36,7 +36,7 @@ fn hash(fields: &[&Field]) -> TokenStream {
         let ty = &field.ty;
         let name = format!("{}", field.ident.as_ref().expect("should be field name"));
         quote! {
-            (#name, <#ty as fory_core::serializer::Serializer>::get_type_id())
+            (#name, <#ty as fory_core::serializer::Serializer>::fory_get_type_id())
         }
     });
 

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -128,7 +128,7 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
 
 pub fn gen_deserialize(struct_ident: &Ident) -> TokenStream {
     quote! {
-        let ref_flag = context.reader.i8();
+        let ref_flag = context.reader.read_i8();
         if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::types::RefFlag::RefValue as i8) {
             match context.get_fory().get_mode() {
                 fory_core::types::Mode::SchemaConsistent => {
@@ -206,8 +206,8 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
     let declare_ts: Vec<TokenStream> = declare_var(fields);
     let assign_ts: Vec<TokenStream> = assign_value(fields);
     quote! {
-        let remote_type_id = context.reader.var_uint32();
-        let meta_index = context.reader.var_uint32();
+        let remote_type_id = context.reader.read_var_uint32();
+        let meta_index = context.reader.read_var_uint32();
         let meta = context.get_meta(meta_index as usize);
         let fields = {
             let meta = context.get_meta(meta_index as usize);

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -26,7 +26,7 @@ fn create_private_field_name(field: &Field) -> Ident {
 }
 
 fn create_deserialize_nullable_fn_name(field: &Field) -> Ident {
-    format_ident!("_deserialize_nullable_{}", field.ident.as_ref().expect(""))
+    format_ident!("fory_deserialize_nullable_{}", field.ident.as_ref().expect(""))
 }
 
 fn declare_var(fields: &[&Field]) -> Vec<TokenStream> {
@@ -99,7 +99,7 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
         });
         quote! {
              #(#declare_var_ts)*
-            let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::get_sorted_field_names(context.get_fory());
+            let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::fory_get_sorted_field_names(context.get_fory());
             for field_name in sorted_field_names {
                 match field_name.as_str() {
                     #(#match_ts),*
@@ -132,11 +132,11 @@ pub fn gen_deserialize(struct_ident: &Ident) -> TokenStream {
         if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::types::RefFlag::RefValue as i8) {
             match context.get_fory().get_mode() {
                 fory_core::types::Mode::SchemaConsistent => {
-                    Self::read_type_info(context, false);
-                    Self::read(context)
+                    Self::fory_read_type_info(context, false);
+                    Self::fory_read(context)
                 },
                 fory_core::types::Mode::Compatible => {
-                    <#struct_ident as fory_core::serializer::StructSerializer>::read_compatible(context)
+                    <#struct_ident as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
                 },
                 _ => unreachable!()
             }

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -25,8 +25,8 @@ fn create_private_field_name(field: &Field) -> Ident {
     format_ident!("_{}", field.ident.as_ref().expect(""))
 }
 
-fn create_deserialize_nullable_fn_name(field: &Field) -> Ident {
-    format_ident!("fory_deserialize_nullable_{}", field.ident.as_ref().expect(""))
+fn create_read_nullable_fn_name(field: &Field) -> Ident {
+    format_ident!("fory_read_nullable_{}", field.ident.as_ref().expect(""))
 }
 
 fn declare_var(fields: &[&Field]) -> Vec<TokenStream> {
@@ -61,7 +61,7 @@ pub fn gen_read_type_info() -> TokenStream {
     }
 }
 
-pub fn gen_read(fields: &[&Field]) -> TokenStream {
+pub fn gen_read_data(fields: &[&Field]) -> TokenStream {
     // read way before:
     // let assign_stmt = fields.iter().map(|field| {
     //     let ty = &field.ty;
@@ -74,7 +74,7 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
         .iter()
         .map(|f| create_private_field_name(f))
         .collect();
-    let sorted_deserialize = if fields.is_empty() {
+    let sorted_read = if fields.is_empty() {
         quote! {}
     } else {
         let declare_var_ts =
@@ -93,7 +93,7 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
             quote! {
                 #name_str => {
                     let skip_ref_flag = fory_core::serializer::get_skip_ref_flag::<#ty>(context.get_fory());
-                    #private_ident = fory_core::serializer::read_data::<#ty>(context, true, skip_ref_flag, false)?;
+                    #private_ident = fory_core::serializer::read_info_data::<#ty>(context, true, skip_ref_flag, false)?;
                 }
             }
         });
@@ -118,7 +118,7 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
             }
         });
     quote! {
-        #sorted_deserialize
+        #sorted_read
         Ok(Self {
             #(#field_idents),*
             // #(#assign_stmt),*
@@ -126,14 +126,14 @@ pub fn gen_read(fields: &[&Field]) -> TokenStream {
     }
 }
 
-pub fn gen_deserialize(struct_ident: &Ident) -> TokenStream {
+pub fn gen_read(struct_ident: &Ident) -> TokenStream {
     quote! {
         let ref_flag = context.reader.read_i8();
         if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::types::RefFlag::RefValue as i8) {
             match context.get_fory().get_mode() {
                 fory_core::types::Mode::SchemaConsistent => {
                     Self::fory_read_type_info(context, false);
-                    Self::fory_read(context)
+                    Self::fory_read_data(context)
                 },
                 fory_core::types::Mode::Compatible => {
                     <#struct_ident as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
@@ -142,7 +142,7 @@ pub fn gen_deserialize(struct_ident: &Ident) -> TokenStream {
             }
         } else if ref_flag == (fory_core::types::RefFlag::Null as i8) {
             Ok(Self::default())
-            // Err(fory_core::error::AnyhowError::msg("Try to deserialize non-option type to null"))?
+            // Err(fory_core::error::AnyhowError::msg("Try to read non-option type to null"))?
         } else if ref_flag == (fory_core::types::RefFlag::Ref as i8) {
             Err(fory_core::error::Error::Ref)
         } else {
@@ -155,7 +155,7 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
     let pattern_items = fields.iter().map(|field| {
         let ty = &field.ty;
         let var_name = create_private_field_name(field);
-        let deserialize_nullable_fn_name = create_deserialize_nullable_fn_name(field);
+        let read_nullable_fn_name = create_read_nullable_fn_name(field);
 
         let generic_tree = parse_generic_tree(ty);
         // dbg!(&generic_tree);
@@ -173,7 +173,7 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
                 let local_field_type = #generic_token;
                 if &_field.field_type == &local_field_type {
                     let skip_ref_flag = fory_core::serializer::get_skip_ref_flag::<#ty>(context.get_fory());
-                    #var_name = Some(fory_core::serializer::read_data::<#ty>(context, true, skip_ref_flag, false).unwrap_or_else(|_err| {
+                    #var_name = Some(fory_core::serializer::read_info_data::<#ty>(context, true, skip_ref_flag, false).unwrap_or_else(|_err| {
                         // same type, err means something wrong
                         panic!("Err at deserializing {:?}: {:?}", #field_name_str, _err);
                     }));
@@ -189,7 +189,7 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
                     } else {
                         println!("Try to deserialize_compatible: {}", #field_name_str);
                         #var_name = Some(
-                            #struct_ident::#deserialize_nullable_fn_name(
+                            #struct_ident::#read_nullable_fn_name(
                                 context,
                                 &local_nullable_type,
                                 &remote_nullable_type
@@ -228,15 +228,15 @@ pub fn gen_read_compatible(fields: &[&Field], struct_ident: &Ident) -> TokenStre
     }
 }
 
-pub fn gen_deserialize_nullable(fields: &[&Field]) -> TokenStream {
+pub fn gen_read_nullable(fields: &[&Field]) -> TokenStream {
     let func_tokens: Vec<TokenStream> = fields
         .iter()
         .map(|field| {
-            let fn_name = create_deserialize_nullable_fn_name(field);
+            let fn_name = create_read_nullable_fn_name(field);
             let ty = &field.ty;
             let generic_tree = parse_generic_tree(ty);
             let nullable_generic_tree = NullableTypeNode::from(generic_tree);
-            let deserialize_tokens = nullable_generic_tree.to_deserialize_tokens(&vec![], true);
+            let read_tokens = nullable_generic_tree.to_read_tokens(&vec![], true);
             quote! {
                 fn #fn_name(
                     context: &mut fory_core::resolver::context::ReadContext,
@@ -245,7 +245,7 @@ pub fn gen_deserialize_nullable(fields: &[&Field]) -> TokenStream {
                 ) -> Result<#ty, fory_core::error::Error> {
                     // println!("remote:{:#?}", remote_nullable_type);
                     // println!("local:{:#?}", local_nullable_type);
-                    #deserialize_tokens
+                    #read_tokens
                 }
             }
         })

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -108,7 +108,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
                 #get_sorted_field_names_ts
             }
 
-            fn fory_type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: &str, type_name: &str, register_by_name: bool) -> Vec<u8> {
+            fn fory_type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: fory_core::meta::MetaString, type_name: fory_core::meta::MetaString, register_by_name: bool) -> Vec<u8> {
                 #type_def_ts
             }
 
@@ -116,7 +116,6 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
                 #read_compatible_ts
             }
         }
-        impl fory_core::types::ForyGeneralList for #name {}
         impl fory_core::serializer::Serializer for #name {
             fn fory_get_type_id(fory: &fory_core::fory::Fory) -> u32 {
                 fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_idx)
@@ -138,7 +137,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
                 #write_data_ts
             }
 
-            fn fory_read_data(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_data(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) -> Result<Self, fory_core::error::Error> {
                 #read_data_ts
             }
 

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -96,57 +96,57 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl fory_core::serializer::StructSerializer for #name {
-            fn type_index() -> u32 {
+            fn fory_type_index() -> u32 {
                 #type_idx
             }
 
-            fn actual_type_id(type_id: u32, register_by_name: bool, mode: &fory_core::types::Mode) -> u32 {
+            fn fory_actual_type_id(type_id: u32, register_by_name: bool, mode: &fory_core::types::Mode) -> u32 {
                 #actual_type_id_ts
             }
 
-            fn get_sorted_field_names(fory: &fory_core::fory::Fory) -> Vec<String> {
+            fn fory_get_sorted_field_names(fory: &fory_core::fory::Fory) -> Vec<String> {
                 #get_sorted_field_names_ts
             }
 
-            fn type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: &str, type_name: &str, register_by_name: bool) -> Vec<u8> {
+            fn fory_type_def(fory: &fory_core::fory::Fory, type_id: u32, namespace: &str, type_name: &str, register_by_name: bool) -> Vec<u8> {
                 #type_def_ts
             }
 
-            fn read_compatible(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_compatible(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
                 #read_compatible_ts
             }
         }
         impl fory_core::types::ForyGeneralList for #name {}
         impl fory_core::serializer::Serializer for #name {
-            fn get_type_id(fory: &fory_core::fory::Fory) -> u32 {
+            fn fory_get_type_id(fory: &fory_core::fory::Fory) -> u32 {
                 fory.get_type_resolver().get_type_id(&std::any::TypeId::of::<Self>(), #type_idx)
             }
 
-            fn reserved_space() -> usize {
+            fn fory_reserved_space() -> usize {
                 #reserved_space_ts
             }
 
-            fn write_type_info(context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+            fn fory_write_type_info(context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
                 #write_type_info_ts
             }
 
-            fn read_type_info(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) {
+            fn fory_read_type_info(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) {
                 #read_type_info_ts
             }
 
-            fn write(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+            fn fory_write(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
                 #write_ts
             }
 
-            fn read(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
+            fn fory_read(context: &mut fory_core::resolver::context::ReadContext) -> Result<Self, fory_core::error::Error> {
                 #read_ts
             }
 
-            fn serialize(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
+            fn fory_serialize(&self, context: &mut fory_core::resolver::context::WriteContext, is_field: bool) {
                 #serialize_ts
             }
 
-            fn deserialize(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) -> Result<Self, fory_core::error::Error> {
+            fn fory_deserialize(context: &mut fory_core::resolver::context::ReadContext, is_field: bool) -> Result<Self, fory_core::error::Error> {
                 #deserialize_ts
             }
         }

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -42,14 +42,14 @@ macro_rules! basic_type_deserialize {
                     if $nullable {
                         quote! {
                             <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::fory_read_data(context)
+                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::fory_read_data(context, true)
                                 .map_err(fory_core::error::Error::from)?);
                             Ok::<Option<$ty>, fory_core::error::Error>(res1)
                         }
                     } else {
                         quote! {
                             <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                            let res2 = <$ty as fory_core::serializer::Serializer>::fory_read_data(context)
+                            let res2 = <$ty as fory_core::serializer::Serializer>::fory_read_data(context, true)
                                 .map_err(fory_core::error::Error::from)?;
                             Ok::<$ty, fory_core::error::Error>(res2)
                         }
@@ -122,7 +122,7 @@ impl NullableTypeNode {
                         None
                     } else {
                         <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                        Some(<#ty_type as fory_core::serializer::Serializer>::fory_read_data(context)
+                        Some(<#ty_type as fory_core::serializer::Serializer>::fory_read_data(context, true)
                             .map_err(fory_core::error::Error::from)?)
                     };
                     Ok::<Option<#ty_type>, fory_core::error::Error>(res1)
@@ -133,7 +133,7 @@ impl NullableTypeNode {
                         Vec::default()
                     } else {
                         <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                        <#ty_type as fory_core::serializer::Serializer>::fory_read_data(context)
+                        <#ty_type as fory_core::serializer::Serializer>::fory_read_data(context, true)
                             .map_err(fory_core::error::Error::from)?
                     };
                     Ok::<#ty_type, fory_core::error::Error>(res2)
@@ -162,7 +162,7 @@ impl NullableTypeNode {
                     let element_tokens = generic_node.to_read_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let vec_ts = quote! {
-                        let length = context.reader.read_var_uint32() as usize;
+                        let length = context.reader.read_varuint32() as usize;
                         if length == 0 {
                             Vec::default()
                         } else {
@@ -213,7 +213,7 @@ impl NullableTypeNode {
                     let element_tokens = generic_node.to_read_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let set_ts = quote! {
-                        let length = context.reader.read_var_uint32() as usize;
+                        let length = context.reader.read_varuint32() as usize;
                         if length == 0 {
                             HashSet::default()
                         } else {
@@ -272,7 +272,7 @@ impl NullableTypeNode {
                     let val_ty: Type = parse_str(&val_generic_node.to_string()).unwrap();
 
                     let map_ts = quote! {
-                        let length = context.reader.read_var_uint32();
+                        let length = context.reader.read_varuint32();
                         let mut map = HashMap::with_capacity(length as usize);
                         if length == 0 {
                             map

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -162,18 +162,18 @@ impl NullableTypeNode {
                     let element_tokens = generic_node.to_deserialize_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let vec_ts = quote! {
-                        let length = context.reader.var_uint32() as usize;
+                        let length = context.reader.read_var_uint32() as usize;
                         if length == 0 {
                             Vec::default()
                         } else {
                             let mut v = Vec::with_capacity(length);
-                            let header = context.reader.u8();
+                            let header = context.reader.read_u8();
                             let has_null = (header & fory_core::serializer::collection::HAS_NULL) != 0;
                             let is_same_type = (header & fory_core::serializer::collection::IS_SAME_TYPE) != 0;
                             let read_ref_flag = !(is_same_type && !has_null);
                             for _ in 0..length {
                                 let ref_flag = if read_ref_flag {
-                                    context.reader.i8()
+                                    context.reader.read_i8()
                                 } else {
                                     fory_core::types::RefFlag::NotNullValue as i8
                                 };
@@ -213,18 +213,18 @@ impl NullableTypeNode {
                     let element_tokens = generic_node.to_deserialize_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let set_ts = quote! {
-                        let length = context.reader.var_uint32() as usize;
+                        let length = context.reader.read_var_uint32() as usize;
                         if length == 0 {
                             HashSet::default()
                         } else {
                             let mut s = HashSet::with_capacity(length);
-                            let header = context.reader.u8();
+                            let header = context.reader.read_u8();
                             let has_null = (header & fory_core::serializer::collection::HAS_NULL) != 0;
                             let is_same_type = (header & fory_core::serializer::collection::IS_SAME_TYPE) != 0;
                             let read_ref_flag = !(is_same_type && !has_null);
                             for _ in 0..length {
                                 let ref_flag = if read_ref_flag {
-                                    context.reader.i8()
+                                    context.reader.read_i8()
                                 } else {
                                     fory_core::types::RefFlag::NotNullValue as i8
                                 };
@@ -272,7 +272,7 @@ impl NullableTypeNode {
                     let val_ty: Type = parse_str(&val_generic_node.to_string()).unwrap();
 
                     let map_ts = quote! {
-                        let length = context.reader.var_uint32();
+                        let length = context.reader.read_var_uint32();
                         let mut map = HashMap::with_capacity(length as usize);
                         if length == 0 {
                             map
@@ -282,7 +282,7 @@ impl NullableTypeNode {
                                 if len_counter == length {
                                     break;
                                 }
-                                let header = context.reader.u8();
+                                let header = context.reader.read_u8();
                                 if header & fory_core::serializer::map::KEY_NULL != 0 && header & fory_core::serializer::map::VALUE_NULL != 0 {
                                     map.insert(<#key_ty>::default(), <#val_ty>::default());
                                     len_counter += 1;
@@ -300,7 +300,7 @@ impl NullableTypeNode {
                                     len_counter += 1;
                                     continue;
                                 }
-                                let chunk_size = context.reader.u8();
+                                let chunk_size = context.reader.read_u8();
                                 <#key_ty as fory_core::serializer::Serializer>::read_type_info(context, true);
                                 <#val_ty as fory_core::serializer::Serializer>::read_type_info(context, true);
                                 for _ in (0..chunk_size).enumerate() {
@@ -396,7 +396,7 @@ impl NullableTypeNode {
             quote! {
                 let read_ref_flag = fory_core::serializer::skip::get_read_ref_flag(cur_remote_nullable_type);
                 let ref_flag = if read_ref_flag {
-                    context.reader.i8()
+                    context.reader.read_i8()
                 } else {
                     fory_core::types::RefFlag::NotNullValue as i8
                 };

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -41,15 +41,15 @@ macro_rules! basic_type_deserialize {
                 $ty_str => {
                     if $nullable {
                         quote! {
-                            <$ty as fory_core::serializer::Serializer>::read_type_info(context, true);
-                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::read(context)
+                            <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
+                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::fory_read(context)
                                 .map_err(fory_core::error::Error::from)?);
                             Ok::<Option<$ty>, fory_core::error::Error>(res1)
                         }
                     } else {
                         quote! {
-                            <$ty as fory_core::serializer::Serializer>::read_type_info(context, true);
-                            let res2 = <$ty as fory_core::serializer::Serializer>::read(context)
+                            <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
+                            let res2 = <$ty as fory_core::serializer::Serializer>::fory_read(context)
                                 .map_err(fory_core::error::Error::from)?;
                             Ok::<$ty, fory_core::error::Error>(res2)
                         }
@@ -121,8 +121,8 @@ impl NullableTypeNode {
                     let res1 = if cur_remote_nullable_type.nullable && ref_flag == (fory_core::types::RefFlag::Null as i8) {
                         None
                     } else {
-                        <#ty_type as fory_core::serializer::Serializer>::read_type_info(context, true);
-                        Some(<#ty_type as fory_core::serializer::Serializer>::read(context)
+                        <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
+                        Some(<#ty_type as fory_core::serializer::Serializer>::fory_read(context)
                             .map_err(fory_core::error::Error::from)?)
                     };
                     Ok::<Option<#ty_type>, fory_core::error::Error>(res1)
@@ -132,8 +132,8 @@ impl NullableTypeNode {
                     let res2 = if cur_remote_nullable_type.nullable && ref_flag == (fory_core::types::RefFlag::Null as i8) {
                         Vec::default()
                     } else {
-                        <#ty_type as fory_core::serializer::Serializer>::read_type_info(context, true);
-                        <#ty_type as fory_core::serializer::Serializer>::read(context)
+                        <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
+                        <#ty_type as fory_core::serializer::Serializer>::fory_read(context)
                             .map_err(fory_core::error::Error::from)?
                     };
                     Ok::<#ty_type, fory_core::error::Error>(res2)
@@ -301,8 +301,8 @@ impl NullableTypeNode {
                                     continue;
                                 }
                                 let chunk_size = context.reader.read_u8();
-                                <#key_ty as fory_core::serializer::Serializer>::read_type_info(context, true);
-                                <#val_ty as fory_core::serializer::Serializer>::read_type_info(context, true);
+                                <#key_ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
+                                <#val_ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
                                 for _ in (0..chunk_size).enumerate() {
                                     let key: #key_ty = {#key_tokens}?;
                                     let value: #val_ty = {#val_tokens}?;
@@ -347,10 +347,10 @@ impl NullableTypeNode {
                         let type_id = cur_remote_nullable_type.type_id;
                         let internal_id = type_id & 0xff;
                         Some(if internal_id == COMPATIBLE_STRUCT_ID || internal_id == NAMED_COMPATIBLE_STRUCT_ID {
-                            <#nullable_ty as fory_core::serializer::StructSerializer>::read_compatible(context)
+                            <#nullable_ty as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
                                     .map_err(fory_core::error::Error::from)?
                         } else if internal_id == ENUM_ID || internal_id == NAMED_ENUM_ID {
-                            <#nullable_ty as fory_core::serializer::StructSerializer>::read_compatible(context)
+                            <#nullable_ty as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
                                 .map_err(fory_core::error::Error::from)?
                         } else {
                             unimplemented!()
@@ -366,10 +366,10 @@ impl NullableTypeNode {
                         let type_id = cur_remote_nullable_type.type_id;
                         let internal_id = type_id & 0xff;
                         if internal_id == COMPATIBLE_STRUCT_ID || internal_id == NAMED_COMPATIBLE_STRUCT_ID {
-                            <#nullable_ty as fory_core::serializer::StructSerializer>::read_compatible(context)
+                            <#nullable_ty as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
                                     .map_err(fory_core::error::Error::from)?
                         } else if internal_id == ENUM_ID || internal_id == NAMED_ENUM_ID {
-                            <#nullable_ty as fory_core::serializer::StructSerializer>::read_compatible(context)
+                            <#nullable_ty as fory_core::serializer::StructSerializer>::fory_read_compatible(context)
                                 .map_err(fory_core::error::Error::from)?
                         } else {
                             unimplemented!("")
@@ -568,7 +568,7 @@ pub(super) fn generic_tree_to_tokens(node: &TypeNode, have_context: bool) -> Tok
         ts
     } else {
         quote! {
-            <#ty as fory_core::serializer::Serializer>::get_type_id(#param)
+            <#ty as fory_core::serializer::Serializer>::fory_get_type_id(#param)
         }
     };
     quote! {
@@ -845,7 +845,7 @@ pub(super) fn get_sort_fields_ts(fields: &[&Field]) -> TokenStream {
                 .map(|(name, ty, _)| {
                     let ty_type: Type = syn::parse_str(ty).unwrap();
                     quote! {
-                        let field_type_id = <#ty_type as fory_core::serializer::Serializer>::get_type_id(fory);
+                        let field_type_id = <#ty_type as fory_core::serializer::Serializer>::fory_get_type_id(fory);
                         let internal_id = field_type_id & 0xff;
                         if internal_id == fory_core::types::TypeId::COMPATIBLE_STRUCT as u32 || internal_id == fory_core::types::TypeId::NAMED_COMPATIBLE_STRUCT as u32 || internal_id == fory_core::types::TypeId::STRUCT as u32 || internal_id == fory_core::types::TypeId::NAMED_STRUCT as u32 {
                             other_fields.push((field_type_id, #name.to_string()));

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -42,14 +42,14 @@ macro_rules! basic_type_deserialize {
                     if $nullable {
                         quote! {
                             <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::fory_read(context)
+                            let res1 = Some(<$ty as fory_core::serializer::Serializer>::fory_read_data(context)
                                 .map_err(fory_core::error::Error::from)?);
                             Ok::<Option<$ty>, fory_core::error::Error>(res1)
                         }
                     } else {
                         quote! {
                             <$ty as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                            let res2 = <$ty as fory_core::serializer::Serializer>::fory_read(context)
+                            let res2 = <$ty as fory_core::serializer::Serializer>::fory_read_data(context)
                                 .map_err(fory_core::error::Error::from)?;
                             Ok::<$ty, fory_core::error::Error>(res2)
                         }
@@ -108,7 +108,7 @@ pub fn try_primitive_vec_type_name(node: &NullableTypeNode) -> Option<String> {
 }
 
 impl NullableTypeNode {
-    pub(super) fn to_deserialize_tokens(
+    pub(super) fn to_read_tokens(
         &self,
         generic_path: &Vec<i8>,
         read_ref_flag: bool,
@@ -122,7 +122,7 @@ impl NullableTypeNode {
                         None
                     } else {
                         <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                        Some(<#ty_type as fory_core::serializer::Serializer>::fory_read(context)
+                        Some(<#ty_type as fory_core::serializer::Serializer>::fory_read_data(context)
                             .map_err(fory_core::error::Error::from)?)
                     };
                     Ok::<Option<#ty_type>, fory_core::error::Error>(res1)
@@ -133,7 +133,7 @@ impl NullableTypeNode {
                         Vec::default()
                     } else {
                         <#ty_type as fory_core::serializer::Serializer>::fory_read_type_info(context, true);
-                        <#ty_type as fory_core::serializer::Serializer>::fory_read(context)
+                        <#ty_type as fory_core::serializer::Serializer>::fory_read_data(context)
                             .map_err(fory_core::error::Error::from)?
                     };
                     Ok::<#ty_type, fory_core::error::Error>(res2)
@@ -159,7 +159,7 @@ impl NullableTypeNode {
                 "Vec" => {
                     new_path.push(0);
                     let generic_node = self.generics.first().unwrap();
-                    let element_tokens = generic_node.to_deserialize_tokens(&new_path, false);
+                    let element_tokens = generic_node.to_read_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let vec_ts = quote! {
                         let length = context.reader.read_var_uint32() as usize;
@@ -210,7 +210,7 @@ impl NullableTypeNode {
                 "HashSet" => {
                     new_path.push(0);
                     let generic_node = self.generics.first().unwrap();
-                    let element_tokens = generic_node.to_deserialize_tokens(&new_path, false);
+                    let element_tokens = generic_node.to_read_tokens(&new_path, false);
                     let element_ty: Type = parse_str(&generic_node.to_string()).unwrap();
                     let set_ts = quote! {
                         let length = context.reader.read_var_uint32() as usize;
@@ -263,10 +263,10 @@ impl NullableTypeNode {
                     let val_generic_node = self.generics.get(1).unwrap();
 
                     new_path.push(0);
-                    let key_tokens = key_generic_node.to_deserialize_tokens(&new_path, false);
+                    let key_tokens = key_generic_node.to_read_tokens(&new_path, false);
                     new_path.pop();
                     new_path.push(1);
-                    let val_tokens = val_generic_node.to_deserialize_tokens(&new_path, false);
+                    let val_tokens = val_generic_node.to_read_tokens(&new_path, false);
 
                     let key_ty: Type = parse_str(&key_generic_node.to_string()).unwrap();
                     let val_ty: Type = parse_str(&val_generic_node.to_string()).unwrap();

--- a/rust/fory-derive/src/object/write.rs
+++ b/rust/fory-derive/src/object/write.rs
@@ -57,7 +57,7 @@ pub fn gen_write_data(fields: &[&Field]) -> TokenStream {
             quote! {
                 #name_str => {
                     let skip_ref_flag = fory_core::serializer::get_skip_ref_flag::<#ty>(context.get_fory());
-                    fory_core::serializer::write_info_data::<#ty>(&self.#ident, context, true, skip_ref_flag, false);
+                    fory_core::serializer::write_ref_info_data::<#ty>(&self.#ident, context, true, skip_ref_flag, false);
                 }
             }
         });

--- a/rust/fory-derive/src/object/write.rs
+++ b/rust/fory-derive/src/object/write.rs
@@ -39,7 +39,7 @@ pub fn gen_write_type_info() -> TokenStream {
     }
 }
 
-pub fn gen_write(fields: &[&Field]) -> TokenStream {
+pub fn gen_write_data(fields: &[&Field]) -> TokenStream {
     // let accessor_expr = fields.iter().map(|field| {
     //     let ty = &field.ty;
     //     let ident = &field.ident;
@@ -57,7 +57,7 @@ pub fn gen_write(fields: &[&Field]) -> TokenStream {
             quote! {
                 #name_str => {
                     let skip_ref_flag = fory_core::serializer::get_skip_ref_flag::<#ty>(context.get_fory());
-                    fory_core::serializer::write_data::<#ty>(&self.#ident, context, true, skip_ref_flag, false);
+                    fory_core::serializer::write_info_data::<#ty>(&self.#ident, context, true, skip_ref_flag, false);
                 }
             }
         });
@@ -79,8 +79,8 @@ pub fn gen_write(fields: &[&Field]) -> TokenStream {
     }
 }
 
-pub fn gen_serialize() -> TokenStream {
+pub fn gen_write() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::serialize::<Self>(self, context, is_field)
+        fory_core::serializer::struct_::write::<Self>(self, context, is_field)
     }
 }

--- a/rust/fory-derive/src/object/write.rs
+++ b/rust/fory-derive/src/object/write.rs
@@ -23,7 +23,7 @@ pub fn gen_reserved_space(fields: &[&Field]) -> TokenStream {
     let reserved_size_expr: Vec<_> = fields.iter().map(|field| {
         let ty = &field.ty;
         quote! {
-            <#ty as fory_core::serializer::Serializer>::reserved_space() + fory_core::types::SIZE_OF_REF_AND_TYPE
+            <#ty as fory_core::serializer::Serializer>::fory_reserved_space() + fory_core::types::SIZE_OF_REF_AND_TYPE
         }
     }).collect();
     if reserved_size_expr.is_empty() {
@@ -62,7 +62,7 @@ pub fn gen_write(fields: &[&Field]) -> TokenStream {
             }
         });
         quote! {
-            let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::get_sorted_field_names(context.get_fory());
+            let sorted_field_names = <Self as fory_core::serializer::StructSerializer>::fory_get_sorted_field_names(context.get_fory());
             for field_name in sorted_field_names {
                 match field_name.as_str() {
                     #(#match_ts),*

--- a/rust/tests/tests/test_buffer.rs
+++ b/rust/tests/tests/test_buffer.rs
@@ -18,7 +18,7 @@
 use fory_core::buffer::{Reader, Writer};
 
 #[test]
-fn test_var_int32() {
+fn test_varint32() {
     let test_data: Vec<i32> = vec![
         // 1 byte(0..127)
         0,
@@ -42,24 +42,24 @@ fn test_var_int32() {
     ];
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.write_var_int32(data);
+        writer.write_varint32(data);
         let binding = writer.dump();
         let mut reader = Reader::new(binding.as_slice());
-        let res = reader.read_var_int32();
+        let res = reader.read_varint32();
         assert_eq!(res, data);
     }
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.write_var_uint32(data as u32);
+        writer.write_varuint32(data as u32);
         let binding = writer.dump();
         let mut reader = Reader::new(binding.as_slice());
-        let res = reader.read_var_uint32();
+        let res = reader.read_varuint32();
         assert_eq!(res, data as u32);
     }
 }
 
 #[test]
-fn test_var_uint36_small() {
+fn test_varuint36_small() {
     let test_data: Vec<u64> = vec![
         // 1 byte
         0,
@@ -85,11 +85,11 @@ fn test_var_uint36_small() {
 
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.write_var_uint36_small(data);
+        writer.write_varuint36_small(data);
         let buf = writer.dump();
 
         let mut reader = Reader::new(buf.as_slice());
-        let value = reader.var_uint36_small();
+        let value = reader.read_varuint36small();
         assert_eq!(value, data, "failed for data {}", data);
     }
 }

--- a/rust/tests/tests/test_buffer.rs
+++ b/rust/tests/tests/test_buffer.rs
@@ -42,18 +42,18 @@ fn test_var_int32() {
     ];
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.var_int32(data);
+        writer.write_var_int32(data);
         let binding = writer.dump();
         let mut reader = Reader::new(binding.as_slice());
-        let res = reader.var_int32();
+        let res = reader.read_var_int32();
         assert_eq!(res, data);
     }
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.var_uint32(data as u32);
+        writer.write_var_uint32(data as u32);
         let binding = writer.dump();
         let mut reader = Reader::new(binding.as_slice());
-        let res = reader.var_uint32();
+        let res = reader.read_var_uint32();
         assert_eq!(res, data as u32);
     }
 }
@@ -85,7 +85,7 @@ fn test_var_uint36_small() {
 
     for &data in &test_data {
         let mut writer = Writer::default();
-        writer.var_uint36_small(data);
+        writer.write_var_uint36_small(data);
         let buf = writer.dump();
 
         let mut reader = Reader::new(buf.as_slice());

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -65,29 +65,29 @@ fn test_buffer() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
     let mut reader = Reader::new(bytes.as_slice());
-    assert_eq!(reader.u8(), 1);
-    assert_eq!(reader.i8(), i8::MAX);
-    assert_eq!(reader.i16(), i16::MAX);
-    assert_eq!(reader.i32(), i32::MAX);
-    assert_eq!(reader.i64(), i64::MAX);
-    assert_eq!(reader.f32(), -1.1f32);
-    assert_eq!(reader.f64(), -1.1f64);
-    assert_eq!(reader.var_uint32(), 100);
-    let bytes_size = reader.i32() as usize;
+    assert_eq!(reader.read_u8(), 1);
+    assert_eq!(reader.read_i8(), i8::MAX);
+    assert_eq!(reader.read_i16(), i16::MAX);
+    assert_eq!(reader.read_i32(), i32::MAX);
+    assert_eq!(reader.read_i64(), i64::MAX);
+    assert_eq!(reader.read_f32(), -1.1f32);
+    assert_eq!(reader.read_f64(), -1.1f64);
+    assert_eq!(reader.read_var_uint32(), 100);
+    let bytes_size = reader.read_i32() as usize;
     let binary = b"ab";
-    assert_eq!(reader.bytes(bytes_size), binary);
+    assert_eq!(reader.read_bytes(bytes_size), binary);
 
     let mut writer = Writer::default();
-    writer.u8(1);
-    writer.i8(i8::MAX);
-    writer.i16(i16::MAX);
-    writer.i32(i32::MAX);
-    writer.i64(i64::MAX);
-    writer.f32(-1.1);
-    writer.f64(-1.1);
-    writer.var_uint32(100);
-    writer.i32(binary.len() as i32);
-    writer.bytes(binary);
+    writer.write_u8(1);
+    writer.write_i8(i8::MAX);
+    writer.write_i16(i16::MAX);
+    writer.write_i32(i32::MAX);
+    writer.write_i64(i64::MAX);
+    writer.write_f32(-1.1);
+    writer.write_f64(-1.1);
+    writer.write_var_uint32(100);
+    writer.write_i32(binary.len() as i32);
+    writer.write_bytes(binary);
 
     fs::write(&data_file_path, writer.dump()).unwrap();
 }
@@ -120,7 +120,7 @@ fn test_buffer_var() {
         i32::MAX,
     ];
     for &expected in &var_int32_values {
-        let value = reader.var_int32();
+        let value = reader.read_var_int32();
         assert_eq!(expected, value, "var_int32 value mismatch");
     }
     let var_uint32_values = vec![
@@ -138,7 +138,7 @@ fn test_buffer_var() {
         i32::MAX,
     ];
     for &expected in &var_uint32_values {
-        let value = reader.var_uint32();
+        let value = reader.read_var_uint32();
         assert_eq!(expected, value as i32, "var_uint32 value mismatch");
     }
     let var_uint64_values = vec![
@@ -163,7 +163,7 @@ fn test_buffer_var() {
         i64::MAX as u64,
     ];
     for &expected in &var_uint64_values {
-        let value = reader.var_uint64();
+        let value = reader.read_var_uint64();
         assert_eq!(expected, value, "var_uint64 value mismatch");
     }
     let var_int64_values = vec![
@@ -184,22 +184,22 @@ fn test_buffer_var() {
         i64::MAX,
     ];
     for &expected in &var_int64_values {
-        let value = reader.var_int64();
+        let value = reader.read_var_int64();
         assert_eq!(expected, value, "var_int64 value mismatch");
     }
 
     let mut writer = Writer::default();
     for &value in &var_int32_values {
-        writer.var_int32(value);
+        writer.write_var_int32(value);
     }
     for &value in &var_uint32_values {
-        writer.var_uint32(value as u32);
+        writer.write_var_uint32(value as u32);
     }
     for &value in &var_uint64_values {
-        writer.var_uint64(value);
+        writer.write_var_uint64(value);
     }
     for &value in &var_int64_values {
-        writer.var_int64(value);
+        writer.write_var_int64(value);
     }
     fs::write(data_file_path, writer.dump()).unwrap();
 }
@@ -211,8 +211,8 @@ fn test_murmurhash3() {
     let bytes = fs::read(&data_file_path).unwrap();
     let mut reader = Reader::new(bytes.as_slice());
     let (h1, h2) = murmurhash3_x64_128(&[1, 2, 8], 47);
-    assert_eq!(reader.i64(), h1 as i64);
-    assert_eq!(reader.i64(), h2 as i64);
+    assert_eq!(reader.read_i64(), h1 as i64);
+    assert_eq!(reader.read_i64(), h2 as i64);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn test_list() {
     let item_list = vec![Some(item), Some(item2)];
     let item_list2 = vec![None, Some(item3)];
 
-    let bytes = reader.slice();
+    let bytes = reader.get_slice();
     let remote_str_list: Vec<Option<String>> = fory.deserialize(bytes).unwrap();
     assert_eq!(remote_str_list, str_list);
     let data_bytes1 = fory.serialize(&remote_str_list);

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -246,14 +246,14 @@ fn test_string_serializer() {
     ];
     for s in &test_strings {
         // make is_field=true to skip read/write type_id
-        assert_eq!(*s, String::read(&mut context).unwrap());
-        assert_eq!(*s, String::read(&mut context_compress).unwrap());
+        assert_eq!(*s, String::fory_read(&mut context).unwrap());
+        assert_eq!(*s, String::fory_read(&mut context_compress).unwrap());
     }
     let mut writer = Writer::default();
     let fory = Fory::default().mode(Compatible).xlang(true);
     let mut context = WriteContext::new(&fory, &mut writer);
     for s in &test_strings {
-        s.write(&mut context, true);
+        s.fory_write(&mut context, true);
     }
     fs::write(&data_file_path, context.writer.dump()).unwrap();
 }

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -72,7 +72,7 @@ fn test_buffer() {
     assert_eq!(reader.read_i64(), i64::MAX);
     assert_eq!(reader.read_f32(), -1.1f32);
     assert_eq!(reader.read_f64(), -1.1f64);
-    assert_eq!(reader.read_var_uint32(), 100);
+    assert_eq!(reader.read_varuint32(), 100);
     let bytes_size = reader.read_i32() as usize;
     let binary = b"ab";
     assert_eq!(reader.read_bytes(bytes_size), binary);
@@ -85,7 +85,7 @@ fn test_buffer() {
     writer.write_i64(i64::MAX);
     writer.write_f32(-1.1);
     writer.write_f64(-1.1);
-    writer.write_var_uint32(100);
+    writer.write_varuint32(100);
     writer.write_i32(binary.len() as i32);
     writer.write_bytes(binary);
 
@@ -99,7 +99,7 @@ fn test_buffer_var() {
     let bytes = fs::read(&data_file_path).unwrap();
     let mut reader = Reader::new(bytes.as_slice());
 
-    let var_int32_values = vec![
+    let varint32_values = vec![
         i32::MIN,
         i32::MIN + 1,
         -1000000,
@@ -119,11 +119,11 @@ fn test_buffer_var() {
         i32::MAX - 1,
         i32::MAX,
     ];
-    for &expected in &var_int32_values {
-        let value = reader.read_var_int32();
-        assert_eq!(expected, value, "var_int32 value mismatch");
+    for &expected in &varint32_values {
+        let value = reader.read_varint32();
+        assert_eq!(expected, value, "varint32 value mismatch");
     }
-    let var_uint32_values = vec![
+    let varuint32_values = vec![
         0,
         1,
         127,
@@ -137,11 +137,11 @@ fn test_buffer_var() {
         i32::MAX - 1,
         i32::MAX,
     ];
-    for &expected in &var_uint32_values {
-        let value = reader.read_var_uint32();
-        assert_eq!(expected, value as i32, "var_uint32 value mismatch");
+    for &expected in &varuint32_values {
+        let value = reader.read_varuint32();
+        assert_eq!(expected, value as i32, "varuint32 value mismatch");
     }
-    let var_uint64_values = vec![
+    let varuint64_values = vec![
         0u64,
         1,
         127,
@@ -162,11 +162,11 @@ fn test_buffer_var() {
         72057594037927936,
         i64::MAX as u64,
     ];
-    for &expected in &var_uint64_values {
-        let value = reader.read_var_uint64();
-        assert_eq!(expected, value, "var_uint64 value mismatch");
+    for &expected in &varuint64_values {
+        let value = reader.read_varuint64();
+        assert_eq!(expected, value, "varuint64 value mismatch");
     }
-    let var_int64_values = vec![
+    let varint64_values = vec![
         i64::MIN,
         i64::MIN + 1,
         -1000000000000,
@@ -183,23 +183,23 @@ fn test_buffer_var() {
         i64::MAX - 1,
         i64::MAX,
     ];
-    for &expected in &var_int64_values {
-        let value = reader.read_var_int64();
-        assert_eq!(expected, value, "var_int64 value mismatch");
+    for &expected in &varint64_values {
+        let value = reader.read_varint64();
+        assert_eq!(expected, value, "varint64 value mismatch");
     }
 
     let mut writer = Writer::default();
-    for &value in &var_int32_values {
-        writer.write_var_int32(value);
+    for &value in &varint32_values {
+        writer.write_varint32(value);
     }
-    for &value in &var_uint32_values {
-        writer.write_var_uint32(value as u32);
+    for &value in &varuint32_values {
+        writer.write_varuint32(value as u32);
     }
-    for &value in &var_uint64_values {
-        writer.write_var_uint64(value);
+    for &value in &varuint64_values {
+        writer.write_varuint64(value);
     }
-    for &value in &var_int64_values {
-        writer.write_var_int64(value);
+    for &value in &varint64_values {
+        writer.write_varint64(value);
     }
     fs::write(data_file_path, writer.dump()).unwrap();
 }
@@ -246,8 +246,11 @@ fn test_string_serializer() {
     ];
     for s in &test_strings {
         // make is_field=true to skip read/write type_id
-        assert_eq!(*s, String::fory_read_data(&mut context).unwrap());
-        assert_eq!(*s, String::fory_read_data(&mut context_compress).unwrap());
+        assert_eq!(*s, String::fory_read_data(&mut context, true).unwrap());
+        assert_eq!(
+            *s,
+            String::fory_read_data(&mut context_compress, true).unwrap()
+        );
     }
     let mut writer = Writer::default();
     let fory = Fory::default().mode(Compatible).xlang(true);

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -246,14 +246,14 @@ fn test_string_serializer() {
     ];
     for s in &test_strings {
         // make is_field=true to skip read/write type_id
-        assert_eq!(*s, String::fory_read(&mut context).unwrap());
-        assert_eq!(*s, String::fory_read(&mut context_compress).unwrap());
+        assert_eq!(*s, String::fory_read_data(&mut context).unwrap());
+        assert_eq!(*s, String::fory_read_data(&mut context_compress).unwrap());
     }
     let mut writer = Writer::default();
     let fory = Fory::default().mode(Compatible).xlang(true);
     let mut context = WriteContext::new(&fory, &mut writer);
     for s in &test_strings {
-        s.fory_write(&mut context, true);
+        s.fory_write_data(&mut context, true);
     }
     fs::write(&data_file_path, context.writer.dump()).unwrap();
 }

--- a/rust/tests/tests/test_ext.rs
+++ b/rust/tests/tests/test_ext.rs
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fory_core::error::Error;
+use fory_core::fory::Fory;
+use fory_core::resolver::context::{ReadContext, WriteContext};
+use fory_core::serializer::Serializer;
+use fory_core::types::Mode::Compatible;
+use fory_derive::Fory;
+
+#[test]
+#[allow(dead_code)]
+fn test_duplicate_impl() {
+    #[derive(Debug, Fory, PartialEq, Default)]
+    struct Item1 {
+        f1: i32,
+    }
+    trait OtherSerializer<T> {
+        fn read() -> Result<T, Error>;
+        fn write(&self);
+    }
+    impl OtherSerializer<Item1> for Item1 {
+        fn read() -> Result<Item1, Error> {
+            todo!()
+        }
+
+        fn write(&self) {
+            todo!()
+        }
+    }
+}
+
+#[test]
+fn test_use() {
+    use fory_core::fory::{read, write};
+    #[derive(Debug, PartialEq, Default)]
+    struct Item {
+        f1: i32,
+        f2: i8,
+    }
+    impl Serializer for Item {
+        fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
+            write(&self.f1, context, is_field);
+        }
+
+        fn fory_read_data(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
+            Ok(Self {
+                f1: read(context, is_field)?,
+                f2: 0,
+            })
+        }
+    }
+    let mut fory = Fory::default().mode(Compatible).xlang(true);
+    let item = Item { f1: 1, f2: 2 };
+    fory.register_serializer::<Item>(100);
+    let bytes = fory.serialize(&item);
+    let new_item: Item = fory.deserialize(&bytes).unwrap();
+    assert_eq!(new_item.f1, item.f1);
+    assert_eq!(new_item.f2, 0);
+}

--- a/rust/tests/tests/test_meta_string.rs
+++ b/rust/tests/tests/test_meta_string.rs
@@ -36,7 +36,10 @@ fn test_encode_meta_string_lower_special() {
     assert_eq!(bytes3.len(), 9);
     let decoder = &TYPE_NAME_DECODER;
     assert_eq!(
-        decoder.decode(&bytes1, Encoding::LowerSpecial).unwrap(),
+        decoder
+            .decode(&bytes1, Encoding::LowerSpecial)
+            .unwrap()
+            .original,
         "abc_def"
     );
     for i in 0..128 {
@@ -48,7 +51,7 @@ fn test_encode_meta_string_lower_special() {
         .collect();
         let encoded = encoder.encode_lower_special(&origin_string).unwrap();
         let decoded = decoder.decode(&encoded, Encoding::LowerSpecial).unwrap();
-        assert_eq!(decoded, origin_string);
+        assert_eq!(decoded.original, origin_string);
     }
 }
 
@@ -80,7 +83,7 @@ fn test_encode_meta_string_lower_upper_digit_special() {
     let decoded = decoder
         .decode(&encoded, Encoding::LowerUpperDigitSpecial)
         .unwrap();
-    assert_eq!(decoded, "ExampleInput123");
+    assert_eq!(decoded.original, "ExampleInput123");
 
     for i in 1..128 {
         let origin_string = create_string(
@@ -94,7 +97,7 @@ fn test_encode_meta_string_lower_upper_digit_special() {
         let decoded = decoder
             .decode(&encoded, Encoding::LowerUpperDigitSpecial)
             .unwrap();
-        assert_eq!(decoded, origin_string);
+        assert_eq!(decoded.original, origin_string);
     }
 }
 
@@ -112,7 +115,7 @@ fn test_meta_string() {
             let new_string = decoder
                 .decode(&meta_string.bytes, meta_string.encoding)
                 .unwrap();
-            assert_eq!(new_string, origin_string);
+            assert_eq!(new_string, meta_string);
         }
     }
 }
@@ -133,7 +136,7 @@ fn test_encode_empty_string() {
         let decoded = decoder
             .decode(&meta_string.bytes, meta_string.encoding)
             .unwrap();
-        assert_eq!(decoded, "");
+        assert_eq!(decoded, meta_string);
     }
 }
 
@@ -155,7 +158,7 @@ fn test_all_to_upper_special_encoding() {
     let decoded_string = decoder
         .decode(&meta_string.bytes, meta_string.encoding)
         .unwrap();
-    assert_eq!(decoded_string, test_string);
+    assert_eq!(decoded_string, meta_string);
 }
 
 #[test]
@@ -168,7 +171,7 @@ fn test_first_to_lower_special_encoding() {
     let decoded_string = decoder
         .decode(&meta_string.bytes, meta_string.encoding)
         .unwrap();
-    assert_eq!(decoded_string, test_string);
+    assert_eq!(decoded_string, meta_string);
 }
 
 #[test]
@@ -181,7 +184,7 @@ fn test_utf8_encoding() {
     let decoded_string = decoder
         .decode(&meta_string.bytes, meta_string.encoding)
         .unwrap();
-    assert_eq!(decoded_string, test_string);
+    assert_eq!(decoded_string.original, test_string);
     let test_string = "aA$";
     let meta_string = encoder.encode(test_string).unwrap();
     assert_eq!(meta_string.encoding, Encoding::Utf8);
@@ -189,7 +192,7 @@ fn test_utf8_encoding() {
     let decoded_string = decoder
         .decode(&meta_string.bytes, meta_string.encoding)
         .unwrap();
-    assert_eq!(decoded_string, test_string);
+    assert_eq!(decoded_string.original, test_string);
 }
 
 #[test]
@@ -213,7 +216,7 @@ fn test_empty_string() {
     let decoded = decoder
         .decode(&meta_string.bytes, meta_string.encoding)
         .unwrap();
-    assert_eq!(decoded, "");
+    assert_eq!(decoded, meta_string);
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?
1. Use `read/write_xxx` style APIs for Buffer methods to align with Java API naming.
2. Add `fory_` prefix to `Serializer` and `StructSerializer` trait methods, to avoid name conflict in user struct when it implement other trait with same method name.
3. Organize the APIs on the trait with hierarchical naming `fory_read`,`fory_read_type_info`,`fory_read_data`. The same applies to the write API. Make them distinct from `serialize`/`deserialize` methods of `Fory`.

## Related issues
- #2658
- #2672 

## Does this PR introduce any user-facing change?
1. If users want to call fory_methods on user-defined struct instance, they need to use methods whose prefix is `fory_`.
2. User now can customize Serializer without `derive Fory`:
```rust
#[test]
fn test_use() {
    use fory_core::fory::{read, write};
    #[derive(Debug, PartialEq, Default)]
    struct Item {
        f1: i32,
        f2: i8,
    }
    impl Serializer for Item {
        fn fory_write_data(&self, context: &mut WriteContext, is_field: bool) {
            write(&self.f1, context, is_field);
        }

        fn fory_read_data(context: &mut ReadContext, is_field: bool) -> Result<Self, Error> {
            Ok(Self {
                f1: read(context, is_field)?,
                f2: 0,
            })
        }
    }
    let mut fory = Fory::default().mode(Compatible).xlang(true);
    fory.register_serializer::<Item>(100);
    let item = Item { f1: 1, f2: 2 };
    let bytes = fory.serialize(&item);
    let new_item: Item = fory.deserialize(&bytes).unwrap();
    assert_eq!(new_item.f1, item.f1);
    assert_eq!(new_item.f2, 0);
}
```