### PR TITLE
fix: typo in the xlang_serialization_spec.md

### DIFF
--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -76,7 +76,7 @@ This specification defines the Fory xlang binary format. The format is dynamic r
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int8 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.


### PR DESCRIPTION


## Why?

Docs - https://github.com/apache/fory/blob/main/docs/specification/xlang_serialization_spec.md
have a typo in the definition of `bool_array`.
## What does this PR do?

Corrects the definition of `bool_array`
Before
```
  - bool_array: one dimensional int16 array.
```
After
```
  - bool_array: one dimensional int8 array.
```
## Related issues
No existing Issue, just a PR.

## Does this PR introduce any user-facing change?
No
## Benchmark

N/A just a typo fix