### PR TITLE
fix(java): Fix flakiness in CollectionSerializersTest#tesPriorityQueueSerializer

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
@@ -374,7 +374,7 @@ public class CollectionSerializersTest extends ForyTestBase {
   public void tesPriorityQueueSerializer(Fory fory) {
     ImmutableList<String> list = ImmutableList.of("a", "b", "c");
     PriorityQueue<String> copy = fory.copy(new PriorityQueue<>(list));
-    Assert.assertEquals(ImmutableList.copyOf(copy), list);
+    Assert.assertEquals(ImmutableList.sortedCopyOf(copy), list);
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

`CollectionSerializersTest#tesPriorityQueueSerializer` tries to compare the content of a PriorityQueue to an expected ImmutableList using `ImmutableList.copyOf()`, but the PriorityQueue is based on a heap and does not guarrentee any ordering in its underlying data structures. Therefore the `toArray()` method which `copyOf()` invokes will return non-deterministic results. 

We can reproduce this non-deterministic failure with [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn -pl fory-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.fory.serializer.collection.CollectionSerializersTest#tesPriorityQueueSerializer
```
This PR uses `sortedCopyOf()` instead to enforce the ordering of elememts in the new ImmutableList, which removes the flakiness. 

This change does not weaken the test in any way because a PriorityQueue preserves natural ordering in the absence of a Comparator (when using `poll()`, for example) which is equivalent to sorting the elements in this case.

## Does this PR introduce any user-facing change?

No

