### PR TITLE
fix(go): reference tracking fails when >127 objects serialized

### DIFF
--- a/go/fory/array.go
+++ b/go/fory/array.go
@@ -46,7 +46,7 @@ func readArrayRefAndType(ctx *ReadContext, refMode RefMode, readType bool, value
 			ctx.SetError(FromError(refErr))
 			return false
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
 				value.Set(obj)

--- a/go/fory/map.go
+++ b/go/fory/map.go
@@ -82,7 +82,7 @@ func readMapRefAndType(ctx *ReadContext, refMode RefMode, readType bool, value r
 			ctx.SetError(FromError(refErr))
 			return false
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
 				value.Set(obj)
@@ -375,7 +375,7 @@ func (s mapSerializer) ReadData(ctx *ReadContext, type_ reflect.Type, value refl
 							ctx.SetError(FromError(err))
 							return
 						}
-						if int8(refID) < NotNullValueFlag {
+						if refID < int32(NotNullValueFlag) {
 							// Reference to existing object
 							obj := refResolver.GetReadObject(refID)
 							if obj.IsValid() {
@@ -466,7 +466,7 @@ func (s mapSerializer) ReadData(ctx *ReadContext, type_ reflect.Type, value refl
 							ctx.SetError(FromError(err))
 							return
 						}
-						if int8(refID) < NotNullValueFlag {
+						if refID < int32(NotNullValueFlag) {
 							// Reference to existing object
 							obj := refResolver.GetReadObject(refID)
 							if obj.IsValid() {

--- a/go/fory/pointer.go
+++ b/go/fory/pointer.go
@@ -103,7 +103,7 @@ func (s *ptrToValueSerializer) Read(ctx *ReadContext, refMode RefMode, readType 
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
@@ -210,7 +210,7 @@ func (s *ptrToInterfaceSerializer) Read(ctx *ReadContext, refMode RefMode, readT
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {

--- a/go/fory/reader.go
+++ b/go/fory/reader.go
@@ -569,7 +569,7 @@ func (c *ReadContext) ReadValue(value reflect.Value) {
 			c.SetError(FromError(err))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found
 			obj := c.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
@@ -625,7 +625,7 @@ func (c *ReadContext) ReadValue(value reflect.Value) {
 
 		// For named structs, register the pointer BEFORE reading data
 		// This is critical for circular references to work correctly
-		if isNamedStruct && int8(refID) >= NotNullValueFlag {
+		if isNamedStruct && refID >= int32(NotNullValueFlag) {
 			c.RefResolver().SetReadObject(refID, newValue)
 		}
 
@@ -643,7 +643,7 @@ func (c *ReadContext) ReadValue(value reflect.Value) {
 		}
 
 		// Register reference after reading data for non-struct types
-		if !isNamedStruct && int8(refID) >= NotNullValueFlag {
+		if !isNamedStruct && refID >= int32(NotNullValueFlag) {
 			c.RefResolver().SetReadObject(refID, newValue)
 		}
 
@@ -701,7 +701,7 @@ func (c *ReadContext) ReadStruct(value reflect.Value) {
 	}
 
 	// Handle null
-	if int8(refID) == NullFlag {
+	if refID == int32(NullFlag) {
 		if isPtr {
 			value.Set(reflect.Zero(valueType))
 		}
@@ -709,7 +709,7 @@ func (c *ReadContext) ReadStruct(value reflect.Value) {
 	}
 
 	// Handle reference to existing object
-	if int8(refID) < NotNullValueFlag {
+	if refID < int32(NotNullValueFlag) {
 		obj := c.RefResolver().GetReadObject(refID)
 		if obj.IsValid() {
 			value.Set(obj)
@@ -771,7 +771,7 @@ func (c *ReadContext) readArrayValue(target reflect.Value) {
 		c.SetError(FromError(err))
 		return
 	}
-	if int8(refID) < NotNullValueFlag {
+	if refID < int32(NotNullValueFlag) {
 		// Reference to existing object
 		obj := c.RefResolver().GetReadObject(refID)
 		if obj.IsValid() {
@@ -812,7 +812,7 @@ func (c *ReadContext) readArrayValue(target reflect.Value) {
 	reflect.Copy(target, tempSlice)
 
 	// Register for circular refs
-	if int8(refID) >= NotNullValueFlag {
+	if refID >= int32(NotNullValueFlag) {
 		c.RefResolver().SetReadObject(refID, target)
 	}
 }

--- a/go/fory/serializer.go
+++ b/go/fory/serializer.go
@@ -214,7 +214,7 @@ func (s *extensionSerializerAdapter) Read(ctx *ReadContext, refMode RefMode, rea
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
 				value.Set(obj)

--- a/go/fory/set.go
+++ b/go/fory/set.go
@@ -290,7 +290,7 @@ func (s setSerializer) readSameType(ctx *ReadContext, buf *ByteBuffer, value ref
 		if trackRefs {
 			// Handle reference tracking if enabled
 			refID, _ = ctx.RefResolver().TryPreserveRefId(buf)
-			if int8(refID) < NotNullValueFlag {
+			if refID < int32(NotNullValueFlag) {
 				// Use existing reference if available
 				elem := ctx.RefResolver().GetReadObject(refID)
 				value.SetMapIndex(reflect.ValueOf(elem), reflect.ValueOf(true))
@@ -328,11 +328,11 @@ func (s setSerializer) readDifferentTypes(ctx *ReadContext, buf *ByteBuffer, val
 				ctx.SetError(FromError(refErr))
 				return
 			}
-			if int8(refID) == NullFlag {
+			if refID == int32(NullFlag) {
 				// Null element - skip for sets
 				continue
 			}
-			if int8(refID) < NotNullValueFlag {
+			if refID < int32(NotNullValueFlag) {
 				// Use existing reference if available
 				elem := ctx.RefResolver().GetReadObject(refID)
 				value.SetMapIndex(elem, reflect.ValueOf(true))
@@ -412,7 +412,7 @@ func (s setSerializer) Read(ctx *ReadContext, refMode RefMode, readType bool, ha
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {

--- a/go/fory/slice.go
+++ b/go/fory/slice.go
@@ -73,7 +73,7 @@ func readSliceRefAndType(ctx *ReadContext, refMode RefMode, readType bool, value
 			ctx.SetError(FromError(refErr))
 			return true
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
 				value.Set(obj)

--- a/go/fory/slice_dyn.go
+++ b/go/fory/slice_dyn.go
@@ -319,11 +319,11 @@ func (s sliceDynSerializer) readSameType(ctx *ReadContext, buf *ByteBuffer, valu
 				ctx.SetError(FromError(refErr))
 				return
 			}
-			if int8(refID) == NullFlag {
+			if refID == int32(NullFlag) {
 				continue
 			}
 			// Handle RefFlag - element references a previously read object
-			if int8(refID) < NotNullValueFlag {
+			if refID < int32(NotNullValueFlag) {
 				obj := ctx.RefResolver().GetReadObject(refID)
 				if obj.IsValid() {
 					value.Index(i).Set(obj)
@@ -379,10 +379,10 @@ func (s sliceDynSerializer) readDifferentTypes(
 				ctx.SetError(FromError(refErr))
 				return
 			}
-			if int8(refID) == NullFlag {
+			if refID == int32(NullFlag) {
 				continue
 			}
-			if int8(refID) < NotNullValueFlag {
+			if refID < int32(NotNullValueFlag) {
 				// Reference to existing object
 				obj := ctx.RefResolver().GetReadObject(refID)
 				if obj.IsValid() {

--- a/go/fory/struct.go
+++ b/go/fory/struct.go
@@ -551,7 +551,7 @@ func (s *structSerializer) Read(ctx *ReadContext, refMode RefMode, readType bool
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found
 			obj := ctx.RefResolver().GetReadObject(refID)
 			if obj.IsValid() {
@@ -2080,7 +2080,7 @@ func (s *skipStructSerializer) Read(ctx *ReadContext, refMode RefMode, readType 
 			ctx.SetError(FromError(refErr))
 			return
 		}
-		if int8(refID) < NotNullValueFlag {
+		if refID < int32(NotNullValueFlag) {
 			// Reference found, nothing to skip
 			return
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes reference tracking bug that causes deserialization to fail with hash mismatch errors when more than 127 objects are serialized with reference tracking enabled.

## Root Cause

The check `if int8(refID) < NotNullValueFlag` in multiple files causes integer overflow when `refID >= 128`:

```go
// BEFORE (buggy):
if int8(refID) < NotNullValueFlag {
```

- `int8(128)` = `-128` (two's complement overflow)
- `-128 < -1` (NotNullValueFlag) = `TRUE` (incorrectly!)

This causes the code to incorrectly enter the "reference found" branch, corrupting buffer positions and causing hash mismatches.

## Fix

Replace int8 cast with int32 comparison:

```go
// AFTER (fixed):
if refID < int32(NotNullValueFlag) {
```

Since `refID` is already `int32` (returned from `TryPreserveRefId`), and the flag constants are small negative int8 values that correctly sign-extend to int32, this comparison is type-safe and avoids truncation.

## Files Changed

- `array.go` (1 occurrence)
- `map.go` (3 occurrences)
- `pointer.go` (2 occurrences)
- `reader.go` (7 occurrences)
- `serializer.go` (1 occurrence)
- `set.go` (4 occurrences)
- `slice.go` (1 occurrence)
- `slice_dyn.go` (4 occurrences)
- `struct.go` (2 occurrences)

## Testing

Added regression test `TestRefTrackingLargeCount` in `ref_resolver_test.go` that verifies serialization/deserialization works correctly with 127, 128, and 200 items.

All existing tests pass.

## Related Issues

Closes #3085

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally with my changes