### PR TITLE
feat(java): custom class info serializer

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfoSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassInfoSerializer.java
@@ -1,0 +1,21 @@
+package org.apache.fory.resolver;
+
+import org.apache.fory.memory.MemoryBuffer;
+
+/**
+ * ClassInfoSerializer provides a mechanism to customize the recording of the ClassInfo
+ * default implementation uses a short value, however when the class registration needs to be customized
+ * this can be set of the ClassResolver to handle storing the ClassInfo is a customized manner
+ */
+public interface ClassInfoSerializer {
+    /**
+     * Writes the provided ClassInfo into the buffer in a customized manner which is consistent
+     * with the readClassInfo method
+     */
+    void writeClassInfo(ClassResolver classResolver, MemoryBuffer buffer, ClassInfo classInfo);
+
+    /**
+     * Reads the ClassInfo from the provided buffer in a manner which is consistent with writeClassInfo
+     */
+    ClassInfo readClassInfo(ClassResolver classResolver, MemoryBuffer buffer);
+}

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ClassInfoSerializerTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ClassInfoSerializerTest.java
@@ -1,0 +1,116 @@
+package org.apache.fory.serializer;
+
+
+import lombok.Data;
+import org.apache.fory.Fory;
+import org.apache.fory.ForyTestBase;
+import org.apache.fory.config.Language;
+import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.resolver.ClassInfo;
+import org.apache.fory.resolver.ClassInfoSerializer;
+import org.apache.fory.resolver.ClassResolver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.UUID;
+
+public class ClassInfoSerializerTest extends ForyTestBase {
+
+    @Data
+    public static class JavaCustomClass implements Serializable {
+        public String name;
+        public transient int age;
+        public static final UUID UUID = new UUID(123L, 456L);
+
+        public JavaCustomClass(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        private void writeObject(java.io.ObjectOutputStream s) throws IOException {
+            s.defaultWriteObject();
+            s.writeInt(age);
+        }
+
+        private void readObject(java.io.ObjectInputStream s) throws Exception {
+            s.defaultReadObject();
+            this.age = s.readInt();
+        }
+    }
+
+    @Data
+    public static class CustomClass {
+        public String name;
+        public static final UUID UUID = new UUID(444L, 555L);
+
+        public CustomClass(String name) {
+            this.name = name;
+        }
+    }
+
+
+    static class Mapper implements ClassInfoSerializer {
+
+        @Override
+        public void writeClassInfo(ClassResolver classResolver, MemoryBuffer buffer, ClassInfo classInfo) {
+            UUID uuid;
+
+            if(classInfo.getCls().equals(JavaCustomClass.class))
+                uuid = JavaCustomClass.UUID;
+            else if(classInfo.getCls().equals(CustomClass.class))
+                uuid = CustomClass.UUID;
+            else
+                throw new RuntimeException("unknown class");
+
+            buffer.writeVarUint64(uuid.getLeastSignificantBits());
+            buffer.writeVarUint64(uuid.getMostSignificantBits());
+        }
+
+        @Override
+        public ClassInfo readClassInfo(ClassResolver classResolver, MemoryBuffer buffer) {
+            long least = buffer.readVarUint64();
+            long most = buffer.readVarUint64();
+            UUID uuid = new UUID(most, least);
+
+            if(uuid.equals(JavaCustomClass.UUID))
+                return classResolver.getClassInfo(JavaCustomClass.class);
+            else if(uuid.equals(CustomClass.UUID))
+                return classResolver.getClassInfo(CustomClass.class);
+            else
+                throw new RuntimeException("unknown class");
+        }
+    }
+
+    @Test
+    public void testJavaObject() {
+        Fory fory =
+                Fory.builder()
+                        .withLanguage(Language.JAVA)
+                        .withRefTracking(false)
+                        .requireClassRegistration(false)
+                        .build();
+
+        fory.getClassResolver().setClassMapper(new Mapper());
+
+        JavaCustomClass deser = serDe(fory, new JavaCustomClass("bob", 10));
+        Assert.assertEquals(deser.name, "bob");
+        Assert.assertEquals(deser.age, 10);
+    }
+
+
+    @Test
+    public void testObject() {
+        Fory fory = Fory.builder()
+                .requireClassRegistration(false)
+                .build();
+
+        fory.getClassResolver().setClassMapper(new Mapper());
+
+        CustomClass deser = serDe(fory, new CustomClass("mike"));
+        Assert.assertEquals(deser.name, "mike");
+    }
+
+}
+


### PR DESCRIPTION
## Why?
In my project we have 1000s of classes that are serialized, we have a custom mechanism for registering those class using a UUID which provides a way to lookup those classes at runtime. It would be useful to be able to hook up this mechanism to the fory serializer. This is my first time trying to contribute to open source project so appreciate any guidance

## What does this PR do?
This PR adds a new interface ClassInfoSerializer which can be implemented to specify a custom way to serialize a class ID instead of the default short id. this can be set on the ClassResolver via setClassInfoSerializer

## Does this PR introduce any user-facing change?
Yes introduces new interface - ClassInfoSerializer  and ClassResolver.setClassInfoSerializer method

-->

- [x] Does this PR introduce any public API change?
- [x] Does this PR introduce any binary protocol compatibility change? - yes if custom class info serializer is set, otherwise no

## Benchmark
not performed yet