### PR TITLE
fix(cpp): fix the type error

### DIFF
--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -75,29 +75,29 @@ public:
   FORY_ALWAYS_INLINE uint32_t reader_index() { return reader_index_; }
 
   FORY_ALWAYS_INLINE void WriterIndex(uint32_t writer_index) {
-    FORY_CHECK(writer_index < std::numeric_limits<int>::max())
+    FORY_CHECK(writer_index < std::numeric_limits<uint32_t>::max())
         << "Buffer overflow writer_index" << writer_index_
         << " target writer_index " << writer_index;
     writer_index_ = writer_index;
   }
 
   FORY_ALWAYS_INLINE void IncreaseWriterIndex(uint32_t diff) {
-    int64_t writer_index = writer_index_ + diff;
-    FORY_CHECK(writer_index < std::numeric_limits<int>::max())
+    uint64_t writer_index = writer_index_ + diff;
+    FORY_CHECK(writer_index < std::numeric_limits<uint32_t>::max())
         << "Buffer overflow writer_index" << writer_index_ << " diff " << diff;
     writer_index_ = writer_index;
   }
 
   FORY_ALWAYS_INLINE void ReaderIndex(uint32_t reader_index) {
-    FORY_CHECK(reader_index < std::numeric_limits<int>::max())
+    FORY_CHECK(reader_index < std::numeric_limits<uint32_t>::max())
         << "Buffer overflow reader_index" << reader_index_
         << " target reader_index " << reader_index;
     reader_index_ = reader_index;
   }
 
   FORY_ALWAYS_INLINE void IncreaseReaderIndex(uint32_t diff) {
-    int64_t reader_index = reader_index_ + diff;
-    FORY_CHECK(reader_index < std::numeric_limits<int>::max())
+    uint64_t reader_index = reader_index_ + diff;
+    FORY_CHECK(reader_index < std::numeric_limits<uint32_t>::max())
         << "Buffer overflow reader_index" << reader_index_ << " diff " << diff;
     reader_index_ = reader_index;
   }


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

<!-- Describe the purpose of this PR. -->
Fix the abnormal data type judgment in CPP buffer.h (std::numeric_limits<int>::max()).

## What does this PR do?

<!-- Describe the details of this PR. -->
run
```bash
cd benchmarks/cpp_benchmark
./profile.sh --duration 10 --filter BM_Fory_Struct_Serialize
```

Got the following error:
```
=== Fory C++ Benchmark Profiler ===
Filter: BM_Fory_Struct_Serialize
Duration: 10s
Output: profile_output

Profiling with samply...
Running: samply record ./fory_benchmark --benchmark_min_time=10s --benchmark_filter=BM_Fory_Struct_Serialize
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2025-12-02T16:23:03+08:00
Running ./fory_benchmark
Run on (10 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x10)
Load Average: 2.09, 2.23, 2.36
[2025-12-02 16:23:11,944] FATAL fory/cpp/fory/util/buffer.h:86:  Check failed: writer_index < std::numeric_limits<int>::max() Buffer overflow writer_index2147483646 diff 1
*** StackTrace Information ***
    fory::GetCallTrace()
    fory::ForyLog::~ForyLog()
    fory::serialization::Serializer<>::write()
    fory::serialization::Fory::serialize_impl<>()
    BM_Fory_Struct_Serialize()
    benchmark::internal::BenchmarkInstance::Run()
    benchmark::internal::(anonymous namespace)::RunInThread()
    benchmark::internal::BenchmarkRunner::DoNIterations()
    benchmark::internal::BenchmarkRunner::DoOneRepetition()
    benchmark::RunSpecifiedBenchmarks()
    benchmark::RunSpecifiedBenchmarks()
    main
    start
```

In `buffer.h`, `writer_index_` and `reader_index_` are of the `uint32_t` type.


