### PR TITLE
refactor(compiler): refactor fory compiler command line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,8 +413,8 @@ Fory uses binary protocols for efficient serialization and deserialization. Fory
 - **Location**: `compiler/` contains the Fory compiler, parser, IR, and code generators.
 - **Install & CLI**:
   - `cd compiler && pip install -e .`
-  - `fory compile --help`
-  - `fory compile schema.fdl --lang <langs> --output <dir>`
+  - `foryc --help`
+  - `foryc schema.fdl --lang <langs> --output <dir>`
 - **Generated code**: Never edit generated files manually; update the `.fdl`/`.proto`/`.fbs` and re-run the compiler.
 - **IDL tests**: Use `integration_tests/idl_tests/generate_idl.py` for test codegen.
   - In `integration_tests/idl_tests`, keep package names aligned with the IDL filename.

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -61,19 +61,19 @@ message Cat [id=103] {
 
 ```bash
 # Generate for all languages
-fory compile schema.fdl --output ./generated
+foryc schema.fdl --output ./generated
 
 # Generate for specific languages
-fory compile schema.fdl --lang java,python --output ./generated
+foryc schema.fdl --lang java,python --output ./generated
 
 # Override package name
-fory compile schema.fdl --package myapp.models --output ./generated
+foryc schema.fdl --package myapp.models --output ./generated
 
 # Language-specific output directories (protoc-style)
-fory compile schema.fdl --java_out=./src/main/java --python_out=./python/src
+foryc schema.fdl --java_out=./src/main/java --python_out=./python/src
 
 # Combine with other options
-fory compile schema.fdl --java_out=./gen --go_out=./gen/go -I ./proto
+foryc schema.fdl --java_out=./gen --go_out=./gen/go -I ./proto
 ```
 
 ### 3. Use Generated Code
@@ -394,7 +394,7 @@ struct Cat {
 ## CLI Reference
 
 ```
-fory compile [OPTIONS] FILES...
+foryc [OPTIONS] FILES...
 
 Arguments:
   FILES                 FDL files to compile
@@ -414,7 +414,7 @@ See the `examples/` directory for sample FDL files and generated output.
 
 ```bash
 # Compile the demo schema
-fory compile examples/demo.fdl --output examples/generated
+foryc examples/demo.fdl --output examples/generated
 ```
 
 ## Development
@@ -427,7 +427,7 @@ pip install -e .
 python -m fory_compiler compile examples/demo.fdl
 
 # Or use the installed command
-fory compile examples/demo.fdl
+foryc examples/demo.fdl
 ```
 
 ## License

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 keywords = ["fory", "serialization", "codegen", "idl", "compiler"]
 
 [project.scripts]
-fory = "fory_compiler.cli:main"
+foryc = "fory_compiler.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/apache/fory"

--- a/docs/compiler/compiler-guide.md
+++ b/docs/compiler/compiler-guide.md
@@ -33,7 +33,7 @@ pip install -e .
 ### Verify Installation
 
 ```bash
-fory compile --help
+foryc --help
 ```
 
 ## Command Line Interface
@@ -41,11 +41,11 @@ fory compile --help
 ### Basic Usage
 
 ```bash
-fory compile [OPTIONS] FILES...
+foryc [OPTIONS] FILES...
 ```
 
 ```bash
-fory scan-generated [OPTIONS]
+foryc --scan-generated [OPTIONS]
 ```
 
 ### Options
@@ -65,25 +65,25 @@ fory scan-generated [OPTIONS]
 
 ### Scan Generated Files
 
-Use `scan-generated` to find files produced by the Fory compiler. The scanner walks
+Use `--scan-generated` to find files produced by the Fory compiler. The scanner walks
 the tree recursively, skips `build/`, `target/`, and hidden directories, and prints
 each generated file as it is found.
 
 ```bash
 # Scan current directory
-fory scan-generated
+foryc --scan-generated
 
 # Scan a specific root
-fory scan-generated --root ./src
+foryc --scan-generated --root ./src
 
 # Print paths relative to the scan root
-fory scan-generated --root ./src --relative
+foryc --scan-generated --root ./src --relative
 
 # Delete scanned generated files
-fory scan-generated --root ./src --delete
+foryc --scan-generated --root ./src --delete
 
 # Dry-run (scan and print only)
-fory scan-generated --root ./src --dry-run
+foryc --scan-generated --root ./src --dry-run
 ```
 
 ### Examples
@@ -91,63 +91,63 @@ fory scan-generated --root ./src --dry-run
 **Compile for all languages:**
 
 ```bash
-fory compile schema.fdl
+foryc schema.fdl
 ```
 
 **Compile for specific languages:**
 
 ```bash
-fory compile schema.fdl --lang java,python
+foryc schema.fdl --lang java,python
 ```
 
 **Specify output directory:**
 
 ```bash
-fory compile schema.fdl --output ./src/generated
+foryc schema.fdl --output ./src/generated
 ```
 
 **Override package name:**
 
 ```bash
-fory compile schema.fdl --package com.myapp.models
+foryc schema.fdl --package com.myapp.models
 ```
 
 **Compile multiple files:**
 
 ```bash
-fory compile user.fdl order.fdl product.fdl --output ./generated
+foryc user.fdl order.fdl product.fdl --output ./generated
 ```
 
 **Use import search paths:**
 
 ```bash
 # Add a single import path
-fory compile src/main.fdl -I libs/common
+foryc src/main.fdl -I libs/common
 
 # Add multiple import paths (repeated option)
-fory compile src/main.fdl -I libs/common -I libs/types
+foryc src/main.fdl -I libs/common -I libs/types
 
 # Add multiple import paths (comma-separated)
-fory compile src/main.fdl -I libs/common,libs/types,third_party/
+foryc src/main.fdl -I libs/common,libs/types,third_party/
 
 # Using --proto_path (protoc-compatible alias)
-fory compile src/main.fdl --proto_path=libs/common
+foryc src/main.fdl --proto_path=libs/common
 
 # Mix all styles
-fory compile src/main.fdl -I libs/common,libs/types --proto_path third_party/
+foryc src/main.fdl -I libs/common,libs/types --proto_path third_party/
 ```
 
 **Language-specific output directories (protoc-style):**
 
 ```bash
 # Generate only Java code to a specific directory
-fory compile schema.fdl --java_out=./src/main/java
+foryc schema.fdl --java_out=./src/main/java
 
 # Generate multiple languages to different directories
-fory compile schema.fdl --java_out=./java/gen --python_out=./python/src --go_out=./go/gen
+foryc schema.fdl --java_out=./java/gen --python_out=./python/src --go_out=./go/gen
 
 # Combine with import paths
-fory compile schema.fdl --java_out=./gen/java -I proto/ -I common/
+foryc schema.fdl --java_out=./gen/java -I proto/ -I common/
 ```
 
 When using `--{lang}_out` options:
@@ -172,7 +172,7 @@ import "common.fdl";  // Found if common.fdl is in the same directory
 
 ```bash
 # No -I needed for same-directory imports
-fory compile main.fdl
+foryc main.fdl
 ```
 
 **Example project structure:**
@@ -188,7 +188,7 @@ project/
 **Without `-I` (fails):**
 
 ```bash
-$ fory compile src/main.fdl
+$ foryc src/main.fdl
 Import error: Import not found: common.fdl
   Searched in: /project/src
 ```
@@ -196,7 +196,7 @@ Import error: Import not found: common.fdl
 **With `-I` (succeeds):**
 
 ```bash
-$ fory compile src/main.fdl -I libs/
+$ foryc src/main.fdl -I libs/
 Compiling src/main.fdl...
   Resolved 1 import(s)
 ```
@@ -397,7 +397,7 @@ setup(
 Add to your Go file:
 
 ```go
-//go:generate fory compile ../schema.fdl --lang go --output .
+//go:generate foryc ../schema.fdl --lang go --output .
 package models
 ```
 
@@ -553,7 +553,7 @@ steps:
     run: pip install ./compiler
 
   - name: Generate Types
-    run: fory compile fdl/*.fdl --output src/generated
+    run: foryc fdl/*.fdl --output src/generated
 
   - name: Build
     run: ./gradlew build

--- a/docs/compiler/flatbuffers-idl.md
+++ b/docs/compiler/flatbuffers-idl.md
@@ -118,13 +118,13 @@ convention).
 Compile a FlatBuffers schema directly:
 
 ```bash
-fory compile schema.fbs --lang java,python --output ./generated
+foryc schema.fbs --lang java,python --output ./generated
 ```
 
 To inspect the translated FDL for debugging:
 
 ```bash
-fory compile schema.fbs --emit-fdl --emit-fdl-path ./translated
+foryc schema.fbs --emit-fdl --emit-fdl-path ./translated
 ```
 
 ## Generated Code Differences

--- a/docs/compiler/index.md
+++ b/docs/compiler/index.md
@@ -106,10 +106,10 @@ message Person [id=100] {
 
 ```bash
 # Generate for all languages
-fory compile example.fdl --output ./generated
+foryc example.fdl --output ./generated
 
 # Generate for specific languages
-fory compile example.fdl --lang java,python --output ./generated
+foryc example.fdl --lang java,python --output ./generated
 ```
 
 ### 4. Use Generated Code


### PR DESCRIPTION


## Why?



## What does this PR do?

refactor fory compiler command line: rename `fory compile` to `foryc`
## Related issues

#3099

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

