### PR TITLE
docs: remove unused type mappings for arrow types

### DIFF
--- a/docs/specification/xlang_type_mapping.md
+++ b/docs/specification/xlang_type_mapping.md
@@ -66,8 +66,6 @@ Note:
 | float16_array           | 35           | float[]         | ndarray(float16)                  | /               | `fory::float16_t[n]/vector<T>` | `[n]float16/[]T` | `Vec<fory::f16>` |
 | float32_array           | 36           | float[]         | ndarray(float32)                  | /               | `float[n]/vector<T>`           | `[n]float32/[]T` | `Vec<f32>`       |
 | float64_array           | 37           | double[]        | ndarray(float64)                  | /               | `double[n]/vector<T>`          | `[n]float64/[]T` | `Vec<f64>`       |
-| arrow record batch      | 38           | /               | /                                 | /               | /                              | /                | /                |
-| arrow table             | 39           | /               | /                                 | /               | /                              | /                | /                |
 
 ## Type info(not implemented currently)
 


### PR DESCRIPTION

<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

<!-- Describe the purpose of this PR. -->

## What does this PR do?

Removed unused entries for 'arrow record batch' and 'arrow table' from type mapping.

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.

Delete section if not applicable.
-->
