### PR TITLE
feat(rust): add i128 and isize type support

### DIFF
--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -547,8 +547,8 @@ impl TypeMeta {
                 TypeId::U16 => 2,
                 TypeId::U32 => 4,
                 TypeId::U64 => 8,
-                TypeId::USIZE => 8,
                 TypeId::U128 => 16,
+                TypeId::INT128 => 16,
                 _ => unreachable!(),
             }
         }

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -591,6 +591,8 @@ impl TypeResolver {
         self.register_internal_serializer::<i16>(TypeId::INT16)?;
         self.register_internal_serializer::<i32>(TypeId::INT32)?;
         self.register_internal_serializer::<i64>(TypeId::INT64)?;
+        self.register_internal_serializer::<isize>(TypeId::ISIZE)?;
+        self.register_internal_serializer::<i128>(TypeId::INT128)?;
         self.register_internal_serializer::<f32>(TypeId::FLOAT32)?;
         self.register_internal_serializer::<f64>(TypeId::FLOAT64)?;
         self.register_internal_serializer::<u8>(TypeId::U8)?;
@@ -616,6 +618,8 @@ impl TypeResolver {
         self.register_internal_serializer::<Vec<u64>>(TypeId::U64_ARRAY)?;
         self.register_internal_serializer::<Vec<usize>>(TypeId::USIZE_ARRAY)?;
         self.register_internal_serializer::<Vec<u128>>(TypeId::U128_ARRAY)?;
+        self.register_internal_serializer::<Vec<isize>>(TypeId::ISIZE_ARRAY)?;
+        self.register_internal_serializer::<Vec<i128>>(TypeId::INT128_ARRAY)?;
         self.register_generic_trait::<Vec<String>>()?;
         self.register_generic_trait::<LinkedList<i32>>()?;
         self.register_generic_trait::<LinkedList<String>>()?;

--- a/rust/fory-core/src/serializer/list.rs
+++ b/rust/fory-core/src/serializer/list.rs
@@ -47,8 +47,10 @@ pub(super) fn get_primitive_type_id<T: Serializer>() -> TypeId {
         TypeId::U16 => TypeId::U16_ARRAY,
         TypeId::U32 => TypeId::U32_ARRAY,
         TypeId::U64 => TypeId::U64_ARRAY,
-        TypeId::USIZE => TypeId::USIZE_ARRAY,
         TypeId::U128 => TypeId::U128_ARRAY,
+        TypeId::INT128 => TypeId::INT128_ARRAY,
+        TypeId::USIZE => TypeId::USIZE_ARRAY,
+        TypeId::ISIZE => TypeId::ISIZE_ARRAY,
         _ => TypeId::UNKNOWN,
     }
 }
@@ -65,13 +67,13 @@ pub(super) fn is_primitive_type<T: Serializer>() -> bool {
             | TypeId::INT16
             | TypeId::INT32
             | TypeId::INT64
+            | TypeId::INT128
             | TypeId::FLOAT32
             | TypeId::FLOAT64
             | TypeId::U8
             | TypeId::U16
             | TypeId::U32
             | TypeId::U64
-            | TypeId::USIZE
             | TypeId::U128,
     )
 }

--- a/rust/fory-core/src/serializer/number.rs
+++ b/rust/fory-core/src/serializer/number.rs
@@ -99,3 +99,10 @@ impl_num_serializer!(
 );
 impl_num_serializer!(f32, Writer::write_f32, Reader::read_f32, TypeId::FLOAT32);
 impl_num_serializer!(f64, Writer::write_f64, Reader::read_f64, TypeId::FLOAT64);
+impl_num_serializer!(i128, Writer::write_i128, Reader::read_i128, TypeId::INT128);
+impl_num_serializer!(
+    isize,
+    Writer::write_isize,
+    Reader::read_isize,
+    TypeId::ISIZE
+);

--- a/rust/fory-core/src/serializer/primitive_list.rs
+++ b/rust/fory-core/src/serializer/primitive_list.rs
@@ -26,7 +26,7 @@ pub fn fory_write_data<T: Serializer>(this: &[T], context: &mut WriteContext) ->
     if context.is_xlang()
         && matches!(
             T::fory_static_type_id(),
-            TypeId::U16 | TypeId::U32 | TypeId::U64 | TypeId::USIZE | TypeId::U128
+            TypeId::U16 | TypeId::U32 | TypeId::U64 | TypeId::U128
         )
     {
         return Err(Error::not_allowed(

--- a/rust/fory-core/src/serializer/skip.rs
+++ b/rust/fory-core/src/serializer/skip.rs
@@ -520,9 +520,6 @@ fn skip_value(
         types::U64 => {
             <u64 as Serializer>::fory_read_data(context)?;
         }
-        types::USIZE => {
-            <usize as Serializer>::fory_read_data(context)?;
-        }
         types::U128 => {
             <u128 as Serializer>::fory_read_data(context)?;
         }
@@ -534,9 +531,6 @@ fn skip_value(
         }
         types::U64_ARRAY => {
             <Vec<u64> as Serializer>::fory_read_data(context)?;
-        }
-        types::USIZE_ARRAY => {
-            <Vec<usize> as Serializer>::fory_read_data(context)?;
         }
         types::U128_ARRAY => {
             <Vec<u128> as Serializer>::fory_read_data(context)?;

--- a/rust/fory-core/src/serializer/unsigned_number.rs
+++ b/rust/fory-core/src/serializer/unsigned_number.rs
@@ -92,10 +92,10 @@ impl_unsigned_num_serializer!(u8, Writer::write_u8, Reader::read_u8, TypeId::U8)
 impl_unsigned_num_serializer!(u16, Writer::write_u16, Reader::read_u16, TypeId::U16);
 impl_unsigned_num_serializer!(u32, Writer::write_u32, Reader::read_u32, TypeId::U32);
 impl_unsigned_num_serializer!(u64, Writer::write_u64, Reader::read_u64, TypeId::U64);
+impl_unsigned_num_serializer!(u128, Writer::write_u128, Reader::read_u128, TypeId::U128);
 impl_unsigned_num_serializer!(
     usize,
     Writer::write_usize,
     Reader::read_usize,
     TypeId::USIZE
 );
-impl_unsigned_num_serializer!(u128, Writer::write_u128, Reader::read_u128, TypeId::U128);

--- a/rust/fory-core/src/serializer/util.rs
+++ b/rust/fory-core/src/serializer/util.rs
@@ -21,8 +21,8 @@ use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
 use crate::types::TypeId;
 use crate::types::{
-    is_user_type, BOOL, ENUM, FLOAT32, FLOAT64, INT16, INT32, INT64, INT8, NAMED_ENUM, U128, U16,
-    U32, U64, U8, USIZE,
+    is_user_type, BOOL, ENUM, FLOAT32, FLOAT64, INT128, INT16, INT32, INT64, INT8, NAMED_ENUM,
+    U128, U16, U32, U64, U8,
 };
 
 #[inline(always)]
@@ -74,13 +74,13 @@ pub const fn field_need_write_ref_into(type_id: u32, nullable: bool) -> bool {
             | INT16
             | INT32
             | INT64
+            | INT128
             | FLOAT32
             | FLOAT64
             | U8
             | U16
             | U32
             | U64
-            | USIZE
             | U128
     )
 }

--- a/rust/fory-core/src/types.rs
+++ b/rust/fory-core/src/types.rs
@@ -84,19 +84,29 @@ pub enum TypeId {
     U8 = 64,
     U16 = 65,
     U32 = 66,
-    U64 = 67,
-    USIZE = 68,
-    U128 = 69,
-    VAR_U32 = 70,
-    VAR_U64 = 71,
-    SLI_U64 = 72,
-    U16_ARRAY = 73,
-    U32_ARRAY = 74,
-    U64_ARRAY = 75,
-    USIZE_ARRAY = 76,
-    U128_ARRAY = 77,
+    VAR_U32 = 67,
+    U64 = 68,
+    VAR_U64 = 69,
+    SLI_U64 = 70,
+    U128 = 71,
+    INT128 = 72,
+    // USIZE/ISIZE must have their own TypeId.
+    // Although usize and u64 have the same size on 64-bit systems, they are
+    // different Rust types.
+    // When deserializing `Box<dyn Any>`, we need to create the exact type.
+    // If we used U64's TypeId for usize, deserialization would create a u64 value,
+    // and `result.downcast_ref::<usize>()` would return None.
+    USIZE = 73,
+    ISIZE = 74,
+    U16_ARRAY = 75,
+    U32_ARRAY = 76,
+    U64_ARRAY = 77,
+    U128_ARRAY = 78,
+    INT128_ARRAY = 79,
+    USIZE_ARRAY = 80,
+    ISIZE_ARRAY = 81,
     // Bound value for range checks (types with id >= BOUND are not internal types).
-    BOUND = 78,
+    BOUND = 82,
 }
 
 pub const BOOL: u32 = TypeId::BOOL as u32;
@@ -107,6 +117,7 @@ pub const VAR_INT32: u32 = TypeId::VAR_INT32 as u32;
 pub const INT64: u32 = TypeId::INT64 as u32;
 pub const VAR_INT64: u32 = TypeId::VAR_INT64 as u32;
 pub const SLI_INT64: u32 = TypeId::SLI_INT64 as u32;
+pub const INT128: u32 = TypeId::INT128 as u32;
 pub const FLOAT16: u32 = TypeId::FLOAT16 as u32;
 pub const FLOAT32: u32 = TypeId::FLOAT32 as u32;
 pub const FLOAT64: u32 = TypeId::FLOAT64 as u32;
@@ -140,7 +151,6 @@ pub const U8: u32 = TypeId::U8 as u32;
 pub const U16: u32 = TypeId::U16 as u32;
 pub const U32: u32 = TypeId::U32 as u32;
 pub const U64: u32 = TypeId::U64 as u32;
-pub const USIZE: u32 = TypeId::USIZE as u32;
 pub const U128: u32 = TypeId::U128 as u32;
 pub const VAR_U32: u32 = TypeId::VAR_U32 as u32;
 pub const VAR_U64: u32 = TypeId::VAR_U64 as u32;
@@ -148,8 +158,12 @@ pub const SLI_U64: u32 = TypeId::SLI_U64 as u32;
 pub const U16_ARRAY: u32 = TypeId::U16_ARRAY as u32;
 pub const U32_ARRAY: u32 = TypeId::U32_ARRAY as u32;
 pub const U64_ARRAY: u32 = TypeId::U64_ARRAY as u32;
-pub const USIZE_ARRAY: u32 = TypeId::USIZE_ARRAY as u32;
 pub const U128_ARRAY: u32 = TypeId::U128_ARRAY as u32;
+pub const INT128_ARRAY: u32 = TypeId::INT128_ARRAY as u32;
+pub const USIZE: u32 = TypeId::USIZE as u32;
+pub const ISIZE: u32 = TypeId::ISIZE as u32;
+pub const USIZE_ARRAY: u32 = TypeId::USIZE_ARRAY as u32;
+pub const ISIZE_ARRAY: u32 = TypeId::ISIZE_ARRAY as u32;
 pub const UNKNOWN: u32 = TypeId::UNKNOWN as u32;
 pub const BOUND: u32 = TypeId::BOUND as u32;
 
@@ -191,16 +205,16 @@ pub static BASIC_TYPES: [TypeId; 29] = [
     TypeId::U16,
     TypeId::U32,
     TypeId::U64,
-    TypeId::USIZE,
     TypeId::U128,
     TypeId::U16_ARRAY,
     TypeId::U32_ARRAY,
     TypeId::U64_ARRAY,
-    TypeId::USIZE_ARRAY,
     TypeId::U128_ARRAY,
+    TypeId::INT128,
+    TypeId::INT128_ARRAY,
 ];
 
-pub static PRIMITIVE_TYPES: [u32; 13] = [
+pub static PRIMITIVE_TYPES: [u32; 12] = [
     TypeId::BOOL as u32,
     TypeId::INT8 as u32,
     TypeId::INT16 as u32,
@@ -212,7 +226,6 @@ pub static PRIMITIVE_TYPES: [u32; 13] = [
     TypeId::U16 as u32,
     TypeId::U32 as u32,
     TypeId::U64 as u32,
-    TypeId::USIZE as u32,
     TypeId::U128 as u32,
 ];
 
@@ -228,16 +241,17 @@ pub static PRIMITIVE_ARRAY_TYPES: [u32; 13] = [
     TypeId::U16_ARRAY as u32,
     TypeId::U32_ARRAY as u32,
     TypeId::U64_ARRAY as u32,
-    TypeId::USIZE_ARRAY as u32,
     TypeId::U128_ARRAY as u32,
+    TypeId::INT128_ARRAY as u32,
 ];
 
-pub static BASIC_TYPE_NAMES: [&str; 16] = [
+pub static BASIC_TYPE_NAMES: [&str; 18] = [
     "bool",
     "i8",
     "i16",
     "i32",
     "i64",
+    "i128",
     "f32",
     "f64",
     "String",
@@ -247,8 +261,9 @@ pub static BASIC_TYPE_NAMES: [&str; 16] = [
     "u16",
     "u32",
     "u64",
-    "usize",
     "u128",
+    "usize",
+    "isize",
 ];
 
 pub static CONTAINER_TYPES: [TypeId; 3] = [TypeId::LIST, TypeId::SET, TypeId::MAP];
@@ -262,13 +277,15 @@ pub static PRIMITIVE_ARRAY_TYPE_MAP: &[(&str, u32, &str)] = &[
     ("i16", TypeId::INT16_ARRAY as u32, "Vec<i16>"),
     ("i32", TypeId::INT32_ARRAY as u32, "Vec<i32>"),
     ("i64", TypeId::INT64_ARRAY as u32, "Vec<i64>"),
+    ("i128", TypeId::INT128_ARRAY as u32, "Vec<i128>"),
     ("f32", TypeId::FLOAT32_ARRAY as u32, "Vec<f32>"),
     ("f64", TypeId::FLOAT64_ARRAY as u32, "Vec<f64>"),
     ("u16", TypeId::U16_ARRAY as u32, "Vec<u16>"),
     ("u32", TypeId::U32_ARRAY as u32, "Vec<u32>"),
     ("u64", TypeId::U64_ARRAY as u32, "Vec<u64>"),
-    ("usize", TypeId::USIZE_ARRAY as u32, "Vec<usize>"),
     ("u128", TypeId::U128_ARRAY as u32, "Vec<u128>"),
+    ("usize", TypeId::USIZE_ARRAY as u32, "Vec<usize>"),
+    ("isize", TypeId::ISIZE_ARRAY as u32, "Vec<isize>"),
 ];
 
 /// Keep as const fn for compile time evaluation or constant folding
@@ -281,14 +298,16 @@ pub const fn is_primitive_type_id(type_id: TypeId) -> bool {
             | TypeId::INT16
             | TypeId::INT32
             | TypeId::INT64
+            | TypeId::INT128
             | TypeId::FLOAT32
             | TypeId::FLOAT64
             | TypeId::U8
             | TypeId::U16
             | TypeId::U32
             | TypeId::U64
-            | TypeId::USIZE
             | TypeId::U128
+            | TypeId::USIZE
+            | TypeId::ISIZE
     )
 }
 
@@ -465,17 +484,21 @@ pub fn format_type_id(type_id: u32) -> String {
         64 => "U8",
         65 => "U16",
         66 => "U32",
-        67 => "U64",
-        68 => "USIZE",
-        69 => "U128",
-        70 => "VAR_U32",
-        71 => "VAR_U64",
-        72 => "SLI_U64",
-        73 => "U16_ARRAY",
-        74 => "U32_ARRAY",
-        75 => "U64_ARRAY",
-        76 => "USIZE_ARRAY",
-        77 => "U128_ARRAY",
+        67 => "VAR_U32",
+        68 => "U64",
+        69 => "VAR_U64",
+        70 => "SLI_U64",
+        71 => "U128",
+        72 => "INT128",
+        73 => "USIZE",
+        74 => "ISIZE",
+        75 => "U16_ARRAY",
+        76 => "U32_ARRAY",
+        77 => "U64_ARRAY",
+        78 => "U128_ARRAY",
+        79 => "INT128_ARRAY",
+        80 => "USIZE_ARRAY",
+        81 => "ISIZE_ARRAY",
         _ => "UNKNOWN_TYPE",
     };
 

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -426,13 +426,13 @@ pub(super) fn generic_tree_to_tokens(node: &TypeNode) -> TokenStream {
                     "i16" => quote! { fory_core::types::TypeId::INT16_ARRAY as u32 },
                     "i32" => quote! { fory_core::types::TypeId::INT32_ARRAY as u32 },
                     "i64" => quote! { fory_core::types::TypeId::INT64_ARRAY as u32 },
+                    "i128" => quote! { fory_core::types::TypeId::INT128_ARRAY as u32 },
                     "f32" => quote! { fory_core::types::TypeId::FLOAT32_ARRAY as u32 },
                     "f64" => quote! { fory_core::types::TypeId::FLOAT64_ARRAY as u32 },
                     "u8" => quote! { fory_core::types::TypeId::U8 as u32 },
                     "u16" => quote! { fory_core::types::TypeId::U16_ARRAY as u32 },
                     "u32" => quote! { fory_core::types::TypeId::U32_ARRAY as u32 },
                     "u64" => quote! { fory_core::types::TypeId::U64_ARRAY as u32 },
-                    "usize" => quote! { fory_core::types::TypeId::USIZE_ARRAY as u32 },
                     "u128" => quote! { fory_core::types::TypeId::U128_ARRAY as u32 },
                     _ => quote! { fory_core::types::TypeId::LIST as u32 },
                 };
@@ -563,7 +563,7 @@ fn extract_option_inner(s: &str) -> Option<&str> {
 }
 
 const PRIMITIVE_TYPE_NAMES: [&str; 13] = [
-    "bool", "i8", "i16", "i32", "i64", "f32", "f64", "u8", "u16", "u32", "u64", "usize", "u128",
+    "bool", "i8", "i16", "i32", "i64", "i128", "f32", "f64", "u8", "u16", "u32", "u64", "u128",
 ];
 
 fn get_primitive_type_id(ty: &str) -> u32 {
@@ -579,8 +579,8 @@ fn get_primitive_type_id(ty: &str) -> u32 {
         "u16" => TypeId::U16 as u32,
         "u32" => TypeId::U32 as u32,
         "u64" => TypeId::U64 as u32,
-        "usize" => TypeId::USIZE as u32,
         "u128" => TypeId::U128 as u32,
+        "i128" => TypeId::INT128 as u32,
         _ => unreachable!("Unknown primitive type: {}", ty),
     }
 }
@@ -683,13 +683,13 @@ pub(crate) fn get_type_id_by_name(ty: &str) -> u32 {
         "Vec<i16>" => return TypeId::INT16_ARRAY as u32,
         "Vec<i32>" => return TypeId::INT32_ARRAY as u32,
         "Vec<i64>" => return TypeId::INT64_ARRAY as u32,
+        "Vec<i128>" => return TypeId::INT128_ARRAY as u32,
         "Vec<f16>" => return TypeId::FLOAT16_ARRAY as u32,
         "Vec<f32>" => return TypeId::FLOAT32_ARRAY as u32,
         "Vec<f64>" => return TypeId::FLOAT64_ARRAY as u32,
         "Vec<u16>" => return TypeId::U16_ARRAY as u32,
         "Vec<u32>" => return TypeId::U32_ARRAY as u32,
         "Vec<u64>" => return TypeId::U64_ARRAY as u32,
-        "Vec<usize>" => return TypeId::USIZE_ARRAY as u32,
         "Vec<u128>" => return TypeId::U128_ARRAY as u32,
         _ => {}
     }
@@ -705,13 +705,13 @@ pub(crate) fn get_type_id_by_name(ty: &str) -> u32 {
                 "i16" => return TypeId::INT16_ARRAY as u32,
                 "i32" => return TypeId::INT32_ARRAY as u32,
                 "i64" => return TypeId::INT64_ARRAY as u32,
+                "i128" => return TypeId::INT128_ARRAY as u32,
                 "f16" => return TypeId::FLOAT16_ARRAY as u32,
                 "f32" => return TypeId::FLOAT32_ARRAY as u32,
                 "f64" => return TypeId::FLOAT64_ARRAY as u32,
                 "u16" => return TypeId::U16_ARRAY as u32,
                 "u32" => return TypeId::U32_ARRAY as u32,
                 "u64" => return TypeId::U64_ARRAY as u32,
-                "usize" => return TypeId::USIZE_ARRAY as u32,
                 "u128" => return TypeId::U128_ARRAY as u32,
                 _ => {
                     // Non-primitive array elements, treat as LIST
@@ -760,11 +760,11 @@ fn get_primitive_type_size(type_id_num: u32) -> i32 {
         TypeId::FLOAT16 => 2,
         TypeId::FLOAT32 => 4,
         TypeId::FLOAT64 => 8,
+        TypeId::INT128 => 16,
         TypeId::U8 => 1,
         TypeId::U16 => 2,
         TypeId::U32 => 4,
         TypeId::U64 => 8,
-        TypeId::USIZE => 8,
         TypeId::U128 => 16,
         _ => unreachable!(),
     }
@@ -793,13 +793,13 @@ fn is_internal_type_id(type_id: u32) -> bool {
         TypeId::INT16_ARRAY as u32,
         TypeId::INT32_ARRAY as u32,
         TypeId::INT64_ARRAY as u32,
+        TypeId::INT128_ARRAY as u32,
         TypeId::FLOAT16_ARRAY as u32,
         TypeId::FLOAT32_ARRAY as u32,
         TypeId::FLOAT64_ARRAY as u32,
         TypeId::U16_ARRAY as u32,
         TypeId::U32_ARRAY as u32,
         TypeId::U64_ARRAY as u32,
-        TypeId::USIZE_ARRAY as u32,
         TypeId::U128_ARRAY as u32,
     ]
     .contains(&type_id)


### PR DESCRIPTION

## Why?

To support serialization of `i128` and `isize` types in Rust, which are needed for cross-language interoperability and broader type coverage.

## What does this PR do?

This PR adds support for `i128` and `isize` types:

1. **Buffer operations**: Added `write_i128`, `write_isize`, `read_i128`, `read_isize` methods to `buffer.rs`
2. **Type IDs**: Added `INT128` (78) and `ISIZE` (79) type identifiers to `types.rs`
3. **Serializer implementations**: Added `Serializer` and `ForyDefault` implementations for `i128` and `isize` in `number.rs`
4. Make `isize` and `usize` aware of different arches.

## Related issues

None

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
  - Yes, adds new public types support: `i128` and `isize` can now be serialized/deserialized
- [ ] Does this PR introduce any binary protocol compatibility change?
  - No, this adds new type IDs (78, 79) without changing existing protocol

## Benchmark


