### PR TITLE
fix(kotlin): support Kotlin field with Java reserved world

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/builder/CodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/CodecBuilder.java
@@ -118,8 +118,11 @@ public abstract class CodecBuilder {
     ctx.reserveName(ROOT_OBJECT_NAME);
     // Don't import other packages to avoid class conflicts.
     // For example user class named as `Date`/`List`/`MemoryBuffer`
+    // Skip Java reserved words since they can't be used as variable names anyway
+    // (e.g., Kotlin allows field names like "new" which are valid at bytecode level)
     ReflectionUtils.getFields(beanType.getRawType(), true).stream()
         .map(Field::getName)
+        .filter(name -> !CodegenContext.JAVA_RESERVED_WORDS.contains(name))
         .collect(Collectors.toSet())
         .forEach(ctx::reserveName);
   }

--- a/kotlin/src/test/kotlin/org/apache/fory/serializer/kotlin/GenericDataClassTest.kt
+++ b/kotlin/src/test/kotlin/org/apache/fory/serializer/kotlin/GenericDataClassTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer.kotlin
+
+import org.apache.fory.Fory
+import org.apache.fory.config.CompatibleMode
+import org.apache.fory.config.Language
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+/** Test class for generic Kotlin data classes. See https://github.com/apache/fory/issues/2768 */
+data class Change<T>(val old: T? = null, val new: T? = null)
+
+class GenericDataClassTest {
+
+  @Test
+  fun testGenericDataClassSerialization() {
+    val fory =
+      Fory.builder()
+        .requireClassRegistration(true)
+        .withCodegen(true)
+        .withLanguage(Language.JAVA)
+        .withRefTracking(false)
+        .withCompatibleMode(CompatibleMode.SCHEMA_CONSISTENT)
+        .build()
+
+    fory.register(Change::class.java)
+
+    val change = Change("A", "B")
+
+    val serializedChange = fory.serialize(change)
+
+    val deserializedChange = fory.deserialize(serializedChange, Change::class.java)
+
+    assertEquals(change, deserializedChange)
+  }
+
+  @Test
+  fun testGenericDataClassWithNullValues() {
+    val fory =
+      Fory.builder()
+        .requireClassRegistration(true)
+        .withCodegen(true)
+        .withLanguage(Language.JAVA)
+        .withRefTracking(false)
+        .withCompatibleMode(CompatibleMode.SCHEMA_CONSISTENT)
+        .build()
+
+    fory.register(Change::class.java)
+
+    val change = Change<String>(old = null, new = "B")
+
+    val serializedChange = fory.serialize(change)
+
+    val deserializedChange = fory.deserialize(serializedChange, Change::class.java)
+
+    assertEquals(change, deserializedChange)
+  }
+
+  @Test
+  fun testGenericDataClassWithIntValues() {
+    val fory =
+      Fory.builder()
+        .requireClassRegistration(true)
+        .withCodegen(true)
+        .withLanguage(Language.JAVA)
+        .withRefTracking(false)
+        .withCompatibleMode(CompatibleMode.SCHEMA_CONSISTENT)
+        .build()
+
+    fory.register(Change::class.java)
+
+    val change = Change(1, 2)
+
+    val serializedChange = fory.serialize(change)
+
+    val deserializedChange = fory.deserialize(serializedChange, Change::class.java)
+
+    assertEquals(change, deserializedChange)
+  }
+}


### PR DESCRIPTION

## What does this PR do?

Kotlin allows field names that are Java reserved words (like "new"), which are
valid at the bytecode level. When Fory tries to reserve these field names for
code generation, it fails because Java reserved words can't be used as variable
names in generated code.

This fix filters out Java reserved words when reserving field names in
CodecBuilder, since they won't conflict with any generated variable names.
    
## Related issues

Fixes #2768


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
