### PR TITLE
fix(java): use single quotes in Python command for Windows compatibility

### DIFF
--- a/java/fory-test-core/src/main/java/org/apache/fory/test/TestUtils.java
+++ b/java/fory-test-core/src/main/java/org/apache/fory/test/TestUtils.java
@@ -116,7 +116,7 @@ public class TestUtils {
           Arrays.asList(
               "python",
               "-c",
-              "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec(\"pyfory\") is None else 1)"),
+              "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('pyfory') is None else 1)"),
           10,
           Collections.emptyMap())) {
         throw new SkipException("pyfory not installed");


### PR DESCRIPTION
## Why?

On Windows 11 PowerShell, the escaped double quotes `\"pyfory\"` in the Python command get processed and removed, causing Python to receive `pyfory` as a variable name instead of the string `"pyfory"`. This results in a `NameError`:

```
NameError: name 'pyfory' is not defined
```

Since Python syntax errors and "pyfory found" both produce the same non-zero exit code, the test incorrectly proceeds instead of being skipped when `pyfory` is not installed.

## What does this PR do?

Replace escaped double quotes `\"pyfory\"` with single quotes `'pyfory'` in the Python command within `verifyPyforyInstalled()` method. Single quotes work correctly on both Windows and Unix systems.

**Changes:**
- Modified `java/fory-test-core/src/main/java/org/apache/fory/test/TestUtils.java`
- Changed `find_spec(\"pyfory\")` to `find_spec('pyfory')`

## Related issues

Fixes #2833

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

No user-facing changes. This is an internal test utility fix.

## Benchmark

Not applicable. This change does not affect performance.