### PR TITLE
feat(rust): implement fine-grained ref tracking for rust

### DIFF
--- a/rust/fory-core/src/lib.rs
+++ b/rust/fory-core/src/lib.rs
@@ -198,4 +198,4 @@ pub use crate::resolver::context::{ReadContext, WriteContext};
 pub use crate::resolver::type_resolver::{TypeInfo, TypeResolver};
 pub use crate::serializer::weak::{ArcWeak, RcWeak};
 pub use crate::serializer::{read_data, write_data, ForyDefault, Serializer, StructSerializer};
-pub use crate::types::{RefFlag, TypeId};
+pub use crate::types::{RefFlag, RefMode, TypeId};

--- a/rust/fory-core/src/resolver/type_resolver.rs
+++ b/rust/fory-core/src/resolver/type_resolver.rs
@@ -22,6 +22,7 @@ use crate::meta::{
     TYPE_NAME_ENCODINGS,
 };
 use crate::serializer::{ForyDefault, Serializer, StructSerializer};
+use crate::types::RefMode;
 use crate::util::get_ext_actual_type_id;
 use crate::TypeId;
 use chrono::{NaiveDate, NaiveDateTime};
@@ -34,12 +35,12 @@ use std::{any::Any, collections::HashMap};
 type WriteFn = fn(
     &dyn Any,
     &mut WriteContext,
-    write_ref_info: bool,
+    ref_mode: RefMode,
     write_type_info: bool,
     has_enerics: bool,
 ) -> Result<(), Error>;
 type ReadFn =
-    fn(&mut ReadContext, read_ref_info: bool, read_type_info: bool) -> Result<Box<dyn Any>, Error>;
+    fn(&mut ReadContext, ref_mode: RefMode, read_type_info: bool) -> Result<Box<dyn Any>, Error>;
 
 type WriteDataFn = fn(&dyn Any, &mut WriteContext, has_generics: bool) -> Result<(), Error>;
 type ReadDataFn = fn(&mut ReadContext) -> Result<Box<dyn Any>, Error>;
@@ -284,7 +285,7 @@ impl TypeInfo {
 fn stub_write_fn(
     _: &dyn Any,
     _: &mut WriteContext,
-    _: bool,
+    _: RefMode,
     _: bool,
     _: bool,
 ) -> Result<(), Error> {
@@ -293,7 +294,7 @@ fn stub_write_fn(
     ))
 }
 
-fn stub_read_fn(_: &mut ReadContext, _: bool, _: bool) -> Result<Box<dyn Any>, Error> {
+fn stub_read_fn(_: &mut ReadContext, _: RefMode, _: bool) -> Result<Box<dyn Any>, Error> {
     Err(Error::type_error(
         "Cannot deserialize unknown remote type - type not registered locally",
     ))
@@ -666,15 +667,13 @@ impl TypeResolver {
         fn write<T2: 'static + Serializer>(
             this: &dyn Any,
             context: &mut WriteContext,
-            write_ref_info: bool,
+            ref_mode: RefMode,
             write_type_info: bool,
             has_generics: bool,
         ) -> Result<(), Error> {
             let this = this.downcast_ref::<T2>();
             match this {
-                Some(v) => {
-                    T2::fory_write(v, context, write_ref_info, write_type_info, has_generics)
-                }
+                Some(v) => T2::fory_write(v, context, ref_mode, write_type_info, has_generics),
                 None => Err(Error::type_error(format!(
                     "Cast type to {:?} error when writing: {:?}",
                     std::any::type_name::<T2>(),
@@ -685,14 +684,10 @@ impl TypeResolver {
 
         fn read<T2: 'static + Serializer + ForyDefault>(
             context: &mut ReadContext,
-            read_ref_info: bool,
+            ref_mode: RefMode,
             read_type_info: bool,
         ) -> Result<Box<dyn Any>, Error> {
-            Ok(Box::new(T2::fory_read(
-                context,
-                read_ref_info,
-                read_type_info,
-            )?))
+            Ok(Box::new(T2::fory_read(context, ref_mode, read_type_info)?))
         }
 
         fn write_data<T2: 'static + Serializer>(
@@ -856,15 +851,13 @@ impl TypeResolver {
         fn write<T2: 'static + Serializer>(
             this: &dyn Any,
             context: &mut WriteContext,
-            write_ref_info: bool,
+            ref_mode: RefMode,
             write_type_info: bool,
             has_generics: bool,
         ) -> Result<(), Error> {
             let this = this.downcast_ref::<T2>();
             match this {
-                Some(v) => {
-                    Ok(v.fory_write(context, write_ref_info, write_type_info, has_generics)?)
-                }
+                Some(v) => v.fory_write(context, ref_mode, write_type_info, has_generics),
                 None => Err(Error::type_error(format!(
                     "Cast type to {:?} error when writing: {:?}",
                     std::any::type_name::<T2>(),
@@ -875,14 +868,10 @@ impl TypeResolver {
 
         fn read<T2: 'static + Serializer + ForyDefault>(
             context: &mut ReadContext,
-            read_ref_info: bool,
+            ref_mode: RefMode,
             read_type_info: bool,
         ) -> Result<Box<dyn Any>, Error> {
-            Ok(Box::new(T2::fory_read(
-                context,
-                read_ref_info,
-                read_type_info,
-            )?))
+            Ok(Box::new(T2::fory_read(context, ref_mode, read_type_info)?))
         }
 
         fn write_data<T2: 'static + Serializer>(

--- a/rust/fory-core/src/serializer/core.rs
+++ b/rust/fory-core/src/serializer/core.rs
@@ -20,7 +20,7 @@ use crate::meta::FieldInfo;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::resolver::type_resolver::TypeInfo;
 use crate::serializer::{bool, struct_};
-use crate::types::{RefFlag, TypeId};
+use crate::types::{RefFlag, RefMode, TypeId};
 use crate::TypeResolver;
 use std::any::Any;
 use std::rc::Rc;
@@ -215,15 +215,18 @@ pub trait Serializer: 'static {
     ///
     /// # Parameters
     ///
-    /// * `write_ref_info` - When `true`, WRITES reference flag (null/not-null/ref). When `false`, SKIPS writing ref flag.
+    /// * `ref_mode` - Controls how reference flags are written:
+    ///   - `RefMode::None`: Skip writing ref flag entirely
+    ///   - `RefMode::NullOnly`: Write `NotNullValue` flag (null check only)
+    ///   - `RefMode::Tracking`: Write ref tracking flags (for Rc/Arc/Weak)
     /// * `write_type_info` - When `true`, WRITES type information. When `false`, SKIPS writing type info.
     /// * `has_generics` - Indicates if the type has generic parameters (used for collection meta).
     ///
-    /// # Default Implementation
+    /// # Default Implementation (Fast Path)
     ///
-    /// The default implementation handles standard non-nullable types:
+    /// The default implementation uses a fast path suitable for primitives, strings, and time types:
     ///
-    /// 1. If `write_ref_info` is true, writes `RefFlag::NotNullValue`
+    /// 1. If `ref_mode != RefMode::None`, writes `RefFlag::NotNullValue`
     /// 2. If `write_type_info` is true, calls [`fory_write_type_info`]
     /// 3. Calls [`fory_write_data_generic`] to write the actual data
     ///
@@ -231,17 +234,11 @@ pub trait Serializer: 'static {
     ///
     /// You should override this method for:
     ///
-    /// - **Option types**: Need to write `RefFlag::Null` for None values
-    /// - **Reference types** (Rc/Arc/Weak): Need custom reference handling
+    /// - **Option types**: Need to handle `None` with `RefFlag::Null`
+    /// - **Reference types** (Rc/Arc/Weak): Need full ref tracking with `RefWriter`
     /// - **Polymorphic types**: Need to write actual runtime type instead of static type
     ///
     /// For regular types (structs, primitives, collections), the default implementation is sufficient.
-    ///
-    /// # Implementation Notes
-    ///
-    /// - This method is implemented by Fory for all built-in types
-    /// - User types with custom serialization typically don't need to override this
-    /// - Focus on implementing [`fory_write_data`] instead
     ///
     /// [`fory_write_data`]: Serializer::fory_write_data
     /// [`fory_write_type_info`]: Serializer::fory_write_type_info
@@ -250,19 +247,18 @@ pub trait Serializer: 'static {
     fn fory_write(
         &self,
         context: &mut WriteContext,
-        write_ref_info: bool,
+        ref_mode: RefMode,
         write_type_info: bool,
         has_generics: bool,
     ) -> Result<(), Error>
     where
         Self: Sized,
     {
-        if write_ref_info {
-            // skip check option/pointer, the Serializer for such types will override `fory_write`.
+        // Fast path: single comparison for primitives/strings/time types
+        if ref_mode != RefMode::None {
             context.writer.write_i8(RefFlag::NotNullValue as i8);
         }
         if write_type_info {
-            // Serializer for dynamic types should override `fory_write` to write actual typeinfo.
             Self::fory_write_type_info(context)?;
         }
         self.fory_write_data_generic(context, has_generics)
@@ -395,7 +391,7 @@ pub trait Serializer: 'static {
     /// ## Struct with nested serializable types
     ///
     /// ```rust
-    /// use fory_core::{Serializer, ForyDefault};
+    /// use fory_core::{Serializer, ForyDefault, RefMode};
     /// use fory_core::resolver::context::WriteContext;
     /// use fory_core::error::Error;
     /// use std::any::Any;
@@ -419,9 +415,9 @@ pub trait Serializer: 'static {
     /// impl Serializer for Person {
     ///     fn fory_write_data(&self, context: &mut WriteContext) -> Result<(), Error> {
     ///         // Write nested types using their Serializer implementations
-    ///         self.name.fory_write(context, false, false, false)?;
+    ///         self.name.fory_write(context, RefMode::None, false, false)?;
     ///         context.writer.write_u32(self.age);
-    ///         self.scores.fory_write(context, false, false, true)?; // has_generics=true for Vec
+    ///         self.scores.fory_write(context, RefMode::None, false, true)?; // has_generics=true for Vec
     ///         Ok(())
     ///     }
     ///
@@ -429,9 +425,9 @@ pub trait Serializer: 'static {
     ///     where
     ///         Self: Sized + fory_core::ForyDefault,
     ///     {
-    ///         let name = String::fory_read(context, false, false)?;
+    ///         let name = String::fory_read(context, RefMode::None, false)?;
     ///         let age = context.reader.read_u32()?;
-    ///         let scores = Vec::<i32>::fory_read(context, false, false)?;
+    ///         let scores = Vec::<i32>::fory_read(context, RefMode::None, false)?;
     ///         Ok(Person { name, age, scores })
     ///     }
     ///
@@ -534,7 +530,10 @@ pub trait Serializer: 'static {
     ///
     /// # Parameters
     ///
-    /// * `read_ref_info` - When `true`, READS reference flag from buffer. When `false`, SKIPS reading ref flag.
+    /// * `ref_mode` - Controls how reference flags are read:
+    ///   - `RefMode::None`: Skip reading ref flag entirely
+    ///   - `RefMode::NullOnly`: Read flag, return default on null
+    ///   - `RefMode::Tracking`: Full ref tracking (for Rc/Arc/Weak)
     /// * `read_type_info` - When `true`, READS type information from buffer. When `false`, SKIPS reading type info.
     ///
     /// # Type Requirements
@@ -544,14 +543,13 @@ pub trait Serializer: 'static {
     /// - **Sized**: Need to construct concrete instances
     /// - **ForyDefault**: Need to create default/null values for optional types
     ///
-    /// # Default Implementation
+    /// # Default Implementation (Fast Path)
     ///
-    /// The default implementation handles standard non-nullable types:
+    /// The default implementation uses a fast path suitable for primitives, strings, and time types:
     ///
-    /// 1. If `read_ref_info` is true:
+    /// 1. If `ref_mode != RefMode::None`:
     ///    - Reads ref flag from buffer
     ///    - Returns `ForyDefault::fory_default()` for null values
-    ///    - Handles ref tracking for shared references
     /// 2. If `read_type_info` is true, calls [`fory_read_type_info`]
     /// 3. Calls [`fory_read_data`] to read the actual data
     ///
@@ -560,18 +558,10 @@ pub trait Serializer: 'static {
     /// Override this method for:
     ///
     /// - **Option types**: Need custom null handling logic
-    /// - **Reference types** (Rc/Arc/Weak): Need custom ref tracking
+    /// - **Reference types** (Rc/Arc/Weak): Need custom ref tracking with RefReader
     /// - **Polymorphic types**: Need to dispatch based on actual runtime type
     ///
     /// For regular types (structs, primitives, collections), the default implementation is sufficient.
-    ///
-    /// # Implementation Notes
-    ///
-    /// - Unlike [`fory_write`], this doesn't need `has_generics` parameter
-    /// - Generic metadata is already in the buffer and parsed during read
-    /// - Implemented by Fory for all built-in types
-    /// - User types with custom serialization typically don't need to override this
-    /// - Focus on implementing [`fory_read_data`] instead
     ///
     /// [`fory_read_data`]: Serializer::fory_read_data
     /// [`fory_read_type_info`]: Serializer::fory_read_type_info
@@ -579,33 +569,24 @@ pub trait Serializer: 'static {
     #[inline(always)]
     fn fory_read(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         read_type_info: bool,
     ) -> Result<Self, Error>
     where
         Self: Sized + ForyDefault,
     {
-        if read_ref_info {
+        // Fast path: single comparison for primitives/strings/time types
+        if ref_mode != RefMode::None {
             let ref_flag = context.reader.read_i8()?;
-            match ref_flag {
-                flag if flag == RefFlag::Null as i8 => Ok(Self::fory_default()),
-                flag if flag == RefFlag::NotNullValue as i8 || flag == RefFlag::RefValue as i8 => {
-                    if read_type_info {
-                        Self::fory_read_type_info(context)?;
-                    }
-                    Self::fory_read_data(context)
-                }
-                flag if flag == RefFlag::Ref as i8 => {
-                    Err(Error::invalid_ref("Invalid ref, current type is not a ref"))
-                }
-                other => Err(Error::invalid_data(format!("Unknown ref flag: {}", other))),
+            if ref_flag == RefFlag::Null as i8 {
+                return Ok(Self::fory_default());
             }
-        } else {
-            if read_type_info {
-                Self::fory_read_type_info(context)?;
-            }
-            Self::fory_read_data(context)
+            // NotNullValue or RefValue both mean "continue reading" for non-trackable types
         }
+        if read_type_info {
+            Self::fory_read_type_info(context)?;
+        }
+        Self::fory_read_data(context)
     }
 
     /// Deserialize with pre-read type information.
@@ -616,7 +597,7 @@ pub trait Serializer: 'static {
     ///
     /// # Parameters
     ///
-    /// * `read_ref_info` - When `true`, READS reference flag from buffer. When `false`, SKIPS reading ref flag.
+    /// * `ref_mode` - Controls how reference flags are read (see [`fory_read`])
     /// * `type_info` - Type information that has already been read ahead. DO NOT read type info again from buffer.
     ///
     /// # Important
@@ -631,11 +612,11 @@ pub trait Serializer: 'static {
     /// ```rust,ignore
     /// fn fory_read_with_type_info(
     ///     context: &mut ReadContext,
-    ///     read_ref_info: bool,
+    ///     ref_mode: RefMode,
     ///     type_info: Rc<TypeInfo>,
     /// ) -> Result<Self, Error> {
     ///     // Ignore type_info since static type matches
-    ///     Self::fory_read(context, read_ref_info, false) // read_type_info=false
+    ///     Self::fory_read(context, ref_mode, false) // read_type_info=false
     /// }
     /// ```
     ///
@@ -653,27 +634,19 @@ pub trait Serializer: 'static {
     /// - **Reference types with polymorphic targets**: Rc\<dyn Trait\>, Arc\<dyn Trait\>
     /// - **Custom polymorphic types**: Types with runtime type variation
     ///
-    /// # Implementation Notes
-    ///
-    /// - Called by Fory's polymorphic deserialization infrastructure
-    /// - The `type_info` parameter contains the actual runtime type ID
-    /// - Implemented by Fory for all polymorphic types
-    /// - User types with custom serialization rarely need to override this
-    ///
     /// [`fory_read`]: Serializer::fory_read
     #[inline(always)]
     #[allow(unused_variables)]
     fn fory_read_with_type_info(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         type_info: Rc<TypeInfo>,
     ) -> Result<Self, Error>
     where
         Self: Sized + ForyDefault,
     {
         // Default implementation ignores the provided typeinfo because the static type matches.
-        // Honor the supplied `read_ref_info` flag so callers can control whether ref metadata is present.
-        Self::fory_read(context, read_ref_info, false)
+        Self::fory_read(context, ref_mode, false)
     }
 
     /// **[USER IMPLEMENTATION REQUIRED]** Deserialize the type's data from the buffer.
@@ -765,7 +738,7 @@ pub trait Serializer: 'static {
     /// ## Struct with nested serializable types
     ///
     /// ```rust
-    /// use fory_core::{Serializer, ForyDefault};
+    /// use fory_core::{Serializer, ForyDefault, RefMode};
     /// use fory_core::resolver::context::{ReadContext, WriteContext};
     /// use fory_core::error::Error;
     /// use std::any::Any;
@@ -789,9 +762,9 @@ pub trait Serializer: 'static {
     ///
     /// impl Serializer for Person {
     ///     fn fory_write_data(&self, context: &mut WriteContext) -> Result<(), Error> {
-    ///         self.name.fory_write(context, false, false, false)?;
+    ///         self.name.fory_write(context, RefMode::None, false, false)?;
     ///         context.writer.write_u32(self.age);
-    ///         self.scores.fory_write(context, false, false, true)?;
+    ///         self.scores.fory_write(context, RefMode::None, false, true)?;
     ///         Ok(())
     ///     }
     ///
@@ -800,9 +773,9 @@ pub trait Serializer: 'static {
     ///         Self: Sized + ForyDefault,
     ///     {
     ///         // Read nested types in the same order as written
-    ///         let name = String::fory_read(context, false, false)?;
+    ///         let name = String::fory_read(context, RefMode::None, false)?;
     ///         let age = context.reader.read_u32()?;
-    ///         let scores = Vec::<i32>::fory_read(context, false, false)?;
+    ///         let scores = Vec::<i32>::fory_read(context, RefMode::None, false)?;
     ///         Ok(Person { name, age, scores })
     ///     }
     ///

--- a/rust/fory-core/src/serializer/enum_.rs
+++ b/rust/fory-core/src/serializer/enum_.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::meta::FieldInfo;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::{ForyDefault, Serializer};
-use crate::types::{RefFlag, TypeId};
+use crate::types::{RefFlag, RefMode, TypeId};
 use crate::TypeResolver;
 
 #[inline(always)]
@@ -36,10 +36,10 @@ pub fn actual_type_id(type_id: u32, register_by_name: bool, _compatible: bool) -
 pub fn write<T: Serializer>(
     this: &T,
     context: &mut WriteContext,
-    write_ref_info: bool,
+    ref_mode: RefMode,
     write_type_info: bool,
 ) -> Result<(), Error> {
-    if write_ref_info {
+    if ref_mode != RefMode::None {
         context.writer.write_i8(RefFlag::NotNullValue as i8);
     }
     if write_type_info {
@@ -73,10 +73,10 @@ pub fn write_type_info<T: Serializer>(context: &mut WriteContext) -> Result<(), 
 #[inline(always)]
 pub fn read<T: Serializer + ForyDefault>(
     context: &mut ReadContext,
-    read_ref_info: bool,
+    ref_mode: RefMode,
     read_type_info: bool,
 ) -> Result<T, Error> {
-    let ref_flag = if read_ref_info {
+    let ref_flag = if ref_mode != RefMode::None {
         context.reader.read_i8()?
     } else {
         RefFlag::NotNullValue as i8

--- a/rust/fory-core/src/serializer/rc.rs
+++ b/rust/fory-core/src/serializer/rc.rs
@@ -19,8 +19,7 @@ use crate::error::Error;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::resolver::type_resolver::{TypeInfo, TypeResolver};
 use crate::serializer::{ForyDefault, Serializer};
-use crate::types::RefFlag;
-use crate::types::TypeId;
+use crate::types::{RefFlag, RefMode, TypeId};
 use std::rc::Rc;
 
 impl<T: Serializer + ForyDefault + 'static> Serializer for Rc<T> {
@@ -31,31 +30,86 @@ impl<T: Serializer + ForyDefault + 'static> Serializer for Rc<T> {
     fn fory_write(
         &self,
         context: &mut WriteContext,
-        write_ref_info: bool,
+        ref_mode: RefMode,
         write_type_info: bool,
         has_generics: bool,
     ) -> Result<(), Error> {
-        if !write_ref_info
-            || !context
-                .ref_writer
-                .try_write_rc_ref(&mut context.writer, self)
-        {
-            if T::fory_is_shared_ref() || T::fory_is_polymorphic() {
-                let inner_write_ref = T::fory_is_shared_ref();
-                return T::fory_write(
-                    &**self,
-                    context,
-                    inner_write_ref,
-                    write_type_info,
-                    has_generics,
-                );
+        match ref_mode {
+            RefMode::None => {
+                // No ref flag - write inner directly
+                if T::fory_is_shared_ref() || T::fory_is_polymorphic() {
+                    let inner_ref_mode = if T::fory_is_shared_ref() {
+                        RefMode::Tracking
+                    } else {
+                        RefMode::None
+                    };
+                    T::fory_write(
+                        &**self,
+                        context,
+                        inner_ref_mode,
+                        write_type_info,
+                        has_generics,
+                    )
+                } else {
+                    if write_type_info {
+                        T::fory_write_type_info(context)?;
+                    }
+                    T::fory_write_data_generic(self, context, has_generics)
+                }
             }
-            if write_type_info {
-                T::fory_write_type_info(context)?;
+            RefMode::NullOnly => {
+                // Only null check, no ref tracking
+                context.writer.write_i8(RefFlag::NotNullValue as i8);
+                if T::fory_is_shared_ref() || T::fory_is_polymorphic() {
+                    let inner_ref_mode = if T::fory_is_shared_ref() {
+                        RefMode::Tracking
+                    } else {
+                        RefMode::None
+                    };
+                    T::fory_write(
+                        &**self,
+                        context,
+                        inner_ref_mode,
+                        write_type_info,
+                        has_generics,
+                    )
+                } else {
+                    if write_type_info {
+                        T::fory_write_type_info(context)?;
+                    }
+                    T::fory_write_data_generic(self, context, has_generics)
+                }
             }
-            T::fory_write_data_generic(self, context, has_generics)
-        } else {
-            Ok(())
+            RefMode::Tracking => {
+                // Full ref tracking with RefWriter
+                if context
+                    .ref_writer
+                    .try_write_rc_ref(&mut context.writer, self)
+                {
+                    // Already written as ref - done
+                    return Ok(());
+                }
+                // First occurrence - write inner
+                if T::fory_is_shared_ref() || T::fory_is_polymorphic() {
+                    let inner_ref_mode = if T::fory_is_shared_ref() {
+                        RefMode::Tracking
+                    } else {
+                        RefMode::None
+                    };
+                    T::fory_write(
+                        &**self,
+                        context,
+                        inner_ref_mode,
+                        write_type_info,
+                        has_generics,
+                    )
+                } else {
+                    if write_type_info {
+                        T::fory_write_type_info(context)?;
+                    }
+                    T::fory_write_data_generic(self, context, has_generics)
+                }
+            }
         }
     }
 
@@ -77,21 +131,21 @@ impl<T: Serializer + ForyDefault + 'static> Serializer for Rc<T> {
 
     fn fory_read(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         read_type_info: bool,
     ) -> Result<Self, Error> {
-        read_rc(context, read_ref_info, read_type_info, None)
+        read_rc(context, ref_mode, read_type_info, None)
     }
 
     fn fory_read_with_type_info(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         typeinfo: Rc<TypeInfo>,
     ) -> Result<Self, Error>
     where
         Self: Sized + ForyDefault,
     {
-        read_rc(context, read_ref_info, false, Some(typeinfo))
+        read_rc(context, ref_mode, false, Some(typeinfo))
     }
 
     fn fory_read_data(_: &mut ReadContext) -> Result<Self, Error> {
@@ -127,34 +181,48 @@ impl<T: Serializer + ForyDefault + 'static> Serializer for Rc<T> {
 
 fn read_rc<T: Serializer + ForyDefault + 'static>(
     context: &mut ReadContext,
-    read_ref_info: bool,
+    ref_mode: RefMode,
     read_type_info: bool,
     typeinfo: Option<Rc<TypeInfo>>,
 ) -> Result<Rc<T>, Error> {
-    let ref_flag = if read_ref_info {
-        context.ref_reader.read_ref_flag(&mut context.reader)?
-    } else {
-        RefFlag::NotNullValue
-    };
-    match ref_flag {
-        RefFlag::Null => Err(Error::invalid_ref("Rc cannot be null")),
-        RefFlag::Ref => {
-            let ref_id = context.ref_reader.read_ref_id(&mut context.reader)?;
-            context
-                .ref_reader
-                .get_rc_ref::<T>(ref_id)
-                .ok_or_else(|| Error::invalid_ref(format!("Rc reference {ref_id} not found")))
-        }
-        RefFlag::NotNullValue => {
+    match ref_mode {
+        RefMode::None => {
+            // No ref flag - read inner directly
             let inner = read_rc_inner::<T>(context, read_type_info, typeinfo)?;
             Ok(Rc::new(inner))
         }
-        RefFlag::RefValue => {
-            let ref_id = context.ref_reader.reserve_ref_id();
+        RefMode::NullOnly => {
+            // Read NotNullValue flag (Null not allowed for Rc)
+            let ref_flag = context.reader.read_i8()?;
+            if ref_flag == RefFlag::Null as i8 {
+                return Err(Error::invalid_ref("Rc cannot be null"));
+            }
             let inner = read_rc_inner::<T>(context, read_type_info, typeinfo)?;
-            let rc = Rc::new(inner);
-            context.ref_reader.store_rc_ref_at(ref_id, rc.clone());
-            Ok(rc)
+            Ok(Rc::new(inner))
+        }
+        RefMode::Tracking => {
+            // Full ref tracking
+            let ref_flag = context.ref_reader.read_ref_flag(&mut context.reader)?;
+            match ref_flag {
+                RefFlag::Null => Err(Error::invalid_ref("Rc cannot be null")),
+                RefFlag::Ref => {
+                    let ref_id = context.ref_reader.read_ref_id(&mut context.reader)?;
+                    context.ref_reader.get_rc_ref::<T>(ref_id).ok_or_else(|| {
+                        Error::invalid_ref(format!("Rc reference {ref_id} not found"))
+                    })
+                }
+                RefFlag::NotNullValue => {
+                    let inner = read_rc_inner::<T>(context, read_type_info, typeinfo)?;
+                    Ok(Rc::new(inner))
+                }
+                RefFlag::RefValue => {
+                    let ref_id = context.ref_reader.reserve_ref_id();
+                    let inner = read_rc_inner::<T>(context, read_type_info, typeinfo)?;
+                    let rc = Rc::new(inner);
+                    context.ref_reader.store_rc_ref_at(ref_id, rc.clone());
+                    Ok(rc)
+                }
+            }
         }
     }
 }
@@ -165,12 +233,20 @@ fn read_rc_inner<T: Serializer + ForyDefault + 'static>(
     typeinfo: Option<Rc<TypeInfo>>,
 ) -> Result<T, Error> {
     if let Some(typeinfo) = typeinfo {
-        let inner_read_ref = T::fory_is_shared_ref();
-        return T::fory_read_with_type_info(context, inner_read_ref, typeinfo);
+        let inner_ref_mode = if T::fory_is_shared_ref() {
+            RefMode::Tracking
+        } else {
+            RefMode::None
+        };
+        return T::fory_read_with_type_info(context, inner_ref_mode, typeinfo);
     }
     if T::fory_is_shared_ref() || T::fory_is_polymorphic() {
-        let inner_read_ref = T::fory_is_shared_ref();
-        return T::fory_read(context, inner_read_ref, read_type_info);
+        let inner_ref_mode = if T::fory_is_shared_ref() {
+            RefMode::Tracking
+        } else {
+            RefMode::None
+        };
+        return T::fory_read(context, inner_ref_mode, read_type_info);
     }
     if read_type_info {
         T::fory_read_type_info(context)?;

--- a/rust/fory-core/src/serializer/refcell.rs
+++ b/rust/fory-core/src/serializer/refcell.rs
@@ -36,7 +36,7 @@ use crate::error::Error;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::resolver::type_resolver::{TypeInfo, TypeResolver};
 use crate::serializer::{ForyDefault, Serializer};
-use crate::types::TypeId;
+use crate::types::{RefMode, TypeId};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -48,7 +48,7 @@ impl<T: Serializer + ForyDefault> Serializer for RefCell<T> {
     #[inline(always)]
     fn fory_read(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         read_type_info: bool,
     ) -> Result<Self, Error>
     where
@@ -56,7 +56,7 @@ impl<T: Serializer + ForyDefault> Serializer for RefCell<T> {
     {
         Ok(RefCell::new(T::fory_read(
             context,
-            read_ref_info,
+            ref_mode,
             read_type_info,
         )?))
     }
@@ -64,16 +64,14 @@ impl<T: Serializer + ForyDefault> Serializer for RefCell<T> {
     #[inline(always)]
     fn fory_read_with_type_info(
         context: &mut ReadContext,
-        read_ref_info: bool,
+        ref_mode: RefMode,
         type_info: Rc<TypeInfo>,
     ) -> Result<Self, Error>
     where
         Self: Sized + ForyDefault,
     {
         Ok(RefCell::new(T::fory_read_with_type_info(
-            context,
-            read_ref_info,
-            type_info,
+            context, ref_mode, type_info,
         )?))
     }
 
@@ -91,7 +89,7 @@ impl<T: Serializer + ForyDefault> Serializer for RefCell<T> {
     fn fory_write(
         &self,
         context: &mut WriteContext,
-        write_ref_info: bool,
+        ref_mode: RefMode,
         write_type_info: bool,
         has_generics: bool,
     ) -> Result<(), Error> {
@@ -100,7 +98,7 @@ impl<T: Serializer + ForyDefault> Serializer for RefCell<T> {
         T::fory_write(
             &*self.borrow(),
             context,
-            write_ref_info,
+            ref_mode,
             write_type_info,
             has_generics,
         )

--- a/rust/fory-core/src/serializer/struct_.rs
+++ b/rust/fory-core/src/serializer/struct_.rs
@@ -19,7 +19,7 @@ use crate::ensure;
 use crate::error::Error;
 use crate::resolver::context::{ReadContext, WriteContext};
 use crate::serializer::Serializer;
-use crate::types::{RefFlag, TypeId};
+use crate::types::{RefFlag, RefMode, TypeId};
 use crate::util::ENABLE_FORY_DEBUG_OUTPUT;
 use std::any::Any;
 
@@ -92,10 +92,10 @@ pub fn read_type_info<T: Serializer>(context: &mut ReadContext) -> Result<(), Er
 pub fn write<T: Serializer>(
     this: &T,
     context: &mut WriteContext,
-    write_ref_info: bool,
+    ref_mode: RefMode,
     write_type_info: bool,
 ) -> Result<(), Error> {
-    if write_ref_info {
+    if ref_mode != RefMode::None {
         context.writer.write_i8(RefFlag::NotNullValue as i8);
     }
     if write_type_info {

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -157,7 +157,7 @@ pub(crate) fn gen_named_variant_meta_type_impl_with_enum_name(
 
 pub fn gen_write(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::write::<Self>(self, context, write_ref_info, write_type_info)
+        fory_core::serializer::enum_::write::<Self>(self, context, ref_mode, write_type_info)
     }
 }
 
@@ -311,7 +311,7 @@ fn rust_compatible_variant_write_branches(
                             context.writer.write_u8(header);
                             use fory_core::serializer::Serializer;
                             #(
-                                #field_idents.fory_write(context, true, true, false)?;
+                                #field_idents.fory_write(context, fory_core::RefMode::NullOnly, true, false)?;
                             )*
                         }
                     }
@@ -395,13 +395,13 @@ pub fn gen_write_type_info() -> TokenStream {
 
 pub fn gen_read(_: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::read::<Self>(context, read_ref_info, read_type_info)
+        fory_core::serializer::enum_::read::<Self>(context, ref_mode, read_type_info)
     }
 }
 
 pub fn gen_read_with_type_info(_: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::read::<Self>(context, read_ref_info, false)
+        fory_core::serializer::enum_::read::<Self>(context, ref_mode, false)
     }
 }
 
@@ -585,7 +585,7 @@ fn rust_compatible_variant_read_branches(
                             quote! {
                                 let #field_ident = if #i < len {
                                     use fory_core::serializer::Serializer;
-                                    <#field_ty>::fory_read(context, true, true)?
+                                    <#field_ty>::fory_read(context, fory_core::RefMode::NullOnly, true)?
                                 } else {
                                     <#field_ty as fory_core::ForyDefault>::fory_default()
                                 }

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -218,7 +218,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
             }
 
             #[inline(always)]
-            fn fory_write(&self, context: &mut fory_core::resolver::context::WriteContext, write_ref_info: bool, write_type_info: bool, _: bool) -> Result<(), fory_core::error::Error> {
+            fn fory_write(&self, context: &mut fory_core::resolver::context::WriteContext, ref_mode: fory_core::RefMode, write_type_info: bool, _: bool) -> Result<(), fory_core::error::Error> {
                 #write_ts
             }
 
@@ -233,12 +233,12 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
             }
 
             #[inline(always)]
-            fn fory_read(context: &mut fory_core::resolver::context::ReadContext, read_ref_info: bool, read_type_info: bool) -> Result<Self, fory_core::error::Error> {
+            fn fory_read(context: &mut fory_core::resolver::context::ReadContext, ref_mode: fory_core::RefMode, read_type_info: bool) -> Result<Self, fory_core::error::Error> {
                 #read_ts
             }
 
             #[inline(always)]
-            fn fory_read_with_type_info(context: &mut fory_core::resolver::context::ReadContext, read_ref_info: bool, type_info: std::rc::Rc<fory_core::TypeInfo>) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_with_type_info(context: &mut fory_core::resolver::context::ReadContext, ref_mode: fory_core::RefMode, type_info: std::rc::Rc<fory_core::TypeInfo>) -> Result<Self, fory_core::error::Error> {
                 #read_with_type_info_ts
             }
 


### PR DESCRIPTION
## Why?

Currently Rust uses a boolean `write_ref_info`/`read_ref_info` parameter which only distinguishes between "write ref flag" vs "don't write ref flag". This doesn't support:
- Nullable types without ref tracking (like `Option<T>` where T is not a shared ref)
- Explicit control over shared reference tracking per field via `#[fory(ref=false)]` attribute
- Alignment with Go's `RefMode` design which has three modes: `None`, `NullOnly`, `Tracking`

## What does this PR do?

### 1. Add `RefMode` enum to replace boolean `write_ref_info`/`read_ref_info`

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
#[repr(u8)]
pub enum RefMode {
    #[default]
    None = 0,      // No ref flag written/read (primitives, non-nullable types)
    NullOnly = 1,  // Write NULL(-3) or NOT_NULL(-1), no ref tracking
    Tracking = 2,  // Full ref tracking with REF(-2) and REF_VALUE(0) flags
}
```

### 2. Update Serializer trait signature

```rust
fn fory_write(&self, context: &mut WriteContext, ref_mode: RefMode, write_type_info: bool, has_generics: bool) -> Result<(), Error>
fn fory_read(context: &mut ReadContext, ref_mode: RefMode, read_type_info: bool) -> Result<Self, Error>
```

### 3. Per-field RefMode determination in derive macro

- Type classification: primitive → `None`, Option → `NullOnly`, Rc/Arc/Weak → `Tracking`
- Field meta attributes respected: `#[fory(ref=false)]` to disable tracking, `#[fory(nullable)]` for null support
- All field types (including trait objects like `Box<dyn Any>`, `Rc<dyn Trait>`, etc.) now respect field attributes

### 4. Add `FieldRefMode` enum with `ToTokens` impl for cleaner macro code generation

```rust
pub(crate) enum FieldRefMode {
    None,
    NullOnly,
    Tracking,
}

impl ToTokens for FieldRefMode {
    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
        // Generates fory_core::RefMode::None/NullOnly/Tracking
    }
}
```

### 5. Add `determine_field_ref_mode(field)` helper

Combines type classification with field meta attributes to determine the correct RefMode for each field, respecting `#[fory(ref=false)]` and `#[fory(nullable)]` annotations.

## Related issues

Closes #3097 

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
  - `Serializer::fory_write` and `Serializer::fory_read` now take `RefMode` instead of `bool`
  - New `RefMode` enum exported from `fory_core`
- [ ] Does this PR introduce any binary protocol compatibility change?
  - No, the wire format is unchanged

## Benchmark

No performance regression expected - the `RefMode` enum comparison (`ref_mode != RefMode::None`) compiles to the same machine code as the previous boolean comparison.