### PR TITLE
perf(Rust): remove clone()/to_owned() on MetaString/MetaStringBytes in MetaStringResolver to improve performance

### DIFF
--- a/rust/fory-core/Cargo.toml
+++ b/rust/fory-core/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.4"
 thiserror = { default-features = false, version = "1.0" }
 num_enum = "0.5.1"
 paste = "1.0"
+once_cell = "1.21.3"
 
 
 [[bench]]

--- a/rust/fory-core/src/meta/meta_string.rs
+++ b/rust/fory-core/src/meta/meta_string.rs
@@ -18,6 +18,7 @@
 use crate::ensure;
 use crate::error::Error;
 use crate::meta::string_util;
+use std::sync::{Arc, OnceLock};
 
 // equal to "std::i16::MAX"
 const SHORT_MAX_VALUE: usize = 32767;
@@ -66,6 +67,8 @@ impl std::hash::Hash for MetaString {
     }
 }
 
+static EMPTY: OnceLock<Arc<MetaString>> = OnceLock::new();
+
 impl MetaString {
     pub fn new(
         original: String,
@@ -94,6 +97,21 @@ impl MetaString {
     pub fn write_to(&self, writer: &mut crate::buffer::Writer) {
         writer.write_varuint32(self.bytes.len() as u32);
         writer.write_bytes(&self.bytes);
+    }
+
+    pub fn get_empty() -> Arc<MetaString> {
+        EMPTY
+            .get_or_init(|| {
+                Arc::new(MetaString {
+                    original: "".to_string(),
+                    encoding: Encoding::default(),
+                    bytes: vec![],
+                    strip_last_char: false,
+                    special_char1: '\0',
+                    special_char2: '\0',
+                })
+            })
+            .clone()
     }
 }
 

--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -26,6 +26,7 @@ use crate::types::{TypeId, PRIMITIVE_TYPES};
 use std::clone::Clone;
 use std::cmp::min;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 const SMALL_NUM_FIELDS_THRESHOLD: usize = 0b11111;
 const REGISTER_BY_NAME_FLAG: u8 = 0b100000;
@@ -236,8 +237,8 @@ impl PartialEq for FieldType {
 #[derive(Debug)]
 pub struct TypeMetaLayer {
     type_id: u32,
-    namespace: MetaString,
-    type_name: MetaString,
+    namespace: Arc<MetaString>,
+    type_name: Arc<MetaString>,
     register_by_name: bool,
     field_infos: Vec<FieldInfo>,
 }
@@ -252,8 +253,8 @@ impl TypeMetaLayer {
     ) -> TypeMetaLayer {
         TypeMetaLayer {
             type_id,
-            namespace,
-            type_name,
+            namespace: Arc::from(namespace),
+            type_name: Arc::from(type_name),
             register_by_name,
             field_infos,
         }
@@ -262,8 +263,8 @@ impl TypeMetaLayer {
     pub fn empty() -> TypeMetaLayer {
         TypeMetaLayer {
             type_id: 0,
-            namespace: MetaString::default(),
-            type_name: MetaString::default(),
+            namespace: MetaString::get_empty(),
+            type_name: MetaString::get_empty(),
             register_by_name: false,
             field_infos: vec![],
         }
@@ -273,12 +274,12 @@ impl TypeMetaLayer {
         self.type_id
     }
 
-    pub fn get_type_name(&self) -> &MetaString {
-        &self.type_name
+    pub fn get_type_name(&self) -> Arc<MetaString> {
+        self.type_name.clone()
     }
 
-    pub fn get_namespace(&self) -> &MetaString {
-        &self.namespace
+    pub fn get_namespace(&self) -> Arc<MetaString> {
+        self.namespace.clone()
     }
 
     pub fn get_field_infos(&self) -> &Vec<FieldInfo> {
@@ -556,11 +557,11 @@ impl TypeMeta {
         self.hash
     }
 
-    pub fn get_type_name(&self) -> MetaString {
+    pub fn get_type_name(&self) -> Arc<MetaString> {
         self.layer.get_type_name().clone()
     }
 
-    pub fn get_namespace(&self) -> MetaString {
+    pub fn get_namespace(&self) -> Arc<MetaString> {
         self.layer.get_namespace().clone()
     }
 

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -86,8 +86,8 @@ pub struct TypeInfo {
     type_def: Arc<Vec<u8>>,
     type_meta: Arc<TypeMeta>,
     type_id: u32,
-    namespace: MetaString,
-    type_name: MetaString,
+    namespace: Arc<MetaString>,
+    type_name: Arc<MetaString>,
     register_by_name: bool,
 }
 
@@ -136,8 +136,8 @@ impl TypeInfo {
             type_def: Arc::from(type_def_bytes),
             type_meta,
             type_id,
-            namespace: namespace_metastring,
-            type_name: type_name_metastring,
+            namespace: Arc::from(namespace_metastring),
+            type_name: Arc::from(type_name_metastring),
             register_by_name,
         })
     }
@@ -166,8 +166,8 @@ impl TypeInfo {
             type_def: Arc::from(type_def),
             type_meta: Arc::new(meta),
             type_id,
-            namespace: namespace_metastring,
-            type_name: type_name_metastring,
+            namespace: Arc::from(namespace_metastring),
+            type_name: Arc::from(type_name_metastring),
             register_by_name,
         })
     }
@@ -176,12 +176,12 @@ impl TypeInfo {
         self.type_id
     }
 
-    pub fn get_namespace(&self) -> &MetaString {
-        &self.namespace
+    pub fn get_namespace(&self) -> Arc<MetaString> {
+        self.namespace.clone()
     }
 
-    pub fn get_type_name(&self) -> &MetaString {
-        &self.type_name
+    pub fn get_type_name(&self) -> Arc<MetaString> {
+        self.type_name.clone()
     }
 
     pub fn get_type_def(&self) -> Arc<Vec<u8>> {
@@ -201,9 +201,9 @@ impl TypeInfo {
 #[derive(Clone)]
 pub struct TypeResolver {
     serializer_map: HashMap<u32, Arc<Harness>>,
-    name_serializer_map: HashMap<(MetaString, MetaString), Arc<Harness>>,
+    name_serializer_map: HashMap<(Arc<MetaString>, Arc<MetaString>), Arc<Harness>>,
     type_id_map: HashMap<std::any::TypeId, u32>,
-    type_name_map: HashMap<std::any::TypeId, (MetaString, MetaString)>,
+    type_name_map: HashMap<std::any::TypeId, (Arc<MetaString>, Arc<MetaString>)>,
     type_info_cache: HashMap<std::any::TypeId, TypeInfo>,
     type_info_map_by_id: HashMap<u32, TypeInfo>,
     type_info_map_by_name: HashMap<(String, String), TypeInfo>,
@@ -272,8 +272,8 @@ impl TypeResolver {
 
     pub fn get_name_harness(
         &self,
-        namespace: &MetaString,
-        type_name: &MetaString,
+        namespace: Arc<MetaString>,
+        type_name: Arc<MetaString>,
     ) -> Option<Arc<Harness>> {
         let key = (namespace.clone(), type_name.clone());
         self.name_serializer_map.get(&key).cloned()
@@ -288,8 +288,8 @@ impl TypeResolver {
 
     pub fn get_ext_name_harness(
         &self,
-        namespace: &MetaString,
-        type_name: &MetaString,
+        namespace: Arc<MetaString>,
+        type_name: Arc<MetaString>,
     ) -> Result<Arc<Harness>, Error> {
         let key = (namespace.clone(), type_name.clone());
         self.name_serializer_map.get(&key).cloned().ok_or_else(|| {
@@ -316,8 +316,8 @@ impl TypeResolver {
                     type_def: Arc::from(vec![]),
                     type_meta: Arc::new(TypeMeta::empty()),
                     type_id: $type_id as u32,
-                    namespace: namespace.clone(),
-                    type_name: type_name.clone(),
+                    namespace: Arc::from(namespace.clone()),
+                    type_name: Arc::from(type_name.clone()),
                     register_by_name: false,
                 };
                 self.register_serializer::<$ty>(&type_info)?;

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -63,10 +63,10 @@ pub fn write_type_info<T: Serializer>(
         context.writer.write_varuint32(meta_index);
     } else {
         let type_info = context.get_type_resolver().get_type_info(rs_type_id)?;
-        let namespace = type_info.get_namespace().to_owned();
-        let type_name = type_info.get_type_name().to_owned();
-        context.write_meta_string_bytes(&namespace)?;
-        context.write_meta_string_bytes(&type_name)?;
+        let namespace = type_info.get_namespace();
+        let type_name = type_info.get_type_name();
+        context.write_meta_string_bytes(namespace)?;
+        context.write_meta_string_bytes(type_name)?;
     }
     Ok(())
 }

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -172,7 +172,7 @@ pub fn skip_field_value(
                 let type_meta = context.get_meta(meta_index as usize);
                 let type_resolver = context.get_type_resolver();
                 type_resolver
-                    .get_ext_name_harness(&type_meta.get_namespace(), &type_meta.get_type_name())?
+                    .get_ext_name_harness(type_meta.get_namespace(), type_meta.get_type_name())?
                     .get_read_data_fn()(context, true)?;
                 Ok(())
             } else {

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -51,10 +51,10 @@ pub fn write_type_info<T: Serializer>(
             context.writer.write_varuint32(meta_index);
         } else {
             let type_info = context.get_type_resolver().get_type_info(rs_type_id)?;
-            let namespace = type_info.get_namespace().to_owned();
-            let type_name = type_info.get_type_name().to_owned();
-            context.write_meta_string_bytes(&namespace)?;
-            context.write_meta_string_bytes(&type_name)?;
+            let namespace = type_info.get_namespace();
+            let type_name = type_info.get_type_name();
+            context.write_meta_string_bytes(namespace)?;
+            context.write_meta_string_bytes(type_name)?;
         }
     } else if type_id & 0xff == TypeId::NAMED_COMPATIBLE_STRUCT as u32
         || type_id & 0xff == TypeId::COMPATIBLE_STRUCT as u32

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -27,3 +27,4 @@ fory-core = { path = "../fory-core" }
 fory-derive = { path = "../fory-derive" }
 
 chrono = "0.4"
+rand = "0.8.5"

--- a/rust/tests/tests/test_metastring_resolver.rs
+++ b/rust/tests/tests/test_metastring_resolver.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fory_core::meta::NAMESPACE_ENCODER;
+use fory_core::resolver::metastring_resolver::{
+    MetaStringReaderResolver, MetaStringWriterResolver,
+};
+use fory_core::{Reader, Writer};
+use std::sync::Arc;
+
+#[test]
+pub fn empty() {
+    let mut ms_writer = MetaStringWriterResolver::default();
+    let mut ms_reader = MetaStringReaderResolver::default();
+
+    for _ in 0..3 {
+        let ms = NAMESPACE_ENCODER.encode("").unwrap();
+        let arc_ms = Arc::from(ms);
+        let mb = ms_writer
+            .get_or_create_meta_string_bytes(arc_ms.clone())
+            .unwrap();
+
+        let mut writer = Writer::default();
+        ms_writer.write_meta_string_bytes(&mut writer, mb.clone());
+
+        let binding = writer.dump();
+        let mut reader = Reader::new(binding.as_slice());
+
+        let read_mb = ms_reader.read_meta_string_bytes(&mut reader).unwrap();
+        assert_eq!(mb, read_mb);
+        ms_writer.reset();
+        ms_reader.reset();
+    }
+}
+#[test]
+pub fn small_ms() {
+    let mut ms_writer = MetaStringWriterResolver::default();
+    let mut ms_reader = MetaStringReaderResolver::default();
+    // test reset
+    for _ in 0..3 {
+        // write
+        let mut data = Vec::new();
+        for i in 0..20 {
+            let ms = NAMESPACE_ENCODER.encode(&format!("ms_{i}")).unwrap();
+            let arc_ms = Arc::from(ms);
+            // test cache
+            for _ in 0..3 {
+                let mb = ms_writer
+                    .get_or_create_meta_string_bytes(arc_ms.clone())
+                    .unwrap();
+                data.push(mb);
+            }
+        }
+        let mut writer = Writer::default();
+        for mb in data.iter() {
+            ms_writer.write_meta_string_bytes(&mut writer, mb.clone());
+        }
+        // read
+        let binding = writer.dump();
+        let mut reader = Reader::new(binding.as_slice());
+        let read_data: Vec<_> = (0..60)
+            .map(|_| ms_reader.read_meta_string_bytes(&mut reader).unwrap())
+            .collect();
+        assert_eq!(data, read_data);
+        ms_writer.reset();
+        ms_reader.reset();
+    }
+}
+
+#[test]
+pub fn big_ms() {
+    let long_string = "a".repeat(50);
+    let mut ms_writer = MetaStringWriterResolver::default();
+    let mut ms_reader = MetaStringReaderResolver::default();
+    // test reset
+    for _ in 0..3 {
+        // write
+        let mut data = Vec::new();
+        for i in 0..20 {
+            let ms = NAMESPACE_ENCODER
+                .encode(&format!("{long_string}_{i}"))
+                .unwrap();
+            let arc_ms = Arc::from(ms);
+            // test cache
+            for _ in 0..3 {
+                let mb = ms_writer
+                    .get_or_create_meta_string_bytes(arc_ms.clone())
+                    .unwrap();
+                data.push(mb);
+            }
+        }
+        let mut writer = Writer::default();
+        for mb in data.iter() {
+            ms_writer.write_meta_string_bytes(&mut writer, mb.clone());
+        }
+        // read
+        let binding = writer.dump();
+        let mut reader = Reader::new(binding.as_slice());
+        let read_data: Vec<_> = (0..60)
+            .map(|_| ms_reader.read_meta_string_bytes(&mut reader).unwrap())
+            .collect();
+        assert_eq!(data, read_data);
+        ms_writer.reset();
+        ms_reader.reset();
+    }
+}


### PR DESCRIPTION
## Why?
`clone()/to_owned()` on `MetaString/MetaStringBytes` is expensive.

## What does this PR do?
1. use `Rc` in  `MetaStringReaderResolver` and use `Arc` in `MetaStringWriterResolver` to remove `clone()/to_owned()`.
2. `not use RefCell` in MetaStringWriterResolver.
3. aligned metastring_resolver logic with Java

> use `Arc` is because WriterResolver uses TypeInfo stored in TypeResolver., and use `Rc` is because ReaderResolver is not.


## Related issues
close #2762 
