### PR TITLE
perf(Rust): remove clone()/to_owned() on MetaString/MetaStringBytes in MetaStringResolver to improve performance

### DIFF
--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -26,6 +26,7 @@ use crate::types::{TypeId, PRIMITIVE_TYPES};
 use std::clone::Clone;
 use std::cmp::min;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 const SMALL_NUM_FIELDS_THRESHOLD: usize = 0b11111;
 const REGISTER_BY_NAME_FLAG: u8 = 0b100000;
@@ -236,8 +237,8 @@ impl PartialEq for FieldType {
 #[derive(Debug)]
 pub struct TypeMetaLayer {
     type_id: u32,
-    namespace: MetaString,
-    type_name: MetaString,
+    namespace: Arc<MetaString>,
+    type_name: Arc<MetaString>,
     register_by_name: bool,
     field_infos: Vec<FieldInfo>,
 }
@@ -252,8 +253,8 @@ impl TypeMetaLayer {
     ) -> TypeMetaLayer {
         TypeMetaLayer {
             type_id,
-            namespace,
-            type_name,
+            namespace: Arc::from(namespace),
+            type_name: Arc::from(type_name),
             register_by_name,
             field_infos,
         }
@@ -262,8 +263,8 @@ impl TypeMetaLayer {
     pub fn empty() -> TypeMetaLayer {
         TypeMetaLayer {
             type_id: 0,
-            namespace: MetaString::default(),
-            type_name: MetaString::default(),
+            namespace: Arc::from(MetaString::default()),
+            type_name: Arc::from(MetaString::default()),
             register_by_name: false,
             field_infos: vec![],
         }
@@ -273,12 +274,12 @@ impl TypeMetaLayer {
         self.type_id
     }
 
-    pub fn get_type_name(&self) -> &MetaString {
-        &self.type_name
+    pub fn get_type_name(&self) -> Arc<MetaString> {
+        self.type_name.clone()
     }
 
-    pub fn get_namespace(&self) -> &MetaString {
-        &self.namespace
+    pub fn get_namespace(&self) -> Arc<MetaString> {
+        self.namespace.clone()
     }
 
     pub fn get_field_infos(&self) -> &Vec<FieldInfo> {
@@ -556,11 +557,11 @@ impl TypeMeta {
         self.hash
     }
 
-    pub fn get_type_name(&self) -> MetaString {
+    pub fn get_type_name(&self) -> Arc<MetaString> {
         self.layer.get_type_name().clone()
     }
 
-    pub fn get_namespace(&self) -> MetaString {
+    pub fn get_namespace(&self) -> Arc<MetaString> {
         self.layer.get_namespace().clone()
     }
 

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -92,8 +92,8 @@ pub struct TypeInfo {
     type_def: Arc<Vec<u8>>,
     type_meta: Arc<TypeMeta>,
     type_id: u32,
-    namespace: MetaString,
-    type_name: MetaString,
+    namespace: Arc<MetaString>,
+    type_name: Arc<MetaString>,
     register_by_name: bool,
 }
 
@@ -120,8 +120,8 @@ impl TypeInfo {
             type_def: Arc::from(type_def_bytes),
             type_meta: Arc::new(type_meta),
             type_id,
-            namespace: namespace_metastring,
-            type_name: type_name_metastring,
+            namespace: Arc::from(namespace_metastring),
+            type_name: Arc::from(type_name_metastring),
             register_by_name,
         })
     }
@@ -151,8 +151,8 @@ impl TypeInfo {
             type_def: Arc::from(type_def),
             type_meta: Arc::new(meta),
             type_id,
-            namespace: namespace_metastring,
-            type_name: type_name_metastring,
+            namespace: Arc::from(namespace_metastring),
+            type_name: Arc::from(type_name_metastring),
             register_by_name,
         })
     }
@@ -161,12 +161,12 @@ impl TypeInfo {
         self.type_id
     }
 
-    pub fn get_namespace(&self) -> &MetaString {
-        &self.namespace
+    pub fn get_namespace(&self) -> Arc<MetaString> {
+        self.namespace.clone()
     }
 
-    pub fn get_type_name(&self) -> &MetaString {
-        &self.type_name
+    pub fn get_type_name(&self) -> Arc<MetaString> {
+        self.type_name.clone()
     }
 
     pub fn get_type_def(&self) -> Arc<Vec<u8>> {
@@ -184,9 +184,9 @@ impl TypeInfo {
 
 pub struct TypeResolver {
     serializer_map: HashMap<u32, Arc<Harness>>,
-    name_serializer_map: HashMap<(MetaString, MetaString), Arc<Harness>>,
+    name_serializer_map: HashMap<(Arc<MetaString>, Arc<MetaString>), Arc<Harness>>,
     type_id_map: HashMap<std::any::TypeId, u32>,
-    type_name_map: HashMap<std::any::TypeId, (MetaString, MetaString)>,
+    type_name_map: HashMap<std::any::TypeId, (Arc<MetaString>, Arc<MetaString>)>,
     type_info_cache: HashMap<std::any::TypeId, TypeInfo>,
     type_info_map_by_id: HashMap<u32, TypeInfo>,
     type_info_map_by_name: HashMap<(String, String), TypeInfo>,
@@ -225,8 +225,8 @@ impl TypeResolver {
                     type_def: Arc::from(vec![]),
                     type_meta: Arc::new(TypeMeta::empty()),
                     type_id: $type_id as u32,
-                    namespace: namespace.clone(),
-                    type_name: type_name.clone(),
+                    namespace: Arc::from(namespace.clone()),
+                    type_name: Arc::from(type_name.clone()),
                     register_by_name: false,
                 };
                 self.register_serializer::<$ty>(&type_info)?;
@@ -567,8 +567,8 @@ impl TypeResolver {
 
     pub fn get_name_harness(
         &self,
-        namespace: &MetaString,
-        type_name: &MetaString,
+        namespace: Arc<MetaString>,
+        type_name: Arc<MetaString>,
     ) -> Option<Arc<Harness>> {
         let key = (namespace.clone(), type_name.clone());
         self.name_serializer_map.get(&key).cloned()
@@ -583,8 +583,8 @@ impl TypeResolver {
 
     pub fn get_ext_name_harness(
         &self,
-        namespace: &MetaString,
-        type_name: &MetaString,
+        namespace: Arc<MetaString>,
+        type_name: Arc<MetaString>,
     ) -> Result<Arc<Harness>, Error> {
         let key = (namespace.clone(), type_name.clone());
         self.name_serializer_map.get(&key).cloned().ok_or_else(|| {

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -66,10 +66,10 @@ pub fn write_type_info<T: Serializer>(
         context.writer.write_varuint32(meta_index);
     } else {
         let type_info = fory.get_type_resolver().get_type_info(rs_type_id)?;
-        let namespace = type_info.get_namespace().to_owned();
-        let type_name = type_info.get_type_name().to_owned();
-        context.write_meta_string_bytes(&namespace)?;
-        context.write_meta_string_bytes(&type_name)?;
+        let namespace = type_info.get_namespace();
+        let type_name = type_info.get_type_name();
+        context.write_meta_string_bytes(namespace)?;
+        context.write_meta_string_bytes(type_name)?;
     }
     Ok(())
 }

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -173,7 +173,7 @@ pub fn skip_field_value(
                 let type_meta = context.get_meta(meta_index as usize);
                 let type_resolver = fory.get_type_resolver();
                 type_resolver
-                    .get_ext_name_harness(&type_meta.get_namespace(), &type_meta.get_type_name())?
+                    .get_ext_name_harness(type_meta.get_namespace(), type_meta.get_type_name())?
                     .get_read_data_fn()(fory, context, true)?;
                 Ok(())
             } else {

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -94,10 +94,10 @@ pub fn write_type_info<T: Serializer>(
             context.writer.write_varuint32(meta_index);
         } else {
             let type_info = fory.get_type_resolver().get_type_info(rs_type_id)?;
-            let namespace = type_info.get_namespace().to_owned();
-            let type_name = type_info.get_type_name().to_owned();
-            context.write_meta_string_bytes(&namespace)?;
-            context.write_meta_string_bytes(&type_name)?;
+            let namespace = type_info.get_namespace();
+            let type_name = type_info.get_type_name();
+            context.write_meta_string_bytes(namespace)?;
+            context.write_meta_string_bytes(type_name)?;
         }
     } else if type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
         || type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32


### PR DESCRIPTION
## Why?
`clone()/to_owned()` on `MetaString/MetaStringBytes` is expensive.

## What does this PR do?
1. use `Rc` in  `MetaStringReaderResolver` and use `Arc` in `MetaStringWriterResolver` to remove `clone()/to_owned()`.
 
> use `Arc` is because WriterResolver uses TypeInfo stored in TypeResolver., and use `Rc` is because ReaderResolver is not.


## Related issues
close #2762 
