### PR TITLE
docs: remove redundant prefix doc id

### DIFF
--- a/docs/guide/cpp/basic-serialization.md
+++ b/docs/guide/cpp/basic-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Basic Serialization
 sidebar_position: 2
-id: cpp_basic_serialization
+id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/configuration.md
+++ b/docs/guide/cpp/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_position: 1
-id: cpp_configuration
+id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/cross-language.md
+++ b/docs/guide/cpp/cross-language.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization
 sidebar_position: 7
-id: cpp_cross_language
+id: cross_language
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/field-configuration.md
+++ b/docs/guide/cpp/field-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Field Configuration
 sidebar_position: 5
-id: cpp_field_configuration
+id: field_configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/index.md
+++ b/docs/guide/cpp/index.md
@@ -1,7 +1,7 @@
 ---
 title: C++ Serialization Guide
 sidebar_position: 0
-id: cpp_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/row-format.md
+++ b/docs/guide/cpp/row-format.md
@@ -1,7 +1,7 @@
 ---
 title: Row Format
 sidebar_position: 8
-id: cpp_row_format
+id: row_format
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/schema-evolution.md
+++ b/docs/guide/cpp/schema-evolution.md
@@ -1,7 +1,7 @@
 ---
 title: Schema Evolution
 sidebar_position: 3
-id: cpp_schema_evolution
+id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/supported-types.md
+++ b/docs/guide/cpp/supported-types.md
@@ -1,7 +1,7 @@
 ---
 title: Supported Types
 sidebar_position: 6
-id: cpp_supported_types
+id: supported_types
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/cpp/type-registration.md
+++ b/docs/guide/cpp/type-registration.md
@@ -1,7 +1,7 @@
 ---
 title: Type Registration
 sidebar_position: 4
-id: cpp_type_registration
+id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/basic-serialization.md
+++ b/docs/guide/go/basic-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Basic Serialization
 sidebar_position: 20
-id: go_basic_serialization
+id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/codegen.md
+++ b/docs/guide/go/codegen.md
@@ -1,7 +1,7 @@
 ---
 title: Code Generation
 sidebar_position: 90
-id: go_codegen
+id: codegen
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/configuration.md
+++ b/docs/guide/go/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_position: 10
-id: go_configuration
+id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/cross-language.md
+++ b/docs/guide/go/cross-language.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization
 sidebar_position: 80
-id: go_cross_language
+id: cross_language
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/custom-serializers.md
+++ b/docs/guide/go/custom-serializers.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Serializers
 sidebar_position: 35
-id: go_custom_serializers
+id: custom_serializers
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/index.md
+++ b/docs/guide/go/index.md
@@ -1,7 +1,7 @@
 ---
 title: Go Serialization Guide
 sidebar_position: 0
-id: go_index
+id: index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/references.md
+++ b/docs/guide/go/references.md
@@ -1,7 +1,7 @@
 ---
 title: References
 sidebar_position: 50
-id: go_references
+id: references
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/schema-evolution.md
+++ b/docs/guide/go/schema-evolution.md
@@ -1,7 +1,7 @@
 ---
 title: Schema Evolution
 sidebar_position: 70
-id: go_schema_evolution
+id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/struct-tags.md
+++ b/docs/guide/go/struct-tags.md
@@ -1,7 +1,7 @@
 ---
 title: Struct Tags
 sidebar_position: 60
-id: go_struct_tags
+id: struct_tags
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/supported-types.md
+++ b/docs/guide/go/supported-types.md
@@ -1,7 +1,7 @@
 ---
 title: Supported Types
 sidebar_position: 40
-id: go_supported_types
+id: supported_types
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/thread-safety.md
+++ b/docs/guide/go/thread-safety.md
@@ -1,7 +1,7 @@
 ---
 title: Thread Safety
 sidebar_position: 100
-id: go_thread_safety
+id: thread_safety
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/troubleshooting.md
+++ b/docs/guide/go/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 sidebar_position: 110
-id: go_troubleshooting
+id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/go/type-registration.md
+++ b/docs/guide/go/type-registration.md
@@ -1,7 +1,7 @@
 ---
 title: Type Registration
 sidebar_position: 30
-id: go_type_registration
+id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/graalvm_guide.md
+++ b/docs/guide/graalvm_guide.md
@@ -1,7 +1,7 @@
 ---
 title: GraalVM Guide
 sidebar_position: 19
-id: graalvm_serialization
+id: serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/advanced-features.md
+++ b/docs/guide/java/advanced-features.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Features
 sidebar_position: 7
-id: java_advanced_features
+id: advanced_features
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/basic-serialization.md
+++ b/docs/guide/java/basic-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Basic Serialization
 sidebar_position: 2
-id: java_basic_serialization
+id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/compression.md
+++ b/docs/guide/java/compression.md
@@ -1,7 +1,7 @@
 ---
 title: Compression
 sidebar_position: 6
-id: java_compression
+id: compression
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/configuration.md
+++ b/docs/guide/java/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration Options
 sidebar_position: 1
-id: java_configuration
+id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/cross-language.md
+++ b/docs/guide/java/cross-language.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization
 sidebar_position: 8
-id: java_cross_language
+id: cross_language
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/custom-serializers.md
+++ b/docs/guide/java/custom-serializers.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Serializers
 sidebar_position: 4
-id: java_custom_serializers
+id: custom_serializers
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/index.md
+++ b/docs/guide/java/index.md
@@ -1,7 +1,7 @@
 ---
 title: Java Serialization Guide
 sidebar_position: 0
-id: java_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/migration.md
+++ b/docs/guide/java/migration.md
@@ -1,7 +1,7 @@
 ---
 title: Migration Guide
 sidebar_position: 10
-id: java_migration
+id: migration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/row-format.md
+++ b/docs/guide/java/row-format.md
@@ -1,7 +1,7 @@
 ---
 title: Row Format
 sidebar_position: 9
-id: java_row_format
+id: row_format
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/schema-evolution.md
+++ b/docs/guide/java/schema-evolution.md
@@ -1,7 +1,7 @@
 ---
 title: Schema Evolution
 sidebar_position: 5
-id: java_schema_evolution
+id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/troubleshooting.md
+++ b/docs/guide/java/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 sidebar_position: 11
-id: java_troubleshooting
+id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/java/type-registration.md
+++ b/docs/guide/java/type-registration.md
@@ -1,7 +1,7 @@
 ---
 title: Type Registration & Security
 sidebar_position: 3
-id: java_type_registration
+id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/kotlin/default-values.md
+++ b/docs/guide/kotlin/default-values.md
@@ -1,7 +1,7 @@
 ---
 title: Default Values
 sidebar_position: 3
-id: kotlin_default_values
+id: default_values
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/kotlin/fory-creation.md
+++ b/docs/guide/kotlin/fory-creation.md
@@ -1,7 +1,7 @@
 ---
 title: Fory Creation
 sidebar_position: 1
-id: kotlin_fory_creation
+id: fory_creation
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/kotlin/index.md
+++ b/docs/guide/kotlin/index.md
@@ -1,7 +1,7 @@
 ---
 title: Kotlin Serialization Guide
 sidebar_position: 0
-id: kotlin_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/kotlin/type-serialization.md
+++ b/docs/guide/kotlin/type-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Type Serialization
 sidebar_position: 2
-id: kotlin_type_serialization
+id: type_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/basic-serialization.md
+++ b/docs/guide/python/basic-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Basic Serialization
 sidebar_position: 2
-id: python_basic_serialization
+id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/configuration.md
+++ b/docs/guide/python/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_position: 1
-id: python_configuration
+id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/cross-language.md
+++ b/docs/guide/python/cross-language.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization
 sidebar_position: 10
-id: python_cross_language
+id: cross_language
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/custom-serializers.md
+++ b/docs/guide/python/custom-serializers.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Serializers
 sidebar_position: 4
-id: python_custom_serializers
+id: custom_serializers
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/index.md
+++ b/docs/guide/python/index.md
@@ -1,7 +1,7 @@
 ---
 title: Python Serialization Guide
 sidebar_position: 0
-id: python_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/migration.md
+++ b/docs/guide/python/migration.md
@@ -1,7 +1,7 @@
 ---
 title: Migration Guide
 sidebar_position: 12
-id: python_migration
+id: migration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/numpy-integration.md
+++ b/docs/guide/python/numpy-integration.md
@@ -1,7 +1,7 @@
 ---
 title: NumPy & Scientific Computing
 sidebar_position: 8
-id: python_numpy_integration
+id: numpy_integration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/out-of-band.md
+++ b/docs/guide/python/out-of-band.md
@@ -1,7 +1,7 @@
 ---
 title: Out-of-Band Serialization
 sidebar_position: 7
-id: python_out_of_band
+id: out_of_band
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/python-native.md
+++ b/docs/guide/python/python-native.md
@@ -1,7 +1,7 @@
 ---
 title: Python Native Mode
 sidebar_position: 5
-id: python_native_mode
+id: native_mode
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/row-format.md
+++ b/docs/guide/python/row-format.md
@@ -1,7 +1,7 @@
 ---
 title: Row Format
 sidebar_position: 11
-id: python_row_format
+id: row_format
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/schema-evolution.md
+++ b/docs/guide/python/schema-evolution.md
@@ -1,7 +1,7 @@
 ---
 title: Schema Evolution
 sidebar_position: 6
-id: python_schema_evolution
+id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/security.md
+++ b/docs/guide/python/security.md
@@ -1,7 +1,7 @@
 ---
 title: Security Best Practices
 sidebar_position: 9
-id: python_security
+id: security
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/troubleshooting.md
+++ b/docs/guide/python/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 sidebar_position: 13
-id: python_troubleshooting
+id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/python/type-registration.md
+++ b/docs/guide/python/type-registration.md
@@ -1,7 +1,7 @@
 ---
 title: Type Registration & Security
 sidebar_position: 3
-id: python_type_registration
+id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/basic-serialization.md
+++ b/docs/guide/rust/basic-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Basic Serialization
 sidebar_position: 2
-id: rust_basic_serialization
+id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/configuration.md
+++ b/docs/guide/rust/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebar_position: 1
-id: rust_configuration
+id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/cross-language.md
+++ b/docs/guide/rust/cross-language.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization
 sidebar_position: 8
-id: rust_cross_language
+id: cross_language
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/custom-serializers.md
+++ b/docs/guide/rust/custom-serializers.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Serializers
 sidebar_position: 4
-id: rust_custom_serializers
+id: custom_serializers
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/index.md
+++ b/docs/guide/rust/index.md
@@ -1,7 +1,7 @@
 ---
 title: Rust Serialization Guide
 sidebar_position: 0
-id: rust_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/polymorphism.md
+++ b/docs/guide/rust/polymorphism.md
@@ -1,7 +1,7 @@
 ---
 title: Trait Object Serialization
 sidebar_position: 6
-id: rust_polymorphism
+id: polymorphism
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/references.md
+++ b/docs/guide/rust/references.md
@@ -1,7 +1,7 @@
 ---
 title: Shared & Circular References
 sidebar_position: 5
-id: rust_references
+id: references
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/row-format.md
+++ b/docs/guide/rust/row-format.md
@@ -1,7 +1,7 @@
 ---
 title: Row Format
 sidebar_position: 9
-id: rust_row_format
+id: row_format
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/schema-evolution.md
+++ b/docs/guide/rust/schema-evolution.md
@@ -1,7 +1,7 @@
 ---
 title: Schema Evolution
 sidebar_position: 7
-id: rust_schema_evolution
+id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/troubleshooting.md
+++ b/docs/guide/rust/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 sidebar_position: 10
-id: rust_troubleshooting
+id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/rust/type-registration.md
+++ b/docs/guide/rust/type-registration.md
@@ -1,7 +1,7 @@
 ---
 title: Type Registration
 sidebar_position: 3
-id: rust_type_registration
+id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/scala/default-values.md
+++ b/docs/guide/scala/default-values.md
@@ -1,7 +1,7 @@
 ---
 title: Default Values
 sidebar_position: 3
-id: scala_default_values
+id: default_values
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/scala/fory-creation.md
+++ b/docs/guide/scala/fory-creation.md
@@ -1,7 +1,7 @@
 ---
 title: Fory Creation
 sidebar_position: 1
-id: scala_fory_creation
+id: fory_creation
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/scala/index.md
+++ b/docs/guide/scala/index.md
@@ -1,7 +1,7 @@
 ---
 title: Scala Serialization Guide
 sidebar_position: 0
-id: scala_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/scala/type-serialization.md
+++ b/docs/guide/scala/type-serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Type Serialization
 sidebar_position: 2
-id: scala_type_serialization
+id: type_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/field-nullability.md
+++ b/docs/guide/xlang/field-nullability.md
@@ -1,7 +1,7 @@
 ---
 title: Field Nullability
 sidebar_position: 40
-id: xlang_field_nullability
+id: field_nullability
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/field-reference-tracking.md
+++ b/docs/guide/xlang/field-reference-tracking.md
@@ -1,7 +1,7 @@
 ---
 title: Reference Tracking
 sidebar_position: 45
-id: xlang_reference_tracking
+id: reference_tracking
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/getting-started.md
+++ b/docs/guide/xlang/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 sidebar_position: 10
-id: xlang_getting_started
+id: getting_started
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/index.md
+++ b/docs/guide/xlang/index.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Language Serialization Guide
 sidebar_position: 0
-id: xlang_serialization_index
+id: serialization_index
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/serialization.md
+++ b/docs/guide/xlang/serialization.md
@@ -1,7 +1,7 @@
 ---
 title: Serialization
 sidebar_position: 30
-id: xlang_serialization
+id: serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/troubleshooting.md
+++ b/docs/guide/xlang/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 sidebar_position: 70
-id: xlang_troubleshooting
+id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/guide/xlang/zero-copy.md
+++ b/docs/guide/xlang/zero-copy.md
@@ -1,7 +1,7 @@
 ---
 title: Zero-Copy Serialization
 sidebar_position: 50
-id: xlang_zero_copy
+id: zero_copy
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/specification/java_serialization_spec.md
+++ b/docs/specification/java_serialization_spec.md
@@ -1,7 +1,7 @@
 ---
 title: Java Serialization Format
 sidebar_position: 1
-id: fory_java_serialization_spec
+id: java_serialization_spec
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/specification/row_format_spec.md
+++ b/docs/specification/row_format_spec.md
@@ -1,7 +1,7 @@
 ---
 title: Row Format
 sidebar_position: 2
-id: fory_row_format_spec
+id: row_format_spec
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -1,7 +1,7 @@
 ---
 title: Xlang Serialization Format
 sidebar_position: 0
-id: fory_xlang_serialization_spec
+id: xlang_serialization_spec
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

