### PR TITLE
chore(CI): Add caching for bazel in github workflows

### DIFF
--- a/.github/workflows/build-containerized-release.yml
+++ b/.github/workflows/build-containerized-release.yml
@@ -49,9 +49,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel/_bazel_*/*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-native-pr.yml
+++ b/.github/workflows/build-native-pr.yml
@@ -53,9 +53,9 @@ jobs:
             ~/.cache/bazel/_bazel_*/*/external
             ~/Library/Caches/bazel/_bazel_*/*/external
             C:\users\runneradmin\_bazel_runneradmin\*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-native-release.yml
+++ b/.github/workflows/build-native-release.yml
@@ -54,9 +54,9 @@ jobs:
             ~/.cache/bazel/_bazel_*/*/external
             ~/Library/Caches/bazel/_bazel_*/*/external
             C:\users\runneradmin\_bazel_runneradmin\*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel/_bazel_*/*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:
@@ -143,9 +143,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel/_bazel_*/*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:
@@ -386,9 +386,9 @@ jobs:
             ~/.cache/bazel/_bazel_*/*/external
             ~/Library/Caches/bazel/_bazel_*/*/external
             C:\users\runneradmin\_bazel_runneradmin\*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-py311-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-py311-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:
@@ -430,9 +430,9 @@ jobs:
             ~/.cache/bazel/_bazel_*/*/external
             ~/Library/Caches/bazel/_bazel_*/*/external
             C:\users\runneradmin\_bazel_runneradmin\*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:
@@ -485,9 +485,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel/_bazel_*/*/external
-          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
           restore-keys: |
-            bazel-repo-${{ runner.os }}-${{ runner.arch }}-
+            bazel-repo-${{ runner.os }}-${{ runner.arch }}-py38-
       - name: Cache Bazel build outputs
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

Due to lack of caching of bazel, every CI run takes too much time

with cache: 
<img width="2613" height="1585" alt="image" src="https://github.com/user-attachments/assets/bcc1b6f5-4512-4f92-9845-cb9df657cb74" />

without cache:
<img width="2282" height="564" alt="image" src="https://github.com/user-attachments/assets/ec5740ff-f915-46fd-b58a-bf941576c316" />


<!-- Describe the purpose of this PR. -->

## What does this PR do?

This PR adds caching for bazel in github workflows

<!-- Describe the details of this PR. -->

## Related issues

closes #2880

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->
