### PR TITLE
chore(rust): revert rust crates version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.14.0"
 rust-version = "1.70"
 description = "Apache Fory: Blazingly fast multi-language serialization framework with trait objects and reference support."
 license = "Apache-2.0"
@@ -42,5 +42,5 @@ keywords = ["serialization", "serde", "trait-object", "zero-copy", "schema-evolu
 categories = ["encoding"]
 
 [workspace.dependencies]
-fory-core = { path = "fory-core", version = "0.15.0" }
-fory-derive = { path = "fory-derive", version = "0.15.0" }
+fory-core = { path = "fory-core", version = "0.14.0" }
+fory-derive = { path = "fory-derive", version = "0.14.0" }


### PR DESCRIPTION



I didn't realize that the version is shared across the entire project, not a separate version for each language.

I'm very sorry about that.

