### PR TITLE
feat(c++): make shared_ptr track ref by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ While working on Fory, please remember:
 - **Cross-Language Consistency**: Maintain consistency across language implementations while respecting language-specific idioms.
 - **GraalVM support using fory codegen**: For GraalVM, use `fory codegen` to generate the serializer when building a native image. Do not use GraalVM reflect-related configuration unless for JDK `proxy`.
 - **Xlang Type System**: Java `native mode(xlang=false)` shares same type systems between type id from `Types.BOOL~Types.STRING` with `xlang mode(xlang=true)`, but for other types, java `native mode` has different type ids.
-- **Remote git repository**: `git@github.com:apache/fory.git` is remote repository, do not use other remote repository when you want to check code under `main` branch.
+- **Remote git repository**: `git@github.com:apache/fory.git` is remote repository, do not use other remote repository when you want to check code under `main` branch, **`apache/main`** is the only target main branch instead of `origin/main`
 - **Contributor git repository**: A contributor should fork the `git@github.com:apache/fory.git` repo, and git push the code changes into their forked repo, then create a pull request from the branch in their forked repo into `git@github.com:apache/fory.git`.
 - **Debug Test Errors**: always set environment variable `ENABLE_FORY_DEBUG_OUTPUT` to `1` to see debug output.
 

--- a/cpp/fory/meta/field_test.cc
+++ b/cpp/fory/meta/field_test.cc
@@ -113,7 +113,7 @@ TEST(Field, SharedPtrNonNullable) {
   using FieldType = field<std::shared_ptr<int32_t>, 3>;
   static_assert(FieldType::tag_id == 3);
   static_assert(FieldType::is_nullable == false);
-  static_assert(FieldType::track_ref == false);
+  static_assert(FieldType::track_ref == true);
 
   FieldType f;
   f = std::make_shared<int32_t>(99);
@@ -126,7 +126,7 @@ TEST(Field, SharedPtrNullable) {
   using FieldType = field<std::shared_ptr<int32_t>, 4, nullable>;
   static_assert(FieldType::tag_id == 4);
   static_assert(FieldType::is_nullable == true);
-  static_assert(FieldType::track_ref == false);
+  static_assert(FieldType::track_ref == true);
 
   FieldType f;
   EXPECT_EQ(f.value, nullptr); // Default is null
@@ -169,7 +169,7 @@ TEST(Field, SharedPtrNotNull) {
   using FieldType = field<std::shared_ptr<int32_t>, 9, not_null>;
   static_assert(FieldType::tag_id == 9);
   static_assert(FieldType::is_nullable == false);
-  static_assert(FieldType::track_ref == false);
+  static_assert(FieldType::track_ref == true);
 }
 
 TEST(Field, SharedPtrNotNullWithRef) {
@@ -222,9 +222,9 @@ TEST(FieldTraits, FieldIsNullable) {
 
 TEST(FieldTraits, FieldTrackRef) {
   static_assert(field_track_ref_v<int> == false);
-  static_assert(field_track_ref_v<std::shared_ptr<int>> == false);
+  static_assert(field_track_ref_v<std::shared_ptr<int>> == true);
   static_assert(field_track_ref_v<field<int, 0>> == false);
-  static_assert(field_track_ref_v<field<std::shared_ptr<int>, 1>> == false);
+  static_assert(field_track_ref_v<field<std::shared_ptr<int>, 1>> == true);
   static_assert(field_track_ref_v<field<std::shared_ptr<int>, 2, ref>> == true);
   static_assert(
       field_track_ref_v<field<std::shared_ptr<int>, 3, nullable, ref>> == true);
@@ -315,7 +315,7 @@ FORY_FIELD_TAGS(Document, (title, 0),     // string: non-nullable
                 (description, 2),         // optional: inherently nullable
                 (author, 3),              // shared_ptr: non-nullable (default)
                 (reviewer, 4, nullable),  // shared_ptr: nullable
-                (parent, 5, ref),         // shared_ptr: non-nullable, with ref
+                (parent, 5, ref),         // shared_ptr: non-nullable, ref
                 (metadata, 6, nullable)); // unique_ptr: nullable
 
 FORY_FIELD_TAGS(Node, (name, 0), (left, 1, nullable, ref),
@@ -371,12 +371,12 @@ TEST(FieldTags, Nullability) {
 }
 
 TEST(FieldTags, RefTracking) {
-  // Only parent has ref tracking
+  // shared_ptr fields track refs by default
   static_assert(detail::GetFieldTagEntry<Document, 0>::track_ref == false);
   static_assert(detail::GetFieldTagEntry<Document, 1>::track_ref == false);
   static_assert(detail::GetFieldTagEntry<Document, 2>::track_ref == false);
-  static_assert(detail::GetFieldTagEntry<Document, 3>::track_ref == false);
-  static_assert(detail::GetFieldTagEntry<Document, 4>::track_ref == false);
+  static_assert(detail::GetFieldTagEntry<Document, 3>::track_ref == true);
+  static_assert(detail::GetFieldTagEntry<Document, 4>::track_ref == true);
   static_assert(detail::GetFieldTagEntry<Document, 5>::track_ref == true);
   static_assert(detail::GetFieldTagEntry<Document, 6>::track_ref == false);
 }

--- a/cpp/fory/serialization/field_serializer_test.cc
+++ b/cpp/fory/serialization/field_serializer_test.cc
@@ -656,7 +656,7 @@ TEST(FieldSerializerTest, FieldMetadataCompileTime) {
 
   // Ref tracking
   static_assert(decltype(FieldRefTrackingHolder::first)::track_ref);
-  static_assert(!decltype(FieldSharedPtrHolder::value)::track_ref);
+  static_assert(decltype(FieldSharedPtrHolder::value)::track_ref);
 
   // not_null doesn't change is_nullable for already non-nullable
   static_assert(!decltype(FieldNotNullRefHolder::node)::is_nullable);

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -604,7 +604,7 @@ template <typename T> struct CompileTimeFieldHelpers {
   }
 
   /// Returns true if reference tracking is enabled for the field at Index.
-  /// Only valid for std::shared_ptr fields with fory::ref tag.
+  /// Defaults to true for std::shared_ptr/SharedWeak fields.
   template <size_t Index> static constexpr bool field_track_ref() {
     if constexpr (FieldCount == 0) {
       return false;
@@ -620,9 +620,9 @@ template <typename T> struct CompileTimeFieldHelpers {
       else if constexpr (::fory::detail::has_field_tags_v<T>) {
         return ::fory::detail::GetFieldTagEntry<T, Index>::track_ref;
       }
-      // Default: no reference tracking
+      // Default: shared_ptr/SharedWeak track refs
       else {
-        return false;
+        return field_track_ref_v<RawFieldType>;
       }
     }
   }

--- a/cpp/fory/serialization/type_resolver.h
+++ b/cpp/fory/serialization/type_resolver.h
@@ -511,7 +511,9 @@ constexpr bool compute_track_ref() {
   } else if constexpr (::fory::detail::has_field_tags_v<T>) {
     return ::fory::detail::GetFieldTagEntry<T, Index>::track_ref;
   } else {
-    return false;
+    using UnwrappedFieldType = fory::unwrap_field_t<ActualFieldType>;
+    return ::fory::detail::is_shared_ptr_v<UnwrappedFieldType> ||
+           ::fory::detail::is_shared_weak_v<UnwrappedFieldType>;
   }
 }
 

--- a/docs/guide/cpp/field-configuration.md
+++ b/docs/guide/cpp/field-configuration.md
@@ -103,7 +103,7 @@ struct Node {
 FORY_STRUCT(Node, name, next);
 ```
 
-**Valid for:** `std::shared_ptr<T>`, `std::unique_ptr<T>`
+**Valid for:** `std::shared_ptr<T>`, `fory::serialization::SharedWeak<T>`, `std::unique_ptr<T>`
 
 **Note:** For nullable primitives or strings, use `std::optional<T>` instead:
 
@@ -123,7 +123,7 @@ Explicitly marks a pointer field as non-nullable. This is the default for smart 
 fory::field<std::shared_ptr<Data>, 0, fory::not_null> data;  // Must not be nullptr
 ```
 
-**Valid for:** `std::shared_ptr<T>`, `std::unique_ptr<T>`
+**Valid for:** `std::shared_ptr<T>`, `fory::serialization::SharedWeak<T>`, `std::unique_ptr<T>`
 
 ### fory::ref
 
@@ -138,7 +138,7 @@ struct Graph {
 FORY_STRUCT(Graph, name, left, right);
 ```
 
-**Valid for:** `std::shared_ptr<T>` only (requires shared ownership)
+**Valid for:** `std::shared_ptr<T>`, `fory::serialization::SharedWeak<T>` (requires shared ownership)
 
 ### fory::dynamic\<V\>
 
@@ -171,7 +171,7 @@ FORY_STRUCT(Zoo, animal, fixed_animal);
 
 ### Combining Tags
 
-Multiple tags can be combined for shared pointers:
+Multiple tags can be combined for shared pointers and SharedWeak:
 
 ```cpp
 // Nullable + ref tracking
@@ -180,12 +180,13 @@ fory::field<std::shared_ptr<Node>, 0, fory::nullable, fory::ref> link;
 
 ## Type Rules
 
-| Type                 | Allowed Options                 | Nullability                        |
-| -------------------- | ------------------------------- | ---------------------------------- |
-| Primitives, strings  | None                            | Use `std::optional<T>` if nullable |
-| `std::optional<T>`   | None                            | Inherently nullable                |
-| `std::shared_ptr<T>` | `nullable`, `ref`, `dynamic<V>` | Non-null by default                |
-| `std::unique_ptr<T>` | `nullable`, `dynamic<V>`        | Non-null by default                |
+| Type                                 | Allowed Options                 | Nullability                        |
+| ------------------------------------ | ------------------------------- | ---------------------------------- |
+| Primitives, strings                  | None                            | Use `std::optional<T>` if nullable |
+| `std::optional<T>`                   | None                            | Inherently nullable                |
+| `std::shared_ptr<T>`                 | `nullable`, `ref`, `dynamic<V>` | Non-null by default                |
+| `fory::serialization::SharedWeak<T>` | `nullable`, `ref`, `dynamic<V>` | Non-null by default                |
+| `std::unique_ptr<T>`                 | `nullable`, `dynamic<V>`        | Non-null by default                |
 
 ## Complete Example
 
@@ -510,21 +511,21 @@ FORY_FIELD_CONFIG(DataV2,
 
 ### FORY_FIELD_CONFIG Options Reference
 
-| Method            | Description                                      | Valid For                  |
-| ----------------- | ------------------------------------------------ | -------------------------- |
-| `.nullable()`     | Mark field as nullable                           | Smart pointers, primitives |
-| `.ref()`          | Enable reference tracking                        | `std::shared_ptr` only     |
-| `.dynamic(true)`  | Force type info to be written (dynamic dispatch) | Smart pointers             |
-| `.dynamic(false)` | Skip type info (use declared type directly)      | Smart pointers             |
-| `.varint()`       | Use variable-length encoding                     | `uint32_t`, `uint64_t`     |
-| `.fixed()`        | Use fixed-size encoding                          | `uint32_t`, `uint64_t`     |
-| `.tagged()`       | Use tagged hybrid encoding                       | `uint64_t` only            |
-| `.compress(v)`    | Enable/disable field compression                 | All types                  |
+| Method            | Description                                      | Valid For                                            |
+| ----------------- | ------------------------------------------------ | ---------------------------------------------------- |
+| `.nullable()`     | Mark field as nullable                           | Smart pointers, primitives                           |
+| `.ref()`          | Enable reference tracking                        | `std::shared_ptr`, `fory::serialization::SharedWeak` |
+| `.dynamic(true)`  | Force type info to be written (dynamic dispatch) | Smart pointers                                       |
+| `.dynamic(false)` | Skip type info (use declared type directly)      | Smart pointers                                       |
+| `.varint()`       | Use variable-length encoding                     | `uint32_t`, `uint64_t`                               |
+| `.fixed()`        | Use fixed-size encoding                          | `uint32_t`, `uint64_t`                               |
+| `.tagged()`       | Use tagged hybrid encoding                       | `uint64_t` only                                      |
+| `.compress(v)`    | Enable/disable field compression                 | All types                                            |
 
 ## Default Values
 
 - **Nullable**: Only `std::optional<T>` is nullable by default; all other types (including `std::shared_ptr`) are non-nullable
-- **Ref tracking**: Disabled by default for all types (including `std::shared_ptr`)
+- **Ref tracking**: Enabled by default for `std::shared_ptr<T>` and `fory::serialization::SharedWeak<T>`, disabled for other types unless configured
 
 You **need to configure fields** when:
 
@@ -552,12 +553,13 @@ FORY_FIELD_CONFIG(User,
 
 ### Default Values Summary
 
-| Type                 | Default Nullable | Default Ref Tracking |
-| -------------------- | ---------------- | -------------------- |
-| Primitives, `string` | `false`          | `false`              |
-| `std::optional<T>`   | `true`           | `false`              |
-| `std::shared_ptr<T>` | `false`          | `true`               |
-| `std::unique_ptr<T>` | `false`          | `false`              |
+| Type                                 | Default Nullable | Default Ref Tracking |
+| ------------------------------------ | ---------------- | -------------------- |
+| Primitives, `string`                 | `false`          | `false`              |
+| `std::optional<T>`                   | `true`           | `false`              |
+| `std::shared_ptr<T>`                 | `false`          | `true`               |
+| `fory::serialization::SharedWeak<T>` | `false`          | `true`               |
+| `std::unique_ptr<T>`                 | `false`          | `false`              |
 
 ## Related Topics
 

--- a/docs/guide/cpp/supported-types.md
+++ b/docs/guide/cpp/supported-types.md
@@ -140,7 +140,7 @@ auto bytes = fory.serialize(shared).value();
 auto decoded = fory.deserialize<std::shared_ptr<Person>>(bytes).value();
 ```
 
-**With reference tracking enabled (`track_ref(true)`):**
+**With reference tracking enabled (default, `track_ref(true)`):**
 
 - Shared objects are serialized once
 - References to the same object are preserved

--- a/docs/guide/xlang/field-reference-tracking.md
+++ b/docs/guide/xlang/field-reference-tracking.md
@@ -113,13 +113,13 @@ By default, **most fields do not track references** even when global `refTrackin
 
 ### Default Behavior by Language
 
-| Language | Default Ref Tracking | Types That Track Refs by Default  |
-| -------- | -------------------- | --------------------------------- |
-| Java     | No                   | None (use annotation to enable)   |
-| Python   | No                   | None (use annotation to enable)   |
-| Go       | No                   | None (use `fory:"ref"` to enable) |
-| C++      | No                   | `std::shared_ptr<T>`              |
-| Rust     | No                   | `Rc<T>`, `Arc<T>`, `Weak<T>`      |
+| Language | Default Ref Tracking | Types That Track Refs by Default                           |
+| -------- | -------------------- | ---------------------------------------------------------- |
+| Java     | No                   | None (use annotation to enable)                            |
+| Python   | No                   | None (use annotation to enable)                            |
+| Go       | No                   | None (use `fory:"ref"` to enable)                          |
+| C++      | Yes                  | `std::shared_ptr<T>`, `fory::serialization::SharedWeak<T>` |
+| Rust     | No                   | `Rc<T>`, `Arc<T>`, `Weak<T>`                               |
 
 ### Customizing Per-Field Ref Tracking
 
@@ -146,17 +146,18 @@ public class Document {
 struct Document {
     std::string title;
 
-    // shared_ptr tracks refs by default
+    // shared_ptr/SharedWeak track refs by default
     std::shared_ptr<Author> author;
+    fory::serialization::SharedWeak<Data> data;
 
-    // Explicitly enable ref tracking
-    fory::field<std::vector<Tag>, 1, fory::track_ref<true>> tags;
-
-    // Explicitly disable ref tracking
-    fory::field<std::shared_ptr<Data>, 2, fory::track_ref<false>> data;
+    // Explicitly mark ref tracking when using field wrappers (optional)
+    fory::field<std::shared_ptr<Tag>, 1, fory::ref> tag_owner;
 };
-FORY_STRUCT(Document, title, author, tags, data);
+FORY_STRUCT(Document, title, author, data, tag_owner);
 ```
+
+To disable reference tracking for C++ entirely, set
+`Fory::builder().track_ref(false)` on the serializer.
 
 #### Rust: Field Attributes
 


### PR DESCRIPTION

## Why?

Make C++ shared ownership fields track references by default and extend ref tracking semantics to SharedWeak to match intended ownership behavior and reduce required annotations.

## What does this PR do?

- Make `std::shared_ptr<T>` (and `fory::serialization::SharedWeak<T>`) track refs by default in field metadata and serializers.
- Extend smart-pointer detection and option validation to include `SharedWeak<T>` alongside `shared_ptr`/`unique_ptr`.
- Update compile-time helpers, resolver logic, and tests to reflect the new default tracking behavior.
- Refresh C++ and xlang docs to document defaults and valid options for `SharedWeak`.

## Related issues

#2906 

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


