### PR TITLE
docs(c++): Add MSVC compatibility to the CMake sample in the CPP document.

### DIFF
--- a/docs/guide/cpp/index.md
+++ b/docs/guide/cpp/index.md
@@ -52,7 +52,9 @@ project(my_project LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
+if(MSVC)
+    add_compile_options(/Zc:preprocessor)
+endif()
 include(FetchContent)
 FetchContent_Declare(
     fory


### PR DESCRIPTION


## Why?

cpp文档中提供的cmake代码在MSVC编译环境下，编译基本示例会出现编译错误。该PR修改了给出的cmake代码对MSVC环境做出兼容。
## What does this PR do?


cpp代码的FORY_STRUCT宏使用了__VA_ARGS__宏命令，并且将__VA_ARGS__作为另一个宏函数的参数传递。这在标准是合法的，但是MSVC的旧版本预处理器的行为并不符合标准，行为和GCC、Clang不一致从而导致编译错误。而MSVC默认使用的预处理器又是旧版本的。

具体为可见 [MSVC 新预处理器概述](https://learn.microsoft.com/zh-cn/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170) 其中的“宏参数已“解压缩””

微软官方提供 /Zc:preprocessor 和/experimental:preprocessor 的编译选项来启用“新预处理器”也就是“标准符合性预处理器”，其中
/Zc:preprocessor  是Visual Studio 2019 版本 16.5 开始提供，/experimental:preprocessor 是Visual Studio 2017 版本 15.8 开始提供的实验版本。

这里我给cmake的样例加上了
```
if(MSVC)
    add_compile_options(/Zc:preprocessor)
endif()
```
从而让MSVC下的代码正常工作。
