### PR TITLE
chore(Java): Make RustXlangTest cases independent from each other

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -95,8 +95,7 @@ public class RustXlangTest extends ForyTestBase {
     }
   }
 
-  @Test
-  List<String> setTestCase(String name) {
+  private List<String> setTestCase(String name) {
     List<String> command = rustBaseCommand;
     command.set(RUST_TESTCASE_INDEX, name);
     return command;


### PR DESCRIPTION
## What does this PR do?
Make RustXlangTest cases independent

## Related issues
#2832