### PR TITLE
fix(rust): enable Union type cross-language serialization between Rust and Java

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -146,6 +146,7 @@ import org.apache.fory.type.Descriptor;
 import org.apache.fory.type.DescriptorGrouper;
 import org.apache.fory.type.GenericType;
 import org.apache.fory.type.TypeUtils;
+import org.apache.fory.type.union.Union;
 import org.apache.fory.util.GraalvmSupport;
 import org.apache.fory.util.Preconditions;
 import org.apache.fory.util.StringUtils;
@@ -705,6 +706,11 @@ public class ClassResolver extends TypeResolver {
       if (clz.isArray()) {
         Class<?> component = TypeUtils.getArrayComponent(clz);
         return isMonomorphic(component);
+      }
+      // Union types (Union2~6) are final classes, treat them as monomorphic
+      // so they don't need to read/write type info
+      if (Union.class.isAssignableFrom(clz)) {
+        return true;
       }
       return (isInnerClass(clz) || clz.isEnum());
     }

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/UnionSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/UnionSerializer.java
@@ -85,6 +85,11 @@ public class UnionSerializer extends Serializer<Union> {
   }
 
   @Override
+  public void write(MemoryBuffer buffer, Union union) {
+    xwrite(buffer, union);
+  }
+
+  @Override
   public void xwrite(MemoryBuffer buffer, Union union) {
     int index = union.getIndex();
     buffer.writeVarUint32(index);
@@ -95,6 +100,11 @@ public class UnionSerializer extends Serializer<Union> {
     } else {
       buffer.writeByte(Fory.NULL_FLAG);
     }
+  }
+
+  @Override
+  public Union read(MemoryBuffer buffer) {
+    return xread(buffer);
   }
 
   @Override

--- a/java/fory-core/src/test/java/org/apache/fory/CPPXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/CPPXlangTest.java
@@ -268,4 +268,11 @@ public class CPPXlangTest extends XlangTestBase {
   public void testEnumSchemaEvolutionCompatible() throws java.io.IOException {
     super.testEnumSchemaEvolutionCompatible();
   }
+
+  @Test
+  @Override
+  public void testUnionXlang() throws java.io.IOException {
+    // Skip: C++ doesn't have Union xlang support yet
+    throw new SkipException("Skipping testUnionXlang: C++ Union xlang support not implemented");
+  }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/GoXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/GoXlangTest.java
@@ -298,4 +298,11 @@ public class GoXlangTest extends XlangTestBase {
     // Go writes null for nil pointers (nullable=true by default for pointer types)
     Assert.assertNull(result2.f2);
   }
+
+  @Test
+  @Override
+  public void testUnionXlang() throws java.io.IOException {
+    // Skip: Go doesn't have Union xlang support yet
+    throw new SkipException("Skipping testUnionXlang: Go Union xlang support not implemented");
+  }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/PythonXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/PythonXlangTest.java
@@ -191,4 +191,11 @@ public class PythonXlangTest extends XlangTestBase {
   public void testPolymorphicMap() throws IOException {
     super.testPolymorphicMap();
   }
+
+  @Override
+  @Test
+  public void testUnionXlang() throws IOException {
+    // Skip: Python doesn't have Union xlang support yet
+    throw new SkipException("Skipping testUnionXlang: Python Union xlang support not implemented");
+  }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/RustXlangTest.java
@@ -230,4 +230,9 @@ public class RustXlangTest extends XlangTestBase {
   public void testEnumSchemaEvolutionCompatible() throws java.io.IOException {
     super.testEnumSchemaEvolutionCompatible();
   }
+
+  @Test
+  public void testUnionXlang() throws java.io.IOException {
+    super.testUnionXlang();
+  }
 }

--- a/rust/fory-core/src/serializer/core.rs
+++ b/rust/fory-core/src/serializer/core.rs
@@ -1346,6 +1346,7 @@ pub trait StructSerializer: Serializer + 'static {
     /// * `type_id` - The base type ID
     /// * `register_by_name` - Whether type was registered by name (vs by hash)
     /// * `compatible` - Whether compatibility mode is enabled
+    /// * `xlang` - Whether cross-language mode is enabled
     ///
     /// # Returns
     ///
@@ -1357,7 +1358,13 @@ pub trait StructSerializer: Serializer + 'static {
     /// - Handles type ID transformations for compatibility
     /// - **Do not override** for user types with custom serialization (EXT types)
     #[inline(always)]
-    fn fory_actual_type_id(type_id: u32, register_by_name: bool, compatible: bool) -> u32 {
+    fn fory_actual_type_id(
+        type_id: u32,
+        register_by_name: bool,
+        compatible: bool,
+        xlang: bool,
+    ) -> u32 {
+        let _ = xlang; // Default implementation ignores xlang parameter
         struct_::actual_type_id(type_id, register_by_name, compatible)
     }
 

--- a/rust/fory-core/src/serializer/util.rs
+++ b/rust/fory-core/src/serializer/util.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
 use crate::types::TypeId;
-use crate::types::{is_user_type, ENUM, NAMED_ENUM};
+use crate::types::{is_user_type, ENUM, NAMED_ENUM, UNION};
 
 #[inline(always)]
 pub(crate) fn read_basic_type_info<T: Serializer>(context: &mut ReadContext) -> Result<(), Error> {
@@ -43,7 +43,7 @@ pub(crate) fn read_basic_type_info<T: Serializer>(context: &mut ReadContext) -> 
 #[inline]
 pub const fn field_need_read_type_info(type_id: u32) -> bool {
     let internal_type_id = type_id & 0xff;
-    if internal_type_id == ENUM || internal_type_id == NAMED_ENUM {
+    if internal_type_id == ENUM || internal_type_id == NAMED_ENUM || internal_type_id == UNION {
         return false;
     }
     is_user_type(internal_type_id)
@@ -52,7 +52,7 @@ pub const fn field_need_read_type_info(type_id: u32) -> bool {
 /// Keep as const fn for compile time evaluation or constant folding
 pub const fn field_need_write_type_info(static_type_id: TypeId) -> bool {
     let static_type_id = static_type_id as u32;
-    if static_type_id == ENUM || static_type_id == NAMED_ENUM {
+    if static_type_id == ENUM || static_type_id == NAMED_ENUM || static_type_id == UNION {
         return false;
     }
     is_user_type(static_type_id)

--- a/rust/fory-core/src/types.rs
+++ b/rust/fory-core/src/types.rs
@@ -229,6 +229,19 @@ pub const ISIZE_ARRAY: u32 = TypeId::ISIZE_ARRAY as u32;
 pub const UNKNOWN: u32 = TypeId::UNKNOWN as u32;
 pub const BOUND: u32 = TypeId::BOUND as u32;
 
+/// Returns true if the given TypeId represents an enum type.
+///
+/// This is used during fingerprint computation to match Java/C++ behavior
+/// where enum fields are always treated as nullable (since Java enums are
+/// reference types that can be null).
+///
+/// **NOTE**: ENUM, NAMED_ENUM, and UNION are all considered enum types since Rust enums
+/// can be represented as Union in xlang mode when they have data-carrying variants.
+#[inline]
+pub const fn is_enum_type_id(type_id: TypeId) -> bool {
+    matches!(type_id, TypeId::ENUM | TypeId::NAMED_ENUM | TypeId::UNION)
+}
+
 const MAX_UNT32: u64 = (1 << 31) - 1;
 
 // todo: struct hash

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -89,7 +89,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
             let variant_meta_types =
                 derive_enum::gen_all_variant_meta_types_with_enum_name(name, s);
             (
-                derive_enum::gen_actual_type_id(),
+                derive_enum::gen_actual_type_id(s),
                 quote! { &[] },
                 derive_enum::gen_field_fields_info(s),
                 derive_enum::gen_variants_fields_info(name, s),
@@ -134,13 +134,13 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
         syn::Data::Enum(e) => (
             derive_enum::gen_write(e),
             derive_enum::gen_write_data(e),
-            derive_enum::gen_write_type_info(),
+            derive_enum::gen_write_type_info(e),
             derive_enum::gen_read(e),
             derive_enum::gen_read_with_type_info(e),
             derive_enum::gen_read_data(e),
-            derive_enum::gen_read_type_info(),
+            derive_enum::gen_read_type_info(e),
             derive_enum::gen_reserved_space(),
-            quote! { fory_core::TypeId::ENUM },
+            derive_enum::gen_static_type_id(e),
         ),
         syn::Data::Union(_) => {
             panic!("Union is not supported")
@@ -165,7 +165,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
             }
 
             #[inline(always)]
-            fn fory_actual_type_id(type_id: u32, register_by_name: bool, compatible: bool) -> u32 {
+            fn fory_actual_type_id(type_id: u32, register_by_name: bool, compatible: bool, xlang: bool) -> u32 {
                 #actual_type_id_ts
             }
 

--- a/rust/fory-derive/src/object/write.rs
+++ b/rust/fory-derive/src/object/write.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use super::util::{
-    classify_trait_object_field, compute_struct_version_hash, create_wrapper_types_arc,
-    create_wrapper_types_rc, determine_field_ref_mode, extract_type_name, get_field_accessor,
+    classify_trait_object_field, create_wrapper_types_arc, create_wrapper_types_rc,
+    determine_field_ref_mode, extract_type_name, gen_struct_version_hash_ts, get_field_accessor,
     get_field_name, get_filtered_source_fields_iter, get_primitive_writer_method, get_struct_name,
     get_type_id_by_type_ast, is_debug_enabled, is_direct_primitive_numeric_type,
     should_skip_type_info_for_field, FieldRefMode, StructField,
@@ -335,11 +335,11 @@ pub fn gen_write_data(source_fields: &[SourceField<'_>]) -> TokenStream {
         .map(|sf| gen_write_field_with_index(sf.field, sf.original_index, true))
         .collect();
 
-    let version_hash = compute_struct_version_hash(&fields);
+    let version_hash_ts = gen_struct_version_hash_ts(&fields);
     quote! {
-        // Write version hash when class version checking is enabled
         if context.is_check_struct_version() {
-            context.writer.write_i32(#version_hash);
+            let version_hash: i32 = #version_hash_ts;
+            context.writer.write_i32(version_hash);
         }
         #(#write_fields_ts)*
         Ok(())


### PR DESCRIPTION



## Why?

### Struct fingerprint mismatch for enum fields

When computing struct version hash for cross-language compatibility, Java and C++ treat enum fields as nullable=true by default. However, Rust's proc-macro cannot determine at compile time whether a field type is an enum, causing fingerprint mismatch.

### Cross-language Union serialization fails

Java's AbstractObjectSerializer expects to read type_id for non-final fields, but Rust/C++ skip type_id for Union fields per xlang spec. This caused Type id 104 not registered errors when Java tried to deserialize Rust-serialized Union data.

## What does this PR do?

### Rust changes:
- Union-compatible enum handling for xlang mode
- Fix `field_need_write_type_info()` to handle UNION TypeId

### Java changes:
- `AbstractObjectSerializer`: Skip `type_id` read for Union types
- `UnionSerializer`: Add `read()`/`write()` delegating to `xread()`/`xwrite()`


### Tests:
- Add testUnionXlang for Rust enum <-> Java Union2 interoperability

## Related issues

## Does this PR introduce any user-facing change?

[ ] Does this PR introduce any public API change?
[x] Does this PR introduce any binary protocol compatibility change?
Note: Struct version hash for structs containing enum fields will now match Java/C++.

## Benchmark


## Others
It's really hard to determine this bug :sob:...


