### PR TITLE
perf(c++): directly error set instead of result to reduce cost on hotpath

### DIFF
--- a/cpp/fory/serialization/array_serializer.h
+++ b/cpp/fory/serialization/array_serializer.h
@@ -93,8 +93,12 @@ struct Serializer<
     if (!has_value) {
       return std::array<T, N>();
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -105,7 +109,11 @@ struct Serializer<
 
   static Result<std::array<T, N>, Error> read_data(ReadContext &ctx) {
     // Read array length
-    FORY_TRY(length, ctx.read_varuint32());
+    Error error;
+    uint32_t length = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
 
     if (length != N) {
       return Unexpected(Error::invalid_data("Array size mismatch: expected " +
@@ -115,7 +123,10 @@ struct Serializer<
 
     std::array<T, N> arr;
     if constexpr (N > 0) {
-      FORY_RETURN_NOT_OK(ctx.read_bytes(arr.data(), N * sizeof(T)));
+      ctx.read_bytes(arr.data(), N * sizeof(T), &error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
     }
     return arr;
   }
@@ -161,8 +172,12 @@ template <size_t N> struct Serializer<std::array<bool, N>> {
     if (!has_value) {
       return std::array<bool, N>();
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -173,7 +188,11 @@ template <size_t N> struct Serializer<std::array<bool, N>> {
 
   static Result<std::array<bool, N>, Error> read_data(ReadContext &ctx) {
     // Read array length
-    FORY_TRY(length, ctx.read_varuint32());
+    Error error;
+    uint32_t length = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (length != N) {
       return Unexpected(Error::invalid_data("Array size mismatch: expected " +
                                             std::to_string(N) + " but got " +
@@ -181,7 +200,10 @@ template <size_t N> struct Serializer<std::array<bool, N>> {
     }
     std::array<bool, N> arr;
     for (size_t i = 0; i < N; ++i) {
-      FORY_TRY(byte, ctx.read_uint8());
+      uint8_t byte = ctx.read_uint8(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       arr[i] = (byte != 0);
     }
     return arr;

--- a/cpp/fory/serialization/basic_serializer.h
+++ b/cpp/fory/serialization/basic_serializer.h
@@ -49,7 +49,11 @@ template <> struct Serializer<bool> {
 
   /// Read and validate type info (primitives use read_varuint32 directly)
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -87,20 +91,31 @@ template <> struct Serializer<bool> {
     if (!has_value) {
       return false;
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    FORY_TRY(value, ctx.read_uint8());
+    uint8_t value = ctx.read_uint8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value != 0;
   }
 
   /// Read boolean data only (no type info)
   static inline Result<bool, Error> read_data(ReadContext &ctx) {
-    FORY_TRY(value, ctx.read_uint8());
+    Error error;
+    uint8_t value = ctx.read_uint8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value != 0;
   }
 
@@ -129,7 +144,11 @@ template <> struct Serializer<int8_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -164,18 +183,31 @@ template <> struct Serializer<int8_t> {
     if (!has_value) {
       return static_cast<int8_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    return ctx.read_int8();
+    int8_t value = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int8_t, Error> read_data(ReadContext &ctx) {
-    return ctx.read_int8();
+    Error error;
+    int8_t value = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int8_t, Error> read_data_generic(ReadContext &ctx,
@@ -200,7 +232,11 @@ template <> struct Serializer<int16_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -235,21 +271,30 @@ template <> struct Serializer<int16_t> {
     if (!has_value) {
       return static_cast<int16_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    int16_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(int16_t)));
+    int16_t value = ctx.read_int16(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<int16_t, Error> read_data(ReadContext &ctx) {
-    int16_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(int16_t)));
+    Error error;
+    int16_t value = ctx.read_int16(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -275,7 +320,11 @@ template <> struct Serializer<int32_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -310,18 +359,31 @@ template <> struct Serializer<int32_t> {
     if (!has_value) {
       return static_cast<int32_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    return ctx.read_varint32();
+    int32_t value = ctx.read_varint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int32_t, Error> read_data(ReadContext &ctx) {
-    return ctx.read_varint32();
+    Error error;
+    int32_t value = ctx.read_varint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int32_t, Error> read_data_generic(ReadContext &ctx,
@@ -346,7 +408,11 @@ template <> struct Serializer<int64_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -381,18 +447,31 @@ template <> struct Serializer<int64_t> {
     if (!has_value) {
       return static_cast<int64_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    return ctx.read_varint64();
+    int64_t value = ctx.read_varint64(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int64_t, Error> read_data(ReadContext &ctx) {
-    return ctx.read_varint64();
+    Error error;
+    int64_t value = ctx.read_varint64(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<int64_t, Error> read_data_generic(ReadContext &ctx,
@@ -417,7 +496,11 @@ template <> struct Serializer<float> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -451,21 +534,30 @@ template <> struct Serializer<float> {
     if (!has_value) {
       return 0.0f;
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    float value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(float)));
+    float value = ctx.read_float(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<float, Error> read_data(ReadContext &ctx) {
-    float value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(float)));
+    Error error;
+    float value = ctx.read_float(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -491,7 +583,11 @@ template <> struct Serializer<double> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -526,21 +622,30 @@ template <> struct Serializer<double> {
     if (!has_value) {
       return 0.0;
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    double value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(double)));
+    double value = ctx.read_double(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<double, Error> read_data(ReadContext &ctx) {
-    double value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(double)));
+    Error error;
+    double value = ctx.read_double(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -570,7 +675,11 @@ template <> struct Serializer<uint8_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -605,18 +714,31 @@ template <> struct Serializer<uint8_t> {
     if (!has_value) {
       return static_cast<uint8_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    return ctx.read_uint8();
+    uint8_t value = ctx.read_uint8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<uint8_t, Error> read_data(ReadContext &ctx) {
-    return ctx.read_uint8();
+    Error error;
+    uint8_t value = ctx.read_uint8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
+    return value;
   }
 
   static inline Result<uint8_t, Error> read_data_generic(ReadContext &ctx,
@@ -641,7 +763,11 @@ template <> struct Serializer<uint16_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -676,21 +802,30 @@ template <> struct Serializer<uint16_t> {
     if (!has_value) {
       return static_cast<uint16_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    uint16_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint16_t)));
+    uint16_t value = ctx.read_uint16(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<uint16_t, Error> read_data(ReadContext &ctx) {
-    uint16_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint16_t)));
+    Error error;
+    uint16_t value = ctx.read_uint16(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -716,7 +851,11 @@ template <> struct Serializer<uint32_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -751,21 +890,30 @@ template <> struct Serializer<uint32_t> {
     if (!has_value) {
       return static_cast<uint32_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    uint32_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint32_t)));
+    uint32_t value = ctx.read_uint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<uint32_t, Error> read_data(ReadContext &ctx) {
-    uint32_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint32_t)));
+    Error error;
+    uint32_t value = ctx.read_uint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -791,7 +939,11 @@ template <> struct Serializer<uint64_t> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -826,21 +978,30 @@ template <> struct Serializer<uint64_t> {
     if (!has_value) {
       return static_cast<uint64_t>(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
       }
     }
-    uint64_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint64_t)));
+    uint64_t value = ctx.read_uint64(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
   static inline Result<uint64_t, Error> read_data(ReadContext &ctx) {
-    uint64_t value;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&value, sizeof(uint64_t)));
+    Error error;
+    uint64_t value = ctx.read_uint64(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return value;
   }
 
@@ -877,7 +1038,11 @@ template <> struct Serializer<std::string> {
   }
 
   static inline Result<void, Error> read_type_info(ReadContext &ctx) {
-    FORY_TRY(actual, ctx.read_varuint32());
+    Error error;
+    uint32_t actual = ctx.read_varuint32(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (actual != static_cast<uint32_t>(type_id)) {
       return Unexpected(
           Error::type_mismatch(actual, static_cast<uint32_t>(type_id)));
@@ -925,8 +1090,12 @@ template <> struct Serializer<std::string> {
     if (!has_value) {
       return std::string();
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -937,7 +1106,11 @@ template <> struct Serializer<std::string> {
 
   static inline Result<std::string, Error> read_data(ReadContext &ctx) {
     // Read size with encoding using varuint36small
-    FORY_TRY(size_with_encoding, ctx.read_varuint36small());
+    Error error;
+    uint64_t size_with_encoding = ctx.read_varuint36small(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
 
     // Extract size and encoding from lower 2 bits
     uint64_t length = size_with_encoding >> 2;
@@ -952,7 +1125,10 @@ template <> struct Serializer<std::string> {
     switch (encoding) {
     case StringEncoding::LATIN1: {
       std::vector<uint8_t> bytes(length);
-      FORY_RETURN_NOT_OK(ctx.read_bytes(bytes.data(), length));
+      ctx.read_bytes(bytes.data(), length, &error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       return latin1ToUtf8(bytes.data(), length);
     }
     case StringEncoding::UTF16: {
@@ -960,14 +1136,20 @@ template <> struct Serializer<std::string> {
         return Unexpected(Error::invalid_data("UTF-16 length must be even"));
       }
       std::vector<uint16_t> utf16_chars(length / 2);
-      FORY_RETURN_NOT_OK(ctx.read_bytes(
-          reinterpret_cast<uint8_t *>(utf16_chars.data()), length));
+      ctx.read_bytes(reinterpret_cast<uint8_t *>(utf16_chars.data()), length,
+                     &error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       return utf16ToUtf8(utf16_chars.data(), utf16_chars.size());
     }
     case StringEncoding::UTF8: {
       // UTF-8: read bytes directly
       std::string result(length, '\0');
-      FORY_RETURN_NOT_OK(ctx.read_bytes(&result[0], length));
+      ctx.read_bytes(&result[0], length, &error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       return result;
     }
     default:

--- a/cpp/fory/serialization/context.h
+++ b/cpp/fory/serialization/context.h
@@ -368,41 +368,96 @@ public:
     }
   }
 
-  /// Read uint8_t value from buffer.
-  inline Result<uint8_t, Error> read_uint8() { return buffer().ReadUint8(); }
+  // ===========================================================================
+  // Read methods with Error* parameter
+  // All methods accept Error* as parameter for reduced overhead.
+  // On success, error->ok() remains true. On failure, error is set.
+  // ===========================================================================
 
-  /// Read int8_t value from buffer.
-  inline Result<int8_t, Error> read_int8() { return buffer().ReadInt8(); }
-
-  /// Read uint32_t value as varint from buffer.
-  inline Result<uint32_t, Error> read_varuint32() {
-    return buffer().ReadVarUint32();
+  /// Read uint8_t value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE uint8_t read_uint8(Error *error) {
+    return buffer().ReadUint8(error);
   }
 
-  /// Read int32_t value as zigzag varint from buffer.
-  inline Result<int32_t, Error> read_varint32() {
-    return buffer().ReadVarInt32();
+  /// Read int8_t value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE int8_t read_int8(Error *error) {
+    return buffer().ReadInt8(error);
   }
 
-  /// Read uint64_t value as varint from buffer.
-  inline Result<uint64_t, Error> read_varuint64() {
-    return buffer().ReadVarUint64();
+  /// Read uint16_t value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE uint16_t read_uint16(Error *error) {
+    return buffer().ReadUint16(error);
   }
 
-  /// Read int64_t value as zigzag varint from buffer.
-  inline Result<int64_t, Error> read_varint64() {
-    return buffer().ReadVarInt64();
+  /// Read int16_t value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE int16_t read_int16(Error *error) {
+    return buffer().ReadInt16(error);
   }
 
-  /// Read uint64_t value as varuint36small from buffer.
-  /// This is the special variable-length encoding used for string headers.
-  inline Result<uint64_t, Error> read_varuint36small() {
-    return buffer().ReadVarUint36Small();
+  /// Read uint32_t value from buffer (fixed 4 bytes). Sets error on failure.
+  FORY_ALWAYS_INLINE uint32_t read_uint32(Error *error) {
+    return buffer().ReadUint32(error);
   }
 
-  /// Read raw bytes from buffer.
-  inline Result<void, Error> read_bytes(void *data, uint32_t length) {
-    return buffer().ReadBytes(data, length);
+  /// Read int32_t value from buffer (fixed 4 bytes). Sets error on failure.
+  FORY_ALWAYS_INLINE int32_t read_int32(Error *error) {
+    return buffer().ReadInt32(error);
+  }
+
+  /// Read uint64_t value from buffer (fixed 8 bytes). Sets error on failure.
+  FORY_ALWAYS_INLINE uint64_t read_uint64(Error *error) {
+    return buffer().ReadUint64(error);
+  }
+
+  /// Read int64_t value from buffer (fixed 8 bytes). Sets error on failure.
+  FORY_ALWAYS_INLINE int64_t read_int64(Error *error) {
+    return buffer().ReadInt64(error);
+  }
+
+  /// Read float value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE float read_float(Error *error) {
+    return buffer().ReadFloat(error);
+  }
+
+  /// Read double value from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE double read_double(Error *error) {
+    return buffer().ReadDouble(error);
+  }
+
+  /// Read uint32_t value as varint from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE uint32_t read_varuint32(Error *error) {
+    return buffer().ReadVarUint32(error);
+  }
+
+  /// Read int32_t value as zigzag varint from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE int32_t read_varint32(Error *error) {
+    return buffer().ReadVarInt32(error);
+  }
+
+  /// Read uint64_t value as varint from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE uint64_t read_varuint64(Error *error) {
+    return buffer().ReadVarUint64(error);
+  }
+
+  /// Read int64_t value as zigzag varint from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE int64_t read_varint64(Error *error) {
+    return buffer().ReadVarInt64(error);
+  }
+
+  /// Read uint64_t value as varuint36small from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE uint64_t read_varuint36small(Error *error) {
+    return buffer().ReadVarUint36Small(error);
+  }
+
+  /// Read raw bytes from buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE void read_bytes(void *data, uint32_t length,
+                                     Error *error) {
+    buffer().ReadBytes(data, length, error);
+  }
+
+  /// Skip bytes in buffer. Sets error on failure.
+  FORY_ALWAYS_INLINE void skip(uint32_t length, Error *error) {
+    buffer().Skip(length, error);
   }
 
   Result<const TypeInfo *, Error>

--- a/cpp/fory/serialization/fory.h
+++ b/cpp/fory/serialization/fory.h
@@ -579,9 +579,11 @@ private:
     // Load TypeMetas at the beginning in compatible mode
     size_t bytes_to_skip = 0;
     if (read_ctx_->is_compatible()) {
-      auto meta_offset_result = buffer.ReadInt32();
-      FORY_RETURN_IF_ERROR(meta_offset_result);
-      int32_t meta_offset = meta_offset_result.value();
+      Error error;
+      int32_t meta_offset = buffer.ReadInt32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (meta_offset != -1) {
         FORY_TRY(meta_size, read_ctx_->load_type_meta(meta_offset));
         bytes_to_skip = meta_size;

--- a/cpp/fory/serialization/smart_ptr_serializers.h
+++ b/cpp/fory/serialization/smart_ptr_serializers.h
@@ -102,7 +102,11 @@ template <typename T> struct Serializer<std::optional<T>> {
     }
 
     const uint32_t flag_pos = ctx.buffer().reader_index();
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
 
     if (flag == NULL_FLAG) {
       return std::optional<T>(std::nullopt);
@@ -137,7 +141,11 @@ template <typename T> struct Serializer<std::optional<T>> {
     }
 
     const uint32_t flag_pos = ctx.buffer().reader_index();
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
 
     if (flag == NULL_FLAG) {
       return std::optional<T>(std::nullopt);
@@ -339,7 +347,11 @@ template <typename T> struct Serializer<std::shared_ptr<T>> {
     }
 
     // Handle read_ref=true case
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (flag == NULL_FLAG) {
       return std::shared_ptr<T>(nullptr);
     }
@@ -349,7 +361,10 @@ template <typename T> struct Serializer<std::shared_ptr<T>> {
         return Unexpected(Error::invalid_ref(
             "Reference flag encountered when reference tracking disabled"));
       }
-      FORY_TRY(ref_id, ctx.read_varuint32());
+      uint32_t ref_id = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       return ctx.ref_reader().template get_shared_ref<T>(ref_id);
     }
 
@@ -432,7 +447,11 @@ template <typename T> struct Serializer<std::shared_ptr<T>> {
     }
 
     // Handle read_ref=true case
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (flag == NULL_FLAG) {
       return std::shared_ptr<T>(nullptr);
     }
@@ -442,7 +461,10 @@ template <typename T> struct Serializer<std::shared_ptr<T>> {
         return Unexpected(Error::invalid_ref(
             "Reference flag encountered when reference tracking disabled"));
       }
-      FORY_TRY(ref_id, ctx.read_varuint32());
+      uint32_t ref_id = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       return ctx.ref_reader().template get_shared_ref<T>(ref_id);
     }
 
@@ -639,7 +661,11 @@ template <typename T> struct Serializer<std::unique_ptr<T>> {
     }
 
     // Handle read_ref=true case
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (flag == NULL_FLAG) {
       return std::unique_ptr<T>(nullptr);
     }
@@ -705,7 +731,11 @@ template <typename T> struct Serializer<std::unique_ptr<T>> {
     }
 
     // Handle read_ref=true case
-    FORY_TRY(flag, ctx.read_int8());
+    Error error;
+    int8_t flag = ctx.read_int8(&error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     if (flag == NULL_FLAG) {
       return std::unique_ptr<T>(nullptr);
     }

--- a/cpp/fory/serialization/temporal_serializers.h
+++ b/cpp/fory/serialization/temporal_serializers.h
@@ -87,8 +87,12 @@ template <> struct Serializer<Duration> {
     if (!has_value) {
       return Duration(0);
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -98,8 +102,12 @@ template <> struct Serializer<Duration> {
   }
 
   static Result<Duration, Error> read_data(ReadContext &ctx) {
+    Error error;
     int64_t nanos;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&nanos, sizeof(int64_t)));
+    ctx.read_bytes(&nanos, sizeof(int64_t), &error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return Duration(nanos);
   }
 };
@@ -142,8 +150,12 @@ template <> struct Serializer<Timestamp> {
     if (!has_value) {
       return Timestamp(Duration(0));
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -153,8 +165,12 @@ template <> struct Serializer<Timestamp> {
   }
 
   static Result<Timestamp, Error> read_data(ReadContext &ctx) {
+    Error error;
     int64_t nanos;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&nanos, sizeof(int64_t)));
+    ctx.read_bytes(&nanos, sizeof(int64_t), &error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return Timestamp(Duration(nanos));
   }
 };
@@ -195,8 +211,12 @@ template <> struct Serializer<LocalDate> {
     if (!has_value) {
       return LocalDate();
     }
+    Error error;
     if (read_type) {
-      FORY_TRY(type_id_read, ctx.read_varuint32());
+      uint32_t type_id_read = ctx.read_varuint32(&error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return Unexpected(std::move(error));
+      }
       if (type_id_read != static_cast<uint32_t>(type_id)) {
         return Unexpected(
             Error::type_mismatch(type_id_read, static_cast<uint32_t>(type_id)));
@@ -206,8 +226,12 @@ template <> struct Serializer<LocalDate> {
   }
 
   static Result<LocalDate, Error> read_data(ReadContext &ctx) {
+    Error error;
     LocalDate date;
-    FORY_RETURN_NOT_OK(ctx.read_bytes(&date.days_since_epoch, sizeof(int32_t)));
+    ctx.read_bytes(&date.days_since_epoch, sizeof(int32_t), &error);
+    if (FORY_PREDICT_FALSE(!error.ok())) {
+      return Unexpected(std::move(error));
+    }
     return date;
   }
 };

--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -583,90 +583,132 @@ public:
 
   // ===========================================================================
   // Safe read methods with bounds checking
+  // All methods accept Error* as parameter for reduced overhead.
+  // On success, error->ok() remains true. On failure, error is set.
   // ===========================================================================
 
-  /// Read uint8_t value from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<uint8_t, Error> ReadUint8() {
+  /// Read uint8_t value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE uint8_t ReadUint8(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     uint8_t value = data_[reader_index_];
     reader_index_ += 1;
     return value;
   }
 
-  /// Read int8_t value from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int8_t, Error> ReadInt8() {
+  /// Read int8_t value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE int8_t ReadInt8(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     int8_t value = static_cast<int8_t>(data_[reader_index_]);
     reader_index_ += 1;
     return value;
   }
 
-  /// Read int16_t value as fixed 2 bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int16_t, Error> ReadInt16() {
+  /// Read uint16_t value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE uint16_t ReadUint16(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 2 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 2, size_));
+      error->set_buffer_out_of_bound(reader_index_, 2, size_);
+      return 0;
+    }
+    uint16_t value =
+        reinterpret_cast<const uint16_t *>(data_ + reader_index_)[0];
+    reader_index_ += 2;
+    return value;
+  }
+
+  /// Read int16_t value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE int16_t ReadInt16(Error *error) {
+    if (FORY_PREDICT_FALSE(reader_index_ + 2 > size_)) {
+      error->set_buffer_out_of_bound(reader_index_, 2, size_);
+      return 0;
     }
     int16_t value = reinterpret_cast<const int16_t *>(data_ + reader_index_)[0];
     reader_index_ += 2;
     return value;
   }
 
-  /// Read int32_t value as fixed 4 bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int32_t, Error> ReadInt32() {
+  /// Read uint32_t value from buffer (fixed 4 bytes). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE uint32_t ReadUint32(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 4 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 4, size_));
+      error->set_buffer_out_of_bound(reader_index_, 4, size_);
+      return 0;
+    }
+    uint32_t value =
+        reinterpret_cast<const uint32_t *>(data_ + reader_index_)[0];
+    reader_index_ += 4;
+    return value;
+  }
+
+  /// Read int32_t value from buffer (fixed 4 bytes). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE int32_t ReadInt32(Error *error) {
+    if (FORY_PREDICT_FALSE(reader_index_ + 4 > size_)) {
+      error->set_buffer_out_of_bound(reader_index_, 4, size_);
+      return 0;
     }
     int32_t value = reinterpret_cast<const int32_t *>(data_ + reader_index_)[0];
     reader_index_ += 4;
     return value;
   }
 
-  /// Read int64_t value as fixed 8 bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int64_t, Error> ReadInt64() {
+  /// Read uint64_t value from buffer (fixed 8 bytes). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE uint64_t ReadUint64(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 8 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 8, size_));
+      error->set_buffer_out_of_bound(reader_index_, 8, size_);
+      return 0;
+    }
+    uint64_t value =
+        reinterpret_cast<const uint64_t *>(data_ + reader_index_)[0];
+    reader_index_ += 8;
+    return value;
+  }
+
+  /// Read int64_t value from buffer (fixed 8 bytes). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE int64_t ReadInt64(Error *error) {
+    if (FORY_PREDICT_FALSE(reader_index_ + 8 > size_)) {
+      error->set_buffer_out_of_bound(reader_index_, 8, size_);
+      return 0;
     }
     int64_t value = reinterpret_cast<const int64_t *>(data_ + reader_index_)[0];
     reader_index_ += 8;
     return value;
   }
 
-  /// Read float value as fixed 4 bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<float, Error> ReadFloat() {
+  /// Read float value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE float ReadFloat(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 4 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 4, size_));
+      error->set_buffer_out_of_bound(reader_index_, 4, size_);
+      return 0.0f;
     }
     float value = reinterpret_cast<const float *>(data_ + reader_index_)[0];
     reader_index_ += 4;
     return value;
   }
 
-  /// Read double value as fixed 8 bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<double, Error> ReadDouble() {
+  /// Read double value from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE double ReadDouble(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 8 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 8, size_));
+      error->set_buffer_out_of_bound(reader_index_, 8, size_);
+      return 0.0;
     }
     double value = reinterpret_cast<const double *>(data_ + reader_index_)[0];
     reader_index_ += 8;
     return value;
   }
 
-  /// Read uint32_t value as varint from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<uint32_t, Error> ReadVarUint32() {
+  /// Read uint32_t value as varint from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE uint32_t ReadVarUint32(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     uint32_t read_bytes = 0;
     uint32_t value = GetVarUint32(reader_index_, &read_bytes);
@@ -674,24 +716,24 @@ public:
     return value;
   }
 
-  /// Read int32_t value as varint (zigzag encoded) from buffer at current
-  /// reader index. Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int32_t, Error> ReadVarInt32() {
+  /// Read int32_t value as varint (zigzag encoded). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE int32_t ReadVarInt32(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     uint32_t read_bytes = 0;
     uint32_t raw = GetVarUint32(reader_index_, &read_bytes);
     IncreaseReaderIndex(read_bytes);
-    int32_t value = static_cast<int32_t>((raw >> 1) ^ (~(raw & 1) + 1));
-    return value;
+    return static_cast<int32_t>((raw >> 1) ^ (~(raw & 1) + 1));
   }
 
-  /// Read uint64_t value as varint from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<uint64_t, Error> ReadVarUint64() {
+  /// Read uint64_t value as varint from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE uint64_t ReadVarUint64(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     uint32_t read_bytes = 0;
     uint64_t value = GetVarUint64(reader_index_, &read_bytes);
@@ -699,24 +741,18 @@ public:
     return value;
   }
 
-  /// Read int64_t value as varint (zigzag encoded) from buffer at current
-  /// reader index. Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<int64_t, Error> ReadVarInt64() {
-    auto result = ReadVarUint64();
-    if (FORY_PREDICT_FALSE(!result.ok())) {
-      return Unexpected(result.error());
-    }
-    uint64_t raw = result.value();
-    int64_t value = static_cast<int64_t>((raw >> 1) ^ (~(raw & 1) + 1));
-    return value;
+  /// Read int64_t value as varint (zigzag encoded). Sets error on bounds
+  /// violation.
+  FORY_ALWAYS_INLINE int64_t ReadVarInt64(Error *error) {
+    uint64_t raw = ReadVarUint64(error);
+    return static_cast<int64_t>((raw >> 1) ^ (~(raw & 1) + 1));
   }
 
-  /// Read uint64_t value as varuint36small from buffer at current reader index.
-  /// This is the special variable-length encoding used for string headers.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<uint64_t, Error> ReadVarUint36Small() {
+  /// Read uint64_t value as varuint36small. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE uint64_t ReadVarUint36Small(Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + 1 > size_)) {
-      return Unexpected(Error::buffer_out_of_bound(reader_index_, 1, size_));
+      error->set_buffer_out_of_bound(reader_index_, 1, size_);
+      return 0;
     }
     uint32_t offset = reader_index_;
     // Fast path: need at least 8 bytes for safe bulk read
@@ -772,28 +808,23 @@ public:
     return result;
   }
 
-  /// Read raw bytes from buffer at current reader index.
-  /// Advances reader index and checks bounds.
-  FORY_ALWAYS_INLINE Result<void, Error> ReadBytes(void *data,
-                                                   uint32_t length) {
+  /// Read raw bytes from buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE void ReadBytes(void *data, uint32_t length, Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + length > size_)) {
-      return Unexpected(
-          Error::buffer_out_of_bound(reader_index_, length, size_));
+      error->set_buffer_out_of_bound(reader_index_, length, size_);
+      return;
     }
     Copy(reader_index_, length, static_cast<uint8_t *>(data));
     IncreaseReaderIndex(length);
-    return Result<void, Error>();
   }
 
-  /// Skip bytes in buffer by advancing reader index.
-  /// Checks bounds to ensure we don't skip past the end.
-  FORY_ALWAYS_INLINE Result<void, Error> Skip(uint32_t length) {
+  /// Skip bytes in buffer. Sets error on bounds violation.
+  FORY_ALWAYS_INLINE void Skip(uint32_t length, Error *error) {
     if (FORY_PREDICT_FALSE(reader_index_ + length > size_)) {
-      return Unexpected(
-          Error::buffer_out_of_bound(reader_index_, length, size_));
+      error->set_buffer_out_of_bound(reader_index_, length, size_);
+      return;
     }
     IncreaseReaderIndex(length);
-    return Result<void, Error>();
   }
 
   /// Return true if both buffers are the same size and contain the same bytes

--- a/cpp/fory/util/error_test.cc
+++ b/cpp/fory/util/error_test.cc
@@ -129,8 +129,10 @@ TEST_F(ErrorTest, ErrorFactories) {
 }
 
 TEST_F(ErrorTest, ErrorSize) {
-  // Error should be the same size as a pointer (unique_ptr)
-  ASSERT_EQ(sizeof(Error), sizeof(void *));
+  // Error contains bool ok_ + unique_ptr<ErrorState> state_
+  // This gives us: 1 byte bool + 7 bytes padding + 8 bytes unique_ptr = 16
+  // bytes on 64-bit systems.
+  ASSERT_EQ(sizeof(Error), sizeof(void *) + sizeof(void *));
 }
 
 } // namespace fory


### PR DESCRIPTION
## What does this PR do?

directly error set instead of result to reduce cost on hotpath for buffer read, so we can remove `Result` cost.
## Related issues

#2958 

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

Before this PR:

| Datatype | Operation | Fory (ns) | Protobuf (ns) | Faster |
|----------|-----------|-----------|---------------|--------|
| Struct | Serialize | 10.7 | 19.8 | Fory (1.9x) |
| Struct | Deserialize | 53.7 | 16.2 | Protobuf (3.3x) |

With this PR:

| Datatype | Operation | Fory (ns) | Protobuf (ns) | Faster |
|----------|-----------|-----------|---------------|--------|
| Struct | Serialize | 10.3 | 19.8 | Fory (1.9x) |
| Struct | Deserialize | 33.6 | 16.5 | Protobuf (2.0x) |