### PR TITLE
feat(java): add config params for IdentityObjectIntMap

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -147,7 +147,7 @@ public final class Fory implements BaseFory {
     longEncoding = config.longEncoding();
     maxDepth = config.maxDepth();
     if (refTracking) {
-      this.refResolver = new MapRefResolver();
+      this.refResolver = new MapRefResolver(config.mapRefLoadFactor());
     } else {
       this.refResolver = new NoRefResolver();
     }

--- a/java/fory-core/src/main/java/org/apache/fory/config/Config.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/Config.java
@@ -66,6 +66,7 @@ public class Config implements Serializable {
   private final boolean serializeEnumByName;
   private final int bufferSizeLimitBytes;
   private final int maxDepth;
+  private final float mapRefLoadFactor;
   boolean foryDebugOutputEnabled =
       "1".equals(System.getenv("ENABLE_FORY_DEBUG_OUTPUT"))
           || "true".equals(System.getenv("ENABLE_FORY_DEBUG_OUTPUT"));
@@ -110,6 +111,7 @@ public class Config implements Serializable {
     serializeEnumByName = builder.serializeEnumByName;
     bufferSizeLimitBytes = builder.bufferSizeLimitBytes;
     maxDepth = builder.maxDepth;
+    mapRefLoadFactor = builder.mapRefLoadFactor;
   }
 
   /** Returns the name for Fory serialization. */
@@ -312,6 +314,7 @@ public class Config implements Serializable {
     Config config = (Config) o;
     return name == config.name
         && trackingRef == config.trackingRef
+        && mapRefLoadFactor == config.mapRefLoadFactor
         && basicTypesRefIgnored == config.basicTypesRefIgnored
         && stringRefIgnored == config.stringRefIgnored
         && timeRefIgnored == config.timeRefIgnored
@@ -346,6 +349,7 @@ public class Config implements Serializable {
     return Objects.hash(
         name,
         language,
+        mapRefLoadFactor,
         trackingRef,
         basicTypesRefIgnored,
         stringRefIgnored,
@@ -390,5 +394,10 @@ public class Config implements Serializable {
   /** Returns max depth for deserialization, when depth exceeds, an exception will be thrown. */
   public int maxDepth() {
     return maxDepth;
+  }
+
+  /** Returns loadFactor of MacRef's writtenObjects. */
+  public float mapRefLoadFactor() {
+    return mapRefLoadFactor;
   }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/config/ForyBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/ForyBuilder.java
@@ -89,6 +89,7 @@ public final class ForyBuilder {
   int bufferSizeLimitBytes = 128 * 1024;
   MetaCompressor metaCompressor = new DeflaterMetaCompressor();
   int maxDepth = 50;
+  float mapRefLoadFactor = 0.51f;
 
   public ForyBuilder() {}
 
@@ -386,6 +387,14 @@ public final class ForyBuilder {
   public ForyBuilder withMaxDepth(int maxDepth) {
     Preconditions.checkArgument(maxDepth >= 2, "maxDepth must >= 2 but got %s", maxDepth);
     this.maxDepth = maxDepth;
+    return this;
+  }
+
+  /** Set loadFactor of MapRefResolver writtenObjects. Default value is 0.51 */
+  public ForyBuilder withMapRefLoadFactor(float loadFactor) {
+    Preconditions.checkArgument(
+        loadFactor > 0 && loadFactor < 1, "loadFactor must > 0 and < 1 but got %s", loadFactor);
+    this.mapRefLoadFactor = loadFactor;
     return this;
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/MapRefResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/MapRefResolver.java
@@ -52,15 +52,16 @@ public final class MapRefResolver implements RefResolver {
   private long writeTotalObjectSize = 0;
   private long readCounter;
   private long readTotalObjectSize = 0;
-  private final IdentityObjectIntMap<Object> writtenObjects =
-      new IdentityObjectIntMap<>(DEFAULT_MAP_CAPACITY, 0.51f);
+  private final IdentityObjectIntMap<Object> writtenObjects;
   private final ObjectArray readObjects = new ObjectArray(DEFAULT_ARRAY_CAPACITY);
   private final IntArray readRefIds = new IntArray(DEFAULT_ARRAY_CAPACITY);
 
   // last read object which is not a reference
   private Object readObject;
 
-  public MapRefResolver() {}
+  public MapRefResolver(float loadFactor) {
+    writtenObjects = new IdentityObjectIntMap<>(DEFAULT_MAP_CAPACITY, loadFactor);
+  }
 
   @Override
   public boolean writeRefOrNull(MemoryBuffer buffer, Object obj) {

--- a/java/fory-core/src/test/java/org/apache/fory/resolver/MapRefResolverTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/resolver/MapRefResolverTest.java
@@ -31,7 +31,7 @@ public class MapRefResolverTest {
 
   @Test
   public void testTrackingReference() {
-    MapRefResolver referenceResolver = new MapRefResolver();
+    MapRefResolver referenceResolver = new MapRefResolver(0.51f);
     MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(32);
     assertTrue(referenceResolver.writeRefOrNull(buffer, null));
     assertFalse(referenceResolver.writeRefOrNull(buffer, new Object()));
@@ -48,7 +48,7 @@ public class MapRefResolverTest {
     // If java jit run and optimized `writeRefOrNull`, set `ENABLE_FORY_REF_PROFILING`
     // by reflection may not take effect too.
     // System.setProperty("fory.enable_ref_profiling", "true");
-    MapRefResolver referenceResolver = new MapRefResolver();
+    MapRefResolver referenceResolver = new MapRefResolver(0.51f);
     MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(32);
     Object obj1 = new Object();
     referenceResolver.writeRefOrNull(buffer, obj1);


### PR DESCRIPTION
Add config params: size and loadFactor of  MapRefResolver's writtenObjects for huge and complex object(#3047); Let user init map size in some situtations.

## Related issues

[3047](https://github.com/apache/fory/issues/3047)

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


