### PR TITLE
fix(java): Fix inconsistency in exception handling when reading EOF stream

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/io/ForyInputStream.java
+++ b/java/fory-core/src/main/java/org/apache/fory/io/ForyInputStream.java
@@ -127,14 +127,14 @@ public class ForyInputStream extends InputStream implements ForyStreamReader {
       len -= remaining;
       dstIndex += remaining;
       try {
-        int read = stream.read(dst, dstIndex, len);
-        while (read < len) {
+        int read = 0;
+        do {
           int newRead = stream.read(dst, dstIndex + read, len - read);
           if (newRead < 0) {
             throw new IndexOutOfBoundsException("No enough data in the stream " + stream);
           }
           read += newRead;
-        }
+        } while (read < len);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/java/fory-core/src/main/java/org/apache/fory/io/ForyInputStream.java
+++ b/java/fory-core/src/main/java/org/apache/fory/io/ForyInputStream.java
@@ -127,6 +127,7 @@ public class ForyInputStream extends InputStream implements ForyStreamReader {
       len -= remaining;
       dstIndex += remaining;
       try {
+        // Check the first read for EOF too, before using its result to advance the offset.
         int read = 0;
         do {
           int newRead = stream.read(dst, dstIndex + read, len - read);

--- a/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.io;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ForyInputStreamTest {
+
+  @Test
+  public void testFillBufferIndexOutOfBoundsException() throws IOException {
+    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0])) ) {
+      try {
+        in.fillBuffer(1);
+        Assert.fail("Expected IndexOutOfBoundsException to be thrown");
+      } catch (IndexOutOfBoundsException e) {
+        Assert.assertTrue(e.getMessage().contains("No enough data in the stream"));
+      }
+    }
+  }
+
+  @Test
+  public void testReadToIndexOutOfBoundsException() throws IOException {
+    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0])) ) {
+      try {
+        in.readTo(new byte[10], 0, 10);
+        Assert.fail("Expected IndexOutOfBoundsException to be thrown");
+      } catch (IndexOutOfBoundsException e) {
+        Assert.assertTrue(e.getMessage().contains("No enough data in the stream"));
+      }
+    }
+  }
+}

--- a/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
@@ -29,7 +29,7 @@ public class ForyInputStreamTest {
 
   @Test
   public void testFillBufferIndexOutOfBoundsException() throws IOException {
-    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0])) ) {
+    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0]))) {
       try {
         in.fillBuffer(1);
         Assert.fail("Expected IndexOutOfBoundsException to be thrown");
@@ -41,7 +41,7 @@ public class ForyInputStreamTest {
 
   @Test
   public void testReadToIndexOutOfBoundsException() throws IOException {
-    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0])) ) {
+    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0]))) {
       try {
         in.readTo(new byte[10], 0, 10);
         Assert.fail("Expected IndexOutOfBoundsException to be thrown");

--- a/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
@@ -19,11 +19,10 @@
 
 package org.apache.fory.io;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class ForyInputStreamTest {
 

--- a/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/io/ForyInputStreamTest.java
@@ -27,26 +27,29 @@ import org.testng.annotations.Test;
 public class ForyInputStreamTest {
 
   @Test
-  public void testFillBufferIndexOutOfBoundsException() throws IOException {
-    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0]))) {
-      try {
-        in.fillBuffer(1);
-        Assert.fail("Expected IndexOutOfBoundsException to be thrown");
-      } catch (IndexOutOfBoundsException e) {
-        Assert.assertTrue(e.getMessage().contains("No enough data in the stream"));
+  public void testReadToEof() throws IOException {
+    for (int dstIndex : new int[] {0, 3}) {
+      EofInputStream stream = new EofInputStream();
+      byte[] dst = new byte[10];
+      int length = dst.length - dstIndex;
+      try (ForyInputStream in = new ForyInputStream(stream)) {
+        Assert.assertThrows(RuntimeException.class, () -> in.readTo(dst, dstIndex, length));
+        Assert.assertEquals(stream.readCalls, 1);
       }
     }
   }
 
-  @Test
-  public void testReadToIndexOutOfBoundsException() throws IOException {
-    try (ForyInputStream in = new ForyInputStream(new ByteArrayInputStream(new byte[0]))) {
-      try {
-        in.readTo(new byte[10], 0, 10);
-        Assert.fail("Expected IndexOutOfBoundsException to be thrown");
-      } catch (IndexOutOfBoundsException e) {
-        Assert.assertTrue(e.getMessage().contains("No enough data in the stream"));
-      }
+  private static class EofInputStream extends ByteArrayInputStream {
+    private int readCalls;
+
+    private EofInputStream() {
+      super(new byte[0]);
+    }
+
+    @Override
+    public synchronized int read(byte[] dst, int offset, int length) {
+      readCalls++;
+      return super.read(dst, offset, length);
     }
   }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

<!-- Describe the purpose of this PR. -->

## What does this PR do?
修改读取EOF流异常不一致问题
<!-- Describe the details of this PR. -->

## Related issues
#2772 
<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
