### PR TITLE
feat(Rust): Support u128 & u128_array

### DIFF
--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -462,6 +462,7 @@ impl TypeMetaLayer {
                 TypeId::U32 => 4,
                 TypeId::U64 => 8,
                 TypeId::USIZE => 8,
+                TypeId::U128 => 16,
                 _ => unreachable!(),
             }
         }

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -553,6 +553,7 @@ impl TypeResolver {
         self.register_internal_serializer::<u32>(TypeId::U32)?;
         self.register_internal_serializer::<u64>(TypeId::U64)?;
         self.register_internal_serializer::<usize>(TypeId::USIZE)?;
+        self.register_internal_serializer::<u128>(TypeId::U128)?;
         self.register_internal_serializer::<String>(TypeId::STRING)?;
         self.register_internal_serializer::<NaiveDateTime>(TypeId::TIMESTAMP)?;
         self.register_internal_serializer::<NaiveDate>(TypeId::LOCAL_DATE)?;
@@ -569,6 +570,7 @@ impl TypeResolver {
         self.register_internal_serializer::<Vec<u32>>(TypeId::U32_ARRAY)?;
         self.register_internal_serializer::<Vec<u64>>(TypeId::U64_ARRAY)?;
         self.register_internal_serializer::<Vec<usize>>(TypeId::USIZE_ARRAY)?;
+        self.register_internal_serializer::<Vec<u128>>(TypeId::U128_ARRAY)?;
         self.register_generic_trait::<Vec<String>>()?;
         self.register_generic_trait::<LinkedList<i32>>()?;
         self.register_generic_trait::<LinkedList<String>>()?;

--- a/rust/fory-core/src/serializer/core.rs
+++ b/rust/fory-core/src/serializer/core.rs
@@ -1073,7 +1073,7 @@ pub trait Serializer: 'static {
     ///
     /// # Type ID Categories
     ///
-    /// - **Primitives**: `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `F32`, `F64`, `BOOL`
+    /// - **Primitives**: `BOOL`, `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `USIZE`, `U128`, `F32`, `F64`
     /// - **Strings**: `STRING`
     /// - **Collections**: `LIST`, `MAP`, `SET`
     /// - **Structs**: `STRUCT`

--- a/rust/fory-core/src/serializer/list.rs
+++ b/rust/fory-core/src/serializer/list.rs
@@ -47,6 +47,7 @@ pub(super) fn get_primitive_type_id<T: Serializer>() -> TypeId {
         TypeId::U32 => TypeId::U32_ARRAY,
         TypeId::U64 => TypeId::U64_ARRAY,
         TypeId::USIZE => TypeId::USIZE_ARRAY,
+        TypeId::U128 => TypeId::U128_ARRAY,
         _ => TypeId::UNKNOWN,
     }
 }
@@ -69,7 +70,8 @@ pub(super) fn is_primitive_type<T: Serializer>() -> bool {
             | TypeId::U16
             | TypeId::U32
             | TypeId::U64
-            | TypeId::USIZE,
+            | TypeId::USIZE
+            | TypeId::U128,
     )
 }
 

--- a/rust/fory-core/src/serializer/primitive_list.rs
+++ b/rust/fory-core/src/serializer/primitive_list.rs
@@ -26,7 +26,7 @@ pub fn fory_write_data<T: Serializer>(this: &[T], context: &mut WriteContext) ->
     if context.is_xlang()
         && matches!(
             T::fory_static_type_id(),
-            TypeId::U8 | TypeId::U16 | TypeId::U32 | TypeId::U64 | TypeId::USIZE
+            TypeId::U8 | TypeId::U16 | TypeId::U32 | TypeId::U64 | TypeId::USIZE | TypeId::U128
         )
     {
         return Err(Error::not_allowed(

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -424,6 +424,9 @@ fn skip_value(
         types::USIZE => {
             <usize as Serializer>::fory_read_data(context)?;
         }
+        types::U128 => {
+            <u128 as Serializer>::fory_read_data(context)?;
+        }
         types::U16_ARRAY => {
             <Vec<u16> as Serializer>::fory_read_data(context)?;
         }
@@ -435,6 +438,9 @@ fn skip_value(
         }
         types::USIZE_ARRAY => {
             <Vec<usize> as Serializer>::fory_read_data(context)?;
+        }
+        types::U128_ARRAY => {
+            <Vec<u128> as Serializer>::fory_read_data(context)?;
         }
 
         // Container types

--- a/rust/fory-core/src/serializer/unsigned_number.rs
+++ b/rust/fory-core/src/serializer/unsigned_number.rs
@@ -98,3 +98,4 @@ impl_unsigned_num_serializer!(
     Reader::read_usize,
     TypeId::USIZE
 );
+impl_unsigned_num_serializer!(u128, Writer::write_u128, Reader::read_u128, TypeId::U128);

--- a/rust/fory-core/src/serializer/util.rs
+++ b/rust/fory-core/src/serializer/util.rs
@@ -21,8 +21,8 @@ use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
 use crate::types::TypeId;
 use crate::types::{
-    is_user_type, BOOL, ENUM, FLOAT32, FLOAT64, INT16, INT32, INT64, INT8, NAMED_ENUM, U16, U32,
-    U64, U8, USIZE,
+    is_user_type, BOOL, ENUM, FLOAT32, FLOAT64, INT16, INT32, INT64, INT8, NAMED_ENUM, U128, U16,
+    U32, U64, U8, USIZE,
 };
 
 #[inline(always)]
@@ -70,7 +70,18 @@ pub const fn field_need_write_ref_into(type_id: u32, nullable: bool) -> bool {
     let internal_type_id = type_id & 0xff;
     !matches!(
         internal_type_id,
-        BOOL | INT8 | INT16 | INT32 | INT64 | FLOAT32 | FLOAT64 | U8 | U16 | U32 | U64 | USIZE
+        BOOL | INT8
+            | INT16
+            | INT32
+            | INT64
+            | FLOAT32
+            | FLOAT64
+            | U8
+            | U16
+            | U32
+            | U64
+            | USIZE
+            | U128
     )
 }
 

--- a/rust/fory-core/src/types.rs
+++ b/rust/fory-core/src/types.rs
@@ -86,14 +86,16 @@ pub enum TypeId {
     U32 = 66,
     U64 = 67,
     USIZE = 68,
-    VAR_U32 = 69,
-    VAR_U64 = 70,
-    SLI_U64 = 71,
-    U16_ARRAY = 72,
-    U32_ARRAY = 73,
-    U64_ARRAY = 74,
-    USIZE_ARRAY = 75,
-    UNKNOWN = 76,
+    U128 = 69,
+    VAR_U32 = 70,
+    VAR_U64 = 71,
+    SLI_U64 = 72,
+    U16_ARRAY = 73,
+    U32_ARRAY = 74,
+    U64_ARRAY = 75,
+    USIZE_ARRAY = 76,
+    U128_ARRAY = 77,
+    UNKNOWN = 78,
 }
 
 pub const BOOL: u32 = TypeId::BOOL as u32;
@@ -140,6 +142,7 @@ pub const U16: u32 = TypeId::U16 as u32;
 pub const U32: u32 = TypeId::U32 as u32;
 pub const U64: u32 = TypeId::U64 as u32;
 pub const USIZE: u32 = TypeId::USIZE as u32;
+pub const U128: u32 = TypeId::U128 as u32;
 pub const VAR_U32: u32 = TypeId::VAR_U32 as u32;
 pub const VAR_U64: u32 = TypeId::VAR_U64 as u32;
 pub const SLI_U64: u32 = TypeId::SLI_U64 as u32;
@@ -147,6 +150,7 @@ pub const U16_ARRAY: u32 = TypeId::U16_ARRAY as u32;
 pub const U32_ARRAY: u32 = TypeId::U32_ARRAY as u32;
 pub const U64_ARRAY: u32 = TypeId::U64_ARRAY as u32;
 pub const USIZE_ARRAY: u32 = TypeId::USIZE_ARRAY as u32;
+pub const U128_ARRAY: u32 = TypeId::U128_ARRAY as u32;
 pub const UNKNOWN: u32 = TypeId::UNKNOWN as u32;
 
 const MAX_UNT32: u64 = (1 << 31) - 1;
@@ -164,7 +168,7 @@ pub fn compute_string_hash(s: &str) -> u32 {
     hash as u32
 }
 
-pub static BASIC_TYPES: [TypeId; 27] = [
+pub static BASIC_TYPES: [TypeId; 29] = [
     TypeId::BOOL,
     TypeId::INT8,
     TypeId::INT16,
@@ -188,13 +192,15 @@ pub static BASIC_TYPES: [TypeId; 27] = [
     TypeId::U32,
     TypeId::U64,
     TypeId::USIZE,
+    TypeId::U128,
     TypeId::U16_ARRAY,
     TypeId::U32_ARRAY,
     TypeId::U64_ARRAY,
     TypeId::USIZE_ARRAY,
+    TypeId::U128_ARRAY,
 ];
 
-pub static PRIMITIVE_TYPES: [u32; 12] = [
+pub static PRIMITIVE_TYPES: [u32; 13] = [
     TypeId::BOOL as u32,
     TypeId::INT8 as u32,
     TypeId::INT16 as u32,
@@ -207,9 +213,10 @@ pub static PRIMITIVE_TYPES: [u32; 12] = [
     TypeId::U32 as u32,
     TypeId::U64 as u32,
     TypeId::USIZE as u32,
+    TypeId::U128 as u32,
 ];
 
-pub static PRIMITIVE_ARRAY_TYPES: [u32; 12] = [
+pub static PRIMITIVE_ARRAY_TYPES: [u32; 13] = [
     TypeId::BOOL_ARRAY as u32,
     TypeId::BINARY as u32,
     TypeId::INT8_ARRAY as u32,
@@ -221,10 +228,11 @@ pub static PRIMITIVE_ARRAY_TYPES: [u32; 12] = [
     TypeId::U16_ARRAY as u32,
     TypeId::U32_ARRAY as u32,
     TypeId::U64_ARRAY as u32,
-    TypeId::U64_ARRAY as u32,
+    TypeId::USIZE_ARRAY as u32,
+    TypeId::U128_ARRAY as u32,
 ];
 
-pub static BASIC_TYPE_NAMES: [&str; 15] = [
+pub static BASIC_TYPE_NAMES: [&str; 16] = [
     "bool",
     "i8",
     "i16",
@@ -240,6 +248,7 @@ pub static BASIC_TYPE_NAMES: [&str; 15] = [
     "u32",
     "u64",
     "usize",
+    "u128",
 ];
 
 pub static CONTAINER_TYPES: [TypeId; 3] = [TypeId::LIST, TypeId::SET, TypeId::MAP];
@@ -259,6 +268,7 @@ pub static PRIMITIVE_ARRAY_TYPE_MAP: &[(&str, u32, &str)] = &[
     ("u32", TypeId::U32_ARRAY as u32, "Vec<u32>"),
     ("u64", TypeId::U64_ARRAY as u32, "Vec<u64>"),
     ("usize", TypeId::USIZE_ARRAY as u32, "Vec<usize>"),
+    ("u128", TypeId::U128_ARRAY as u32, "Vec<u128>"),
 ];
 
 /// Keep as const fn for compile time evaluation or constant folding
@@ -278,6 +288,7 @@ pub const fn is_primitive_type_id(type_id: TypeId) -> bool {
             | TypeId::U32
             | TypeId::U64
             | TypeId::USIZE
+            | TypeId::U128
     )
 }
 

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -408,6 +408,7 @@ pub(super) fn generic_tree_to_tokens(node: &TypeNode) -> TokenStream {
                     "u32" => quote! { fory_core::types::TypeId::U32_ARRAY as u32 },
                     "u64" => quote! { fory_core::types::TypeId::U64_ARRAY as u32 },
                     "usize" => quote! { fory_core::types::TypeId::USIZE_ARRAY as u32 },
+                    "u128" => quote! { fory_core::types::TypeId::U128_ARRAY as u32 },
                     _ => quote! { fory_core::types::TypeId::LIST as u32 },
                 };
                 return quote! {
@@ -528,8 +529,8 @@ fn extract_option_inner(s: &str) -> Option<&str> {
     s.strip_prefix("Option<")?.strip_suffix(">")
 }
 
-const PRIMITIVE_TYPE_NAMES: [&str; 12] = [
-    "bool", "i8", "i16", "i32", "i64", "f32", "f64", "u8", "u16", "u32", "u64", "usize",
+const PRIMITIVE_TYPE_NAMES: [&str; 13] = [
+    "bool", "i8", "i16", "i32", "i64", "f32", "f64", "u8", "u16", "u32", "u64", "usize", "u128",
 ];
 
 fn get_primitive_type_id(ty: &str) -> u32 {
@@ -546,6 +547,7 @@ fn get_primitive_type_id(ty: &str) -> u32 {
         "u32" => TypeId::U32 as u32,
         "u64" => TypeId::U64 as u32,
         "usize" => TypeId::USIZE as u32,
+        "u128" => TypeId::U128 as u32,
         _ => unreachable!("Unknown primitive type: {}", ty),
     }
 }
@@ -569,6 +571,7 @@ static PRIMITIVE_IO_METHODS: &[(&str, &str, &str)] = &[
     ("u32", "write_u32", "read_u32"),
     ("u64", "write_u64", "read_u64"),
     ("usize", "write_usize", "read_usize"),
+    ("u128", "write_u128", "read_u128"),
 ];
 
 /// Check if a type is a direct primitive numeric type (not wrapped in Option, Vec, etc.)
@@ -654,6 +657,7 @@ pub(crate) fn get_type_id_by_name(ty: &str) -> u32 {
         "Vec<u32>" => return TypeId::U32_ARRAY as u32,
         "Vec<u64>" => return TypeId::U64_ARRAY as u32,
         "Vec<usize>" => return TypeId::USIZE_ARRAY as u32,
+        "Vec<u128>" => return TypeId::U128_ARRAY as u32,
         _ => {}
     }
 
@@ -675,6 +679,7 @@ pub(crate) fn get_type_id_by_name(ty: &str) -> u32 {
                 "u32" => return TypeId::U32_ARRAY as u32,
                 "u64" => return TypeId::U64_ARRAY as u32,
                 "usize" => return TypeId::USIZE_ARRAY as u32,
+                "u128" => return TypeId::U128_ARRAY as u32,
                 _ => {
                     // Non-primitive array elements, treat as LIST
                     return TypeId::LIST as u32;
@@ -727,6 +732,7 @@ fn get_primitive_type_size(type_id_num: u32) -> i32 {
         TypeId::U32 => 4,
         TypeId::U64 => 8,
         TypeId::USIZE => 8,
+        TypeId::U128 => 16,
         _ => unreachable!(),
     }
 }
@@ -757,6 +763,11 @@ fn is_internal_type_id(type_id: u32) -> bool {
         TypeId::FLOAT16_ARRAY as u32,
         TypeId::FLOAT32_ARRAY as u32,
         TypeId::FLOAT64_ARRAY as u32,
+        TypeId::U16_ARRAY as u32,
+        TypeId::U32_ARRAY as u32,
+        TypeId::U64_ARRAY as u32,
+        TypeId::USIZE_ARRAY as u32,
+        TypeId::U128_ARRAY as u32,
     ]
     .contains(&type_id)
 }

--- a/rust/tests/tests/test_unsigned.rs
+++ b/rust/tests/tests/test_unsigned.rs
@@ -29,6 +29,7 @@ fn test_unsigned_numbers() {
     test_roundtrip(&fory, u32::MAX);
     test_roundtrip(&fory, u64::MAX);
     test_roundtrip(&fory, usize::MAX);
+    test_roundtrip(&fory, u128::MAX);
 }
 
 #[test]
@@ -39,6 +40,7 @@ fn test_unsigned_arrays() {
     test_roundtrip(&fory, vec![0u32, 1000, 1000000, u32::MAX]);
     test_roundtrip(&fory, vec![0u64, 1000000, 1000000000000, u64::MAX]);
     test_roundtrip(&fory, vec![0usize, 1000000, 1000000000000, usize::MAX]);
+    test_roundtrip(&fory, vec![0u128, 1000000000000, u128::MAX]);
 }
 
 #[test]
@@ -49,6 +51,7 @@ fn test_unsigned_arrays_when_xlang() {
     assert!(fory.serialize(&vec![u32::MAX]).is_err());
     assert!(fory.serialize(&vec![u64::MAX]).is_err());
     assert!(fory.serialize(&vec![usize::MAX]).is_err());
+    assert!(fory.serialize(&vec![u128::MAX]).is_err());
 }
 
 #[test]
@@ -60,11 +63,13 @@ fn test_unsigned_struct_non_compatible() {
         c: u32,
         d: u64,
         e: usize,
+        f: u128,
         vec_u8: Vec<u8>,
         vec_u16: Vec<u16>,
         vec_u32: Vec<u32>,
         vec_u64: Vec<u64>,
         vec_usize: Vec<usize>,
+        vec_u128: Vec<u128>,
     }
 
     let mut fory = Fory::default();
@@ -76,11 +81,13 @@ fn test_unsigned_struct_non_compatible() {
         c: u32::MAX,
         d: u64::MAX,
         e: usize::MAX,
+        f: u128::MAX,
         vec_u8: vec![0, 1, 10, u8::MAX],
         vec_u16: vec![0, 100, 1000, u16::MAX],
         vec_u32: vec![0, 1000, 1000000, u32::MAX],
         vec_u64: vec![0, 1000000, 1000000000000, u64::MAX],
         vec_usize: vec![0, 1000000, 1000000000000, usize::MAX],
+        vec_u128: vec![0u128, 1000000000000, u128::MAX],
     };
 
     let bytes = fory.serialize(&data).unwrap();
@@ -97,11 +104,13 @@ fn test_unsigned_struct_compatible() {
         c: u32,
         d: u64,
         e: usize,
+        f: u128,
         vec_u8: Vec<u8>,
         vec_u16: Vec<u16>,
         vec_u32: Vec<u32>,
         vec_u64: Vec<u64>,
         vec_usize: Vec<usize>,
+        vec_u128: Vec<u128>,
     }
 
     let mut fory = Fory::default().compatible(true);
@@ -113,11 +122,13 @@ fn test_unsigned_struct_compatible() {
         c: u32::MAX,
         d: u64::MAX,
         e: usize::MAX,
+        f: u128::MAX,
         vec_u8: vec![0, 1, 10, u8::MAX],
         vec_u16: vec![0, 100, 1000, u16::MAX],
         vec_u32: vec![0, 1000, 1000000, u32::MAX],
         vec_u64: vec![0, 1000000, 1000000000000, u64::MAX],
         vec_usize: vec![0, 1000000, 1000000000000, usize::MAX],
+        vec_u128: vec![0u128, 1000000000000, u128::MAX],
     };
 
     let bytes = fory.serialize(&data).unwrap();
@@ -195,6 +206,7 @@ fn test_unsigned_edge_cases() {
     test_roundtrip(&fory, 0u32);
     test_roundtrip(&fory, 0u64);
     test_roundtrip(&fory, 0usize);
+    test_roundtrip(&fory, 0u128);
 
     // Test maximum values
     test_roundtrip(&fory, u8::MAX);
@@ -202,6 +214,7 @@ fn test_unsigned_edge_cases() {
     test_roundtrip(&fory, u32::MAX);
     test_roundtrip(&fory, u64::MAX);
     test_roundtrip(&fory, usize::MAX);
+    test_roundtrip(&fory, u128::MAX);
 
     // Test empty arrays
     test_roundtrip(&fory, Vec::<u8>::new());
@@ -209,6 +222,7 @@ fn test_unsigned_edge_cases() {
     test_roundtrip(&fory, Vec::<u32>::new());
     test_roundtrip(&fory, Vec::<u64>::new());
     test_roundtrip(&fory, Vec::<usize>::new());
+    test_roundtrip(&fory, Vec::<u128>::new());
 }
 
 #[test]
@@ -220,6 +234,7 @@ fn test_unsigned_with_option_non_compatible() {
         opt_u32: Option<u32>,
         opt_u64: Option<u64>,
         opt_usize: Option<usize>,
+        opt_u128: Option<u128>,
     }
 
     let mut fory = Fory::default();
@@ -232,6 +247,7 @@ fn test_unsigned_with_option_non_compatible() {
         opt_u32: Some(u32::MAX),
         opt_u64: Some(u64::MAX),
         opt_usize: Some(usize::MAX),
+        opt_u128: Some(u128::MAX),
     };
 
     let bytes = fory.serialize(&data_some).unwrap();
@@ -245,6 +261,7 @@ fn test_unsigned_with_option_non_compatible() {
         opt_u32: None,
         opt_u64: None,
         opt_usize: None,
+        opt_u128: None,
     };
 
     let bytes = fory.serialize(&data_none).unwrap();
@@ -261,6 +278,7 @@ fn test_unsigned_with_option_compatible() {
         opt_u32: Option<u32>,
         opt_u64: Option<u64>,
         opt_usize: Option<usize>,
+        opt_u128: Option<u128>,
     }
 
     let mut fory = Fory::default().compatible(true);
@@ -273,6 +291,7 @@ fn test_unsigned_with_option_compatible() {
         opt_u32: Some(u32::MAX),
         opt_u64: Some(u64::MAX),
         opt_usize: Some(usize::MAX),
+        opt_u128: Some(u128::MAX),
     };
 
     let bytes = fory.serialize(&data_some).unwrap();
@@ -286,6 +305,7 @@ fn test_unsigned_with_option_compatible() {
         opt_u32: None,
         opt_u64: None,
         opt_usize: None,
+        opt_u128: None,
     };
 
     let bytes = fory.serialize(&data_none).unwrap();
@@ -310,6 +330,7 @@ fn test_unsigned_mixed_fields_compatible() {
         new_u64: u64,
         new_opt_u32: Option<u32>,
         new_usize: usize,
+        new_u128: u128,
     }
 
     let mut fory1 = Fory::default().compatible(true);
@@ -330,7 +351,8 @@ fn test_unsigned_mixed_fields_compatible() {
     assert_eq!(result.vec_u32, vec![1000, 2000, 3000]);
     assert_eq!(result.new_u64, 0); // Default value
     assert_eq!(result.new_opt_u32, None); // Default value
-    assert_eq!(result.new_usize, 0)
+    assert_eq!(result.new_usize, 0); // Default value
+    assert_eq!(result.new_u128, 0); // Default value
 }
 
 #[test]
@@ -343,6 +365,7 @@ fn test_unsigned_with_smart_pointers() {
     test_box_any(&fory, u32::MAX);
     test_box_any(&fory, u64::MAX);
     test_box_any(&fory, usize::MAX);
+    test_box_any(&fory, u128::MAX);
 
     // Test Rc<dyn Any> with unsigned types
     test_rc_any(&fory, u8::MAX);
@@ -350,6 +373,7 @@ fn test_unsigned_with_smart_pointers() {
     test_rc_any(&fory, u32::MAX);
     test_rc_any(&fory, u64::MAX);
     test_rc_any(&fory, usize::MAX);
+    test_rc_any(&fory, u128::MAX);
 
     // Test Arc<dyn Any> with unsigned types
     test_arc_any(&fory, u8::MAX);
@@ -357,6 +381,7 @@ fn test_unsigned_with_smart_pointers() {
     test_arc_any(&fory, u32::MAX);
     test_arc_any(&fory, u64::MAX);
     test_arc_any(&fory, usize::MAX);
+    test_arc_any(&fory, u128::MAX);
 
     // Test Box<dyn Any> with unsigned arrays
     test_box_any(&fory, vec![0u8, 127, u8::MAX]);
@@ -364,6 +389,7 @@ fn test_unsigned_with_smart_pointers() {
     test_box_any(&fory, vec![0u32, 1000000, u32::MAX]);
     test_box_any(&fory, vec![0u64, 1000000000000, u64::MAX]);
     test_box_any(&fory, vec![0usize, 1000000000000, usize::MAX]);
+    test_box_any(&fory, vec![0u128, 1000000000000, u128::MAX]);
 
     // Test Rc<dyn Any> with unsigned arrays
     test_rc_any(&fory, vec![0u8, 127, u8::MAX]);
@@ -371,6 +397,7 @@ fn test_unsigned_with_smart_pointers() {
     test_rc_any(&fory, vec![1000u32, 2000, 3000, u32::MAX]);
     test_rc_any(&fory, vec![0u64, 1000000000000, u64::MAX]);
     test_rc_any(&fory, vec![0usize, 1000000000000, usize::MAX]);
+    test_rc_any(&fory, vec![0u128, 1000000000000, u128::MAX]);
 
     // Test Arc<dyn Any> with unsigned arrays
     test_arc_any(&fory, vec![0u8, 127, u8::MAX]);
@@ -378,4 +405,5 @@ fn test_unsigned_with_smart_pointers() {
     test_arc_any(&fory, vec![999u32, 888, 777, u32::MAX]);
     test_arc_any(&fory, vec![123u64, 456789, 987654321, u64::MAX]);
     test_arc_any(&fory, vec![123usize, 456789, 987654321, usize::MAX]);
+    test_arc_any(&fory, vec![0u128, 1000000000000, u128::MAX]);
 }


### PR DESCRIPTION
## What does this PR do?
Support `u128` & `u128_array` in Rust native protocol.

## Related issues
close #2895