### PR TITLE
fix(java): handle TypeVariable in row format type inference

### DIFF
--- a/java/fory-format/src/test/java/org/apache/fory/format/type/TypeInferenceTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/type/TypeInferenceTest.java
@@ -21,10 +21,14 @@ package org.apache.fory.format.type;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.base.CaseFormat;
+import java.lang.reflect.TypeVariable;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.fory.reflect.TypeRef;
 import org.apache.fory.test.bean.BeanA;
 import org.apache.fory.type.Descriptor;
 import org.testng.annotations.Test;
@@ -42,5 +46,54 @@ public class TypeInferenceTest {
             .collect(Collectors.toList());
     assertEquals(fieldNames, expectedFieldNames);
     assertNotNull(schema.getFieldByName("double_list"));
+  }
+
+  /**
+   * Test that TypeVariable types (like K, V from Map<K, V>) are handled correctly by resolving to
+   * their bounds. This can happen with Scala 3 LTS where generic type information may not be fully
+   * resolved. See https://github.com/apache/fory/issues/2439
+   */
+  @Test
+  public void testTypeVariableInference() {
+    // Get the TypeVariable K from Map<K, V>
+    TypeVariable<?>[] typeParams = Map.class.getTypeParameters();
+    assertEquals(typeParams.length, 2);
+    TypeVariable<?> keyTypeVar = typeParams[0]; // K
+    TypeVariable<?> valueTypeVar = typeParams[1]; // V
+
+    // Verify these are indeed TypeVariables
+    assertTrue(keyTypeVar instanceof TypeVariable);
+    assertTrue(valueTypeVar instanceof TypeVariable);
+
+    // TypeVariable K has bound Object which is not a supported row format type,
+    // but the TypeVariable resolution itself should work.
+    // The fix ensures TypeVariable is resolved to its bound before failing.
+    TypeRef<?> keyTypeRef = TypeRef.of(keyTypeVar);
+    try {
+      TypeInference.inferDataType(keyTypeRef);
+    } catch (UnsupportedOperationException e) {
+      // Expected: Object is not a supported type, but the error should mention Object,
+      // not the TypeVariable name "K"
+      assertTrue(
+          e.getMessage().contains("java.lang.Object"),
+          "TypeVariable should be resolved to Object, not remain as K");
+    }
+  }
+
+  /** Test inferring schema for a class with Map field containing Long keys and values. */
+  @Test
+  public void testMapFieldTypeInference() {
+    Schema schema = TypeInference.inferSchema(ClassWithMapField.class);
+    assertNotNull(schema);
+    Field mapField = schema.getFieldByName("long_map");
+    assertNotNull(mapField);
+    assertTrue(mapField.type() instanceof DataTypes.MapType);
+    DataTypes.MapType mapType = (DataTypes.MapType) mapField.type();
+    assertEquals(mapType.keyType(), DataTypes.int64());
+    assertEquals(mapType.itemType(), DataTypes.int64());
+  }
+
+  private static class ClassWithMapField {
+    public Map<Long, Long> longMap;
   }
 }


### PR DESCRIPTION





## What does this PR do?

When inferring field types for row format encoding, TypeVariable types (like K, V from Map<K, V>) were not handled, causing UnsupportedOperationException with message like "Unsupported type K".

This can happen with Scala 3 LTS where generic type information may not be fully resolved in the bytecode. The fix resolves TypeVariable to its bound (e.g., K -> Object) before proceeding with type inference.


## Related issues

Fixes #2439
## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
