### PR TITLE
fix(c++): issue 3229 - compile error on gcc16

### DIFF
--- a/cpp/fory/util/error.h
+++ b/cpp/fory/util/error.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <string>


### PR DESCRIPTION


## Why?

compile error on gcc16

## What does this PR do?

Add `#include <cstdint>` to cpp/fory/util/error.h to fix compilation 
error where uint32_t was undeclared in Error::type_mismatch() method.

## Related issues

- Fixes #3229 


## Does this PR introduce any user-facing change?
No

- [ ] Does this PR introduce any public API change?
No
- [ ] Does this PR introduce any binary protocol compatibility change?
No

## Benchmark

No need