### PR TITLE
feat(c++): add iterator container serialization support

### DIFF
--- a/cpp/fory/serialization/serializer_traits.h
+++ b/cpp/fory/serialization/serializer_traits.h
@@ -25,6 +25,7 @@
 #include "fory/type/type.h"
 #include <array>
 #include <deque>
+#include <forward_list>
 #include <list>
 #include <map>
 #include <memory>
@@ -77,6 +78,31 @@ template <typename T, typename Alloc>
 struct is_vector<std::vector<T, Alloc>> : std::true_type {};
 
 template <typename T> inline constexpr bool is_vector_v = is_vector<T>::value;
+
+/// Detect std::list
+template <typename T> struct is_list : std::false_type {};
+
+template <typename T, typename Alloc>
+struct is_list<std::list<T, Alloc>> : std::true_type {};
+
+template <typename T> inline constexpr bool is_list_v = is_list<T>::value;
+
+/// Detect std::deque
+template <typename T> struct is_deque : std::false_type {};
+
+template <typename T, typename Alloc>
+struct is_deque<std::deque<T, Alloc>> : std::true_type {};
+
+template <typename T> inline constexpr bool is_deque_v = is_deque<T>::value;
+
+/// Detect std::forward_list
+template <typename T> struct is_forward_list : std::false_type {};
+
+template <typename T, typename Alloc>
+struct is_forward_list<std::forward_list<T, Alloc>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_forward_list_v = is_forward_list<T>::value;
 
 /// Detect std::optional
 template <typename T> struct is_optional : std::false_type {};
@@ -240,6 +266,15 @@ struct is_generic_type<std::set<T, Args...>> : std::true_type {};
 
 template <typename T, typename... Args>
 struct is_generic_type<std::unordered_set<T, Args...>> : std::true_type {};
+
+template <typename T, typename Alloc>
+struct is_generic_type<std::list<T, Alloc>> : std::true_type {};
+
+template <typename T, typename Alloc>
+struct is_generic_type<std::deque<T, Alloc>> : std::true_type {};
+
+template <typename T, typename Alloc>
+struct is_generic_type<std::forward_list<T, Alloc>> : std::true_type {};
 
 template <typename... Ts>
 struct is_generic_type<std::tuple<Ts...>> : std::true_type {};
@@ -454,6 +489,12 @@ template <typename T> struct TypeIndex<std::list<T>> {
 template <typename T> struct TypeIndex<std::deque<T>> {
   static constexpr uint64_t value =
       fnv1a_64_combine(fnv1a_64("std::deque"), type_index<T>());
+};
+
+// forward_list<T>
+template <typename T> struct TypeIndex<std::forward_list<T>> {
+  static constexpr uint64_t value =
+      fnv1a_64_combine(fnv1a_64("std::forward_list"), type_index<T>());
 };
 
 // set<T>

--- a/cpp/fory/serialization/type_resolver.h
+++ b/cpp/fory/serialization/type_resolver.h
@@ -335,6 +335,42 @@ struct FieldTypeBuilder<T, std::enable_if_t<is_vector_v<decay_t<T>>>> {
 };
 
 template <typename T>
+struct FieldTypeBuilder<T, std::enable_if_t<is_list_v<decay_t<T>>>> {
+  using List = decay_t<T>;
+  using Element = typename List::value_type;
+  static FieldType build(bool nullable) {
+    FieldType elem = FieldTypeBuilder<Element>::build(false);
+    FieldType ft(to_type_id(TypeId::LIST), nullable);
+    ft.generics.push_back(std::move(elem));
+    return ft;
+  }
+};
+
+template <typename T>
+struct FieldTypeBuilder<T, std::enable_if_t<is_deque_v<decay_t<T>>>> {
+  using Deque = decay_t<T>;
+  using Element = typename Deque::value_type;
+  static FieldType build(bool nullable) {
+    FieldType elem = FieldTypeBuilder<Element>::build(false);
+    FieldType ft(to_type_id(TypeId::LIST), nullable);
+    ft.generics.push_back(std::move(elem));
+    return ft;
+  }
+};
+
+template <typename T>
+struct FieldTypeBuilder<T, std::enable_if_t<is_forward_list_v<decay_t<T>>>> {
+  using FList = decay_t<T>;
+  using Element = typename FList::value_type;
+  static FieldType build(bool nullable) {
+    FieldType elem = FieldTypeBuilder<Element>::build(false);
+    FieldType ft(to_type_id(TypeId::LIST), nullable);
+    ft.generics.push_back(std::move(elem));
+    return ft;
+  }
+};
+
+template <typename T>
 struct FieldTypeBuilder<T, std::enable_if_t<is_set_like_v<decay_t<T>>>> {
   using Set = decay_t<T>;
   using Element = element_type_t<Set>;
@@ -409,13 +445,14 @@ struct FieldTypeBuilder<T, std::enable_if_t<std::is_enum_v<decay_t<T>>>> {
 
 template <typename T>
 struct FieldTypeBuilder<
-    T,
-    std::enable_if_t<
-        !is_optional_v<decay_t<T>> && !is_shared_ptr_v<decay_t<T>> &&
-        !is_unique_ptr_v<decay_t<T>> && !is_vector_v<decay_t<T>> &&
-        !is_set_like_v<decay_t<T>> && !is_map_like_v<decay_t<T>> &&
-        !is_string_view_v<decay_t<T>> && !is_tuple_v<decay_t<T>> &&
-        !std::is_enum_v<decay_t<T>> && has_serializer_type_id_v<decay_t<T>>>> {
+    T, std::enable_if_t<
+           !is_optional_v<decay_t<T>> && !is_shared_ptr_v<decay_t<T>> &&
+           !is_unique_ptr_v<decay_t<T>> && !is_vector_v<decay_t<T>> &&
+           !is_list_v<decay_t<T>> && !is_deque_v<decay_t<T>> &&
+           !is_forward_list_v<decay_t<T>> && !is_set_like_v<decay_t<T>> &&
+           !is_map_like_v<decay_t<T>> && !is_string_view_v<decay_t<T>> &&
+           !is_tuple_v<decay_t<T>> && !std::is_enum_v<decay_t<T>> &&
+           has_serializer_type_id_v<decay_t<T>>>> {
   using Decayed = decay_t<T>;
   static FieldType build(bool nullable) {
     return FieldType(to_type_id(Serializer<Decayed>::type_id), nullable);


### PR DESCRIPTION
## Why?

Per xlang specification, Fory needs to support serialization of iterator-based containers. Currently, only `std::vector` and `std::set` are supported in C++. This PR adds support for additional sequence containers (`std::list`, `std::deque`, `std::forward_list`) to provide more flexibility for C++ users.

## What does this PR do?

Add serialization support for C++ iterator containers:
- `std::list<T>`
- `std::deque<T>` 
- `std::forward_list<T>`

All these containers are serialized as `TypeId::LIST` (value 21) per xlang specification, which only distinguishes between LIST and SET collection types. Set-like classes (`std::set`, `std::unordered_set`) continue to use `TypeId::SET`.

**Changes:**
- `serializer_traits.h`: Add `is_list`, `is_deque`, `is_forward_list` type traits and `is_generic_type` specializations
- `collection_serializer.h`: Add complete `Serializer` specializations for `std::list`, `std::deque`, `std::forward_list` with full read/write support
- `type_resolver.h`: Add `FieldTypeBuilder` specializations for new container types to support struct field serialization
- `collection_serializer_test.cc`: Add 9 comprehensive test cases covering string, integer, and empty collection scenarios

## Related issues

Closes #2911

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
  - Adds new public serialization support for `std::list`, `std::deque`, and `std::forward_list` containers
- [ ] Does this PR introduce any binary protocol compatibility change?
  - No, uses existing `TypeId::LIST` protocol

## Benchmark

N/A - This PR adds new functionality without modifying existing serialization paths. The new container serializers follow the same patterns as the existing `std::vector` serializer.