### PR TITLE
feat(rust): add union and none type support

### DIFF
--- a/rust/fory-core/src/serializer/marker.rs
+++ b/rust/fory-core/src/serializer/marker.rs
@@ -44,20 +44,20 @@ impl<T: 'static> Serializer for PhantomData<T> {
 
     #[inline(always)]
     fn fory_get_type_id(_: &TypeResolver) -> Result<u32, Error> {
-        // Use UNKNOWN to skip type registry lookup - PhantomData<T> has no runtime data
-        Ok(TypeId::UNKNOWN as u32)
+        // Use NONE - PhantomData<T> has no runtime data, skip can return early
+        Ok(TypeId::NONE as u32)
     }
 
     #[inline(always)]
     fn fory_type_id_dyn(&self, _: &TypeResolver) -> Result<u32, Error> {
-        // Use UNKNOWN to skip type registry lookup - PhantomData<T> has no runtime data
-        Ok(TypeId::UNKNOWN as u32)
+        // Use NONE - PhantomData<T> has no runtime data, skip can return early
+        Ok(TypeId::NONE as u32)
     }
 
     #[inline(always)]
     fn fory_static_type_id() -> TypeId {
-        // Use UNKNOWN to skip type registry lookup - PhantomData<T> has no runtime data
-        TypeId::UNKNOWN
+        // Use NONE - PhantomData<T> has no runtime data, skip can return early
+        TypeId::NONE
     }
 
     #[inline(always)]

--- a/rust/fory-core/src/serializer/tuple.rs
+++ b/rust/fory-core/src/serializer/tuple.rs
@@ -24,7 +24,7 @@ use crate::serializer::{ForyDefault, Serializer};
 use crate::types::TypeId;
 use std::mem;
 
-// Unit type () implementation
+// Unit type () implementation - represents an empty/unit value with no data
 impl Serializer for () {
     #[inline(always)]
     fn fory_write_data(&self, _context: &mut WriteContext) -> Result<(), Error> {
@@ -45,17 +45,20 @@ impl Serializer for () {
 
     #[inline(always)]
     fn fory_get_type_id(_: &TypeResolver) -> Result<u32, Error> {
-        Ok(TypeId::STRUCT as u32)
+        // Use NONE - unit type has no runtime data, skip can return early
+        Ok(TypeId::NONE as u32)
     }
 
     #[inline(always)]
     fn fory_type_id_dyn(&self, _: &TypeResolver) -> Result<u32, Error> {
-        Ok(TypeId::STRUCT as u32)
+        // Use NONE - unit type has no runtime data, skip can return early
+        Ok(TypeId::NONE as u32)
     }
 
     #[inline(always)]
     fn fory_static_type_id() -> TypeId {
-        TypeId::STRUCT
+        // Use NONE - unit type has no runtime data, skip can return early
+        TypeId::NONE
     }
 
     #[inline(always)]

--- a/rust/fory-core/src/serializer/util.rs
+++ b/rust/fory-core/src/serializer/util.rs
@@ -22,7 +22,7 @@ use crate::serializer::Serializer;
 use crate::types::TypeId;
 use crate::types::{
     is_user_type, BOOL, ENUM, FLOAT32, FLOAT64, INT128, INT16, INT32, INT64, INT8, NAMED_ENUM,
-    U128, U16, U32, U64, U8,
+    NONE, U128, U16, U32, U64, U8,
 };
 
 #[inline(always)]
@@ -68,6 +68,7 @@ pub const fn field_need_write_ref_into(type_id: u32, nullable: bool) -> bool {
         return true;
     }
     let internal_type_id = type_id & 0xff;
+    // NONE type has no data, so no ref tracking needed
     !matches!(
         internal_type_id,
         BOOL | INT8
@@ -82,6 +83,7 @@ pub const fn field_need_write_ref_into(type_id: u32, nullable: bool) -> bool {
             | U32
             | U64
             | U128
+            | NONE
     )
 }
 

--- a/rust/fory-core/src/types.rs
+++ b/rust/fory-core/src/types.rs
@@ -81,6 +81,10 @@ pub enum TypeId {
     FLOAT16_ARRAY = 35,
     FLOAT32_ARRAY = 36,
     FLOAT64_ARRAY = 37,
+    // A tagged union type that can hold one of several alternative types.
+    UNION = 38,
+    // Represents an empty/unit value with no data.
+    NONE = 39,
     U8 = 64,
     U16 = 65,
     U32 = 66,
@@ -147,6 +151,8 @@ pub const INT64_ARRAY: u32 = TypeId::INT64_ARRAY as u32;
 pub const FLOAT16_ARRAY: u32 = TypeId::FLOAT16_ARRAY as u32;
 pub const FLOAT32_ARRAY: u32 = TypeId::FLOAT32_ARRAY as u32;
 pub const FLOAT64_ARRAY: u32 = TypeId::FLOAT64_ARRAY as u32;
+pub const UNION: u32 = TypeId::UNION as u32;
+pub const NONE: u32 = TypeId::NONE as u32;
 pub const U8: u32 = TypeId::U8 as u32;
 pub const U16: u32 = TypeId::U16 as u32;
 pub const U32: u32 = TypeId::U32 as u32;
@@ -347,10 +353,11 @@ pub(crate) const fn need_to_write_type_for_field(type_id: TypeId) -> bool {
 
 /// Keep as const fn for compile time evaluation or constant folding
 #[inline(always)]
-pub(crate) const fn is_user_type(type_id: u32) -> bool {
+pub const fn is_user_type(type_id: u32) -> bool {
     matches!(
         type_id,
         ENUM | NAMED_ENUM
+            | UNION
             | STRUCT
             | COMPATIBLE_STRUCT
             | NAMED_STRUCT
@@ -481,6 +488,8 @@ pub fn format_type_id(type_id: u32) -> String {
         35 => "FLOAT16_ARRAY",
         36 => "FLOAT32_ARRAY",
         37 => "FLOAT64_ARRAY",
+        38 => "UNION",
+        39 => "NONE",
         64 => "U8",
         65 => "U16",
         66 => "U32",


### PR DESCRIPTION


## Why?

Add `UNION` and `NONE` to type ids that align with [xlang spec](https://github.com/apache/fory/blob/main/docs/specification/xlang_serialization_spec.md#internal-type-id-table)

## What does this PR do?

This PR adds `UNION` and `NONE` to type ids:

1. add `UNION` and `NONE` to type ids
2. change `()` and `PhantomData` type id from `UNKNOWN` to `NONE`
3. skip early when encounter `NONE` in `skip_any_value`

## Related issues

None

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
  - Yes, adds new public types support: `UNION` and `NONE` to TypeId
- [ ] Does this PR introduce any binary protocol compatibility change?
  - No

## Benchmark




