### PR TITLE
feat(python): add support for np.float16

### DIFF
--- a/python/pyfory/serializer.py
+++ b/python/pyfory/serializer.py
@@ -112,6 +112,7 @@ from pyfory.type import (
     Int16NDArrayType,
     Int32NDArrayType,
     Int64NDArrayType,
+    Float16NDArrayType,
     Float32NDArrayType,
     Float64NDArrayType,
     TypeId,
@@ -978,6 +979,7 @@ if np:
             np.dtype(np.int16): (2, "h", Int16NDArrayType, TypeId.INT16_ARRAY),
             np.dtype(np.int32): (4, "i", Int32NDArrayType, TypeId.INT32_ARRAY),
             np.dtype(np.int64): (8, "l", Int64NDArrayType, TypeId.INT64_ARRAY),
+            np.dtype(np.float16): (2, "e", Float16NDArrayType, TypeId.FLOAT16_ARRAY),
             np.dtype(np.float32): (4, "f", Float32NDArrayType, TypeId.FLOAT32_ARRAY),
             np.dtype(np.float64): (8, "d", Float64NDArrayType, TypeId.FLOAT64_ARRAY),
         }
@@ -987,6 +989,7 @@ if np:
             np.dtype(np.int16): (2, "h", Int16NDArrayType, TypeId.INT16_ARRAY),
             np.dtype(np.int32): (4, "l", Int32NDArrayType, TypeId.INT32_ARRAY),
             np.dtype(np.int64): (8, "q", Int64NDArrayType, TypeId.INT64_ARRAY),
+            np.dtype(np.float16): (2, "e", Float16NDArrayType, TypeId.FLOAT16_ARRAY),
             np.dtype(np.float32): (4, "f", Float32NDArrayType, TypeId.FLOAT32_ARRAY),
             np.dtype(np.float64): (8, "d", Float64NDArrayType, TypeId.FLOAT64_ARRAY),
         }
@@ -1014,7 +1017,7 @@ class Numpy1DArraySerializer(Serializer):
         assert view.itemsize == self.itemsize
         nbytes = len(value) * self.itemsize
         buffer.write_varuint32(nbytes)
-        if self.dtype == np.dtype("bool") or not view.c_contiguous:
+        if self.dtype == np.dtype("bool") or self.dtype == np.dtype("float16") or not view.c_contiguous:
             buffer.write_bytes(value.tobytes())
         else:
             buffer.write_buffer(value)
@@ -1037,7 +1040,7 @@ class NDArraySerializer(Serializer):
         nbytes = len(value) * itemsize
         buffer.write_varuint32(type_id)
         buffer.write_varuint32(nbytes)
-        if value.dtype == np.dtype("bool") or not view.c_contiguous:
+        if value.dtype == np.dtype("bool") or value.dtype == np.dtype("float16") or not view.c_contiguous:
             buffer.write_bytes(value.tobytes())
         else:
             buffer.write_buffer(value)

--- a/python/pyfory/tests/test_pickle_buffer.py
+++ b/python/pyfory/tests/test_pickle_buffer.py
@@ -259,6 +259,7 @@ def test_numpy_array_different_dtypes_out_of_band():
     fory = Fory(xlang=False, ref=False, strict=False)
 
     arrays = {
+        "float16": np.arange(100).reshape(10, 10).astype(np.float16),
         "float32": np.arange(100).reshape(10, 10).astype(np.float32),
         "float64": np.arange(100).reshape(10, 10).astype(np.float64),
         "int8": np.arange(100).reshape(10, 10).astype(np.int8),

--- a/python/pyfory/type.py
+++ b/python/pyfory/type.py
@@ -300,6 +300,7 @@ BoolNDArrayType = TypeVar("BoolNDArrayType", bound=ndarray)
 Int16NDArrayType = TypeVar("Int16NDArrayType", bound=ndarray)
 Int32NDArrayType = TypeVar("Int32NDArrayType", bound=ndarray)
 Int64NDArrayType = TypeVar("Int64NDArrayType", bound=ndarray)
+Float16NDArrayType = TypeVar("Float16NDArrayType", bound=ndarray)
 Float32NDArrayType = TypeVar("Float32NDArrayType", bound=ndarray)
 Float64NDArrayType = TypeVar("Float64NDArrayType", bound=ndarray)
 
@@ -317,6 +318,7 @@ _np_array_types = {
     Int16NDArrayType,
     Int32NDArrayType,
     Int64NDArrayType,
+    Float16NDArrayType,
     Float32NDArrayType,
     Float64NDArrayType,
 }


### PR DESCRIPTION
## Why?

FP16 is a very common format, especially on ML applications (e.g. when running a model on half precision). It seems like a waste of cycles to upcast the ndarray to 32 to serialize it, and it will have a higher bytesize than the fp16 representation.

## What does this PR do?

Float16 is not a native array/memoryview format, so this PR adds a new condition to handle fp16 arrays similarly to boolean arrays.

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
