### PR TITLE
chore: bump release version to 0.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,24 +127,8 @@ For more detailed benchmarks and methodology, see [Rust Benchmarks](benchmarks/r
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
-<!-- Optional row format support -->
-<!--
-<dependency>
-  <groupId>org.apache.fory</groupId>
-  <artifactId>fory-format</artifactId>
-  <version>0.13.1</version>
-</dependency>
--->
-<!-- SIMD acceleration for array compression (Java 16+) -->
-<!--
-<dependency>
-  <groupId>org.apache.fory</groupId>
-  <artifactId>fory-simd</artifactId>
-  <version>0.13.1</version>
-</dependency>
--->
 ```
 
 Snapshots are available from `https://repository.apache.org/snapshots/` (version `0.14.0-SNAPSHOT`).
@@ -153,10 +137,10 @@ Snapshots are available from `https://repository.apache.org/snapshots/` (version
 
 ```sbt
 // Scala 2.13
-libraryDependencies += "org.apache.fory" % "fory-scala_2.13" % "0.13.1"
+libraryDependencies += "org.apache.fory" % "fory-scala_2.13" % "0.13.2"
 
 // Scala 3
-libraryDependencies += "org.apache.fory" % "fory-scala_3" % "0.13.1"
+libraryDependencies += "org.apache.fory" % "fory-scala_3" % "0.13.2"
 ```
 
 **Kotlin**:
@@ -165,7 +149,7 @@ libraryDependencies += "org.apache.fory" % "fory-scala_3" % "0.13.1"
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 ```
 

--- a/docs/guide/java_serialization_guide.md
+++ b/docs/guide/java_serialization_guide.md
@@ -286,7 +286,7 @@ For Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-simd</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 ```
 

--- a/docs/guide/scala_guide.md
+++ b/docs/guide/scala_guide.md
@@ -34,7 +34,7 @@ Scala 2 and 3 are both supported.
 To add a dependency on Apache Fory™ scala for with sbt, use the following:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "0.13.1"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "0.13.2"
 ```
 
 ## Quick Start

--- a/java/README.md
+++ b/java/README.md
@@ -60,28 +60,28 @@ Apache Fory™ Java provides blazingly-fast serialization for the Java ecosystem
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 
 <!-- Optional: Row format support -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 
 <!-- Optional: Serializers for Protobuf data -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-extensions</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 
 <!-- Optional: SIMD acceleration (Java 16+) -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-simd</artifactId>
-  <version>0.13.1</version>
+  <version>0.13.2</version>
 </dependency>
 ```
 
@@ -89,11 +89,11 @@ Apache Fory™ Java provides blazingly-fast serialization for the Java ecosystem
 
 ```gradle
 dependencies {
-    implementation 'org.apache.fory:fory-core:0.13.1'
+    implementation 'org.apache.fory:fory-core:0.13.2'
     // Optional modules
-    implementation 'org.apache.fory:fory-format:0.13.1'
-    implementation 'org.apache.fory:fory-simd:0.13.1'
-    implementation 'org.apache.fory:fory-extensions:0.13.1'
+    implementation 'org.apache.fory:fory-format:0.13.2'
+    implementation 'org.apache.fory:fory-simd:0.13.2'
+    implementation 'org.apache.fory:fory-extensions:0.13.2'
 }
 ```
 

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -2779,7 +2779,7 @@
       "license": "ISC"
     },
     "node_modules/emittery": {
-      "version": "0.13.1",
+      "version": "0.13.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4133,7 +4133,7 @@
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
+        "emittery": "^0.13.2",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.7.0",
         "jest-environment-node": "^29.7.0",
@@ -4278,7 +4278,7 @@
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
+        "emittery": "^0.13.2",
         "jest-util": "^29.7.0",
         "string-length": "^4.0.1"
       },


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

