### PR TITLE
feat(python): add buffer index accessors

### DIFF
--- a/python/pyfory/buffer.pxd
+++ b/python/pyfory/buffer.pxd
@@ -52,6 +52,14 @@ cdef class Buffer:
 
     cpdef inline reserve(self, int32_t new_size)
 
+    cpdef inline int32_t get_reader_index(self)
+
+    cpdef inline void set_reader_index(self, int32_t value)
+
+    cpdef inline int32_t get_writer_index(self)
+
+    cpdef inline void set_writer_index(self, int32_t value)
+
     cpdef inline int32_t size(self)
 
     cpdef inline grow(self, int32_t needed_size)

--- a/python/pyfory/buffer.pyx
+++ b/python/pyfory/buffer.pyx
@@ -102,23 +102,21 @@ cdef class Buffer:
             self._error.reset()
             raise_fory_error(code, message)
 
-    property reader_index:
-        def __get__(self):
-            return self.c_buffer.reader_index()
+    cpdef inline int32_t get_reader_index(self):
+        return <int32_t>self.c_buffer.reader_index()
 
-        def __set__(self, int32_t value):
-            if value < 0:
-                raise ValueError("reader_index must be >= 0")
-            self.c_buffer.ReaderIndex(<uint32_t>value)
+    cpdef inline void set_reader_index(self, int32_t value):
+        if value < 0:
+            raise ValueError("reader_index must be >= 0")
+        self.c_buffer.ReaderIndex(<uint32_t>value)
 
-    property writer_index:
-        def __get__(self):
-            return self.c_buffer.writer_index()
+    cpdef inline int32_t get_writer_index(self):
+        return <int32_t>self.c_buffer.writer_index()
 
-        def __set__(self, int32_t value):
-            if value < 0:
-                raise ValueError("writer_index must be >= 0")
-            self.c_buffer.WriterIndex(<uint32_t>value)
+    cpdef inline void set_writer_index(self, int32_t value):
+        if value < 0:
+            raise ValueError("writer_index must be >= 0")
+        self.c_buffer.WriterIndex(<uint32_t>value)
 
     cpdef c_bool own_data(self):
         return self.c_buffer.own_data()
@@ -625,7 +623,7 @@ cdef class Buffer:
 
     def __repr__(self):
         return "Buffer(reader_index={}, writer_index={}, size={})".format(
-            self.reader_index, self.writer_index, self.size()
+            self.get_reader_index(), self.get_writer_index(), self.size()
         )
 
 

--- a/python/pyfory/collection.pxi
+++ b/python/pyfory/collection.pxi
@@ -199,12 +199,14 @@ cdef class CollectionSerializer(Serializer):
             self._add_element(collection_, i, buffer.read_varint64())
 
     cdef inline _write_bool(self, Buffer buffer, value):
+        cdef int32_t writer_index
         value_type = type(value)
         if value_type is list or value_type is tuple:
             size = sizeof(bool) * Py_SIZE(value)
             buffer.grow(<int32_t>size)
-            Fory_PyBooleanSequenceWriteToBuffer(value, &buffer.c_buffer, buffer.writer_index)
-            buffer.writer_index += size
+            writer_index = buffer.get_writer_index()
+            Fory_PyBooleanSequenceWriteToBuffer(value, &buffer.c_buffer, writer_index)
+            buffer.set_writer_index(writer_index + size)
         else:
             for s in value:
                 buffer.write_bool(s)
@@ -214,12 +216,14 @@ cdef class CollectionSerializer(Serializer):
             self._add_element(collection_, i, buffer.read_bool())
 
     cdef inline _write_float(self, Buffer buffer, value):
+        cdef int32_t writer_index
         value_type = type(value)
         if value_type is list or value_type is tuple:
             size = sizeof(double) * Py_SIZE(value)
             buffer.grow(<int32_t>size)
-            Fory_PyFloatSequenceWriteToBuffer(value, &buffer.c_buffer, buffer.writer_index)
-            buffer.writer_index += size
+            writer_index = buffer.get_writer_index()
+            Fory_PyFloatSequenceWriteToBuffer(value, &buffer.c_buffer, writer_index)
+            buffer.set_writer_index(writer_index + size)
         else:
             for s in value:
                 buffer.write_double(s)
@@ -795,7 +799,7 @@ cdef class MapSerializer(Serializer):
             key_cls = type(key)
             value_cls = type(value)
             buffer.write_int16(-1)
-            chunk_size_offset = buffer.writer_index - 1
+            chunk_size_offset = buffer.get_writer_index() - 1
             chunk_header = 0
             if key_serializer is not None:
                 chunk_header |= KEY_DECL_TYPE

--- a/python/pyfory/collection.py
+++ b/python/pyfory/collection.py
@@ -450,7 +450,7 @@ class MapSerializer(Serializer):
             key_cls = type(key)
             value_cls = type(value)
             buffer.write_int16(-1)
-            chunk_size_offset = buffer.writer_index - 1
+            chunk_size_offset = buffer.get_writer_index() - 1
             chunk_header = 0
 
             if key_serializer is not None:

--- a/python/pyfory/format/encoder.py
+++ b/python/pyfory/format/encoder.py
@@ -34,7 +34,7 @@ class Encoder:
         buffer.write_int64(self.schema_hash)
         row_bytes = row.to_bytes()
         buffer.write_bytes(row_bytes)
-        return buffer.to_bytes(0, buffer.writer_index)
+        return buffer.to_bytes(0, buffer.get_writer_index())
 
     def decode(self, binary: bytes):
         buf = pyfory.Buffer(binary, 0, len(binary))

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -98,7 +98,7 @@ def encode_typedef(type_resolver, cls):
     write_fields_info(type_resolver, buffer, field_infos)
 
     # Get the encoded binary (only the written portion, not the full buffer)
-    binary = buffer.to_bytes(0, buffer.writer_index)
+    binary = buffer.to_bytes(0, buffer.get_writer_index())
 
     # Compress if beneficial
     compressed_binary = type_resolver.get_meta_compressor().compress(binary)
@@ -139,7 +139,7 @@ def prepend_header(buffer: bytes, is_compressed: bool, has_fields_meta: bool):
         result.write_varuint32(meta_size - META_SIZE_MASKS)
 
     result.write_bytes(buffer)
-    return result.to_bytes(0, result.writer_index)
+    return result.to_bytes(0, result.get_writer_index())
 
 
 def write_namespace(buffer: Buffer, namespace: str):

--- a/python/pyfory/struct.py
+++ b/python/pyfory/struct.py
@@ -1073,7 +1073,7 @@ class DataClassSerializer(Serializer):
                 if ref_id == -3:
                     field_value = None
                 else:
-                    buffer.reader_index -= 1
+                    buffer.set_reader_index(buffer.get_reader_index() - 1)
                     # dynamic=True: don't pass serializer, read type info from buffer
                     # dynamic=False: pass serializer, use declared type
                     field_value = self.fory.xread_ref(buffer, serializer=None if is_dynamic else serializer)

--- a/python/pyfory/tests/test_buffer.py
+++ b/python/pyfory/tests/test_buffer.py
@@ -43,8 +43,8 @@ def test_buffer():
     binary = b"b" * 100
     buffer.write_bytes(binary)
     buffer.write_bytes_and_size(binary)
-    print(f"buffer size {buffer.size()}, writer_index {buffer.writer_index}")
-    new_buffer = Buffer(buffer.get_bytes(0, buffer.writer_index))
+    print(f"buffer size {buffer.size()}, writer_index {buffer.get_writer_index()}")
+    new_buffer = Buffer(buffer.get_bytes(0, buffer.get_writer_index()))
     assert new_buffer.read_bool() is True
     assert new_buffer.read_int8() == -1
     assert new_buffer.read_int8() == 2**7 - 1
@@ -120,19 +120,19 @@ def test_write_varint32():
 
 
 def check_varuint32(buf: Buffer, value: int, bytes_written: int):
-    assert buf.writer_index == buf.reader_index
+    assert buf.get_writer_index() == buf.get_reader_index()
     actual_bytes_written = buf.write_varuint32(value)
     assert actual_bytes_written == bytes_written
     varint = buf.read_varuint32()
-    assert buf.writer_index == buf.reader_index
+    assert buf.get_writer_index() == buf.get_reader_index()
     assert value == varint
 
 
 def check_varint32(buf: Buffer, value: int):
-    assert buf.writer_index == buf.reader_index
+    assert buf.get_writer_index() == buf.get_reader_index()
     buf.write_varint32(value)
     varint = buf.read_varint32()
-    assert buf.writer_index == buf.reader_index
+    assert buf.get_writer_index() == buf.get_reader_index()
     assert value == varint
 
 
@@ -210,15 +210,15 @@ def test_write_varuint64():
 
 
 def check_varuint64(buf: Buffer, value: int, bytes_written: int):
-    reader_index = buf.reader_index
-    assert buf.writer_index == buf.reader_index
+    reader_index = buf.get_reader_index()
+    assert buf.get_writer_index() == buf.get_reader_index()
     actual_bytes_written = buf.write_varuint64(value)
     assert actual_bytes_written == bytes_written
     varint = buf.read_varuint64()
-    assert buf.writer_index == buf.reader_index
+    assert buf.get_writer_index() == buf.get_reader_index()
     assert value == varint
     # test slow read branch in `read_varint64`
-    assert buf.slice(reader_index, buf.reader_index - reader_index).read_varuint64() == value
+    assert buf.slice(reader_index, buf.get_reader_index() - reader_index).read_varuint64() == value
 
 
 def test_write_buffer():
@@ -226,7 +226,7 @@ def test_write_buffer():
     buf.write(b"")
     buf.write(b"123")
     buf.write(Buffer.allocate(32))
-    assert buf.writer_index == 35
+    assert buf.get_writer_index() == 35
     assert buf.read(0) == b""
     assert buf.read(3) == b"123"
 

--- a/python/pyfory/tests/test_cross_language.py
+++ b/python/pyfory/tests/test_cross_language.py
@@ -284,7 +284,7 @@ def test_buffer(data_file_path):
         buffer.write_int32(len(binary))
         buffer.write_bytes(binary)
     with open(data_file_path, "wb+") as f:
-        f.write(buffer.get_bytes(0, buffer.writer_index))
+        f.write(buffer.get_bytes(0, buffer.get_writer_index()))
 
 
 @cross_language_test
@@ -360,7 +360,7 @@ def test_cross_language_serializer(data_file_path):
         for obj in objects:
             fory.serialize(obj, buffer=new_buf)
     with open(data_file_path, "wb+") as f:
-        f.write(new_buf.get_bytes(0, new_buf.writer_index))
+        f.write(new_buf.get_bytes(0, new_buf.get_writer_index()))
 
 
 @cross_language_test
@@ -391,7 +391,7 @@ def test_cross_language_reference(data_file_path):
         new_buf = pyfory.Buffer.allocate(32)
         fory.serialize(new_list, buffer=new_buf)
     with open(data_file_path, "wb+") as f:
-        f.write(new_buf.get_bytes(0, new_buf.writer_index))
+        f.write(new_buf.get_bytes(0, new_buf.get_writer_index()))
 
 
 @dataclass
@@ -661,7 +661,7 @@ def test_register_serializer(data_file_path):
     assert fory.deserialize(fory.serialize(new_obj)) == new_obj, new_obj
     print(f"test_register_serializer: {new_obj}")
     with open(data_file_path, "wb+") as f:
-        f.write(new_buf.get_bytes(0, new_buf.writer_index))
+        f.write(new_buf.get_bytes(0, new_buf.get_writer_index()))
 
 
 @cross_language_test
@@ -675,9 +675,9 @@ def test_oob_buffer(in_band_file_path, out_of_band_file_path):
     buffers = []
     for i in range(n_buffers):
         length = out_of_band_buffer.read_int32()
-        reader_index = out_of_band_buffer.reader_index
+        reader_index = out_of_band_buffer.get_reader_index()
         buffers.append(out_of_band_buffer.slice(reader_index, length))
-        out_of_band_buffer.reader_index += length
+        out_of_band_buffer.set_reader_index(out_of_band_buffer.get_reader_index() + length)
     new_obj = fory.deserialize(in_band_bytes, buffers)
     obj = [bytes(bytearray([0, 1])) for _ in range(10)]
     assert new_obj == obj, (obj, new_obj)
@@ -707,7 +707,7 @@ def test_oob_buffer(in_band_file_path, out_of_band_file_path):
         out_of_band_buffer.write_int32(buffer_object.total_bytes())
         buffer_object.write_to(out_of_band_buffer)
     with open(out_of_band_file_path, "wb+") as f:
-        f.write(out_of_band_buffer.to_bytes(0, out_of_band_buffer.writer_index))
+        f.write(out_of_band_buffer.to_bytes(0, out_of_band_buffer.get_writer_index()))
 
 
 @cross_language_test

--- a/python/pyfory/tests/test_serializer.py
+++ b/python/pyfory/tests/test_serializer.py
@@ -212,12 +212,12 @@ def test_tmp_ref(language):
     #  address of released tmp object.
     fory = Fory(language=language, ref=True)
     buffer = Buffer.allocate(128)
-    writer_index = buffer.writer_index
+    writer_index = buffer.get_writer_index()
     x = 1
     fory.serialize([x], buffer)
     fory.serialize([x], buffer)
     fory.serialize([x], buffer)
-    assert buffer.writer_index > writer_index + 15
+    assert buffer.get_writer_index() > writer_index + 15
 
     l1 = fory.deserialize(buffer)
     l2 = fory.deserialize(buffer)
@@ -320,15 +320,15 @@ def test_pickle():
     pickler.dump(b"abc")
     buf.write_int32(-1)
     pickler.dump("abcd")
-    assert buf.writer_index - 4 == len(pickle.dumps(b"abc")) + len(pickle.dumps("abcd"))
-    print(f"writer_index {buf.writer_index}")
+    assert buf.get_writer_index() - 4 == len(pickle.dumps(b"abc")) + len(pickle.dumps("abcd"))
+    print(f"writer_index {buf.get_writer_index()}")
 
     bytes_io_ = io.BytesIO(buf)
     unpickler = pickle.Unpickler(bytes_io_)
     assert unpickler.load() == b"abc"
     bytes_io_.seek(bytes_io_.tell() + 4)
     assert unpickler.load() == "abcd"
-    print(f"reader_index {buf.reader_index} {bytes_io_.tell()}")
+    print(f"reader_index {buf.get_reader_index()} {bytes_io_.tell()}")
 
     if pa:
         pa_buf = pa.BufferReader(buf)
@@ -336,13 +336,13 @@ def test_pickle():
         assert unpickler.load() == b"abc"
         pa_buf.seek(pa_buf.tell() + 4)
         assert unpickler.load() == "abcd"
-        print(f"reader_index {buf.reader_index} {pa_buf.tell()} {buf.reader_index}")
+        print(f"reader_index {buf.get_reader_index()} {pa_buf.tell()} {buf.get_reader_index()}")
 
     unpickler = pickle.Unpickler(buf)
     assert unpickler.load() == b"abc"
-    buf.reader_index = buf.reader_index + 4
+    buf.set_reader_index(buf.get_reader_index() + 4)
     assert unpickler.load() == "abcd"
-    print(f"reader_index {buf.reader_index}")
+    print(f"reader_index {buf.get_reader_index()}")
 
 
 @dataclass

--- a/python/pyfory/tests/xlang_test_main.py
+++ b/python/pyfory/tests/xlang_test_main.py
@@ -342,7 +342,7 @@ def test_string_serializer():
         fory.serialize(s, buffer=new_buffer)
 
     with open(data_file, "wb") as f:
-        f.write(new_buffer.get_bytes(0, new_buffer.writer_index))
+        f.write(new_buffer.get_bytes(0, new_buffer.get_writer_index()))
 
 
 def test_simple_struct():
@@ -498,7 +498,7 @@ def test_consistent_named():
         fory.serialize(my_ext, buffer=new_buffer)
 
     with open(data_file, "wb") as f:
-        f.write(new_buffer.get_bytes(0, new_buffer.writer_index))
+        f.write(new_buffer.get_bytes(0, new_buffer.get_writer_index()))
 
 
 def test_struct_version_check():
@@ -565,7 +565,7 @@ def test_polymorphic_list():
     fory.serialize(holder, buffer=new_buffer)
 
     with open(data_file, "wb") as f:
-        f.write(new_buffer.get_bytes(0, new_buffer.writer_index))
+        f.write(new_buffer.get_bytes(0, new_buffer.get_writer_index()))
 
 
 def test_polymorphic_map():
@@ -612,7 +612,7 @@ def test_polymorphic_map():
     fory.serialize(holder, buffer=new_buffer)
 
     with open(data_file, "wb") as f:
-        f.write(new_buffer.get_bytes(0, new_buffer.writer_index))
+        f.write(new_buffer.get_bytes(0, new_buffer.get_writer_index()))
 
 
 def test_one_string_field_schema():


### PR DESCRIPTION
## Why?

Buffer index access is currently exposed as Python properties. This change standardizes access through explicit getters/setters to make call sites uniform across Cython and Python and avoid property usage.

## What does this PR do?

- Add `get_reader_index`/`set_reader_index` and `get_writer_index`/`set_writer_index` on `Buffer`.
- Replace `reader_index`/`writer_index` property usage across Python and Cython code paths.
- Update Python tests and helpers to use the new accessors.

## Related issues

None.

## Does this PR introduce any user-facing change?

Yes. Python `Buffer` index access now uses explicit get/set methods instead of properties.

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

Not run (not requested).
