### PR TITLE
 perf(rust): optimize set_bytes with direct copy_nonoverlapping

### DIFF
--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -67,10 +67,17 @@ impl<'a> Writer<'a> {
 
     #[inline(always)]
     pub fn set_bytes(&mut self, offset: usize, data: &[u8]) {
-        self.bf
-            .get_mut(offset..offset + data.len())
-            .unwrap()
-            .copy_from_slice(data);
+        debug_assert!(offset + data.len() <= self.bf.len());
+        // SAFETY: Callers write placeholder bytes first (via write_*/skip), then
+        // call set_bytes to back-fill. The offset always points to previously
+        // written data within bounds.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                self.bf.as_mut_ptr().add(offset),
+                data.len(),
+            );
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION

## Why?
 All `set_bytes` callers follow the same pattern: save `writer.len()` as offset, write placeholder bytes (via `write_*`/`skip`), then call `set_bytes` to back-fill. Since bounds are already guaranteed by this usage pattern, the runtime checks are redundant I guess. This allows us to optimize them away while keeping a `debug_assert!` for safety...


## What does this PR do?
Replace bounds-checked `get_mut().unwrap().copy_from_slice()` with direct `ptr::copy_nonoverlapping`.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

No benchmarks yet, but the improvement should be noticeable: https://godbolt.org/z/75bhPWxfW
