### PR TITLE
fix(java): retain serializers in graalvm native images

### DIFF
--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fory/graalvm/EnsureSerializerExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fory/graalvm/EnsureSerializerExample.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.graalvm;
+
+import org.apache.fory.Fory;
+import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.serializer.Serializer;
+import org.apache.fory.util.Preconditions;
+
+public class EnsureSerializerExample {
+  static Fory fory;
+
+  static {
+    fory =
+        Fory.builder()
+            .withName(EnsureSerializerExample.class.getName())
+            .requireClassRegistration(true)
+            .build();
+    // register and generate serializer code.
+    fory.registerSerializer(Custom.class, new CustomSerializer(fory));
+    fory.register(EnsureSerializerExample.class);
+    fory.ensureSerializersCompiled();
+  }
+
+  public Custom custom = new Custom();
+
+  static void test(Fory fory) {
+    EnsureSerializerExample obj = new EnsureSerializerExample();
+    EnsureSerializerExample out = (EnsureSerializerExample) fory.deserialize(fory.serialize(obj));
+    Preconditions.checkArgument(42 == out.custom.i);
+  }
+
+  public static void main(String[] args) {
+    test(fory);
+    System.out.println("EnsureSerializerExample succeed");
+  }
+
+  public static class Custom {
+    public int i = 42;
+  }
+
+  private static class CustomSerializer extends Serializer<Custom> {
+    public CustomSerializer(Fory fory) {
+      super(fory, Custom.class);
+    }
+
+    @Override
+    public void write(MemoryBuffer buffer, Custom value) {}
+
+    @Override
+    public Custom read(MemoryBuffer buffer) {
+      return new Custom();
+    }
+  }
+}

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fory/graalvm/Main.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fory/graalvm/Main.java
@@ -36,6 +36,7 @@ public class Main {
     CompatibleThreadSafeExample.main(args);
     ProxyExample.main(args);
     ObjectStreamExample.main(args);
+    EnsureSerializerExample.main(args);
     Benchmark.main(args);
     CollectionExample.main(args);
     ArrayExample.main(args);

--- a/integration_tests/graalvm_tests/src/main/resources/META-INF/native-image/org.apache.fory/graalvm_tests/native-image.properties
+++ b/integration_tests/graalvm_tests/src/main/resources/META-INF/native-image/org.apache.fory/graalvm_tests/native-image.properties
@@ -28,6 +28,8 @@ Args=-H:+ReportExceptionStackTraces \
   org.apache.fory.graalvm.CompatibleThreadSafeExample,\
   org.apache.fory.graalvm.ProxyExample,\
   org.apache.fory.graalvm.ObjectStreamExample,\
+  org.apache.fory.graalvm.EnsureSerializerExample,\
+  org.apache.fory.graalvm.EnsureSerializerExample$CustomSerializer,\
   org.apache.fory.graalvm.CollectionExample,\
   org.apache.fory.graalvm.ArrayExample,\
   org.apache.fory.graalvm.Benchmark,\

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -271,14 +271,6 @@ public class ClassResolver extends TypeResolver {
     addDefaultSerializers();
     shimDispatcher.initialize();
     innerEndClassId = extRegistry.classIdGenerator;
-    if (GraalvmSupport.isGraalBuildtime()) {
-      classInfoMap.forEach(
-          (cls, classInfo) -> {
-            if (classInfo.serializer != null) {
-              extRegistry.initialClassInfos.add(classInfo);
-            }
-          });
-    }
   }
 
   private void addDefaultSerializers() {
@@ -1802,15 +1794,6 @@ public class ClassResolver extends TypeResolver {
               }
             }
           });
-      if (GraalvmSupport.isGraalBuildtime()) {
-        classInfoMap.forEach(
-            (cls, classInfo) -> {
-              if (classInfo.serializer != null
-                  && !extRegistry.initialClassInfos.contains(classInfo)) {
-                classInfo.serializer = null;
-              }
-            });
-      }
       classInfoCache = NIL_CLASS_INFO;
     } finally {
       fory.getJITContext().unlock();

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -697,7 +697,6 @@ public abstract class TypeResolver {
     final IdentityMap<Type, GenericType> genericTypes = new IdentityMap<>();
     final Map<Class, Map<String, GenericType>> classGenericTypes = new HashMap<>();
     final Map<List<ClassLoader>, CodeGenerator> codeGeneratorMap = new HashMap<>();
-    final Set<ClassInfo> initialClassInfos = new HashSet<>();
     boolean ensureSerializersCompiled;
   }
 }

--- a/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
+++ b/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
@@ -307,6 +307,9 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.serializer.ArraySerializers$ShortArraySerializer,\
     org.apache.fory.serializer.ArraySerializers$StringArraySerializer,\
     org.apache.fory.serializer.ArraySerializers,\
+    org.apache.fory.serializer.BufferSerializers$ByteBufferSerializer,\
+    org.apache.fory.serializer.CompatibleSerializer,\
+    org.apache.fory.serializer.EnumSerializer,\
     org.apache.fory.serializer.collection.SubListSerializers,\
     org.apache.fory.serializer.collection.SubListSerializers$SubListViewSerializer,\
     org.apache.fory.serializer.collection.SubListSerializers$SubListSerializer,\
@@ -346,6 +349,7 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.serializer.ReplaceResolveSerializer$1,\
     org.apache.fory.serializer.ReplaceResolveSerializer$ReplaceStub,\
     org.apache.fory.serializer.ReplaceResolveSerializer,\
+    org.apache.fory.serializer.ReplaceResolveSerializer$MethodInfoCache,\
     org.apache.fory.serializer.ReplaceResolveSerializer$ReplaceResolveInfo,\
     org.apache.fory.serializer.Serializers$AtomicBooleanSerializer,\
     org.apache.fory.serializer.Serializers$AtomicIntegerSerializer,\
@@ -394,7 +398,9 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.serializer.collection.CollectionSerializers$EmptyListSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$EmptySetSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$EmptySortedSetSerializer,\
+    org.apache.fory.serializer.collection.CollectionSerializers$EnumSetSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$HashSetSerializer,\
+    org.apache.fory.serializer.collection.CollectionSerializers$JDKCompatibleCollectionSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$LinkedHashSetSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$PriorityQueueSerializer,\
     org.apache.fory.serializer.collection.CollectionSerializers$SetFromMapSerializer,\
@@ -458,7 +464,10 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.serializer.converter.FieldConverters$StringConverter,\
     org.apache.fory.serializer.ObjectStreamSerializer,\
     org.apache.fory.serializer.ObjectStreamSerializer$1,\
+    org.apache.fory.serializer.ObjectStreamSerializer$ForyObjectInputStream,\
+    org.apache.fory.serializer.ObjectStreamSerializer$ForyObjectOutputStream,\
     org.apache.fory.serializer.ObjectStreamSerializer$StreamClassInfo,\
+    org.apache.fory.serializer.ObjectStreamSerializer$SlotsInfo,\
     org.apache.fory.serializer.collection.ChildContainerSerializers$ChildCollectionSerializer,\
     org.apache.fory.serializer.collection.ChildContainerSerializers$ChildMapSerializer,\
     org.apache.fory.shaded.org.codehaus.janino.IClass$1,\
@@ -479,6 +488,7 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.util.DelayedRef,\
     org.apache.fory.util.function.Functions,\
     org.apache.fory.util.GraalvmSupport,\
+    org.apache.fory.util.GraalvmSupport$GraalvmSerializerHolder,\
     org.apache.fory.util.LoaderBinding$1,\
     org.apache.fory.util.LoaderBinding$StagingType,\
     org.apache.fory.util.LoaderBinding,\


### PR DESCRIPTION
## Why?

Custom serializers are not retained during GraalVM native image builds.

## What does this PR do?

The original code checks against `initialClassInfos` and removes serializers outside the set during native image builds. This PR removes that as well as `initialClassInfos`.

I don't know what `initialClassInfos` is for, because it is only involved in clearing serializers, which this PR is to remove.

Also, since the tests before weren't retaining some serializers, it turns out the original `native-image.properties` might be incomplete. And I added more classes to `--initialize-at-build-time` as is hinted by the `native-image` command.

## Related issues

- Fixes #2669 
