### PR TITLE
fix(Rust): Make registration lazy to avoid errors caused by missing dependent types due to registration order

### DIFF
--- a/rust/fory-core/src/resolver/context.rs
+++ b/rust/fory-core/src/resolver/context.rs
@@ -70,9 +70,10 @@ impl WriteContext {
         }
     }
 
-    pub fn new_from_fory(writer: Writer, fory: &Fory) -> WriteContext {
-        WriteContext {
-            type_resolver: fory.get_type_resolver().clone(),
+    pub fn new_from_fory(writer: Writer, fory: &Fory) -> Result<WriteContext, Error> {
+        fory.get_type_resolver().finalize_registration()?;
+        Ok(WriteContext {
+            type_resolver: fory.get_type_resolver().build(),
             compatible: fory.is_compatible(),
             share_meta: fory.is_share_meta(),
             compress_string: fory.is_compress_string(),
@@ -82,7 +83,7 @@ impl WriteContext {
             meta_resolver: MetaWriterResolver::default(),
             meta_string_resolver: MetaStringWriterResolver::default(),
             ref_writer: RefWriter::new(),
-        }
+        })
     }
 
     /// Get type resolver
@@ -261,9 +262,10 @@ impl ReadContext {
         }
     }
 
-    pub fn new_from_fory(reader: Reader, fory: &Fory) -> ReadContext {
-        ReadContext {
-            type_resolver: fory.get_type_resolver().clone(),
+    pub fn new_from_fory(reader: Reader, fory: &Fory) -> Result<ReadContext, Error> {
+        fory.get_type_resolver().finalize_registration()?;
+        Ok(ReadContext {
+            type_resolver: fory.get_type_resolver().build(),
             compatible: fory.is_compatible(),
             share_meta: fory.is_share_meta(),
             xlang: fory.is_xlang(),
@@ -274,7 +276,7 @@ impl ReadContext {
             meta_string_resolver: MetaStringReaderResolver::default(),
             ref_reader: RefReader::new(),
             current_depth: 0,
-        }
+        })
     }
 
     /// Get type resolver

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -394,7 +394,7 @@ pub(super) fn generic_tree_to_tokens(node: &TypeNode) -> TokenStream {
         ts
     } else {
         quote! {
-            <#ty as fory_core::serializer::Serializer>::fory_get_type_id(type_resolver)?
+            type_resolver.get_actual_type_id::<#ty>()?
         }
     };
 


### PR DESCRIPTION
## What does this PR do?
1. Changed `register` to a lazy form, and `finalize_registration()` is only called for the actual registration during `serialize()`, `deserialize()`, or `new_from_fory()`.

2. Adjusted the `register_xx` methods of `TypeResolver` and exposed lazy `register` methods externally.

3. To distinguish between `Context::TypeResolver` and `Fory::TypeResolver`, a new struct `SharedTypeResolver` was introduced. It is responsible for collecting lazy registration information and finalizing it. Using `UnsafeCell` avoids needing `mut fory`, and `Once` ensures finalization happens only once. After finalization, `get_clone()` can return a clone of the internal `TypeResolver` to be inserted into `Context`.

4. Use BTreeMap to store lazy registration information, because HashMap is unordered, iterating over its values(Types) can produce different traversal orders for the same register sequence. Using a BTreeMap makes my testing more convenient.

5. modify `struct::fory_fields_info()` logic, when field_type not found in TypeResolver, will register it immediately and `retry` to get its fory_type_id. Use a HashSet to record Types have been registered.


## Related issues
#2793
close #2794

## Does this PR introduce any user-facing change?
- [x] Does this PR introduce any public API change?
The `Read/WriteContext::new_from_fory()` will return `Result<Read/WriteContext, Error>`