### PR TITLE
refactor(rust): use compatible bool instead of enum to simplify API

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -305,7 +305,6 @@ Apache Fory™ supports polymorphic serialization through trait objects, enablin
 use fory::{Fory, register_trait_type};
 use fory::Serializer;
 use fory::ForyObject;
-use fory::Mode;
 
 trait Animal: Serializer {
     fn speak(&self) -> String;
@@ -336,7 +335,7 @@ struct Zoo {
     star_animal: Box<dyn Animal>,
 }
 
-let mut fory = Fory::default().mode(Mode::Compatible);
+let mut fory = Fory::default().compatible(true);
 fory.register::<Dog>(100);
 fory.register::<Cat>(101);
 fory.register::<Zoo>(102);
@@ -425,7 +424,7 @@ struct AnimalShelter {
     registry: HashMap<String, Arc<dyn Animal>>,
 }
 
-let mut fory = Fory::default().mode(Mode::Compatible);
+let mut fory = Fory::default().compatible(true);
 fory.register::<Dog>(100);
 fory.register::<Cat>(101);
 fory.register::<AnimalShelter>(102);
@@ -510,7 +509,6 @@ Apache Fory™ supports schema evolution in **Compatible mode**, allowing serial
 
 ```rust
 use fory::Fory;
-use fory::Mode;
 use fory::ForyObject;
 use std::collections::HashMap;
 
@@ -531,10 +529,10 @@ struct PersonV2 {
     metadata: HashMap<String, String>,
 }
 
-let mut fory1 = Fory::default().mode(Mode::Compatible);
+let mut fory1 = Fory::default().compatible(true);
 fory1.register::<PersonV1>(1);
 
-let mut fory2 = Fory::default().mode(Mode::Compatible);
+let mut fory2 = Fory::default().compatible(true);
 fory2.register::<PersonV2>(1);
 
 let person_v1 = PersonV1 {
@@ -789,11 +787,10 @@ Apache Fory™ supports seamless data exchange across multiple languages:
 
 ```rust
 use fory::Fory;
-use fory::Mode;
 
 // Enable cross-language mode
 let mut fory = Fory::default()
-    .mode(Mode::Compatible)
+    .compatible(true)
     .xlang(true);
 
 // Register types with consistent IDs across languages
@@ -887,9 +884,7 @@ let fory = Fory::default(); // SchemaConsistent by default
 Allows independent schema evolution:
 
 ```rust
-use fory::Mode;
-
-let fory = Fory::default().mode(Mode::Compatible);
+let fory = Fory::default().compatible(true);
 ```
 
 ## ⚙️ Configuration

--- a/rust/fory-core/src/lib.rs
+++ b/rust/fory-core/src/lib.rs
@@ -70,7 +70,7 @@
 //! Define custom traits and register implementations:
 //!
 //! ```rust,ignore
-//! use fory_core::{Fory, register_trait_type, Serializer, Mode};
+//! use fory_core::{Fory, register_trait_type, Serializer};
 //! use fory_derive::ForyObject;
 //!
 //! trait Animal: Serializer {
@@ -99,7 +99,7 @@
 //! }
 //!
 //! # fn main() {
-//! let mut fory = Fory::default().mode(Mode::Compatible);
+//! let mut fory = Fory::default().compatible(true);
 //! fory.register::<Dog>(100);
 //! fory.register::<Cat>(101);
 //! fory.register::<Zoo>(102);
@@ -143,12 +143,11 @@
 //! ```rust
 //! use fory_core::fory::Fory;
 //! use fory_core::error::Error;
-//! use fory_core::types::Mode;
 //! use fory_core::row::{to_row, from_row};
 //! use std::collections::HashMap;
 //!
 //! // Create a Fory instance
-//! let mut fory = Fory::default().mode(Mode::Compatible);
+//! let mut fory = Fory::default().compatible(true);
 //!
 //! // Serialize String
 //! let text = String::from("Hello, Fory!");
@@ -196,4 +195,4 @@ pub use crate::resolver::context::{ReadContext, WriteContext};
 pub use crate::resolver::type_resolver::TypeResolver;
 pub use crate::serializer::weak::{ArcWeak, RcWeak};
 pub use crate::serializer::{ForyDefault, Serializer};
-pub use crate::types::{Mode, RefFlag, TypeId};
+pub use crate::types::{RefFlag, TypeId};

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -20,10 +20,10 @@ use crate::fory::Fory;
 use crate::meta::{MetaString, TypeMeta};
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::{ForyDefault, Serializer};
-use crate::types::{Mode, RefFlag, TypeId};
+use crate::types::{RefFlag, TypeId};
 
 #[inline(always)]
-pub fn actual_type_id(type_id: u32, register_by_name: bool, _mode: &Mode) -> u32 {
+pub fn actual_type_id(type_id: u32, register_by_name: bool, _compatible: bool) -> u32 {
     if register_by_name {
         TypeId::NAMED_ENUM as u32
     } else {

--- a/rust/fory-core/src/serializer/mod.rs
+++ b/rust/fory-core/src/serializer/mod.rs
@@ -19,7 +19,7 @@ use crate::error::Error;
 use crate::fory::Fory;
 use crate::meta::{MetaString, TypeMeta, NAMESPACE_DECODER, TYPE_NAME_DECODER};
 use crate::resolver::context::{ReadContext, WriteContext};
-use crate::types::{Mode, RefFlag, TypeId, PRIMITIVE_TYPES};
+use crate::types::{RefFlag, TypeId, PRIMITIVE_TYPES};
 use anyhow::anyhow;
 use std::any::Any;
 
@@ -325,8 +325,8 @@ pub trait StructSerializer: Serializer + 'static {
     fn fory_type_index() -> u32 {
         unimplemented!()
     }
-    fn fory_actual_type_id(type_id: u32, register_by_name: bool, mode: &Mode) -> u32 {
-        struct_::actual_type_id(type_id, register_by_name, mode)
+    fn fory_actual_type_id(type_id: u32, register_by_name: bool, compatible: bool) -> u32 {
+        struct_::actual_type_id(type_id, register_by_name, compatible)
     }
 
     fn fory_get_sorted_field_names(_fory: &Fory) -> &'static [&'static str] {

--- a/rust/fory-core/src/serializer/trait_object.rs
+++ b/rust/fory-core/src/serializer/trait_object.rs
@@ -29,12 +29,12 @@ pub fn write_trait_object_headers(
     fory_type_id: u32,
     concrete_type_id: std::any::TypeId,
 ) {
-    use crate::types::{Mode, RefFlag, TypeId};
+    use crate::types::{RefFlag, TypeId};
 
     context.writer.write_i8(RefFlag::NotNullValue as i8);
     context.writer.write_varuint32(fory_type_id);
 
-    if fory.get_mode() == &Mode::Compatible
+    if fory.is_compatible()
         && (fory_type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
             || fory_type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32)
     {
@@ -45,7 +45,7 @@ pub fn write_trait_object_headers(
 
 /// Reads common trait object headers and returns the type ID
 pub fn read_trait_object_headers(fory: &Fory, context: &mut ReadContext) -> Result<u32, Error> {
-    use crate::types::{Mode, RefFlag, TypeId};
+    use crate::types::{RefFlag, TypeId};
 
     let ref_flag = context.reader.read_i8();
     if ref_flag != RefFlag::NotNullValue as i8 {
@@ -57,7 +57,7 @@ pub fn read_trait_object_headers(fory: &Fory, context: &mut ReadContext) -> Resu
 
     let fory_type_id = context.reader.read_varuint32();
 
-    if fory.get_mode() == &Mode::Compatible
+    if fory.is_compatible()
         && (fory_type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
             || fory_type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32)
     {
@@ -121,7 +121,7 @@ macro_rules! resolve_and_deserialize {
 /// # Example
 ///
 /// ```rust,ignore
-/// use fory_core::{fory::Fory, register_trait_type, serializer::Serializer, types::Mode};
+/// use fory_core::{fory::Fory, register_trait_type, serializer::Serializer};
 /// use fory_derive::ForyObject;
 ///
 /// trait Animal: Serializer {
@@ -148,7 +148,7 @@ macro_rules! resolve_and_deserialize {
 /// register_trait_type!(Animal, Dog, Cat);
 ///
 /// # fn main() {
-/// let mut fory = Fory::default().mode(Mode::Compatible);
+/// let mut fory = Fory::default().compatible(true);
 /// fory.register::<Dog>(100);
 /// fory.register::<Cat>(101);
 ///

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -21,7 +21,7 @@ use syn::DataEnum;
 
 pub fn gen_actual_type_id() -> TokenStream {
     quote! {
-       fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, mode)
+       fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, compatible)
     }
 }
 

--- a/rust/fory-derive/src/object/misc.rs
+++ b/rust/fory-derive/src/object/misc.rs
@@ -60,7 +60,7 @@ fn hash(fields: &[&Field]) -> TokenStream {
 
 pub fn gen_actual_type_id() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::actual_type_id(type_id, register_by_name, mode)
+        fory_core::serializer::struct_::actual_type_id(type_id, register_by_name, compatible)
     }
 }
 

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -391,15 +391,11 @@ pub fn gen_read(struct_ident: &Ident) -> TokenStream {
     quote! {
         let ref_flag = context.reader.read_i8();
         if ref_flag == (fory_core::types::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::types::RefFlag::RefValue as i8) {
-            match fory.get_mode() {
-                fory_core::types::Mode::SchemaConsistent => {
-                    <Self as fory_core::serializer::Serializer>::fory_read_type_info(fory, context, false);
-                    <Self as fory_core::serializer::Serializer>::fory_read_data(fory, context, false)
-                },
-                fory_core::types::Mode::Compatible => {
-                    <#struct_ident as fory_core::serializer::Serializer>::fory_read_compatible(fory, context)
-                },
-                _ => unreachable!()
+            if fory.is_compatible() {
+                <#struct_ident as fory_core::serializer::Serializer>::fory_read_compatible(fory, context)
+            } else {
+                <Self as fory_core::serializer::Serializer>::fory_read_type_info(fory, context, false);
+                <Self as fory_core::serializer::Serializer>::fory_read_data(fory, context, false)
             }
         } else if ref_flag == (fory_core::types::RefFlag::Null as i8) {
             Ok(<Self as fory_core::serializer::ForyDefault>::fory_default())

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -120,7 +120,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput) -> TokenStream {
                 #type_idx
             }
 
-            fn fory_actual_type_id(type_id: u32, register_by_name: bool, mode: &fory_core::types::Mode) -> u32 {
+            fn fory_actual_type_id(type_id: u32, register_by_name: bool, compatible: bool) -> u32 {
                 #actual_type_id_ts
             }
 

--- a/rust/fory/src/lib.rs
+++ b/rust/fory/src/lib.rs
@@ -334,7 +334,7 @@
 //! #### Basic Trait Object Serialization
 //!
 //! ```rust
-//! use fory::{Fory, register_trait_type, Serializer, Mode, Error};
+//! use fory::{Fory, register_trait_type, Serializer, Error};
 //! use fory::ForyObject;
 //!
 //! trait Animal: Serializer {
@@ -366,7 +366,7 @@
 //! }
 //!
 //! # fn main() -> Result<(), Error> {
-//! let mut fory = Fory::default().mode(Mode::Compatible);
+//! let mut fory = Fory::default().compatible(true);
 //! fory.register::<Dog>(100);
 //! fory.register::<Cat>(101);
 //! fory.register::<Zoo>(102);
@@ -463,7 +463,7 @@
 //! automatically handles the conversion without needing wrappers:
 //!
 //! ```rust
-//! use fory::{Fory, register_trait_type, Serializer, Mode, Error};
+//! use fory::{Fory, register_trait_type, Serializer, Error};
 //! use fory::ForyObject;
 //! use std::sync::Arc;
 //! use std::rc::Rc;
@@ -493,7 +493,7 @@
 //! }
 //!
 //! # fn main() -> Result<(), Error> {
-//! let mut fory = Fory::default().mode(Mode::Compatible);
+//! let mut fory = Fory::default().compatible(true);
 //! fory.register::<Dog>(100);
 //! fory.register::<Cat>(101);
 //! fory.register::<AnimalShelter>(102);
@@ -529,7 +529,7 @@
 //! The `register_trait_type!` macro generates `AnimalRc` and `AnimalArc` wrapper types:
 //!
 //! ```rust
-//! use fory::{Fory, Mode, Error, register_trait_type, Serializer};
+//! use fory::{Fory, Error, register_trait_type, Serializer};
 //! use fory::ForyObject;
 //! use std::sync::Arc;
 //! use std::rc::Rc;
@@ -547,7 +547,7 @@
 //! register_trait_type!(Animal, Dog);
 //!
 //! # fn main() -> Result<(), Error> {
-//! let mut fory = Fory::default().mode(Mode::Compatible);
+//! let mut fory = Fory::default().compatible(true);
 //! fory.register::<Dog>(100);
 //!
 //! // For Rc<dyn Trait>
@@ -602,7 +602,7 @@
 //! - Nested struct types must be registered on both sides
 //!
 //! ```rust
-//! use fory::{Fory, Error, Mode};
+//! use fory::{Fory, Error};
 //! use fory::ForyObject;
 //! use std::collections::HashMap;
 //!
@@ -622,10 +622,10 @@
 //! }
 //!
 //! # fn main() -> Result<(), Error> {
-//! let mut fory1 = Fory::default().mode(Mode::Compatible);
+//! let mut fory1 = Fory::default().compatible(true);
 //! fory1.register::<PersonV1>(1);
 //!
-//! let mut fory2 = Fory::default().mode(Mode::Compatible);
+//! let mut fory2 = Fory::default().compatible(true);
 //! fory2.register::<PersonV2>(1);
 //!
 //! let person_v1 = PersonV1 {
@@ -923,9 +923,9 @@
 //! - Essential for zero-downtime deployments
 //!
 //! ```rust
-//! use fory::{Fory, Mode};
+//! use fory::Fory;
 //!
-//! let fory = Fory::default().mode(Mode::Compatible);
+//! let fory = Fory::default().compatible(true);
 //! ```
 //!
 //! ## Cross-Language Serialization
@@ -939,11 +939,11 @@
 //! **How to enable:**
 //!
 //! ```rust
-//! use fory::{Fory, Mode};
+//! use fory::Fory;
 //! use fory::ForyObject;
 //!
 //! let mut fory = Fory::default()
-//!     .mode(Mode::Compatible)
+//!     .compatible(true)
 //!     .xlang(true);
 //!
 //! #[derive(ForyObject)]
@@ -1046,7 +1046,7 @@
 //! - **[GitHub Repository](https://github.com/apache/fory)** - Source code and issue tracking
 
 pub use fory_core::{
-    error::Error, fory::Fory, register_trait_type, row::from_row, row::to_row, types::Mode,
-    types::TypeId, ArcWeak, ForyDefault, RcWeak, ReadContext, Serializer, WriteContext,
+    error::Error, fory::Fory, register_trait_type, row::from_row, row::to_row, types::TypeId,
+    ArcWeak, ForyDefault, RcWeak, ReadContext, Serializer, WriteContext,
 };
 pub use fory_derive::{ForyObject, ForyRow};

--- a/rust/tests/tests/compatible/test_basic_type.rs
+++ b/rust/tests/tests/compatible/test_basic_type.rs
@@ -19,7 +19,6 @@ use chrono::{NaiveDate, NaiveDateTime};
 use fory_core::buffer::{Reader, Writer};
 use fory_core::fory::Fory;
 use fory_core::resolver::context::{ReadContext, WriteContext};
-use fory_core::types::Mode::Compatible;
 
 // primitive_val
 const BOOL_VAL: bool = true;
@@ -437,7 +436,7 @@ fn deserialize_nullable(fory: &Fory, context: &mut ReadContext, auto_conv: bool,
 // non-null <-> non-null
 #[test]
 fn basic() {
-    let fory = Fory::default().mode(Compatible);
+    let fory = Fory::default().compatible(true);
     // serialize
     let writer = Writer::default();
     let mut write_context = WriteContext::new(writer);
@@ -452,7 +451,7 @@ fn basic() {
 // nullable <-> nullable
 #[test]
 fn basic_nullable() {
-    let fory = Fory::default().mode(Compatible);
+    let fory = Fory::default().compatible(true);
     // serialize
     let writer = Writer::default();
     let mut write_context = WriteContext::new(writer);
@@ -467,7 +466,7 @@ fn basic_nullable() {
 // non-null -> nullable -> non-null
 #[test]
 fn auto_conv() {
-    let fory = Fory::default().mode(Compatible);
+    let fory = Fory::default().compatible(true);
     // serialize_non-null
     let writer = Writer::default();
     let mut write_context = WriteContext::new(writer);

--- a/rust/tests/tests/compatible/test_container.rs
+++ b/rust/tests/tests/compatible/test_container.rs
@@ -20,7 +20,6 @@ use std::collections::{HashMap, HashSet};
 use fory_core::buffer::{Reader, Writer};
 use fory_core::fory::Fory;
 use fory_core::resolver::context::{ReadContext, WriteContext};
-use fory_core::types::Mode::Compatible;
 use fory_derive::ForyObject;
 
 #[derive(ForyObject, PartialEq, Eq, Hash, Debug)]
@@ -221,7 +220,7 @@ fn complex_container2() -> Vec<HashMap<Vec<Item>, Vec<Item>>> {
 
 #[test]
 fn container_outer_auto_conv() {
-    let fory = Fory::default().mode(Compatible);
+    let fory = Fory::default().compatible(true);
     // serialize_outer_non-null
     let writer = Writer::default();
     let mut write_context = WriteContext::new(writer);
@@ -296,9 +295,9 @@ fn container_outer_auto_conv() {
 
 #[test]
 fn collection_inner() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Item>(101);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Item>("item");
     for fory in [fory1, fory2] {
         // serialize
@@ -362,9 +361,9 @@ fn collection_inner() {
 
 #[test]
 fn collection_inner_auto_conv() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Item>(101);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Item>("item");
     for fory in [fory1, fory2] {
         // serialize_non-null
@@ -436,9 +435,9 @@ fn collection_inner_auto_conv() {
 
 #[test]
 fn map_inner() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Item>(101);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Item>("item");
     for fory in [fory1, fory2] {
         // serialize
@@ -480,9 +479,9 @@ fn map_inner() {
 
 #[test]
 fn map_inner_auto_conv() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Item>(101);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Item>("item");
     for fory in [fory1, fory2] {
         // serialize_non-null
@@ -532,9 +531,9 @@ fn map_inner_auto_conv() {
 
 #[test]
 fn complex() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Item>(101);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Item>("item");
     for fory in [fory1, fory2] {
         let writer = Writer::default();

--- a/rust/tests/tests/compatible/test_struct.rs
+++ b/rust/tests/tests/compatible/test_struct.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use fory_core::fory::Fory;
-use fory_core::types::Mode::Compatible;
 use fory_derive::ForyObject;
 use std::collections::{HashMap, HashSet};
 
@@ -44,8 +43,8 @@ fn simple() {
         f7: i16,
         last: i8,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Animal1>(999);
     fory2.register::<Animal2>(999);
     let animal: Animal1 = Animal1 {
@@ -83,8 +82,8 @@ fn skip_option() {
         f2: i8,
         last: i64,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item1>(999);
     fory2.register::<Item2>(999);
     let item1 = Item1 {
@@ -122,8 +121,8 @@ fn nonexistent_struct() {
         f3: i64,
         last: String,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item1>(899);
     fory1.register::<Person1>(999);
     fory2.register::<Item2>(799);
@@ -152,7 +151,7 @@ fn option() {
         f5: Vec<Option<Vec<Option<String>>>>,
         last: i64,
     }
-    let mut fory = Fory::default().mode(Compatible);
+    let mut fory = Fory::default().compatible(true);
     fory.register::<Animal>(999);
     let animal: Animal = Animal {
         f1: Some(String::from("f1")),
@@ -196,8 +195,8 @@ fn nullable() {
         last: i64,
     }
 
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item1>(999);
     fory2.register::<Item2>(999);
 
@@ -250,8 +249,8 @@ fn nullable_container() {
         last: i64,
     }
 
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item1>(999);
     fory2.register::<Item2>(999);
 
@@ -300,8 +299,8 @@ fn inner_nullable() {
         f3: HashMap<i8, i8>,
         last: i64,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item1>(999);
     fory2.register::<Item2>(999);
 
@@ -344,8 +343,8 @@ fn nullable_struct() {
         f3: Item,
         last: i64,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Item>(199);
     fory1.register::<Person1>(200);
     fory2.register::<Item>(199);
@@ -418,11 +417,11 @@ fn enum_without_payload() {
         last: i8,
     }
 
-    let mut fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory1 = Fory::default().compatible(true).xlang(true);
     fory1.register::<Color1>(101);
     fory1.register::<Color2>(102);
     fory1.register::<Person1>(103);
-    let mut fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory2 = Fory::default().compatible(true).xlang(true);
     fory2.register::<Color1>(101);
     fory2.register::<Color2>(102);
     fory2.register::<Person2>(103);
@@ -482,10 +481,10 @@ fn named_enum() {
         f6: Option<Color>,
         last: i8,
     }
-    let mut fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory1 = Fory::default().compatible(true).xlang(true);
     fory1.register_by_name::<Color>("a");
     fory1.register::<Item1>(101);
-    let mut fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory2 = Fory::default().compatible(true).xlang(true);
     fory2.register_by_name::<Color>("a");
     fory2.register::<Item2>(101);
     let item1 = Item1 {
@@ -538,9 +537,9 @@ fn boxed() {
         f6: Option<i32>,
     }
 
-    let mut fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory1 = Fory::default().compatible(true).xlang(true);
     fory1.register::<Item1>(101);
-    let mut fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut fory2 = Fory::default().compatible(true).xlang(true);
     fory2.register::<Item2>(101);
 
     let f1 = 1;

--- a/rust/tests/tests/compatible/test_struct_enum.rs
+++ b/rust/tests/tests/compatible/test_struct_enum.rs
@@ -21,7 +21,6 @@ use fory_core::error::Error;
 use fory_core::fory::{read_data, write_data, Fory};
 use fory_core::resolver::context::{ReadContext, WriteContext};
 use fory_core::serializer::{ForyDefault, Serializer};
-use fory_core::types::Mode::Compatible;
 use fory_derive::ForyObject;
 use std::collections::{HashMap, HashSet};
 
@@ -82,11 +81,11 @@ struct Empty {}
 
 #[test]
 fn basic() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Color>(101);
     fory1.register::<Item>(102);
     fory1.register::<Person>(103);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Color>("color");
     fory2.register_by_name::<Item>("item");
     fory2.register_by_name::<Person>("person");
@@ -115,11 +114,11 @@ fn basic() {
 
 #[test]
 fn outer_nullable() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register::<Color>(101);
     fory1.register::<Item>(102);
     fory1.register::<Person>(103);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Color>("color");
     fory2.register_by_name::<Item>("item");
     fory2.register_by_name::<Person>("person");
@@ -138,18 +137,18 @@ fn skip_basic() {
     let person_default = Person::default();
     let person2_default = Empty::default();
 
-    let mut id_fory1 = Fory::default().mode(Compatible);
+    let mut id_fory1 = Fory::default().compatible(true);
     id_fory1.register::<Color>(101);
     id_fory1.register::<Item>(102);
     id_fory1.register::<Person>(103);
-    let mut id_fory2 = Fory::default().mode(Compatible);
+    let mut id_fory2 = Fory::default().compatible(true);
     id_fory2.register::<Empty>(103);
 
-    let mut name_fory1 = Fory::default().mode(Compatible);
+    let mut name_fory1 = Fory::default().compatible(true);
     name_fory1.register_by_name::<Color>("color");
     name_fory1.register_by_name::<Item>("item");
     name_fory1.register_by_name::<Person>("person");
-    let mut name_fory2 = Fory::default().mode(Compatible);
+    let mut name_fory2 = Fory::default().compatible(true);
     name_fory2.register_by_name::<Empty>("person");
 
     for (fory1, fory2) in [(id_fory1, id_fory2), (name_fory1, name_fory2)] {
@@ -181,20 +180,20 @@ fn nested() {
         f6: HashMap<Color, Color>,
         f7: Element,
     }
-    let mut id_fory1 = Fory::default().mode(Compatible);
+    let mut id_fory1 = Fory::default().compatible(true);
     id_fory1.register::<Item>(101);
     id_fory1.register::<Color>(102);
     id_fory1.register::<Element>(103);
     id_fory1.register::<Nested>(104);
-    let mut id_fory2 = Fory::default().mode(Compatible);
+    let mut id_fory2 = Fory::default().compatible(true);
     id_fory2.register::<Empty>(104);
 
-    let mut name_fory1 = Fory::default().mode(Compatible);
+    let mut name_fory1 = Fory::default().compatible(true);
     name_fory1.register_by_name::<Item>("item");
     name_fory1.register_by_name::<Color>("color");
     name_fory1.register_by_name::<Element>("element");
     name_fory1.register_by_name::<Nested>("nested");
-    let mut name_fory2 = Fory::default().mode(Compatible);
+    let mut name_fory2 = Fory::default().compatible(true);
     name_fory2.register_by_name::<Empty>("nested");
 
     for (fory1, fory2) in [(id_fory1, id_fory2), (name_fory1, name_fory2)] {
@@ -288,20 +287,20 @@ fn compatible_nullable() {
         f28: Some(HashSet::<String>::default()),
         f29: Some(HashMap::<String, i32>::default()),
     };
-    let mut id_fory1 = Fory::default().mode(Compatible);
+    let mut id_fory1 = Fory::default().compatible(true);
     id_fory1.register::<Color>(101);
     id_fory1.register::<Item>(102);
     id_fory1.register::<Nonnull>(103);
-    let mut id_fory2 = Fory::default().mode(Compatible);
+    let mut id_fory2 = Fory::default().compatible(true);
     id_fory2.register::<Color>(101);
     id_fory2.register::<Item>(102);
     id_fory2.register::<Nullable>(103);
 
-    let mut name_fory1 = Fory::default().mode(Compatible);
+    let mut name_fory1 = Fory::default().compatible(true);
     name_fory1.register_by_name::<Color>("color");
     name_fory1.register_by_name::<Item>("item");
     name_fory1.register_by_name::<Nonnull>("obj");
-    let mut name_fory2 = Fory::default().mode(Compatible);
+    let mut name_fory2 = Fory::default().compatible(true);
     name_fory2.register_by_name::<Color>("color");
     name_fory2.register_by_name::<Item>("item");
     name_fory2.register_by_name::<Nullable>("obj");
@@ -351,20 +350,20 @@ fn name_mismatch() {
         f29: HashSet<String>,
         f30: HashMap<String, i32>,
     }
-    let mut id_fory1 = Fory::default().mode(Compatible);
+    let mut id_fory1 = Fory::default().compatible(true);
     id_fory1.register::<Color>(101);
     id_fory1.register::<Item>(102);
     id_fory1.register::<Person>(103);
-    let mut id_fory2 = Fory::default().mode(Compatible);
+    let mut id_fory2 = Fory::default().compatible(true);
     id_fory2.register::<Color>(101);
     id_fory2.register::<Item>(102);
     id_fory2.register::<MismatchPerson>(103);
 
-    let mut name_fory1 = Fory::default().mode(Compatible);
+    let mut name_fory1 = Fory::default().compatible(true);
     name_fory1.register_by_name::<Color>("color");
     name_fory1.register_by_name::<Item>("item");
     name_fory1.register_by_name::<Person>("person");
-    let mut name_fory2 = Fory::default().mode(Compatible);
+    let mut name_fory2 = Fory::default().compatible(true);
     name_fory2.register_by_name::<Color>("color");
     name_fory2.register_by_name::<Item>("item");
     name_fory2.register_by_name::<MismatchPerson>("person");
@@ -421,11 +420,11 @@ fn ext() {
         f1: ExtItem,
     }
 
-    let mut id_fory = Fory::default().mode(Compatible).xlang(true);
+    let mut id_fory = Fory::default().compatible(true).xlang(true);
     id_fory.register_serializer::<ExtItem>(100);
     id_fory.register::<ExtWrapper>(101);
 
-    let mut name_fory = Fory::default().mode(Compatible).xlang(true);
+    let mut name_fory = Fory::default().compatible(true).xlang(true);
     name_fory.register_serializer_by_name::<ExtItem>("ext_item");
     name_fory.register::<ExtWrapper>(101);
 
@@ -475,17 +474,17 @@ fn skip_ext() {
     struct ExtWrapper {
         f1: ExtItem,
     }
-    let mut id_fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut id_fory1 = Fory::default().compatible(true).xlang(true);
     id_fory1.register_serializer::<ExtItem>(100);
     id_fory1.register::<ExtWrapper>(101);
-    let mut id_fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut id_fory2 = Fory::default().compatible(true).xlang(true);
     id_fory2.register_serializer::<ExtItem>(100);
     id_fory2.register::<Empty>(101);
 
-    let mut name_fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut name_fory1 = Fory::default().compatible(true).xlang(true);
     name_fory1.register_serializer_by_name::<ExtItem>("ext_item");
     name_fory1.register::<ExtWrapper>(101);
-    let mut name_fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut name_fory2 = Fory::default().compatible(true).xlang(true);
     name_fory2.register_serializer_by_name::<ExtItem>("ext_item");
     name_fory2.register::<Empty>(101);
 
@@ -541,17 +540,17 @@ fn compatible_ext() {
     struct ExtWrapper2 {
         f1: Option<ExtItem>,
     }
-    let mut id_fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut id_fory1 = Fory::default().compatible(true).xlang(true);
     id_fory1.register_serializer::<ExtItem>(100);
     id_fory1.register::<ExtWrapper1>(101);
-    let mut id_fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut id_fory2 = Fory::default().compatible(true).xlang(true);
     id_fory2.register_serializer::<ExtItem>(100);
     id_fory2.register::<ExtWrapper2>(101);
 
-    let mut name_fory1 = Fory::default().mode(Compatible).xlang(true);
+    let mut name_fory1 = Fory::default().compatible(true).xlang(true);
     name_fory1.register_serializer_by_name::<ExtItem>("ext_item");
     name_fory1.register::<ExtWrapper1>(101);
-    let mut name_fory2 = Fory::default().mode(Compatible).xlang(true);
+    let mut name_fory2 = Fory::default().compatible(true).xlang(true);
     name_fory2.register_serializer_by_name::<ExtItem>("ext_item");
     name_fory2.register::<ExtWrapper2>(101);
 

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -22,7 +22,6 @@ use fory_core::fory::{read_data, write_data, Fory};
 use fory_core::meta::murmurhash3_x64_128;
 use fory_core::resolver::context::{ReadContext, WriteContext};
 use fory_core::serializer::{ForyDefault, Serializer};
-use fory_core::types::Mode::{Compatible, SchemaConsistent};
 use fory_derive::ForyObject;
 use std::collections::{HashMap, HashSet};
 use std::{fs, vec};
@@ -226,13 +225,13 @@ fn test_string_serializer() {
     let bytes = fs::read(&data_file_path).unwrap();
     let reader = Reader::new(bytes.as_slice());
     let fory = Fory::default()
-        .mode(Compatible)
+        .compatible(true)
         .xlang(true)
         .compress_string(false);
     let mut context = ReadContext::new(reader, 5);
     let reader_compress = Reader::new(bytes.as_slice());
     let fory_compress = Fory::default()
-        .mode(Compatible)
+        .compatible(true)
         .xlang(true)
         .compress_string(true);
     let mut context_compress = ReadContext::new(reader_compress, 5);
@@ -260,7 +259,7 @@ fn test_string_serializer() {
         );
     }
     let writer = Writer::default();
-    let fory = Fory::default().mode(Compatible).xlang(true);
+    let fory = Fory::default().compatible(true).xlang(true);
     let mut context = WriteContext::new(writer);
     for s in &test_strings {
         s.fory_write_data(&fory, &mut context, true);
@@ -292,7 +291,7 @@ fn test_cross_language_serializer() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
     let reader = Reader::new(bytes.as_slice());
-    let mut fory = Fory::default().mode(Compatible).xlang(true);
+    let mut fory = Fory::default().compatible(true).xlang(true);
     fory.register::<Color>(101);
     let mut context = ReadContext::new(reader, 5);
     assert_de!(fory, context, bool, true);
@@ -358,7 +357,7 @@ fn test_cross_language_serializer() {
 fn test_simple_struct() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
-    let mut fory = Fory::default().mode(Compatible).xlang(true);
+    let mut fory = Fory::default().compatible(true).xlang(true);
     fory.register::<Color>(101);
     fory.register::<Item>(102);
     fory.register::<SimpleStruct>(103);
@@ -389,7 +388,7 @@ fn test_simple_struct() {
 fn test_simple_named_struct() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
-    let mut fory = Fory::default().mode(Compatible).xlang(true);
+    let mut fory = Fory::default().compatible(true).xlang(true);
     fory.register_by_namespace::<Color>("demo", "color");
     fory.register_by_namespace::<Item>("demo", "item");
     fory.register_by_namespace::<SimpleStruct>("demo", "simple_struct");
@@ -421,7 +420,7 @@ fn test_list() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
 
-    let mut fory = Fory::default().mode(Compatible);
+    let mut fory = Fory::default().compatible(true);
     fory.register::<Item>(102);
     let reader = Reader::new(bytes.as_slice());
     let mut context = ReadContext::new(reader, 5);
@@ -466,7 +465,7 @@ fn test_map() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
 
-    let mut fory = Fory::default().mode(Compatible);
+    let mut fory = Fory::default().compatible(true);
     fory.register::<Item>(102);
     let reader = Reader::new(bytes.as_slice());
     let mut context = ReadContext::new(reader, 5);
@@ -535,7 +534,7 @@ fn test_integer() {
     let data_file_path = get_data_file();
     let bytes = fs::read(&data_file_path).unwrap();
 
-    let mut fory = Fory::default().mode(Compatible);
+    let mut fory = Fory::default().compatible(true);
     fory.register::<Item2>(101);
     let reader = Reader::new(bytes.as_slice());
 
@@ -645,10 +644,10 @@ fn _test_skip_custom(fory1: &Fory, fory2: &Fory) {
 
 #[test]
 fn test_kankankan() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register_serializer::<MyExt>(103);
     fory1.register::<Empty>(104);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register::<Color>(101);
     fory2.register::<MyStruct>(102);
     fory2.register_serializer::<MyExt>(103);
@@ -665,10 +664,10 @@ fn test_kankankan() {
 #[test]
 #[ignore]
 fn test_skip_id_custom() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register_serializer::<MyExt>(103);
     fory1.register::<Empty>(104);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register::<Color>(101);
     fory2.register::<MyStruct>(102);
     fory2.register_serializer::<MyExt>(103);
@@ -679,10 +678,10 @@ fn test_skip_id_custom() {
 #[test]
 #[ignore]
 fn test_skip_name_custom() {
-    let mut fory1 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
     fory1.register_serializer_by_name::<MyExt>("my_ext");
     fory1.register_by_name::<Empty>("my_wrapper");
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory2 = Fory::default().compatible(true);
     fory2.register_by_name::<Color>("color");
     fory2.register_by_name::<MyStruct>("my_struct");
     fory2.register_serializer_by_name::<MyExt>("my_ext");
@@ -693,7 +692,7 @@ fn test_skip_name_custom() {
 #[test]
 #[ignore]
 fn test_consistent_named() {
-    let mut fory = Fory::default().mode(SchemaConsistent);
+    let mut fory = Fory::default().compatible(false);
     fory.register_by_name::<Color>("color");
     fory.register_by_name::<MyStruct>("my_struct");
     fory.register_serializer_by_name::<MyExt>("my_ext");

--- a/rust/tests/tests/test_ext.rs
+++ b/rust/tests/tests/test_ext.rs
@@ -19,7 +19,6 @@ use fory_core::error::Error;
 use fory_core::fory::Fory;
 use fory_core::resolver::context::{ReadContext, WriteContext};
 use fory_core::serializer::{ForyDefault, Serializer};
-use fory_core::types::Mode::Compatible;
 use fory_derive::ForyObject;
 
 #[test]
@@ -83,7 +82,7 @@ fn test_use() {
             self
         }
     }
-    let mut fory = Fory::default().mode(Compatible).xlang(true);
+    let mut fory = Fory::default().compatible(true).xlang(true);
     let item = Item { f1: 1, f2: 2 };
     fory.register_serializer::<Item>(100);
     let bytes = fory.serialize(&item);

--- a/rust/tests/tests/test_max_dyn_depth.rs
+++ b/rust/tests/tests/test_max_dyn_depth.rs
@@ -27,9 +27,8 @@ struct Container {
 
 #[test]
 fn test_max_dyn_depth_exceeded_box_dyn_any() {
-    use fory_core::types::Mode;
-    for mode in [Mode::SchemaConsistent, Mode::Compatible] {
-        let mut fory = Fory::default().max_dyn_depth(2).mode(mode);
+    for compatible in [false, true] {
+        let mut fory = Fory::default().max_dyn_depth(2).compatible(compatible);
         fory.register::<Container>(100);
 
         let level3 = Container {

--- a/rust/tests/tests/test_rc_arc_trait_object.rs
+++ b/rust/tests/tests/test_rc_arc_trait_object.rs
@@ -18,7 +18,6 @@
 use fory_core::fory::Fory;
 use fory_core::register_trait_type;
 use fory_core::serializer::Serializer;
-use fory_core::types::Mode;
 use fory_core::{unwrap_rc, wrap_rc, wrap_vec_rc};
 use fory_derive::ForyObject;
 use std::collections::HashMap;
@@ -26,7 +25,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 fn fory_compatible() -> Fory {
-    Fory::default().mode(Mode::Compatible)
+    Fory::default().compatible(true)
 }
 
 trait Animal: Serializer + Send + Sync {

--- a/rust/tests/tests/test_simple_struct.rs
+++ b/rust/tests/tests/test_simple_struct.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use fory_core::fory::Fory;
-use fory_core::types::Mode::Compatible;
 use fory_derive::ForyObject;
 use std::collections::HashMap;
 
@@ -46,8 +45,8 @@ fn test_simple() {
         f7: i16,
         last: i8,
     }
-    let mut fory1 = Fory::default().mode(Compatible);
-    let mut fory2 = Fory::default().mode(Compatible);
+    let mut fory1 = Fory::default().compatible(true);
+    let mut fory2 = Fory::default().compatible(true);
     fory1.register::<Animal1>(999);
     fory2.register::<Animal2>(999);
     let animal: Animal1 = Animal1 {

--- a/rust/tests/tests/test_trait_object.rs
+++ b/rust/tests/tests/test_trait_object.rs
@@ -18,12 +18,11 @@
 use fory_core::fory::Fory;
 use fory_core::register_trait_type;
 use fory_core::serializer::Serializer;
-use fory_core::types::Mode;
 use fory_derive::ForyObject;
 use std::collections::{HashMap, HashSet};
 
 fn fory_compatible() -> Fory {
-    Fory::default().mode(Mode::Compatible)
+    Fory::default().compatible(true)
 }
 
 #[test]


### PR DESCRIPTION

## Why?

<!-- Describe the purpose of this PR. -->

## What does this PR do?

use compatible bool isntead enum to simplify API:
```rust
let fory = Fory::default().compatible(true);
```

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
