### PR TITLE
fix(java): serialize collections with only null elements in xlang mode

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/XtypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/XtypeResolver.java
@@ -550,6 +550,8 @@ public class XtypeResolver extends TypeResolver {
       } else {
         xtypeId = shareMeta ? Types.COMPATIBLE_STRUCT : Types.STRUCT;
       }
+    } else if (cls == Object.class) {
+      return classResolver.getClassInfo(cls);
     } else {
       Class<Enum> enclosingClass = (Class<Enum>) cls.getEnclosingClass();
       if (enclosingClass != null && enclosingClass.isEnum()) {

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/XlangCollectionSerializerTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/XlangCollectionSerializerTest.java
@@ -60,4 +60,13 @@ public class XlangCollectionSerializerTest extends ForyTestBase {
     Assert.assertEquals(obj.list1.getClass(), LinkedList.class);
     Assert.assertEquals(obj.map1.getClass(), LinkedHashMap.class);
   }
+
+  @Test
+  public void testSerializeListWithNullElements() {
+    Fory fory = Fory.builder().withLanguage(Language.XLANG).build();
+    ArrayList<String> strList = new ArrayList<>();
+    strList.add(null);
+    byte[] serialized = fory.serialize(strList);
+    Assert.assertTrue(serialized.length > 0);
+  }
 }


### PR DESCRIPTION

## What does this PR do?
When all collection elements are null, elemClass is set to Object.class
which needs to be handled by classResolver in XLANG mode.

## Related issues
Fixes #2203
<!--
Is there any related issue? If this PR closes them you say say fix/closes:


-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
