### PR TITLE
fix(go): prevent panic in readUTF16LE with odd byte counts

### DIFF
--- a/go/fory/doc.go
+++ b/go/fory/doc.go
@@ -305,6 +305,7 @@ Common error kinds:
   - ErrKindUnknownType: Unknown type encountered
   - ErrKindMaxDepthExceeded: Recursion depth limit exceeded
   - ErrKindHashMismatch: Struct hash mismatch (schema changed)
+  - ErrKindInvalidUTF16String: Malformed UTF-16 string payload
 
 # Best Practices
 

--- a/go/fory/errors.go
+++ b/go/fory/errors.go
@@ -50,6 +50,8 @@ const (
 	ErrKindHashMismatch
 	// ErrKindInvalidTag indicates invalid fory struct tag configuration
 	ErrKindInvalidTag
+	// ErrKindInvalidUTF16String indicates malformed UTF-16 string data
+	ErrKindInvalidUTF16String
 )
 
 // Error is a lightweight error type optimized for hot path performance.
@@ -254,6 +256,14 @@ func InvalidTagErrorf(format string, args ...any) Error {
 	return panicIfEnabled(Error{
 		kind:    ErrKindInvalidTag,
 		message: fmt.Sprintf(format, args...),
+	})
+}
+
+// InvalidUTF16StringError creates an invalid UTF-16 string error
+func InvalidUTF16StringError(byteCount int) Error {
+	return panicIfEnabled(Error{
+		kind:    ErrKindInvalidUTF16String,
+		message: fmt.Sprintf("invalid UTF-16 string byte count %d: must be even", byteCount),
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in `readUTF16LE` when the byte count is odd (malformed UTF-16 data).

## Problem

When `readUTF16LE` receives an odd byte count, the function panics with:
```
panic: runtime error: index out of range [N] with length N
```

This occurs because the loop iterates up to `byteCount` but tries to access `data[i+1]` on the last iteration when `i = byteCount - 1` (for odd `byteCount`).

### Steps to Reproduce

```go
func TestReadUTF16LE_OddByteCount(t *testing.T) {
    // Data: 5 bytes where only first 4 form valid UTF-16
    data := []byte{0x48, 0x00, 0x69, 0x00, 0xFF}
    buf := NewByteBuffer(data)
    err := &Error{}

    // This panics without the fix
    result := readUTF16LE(buf, 5, err)
}
```

### Root Cause

In `go/fory/string.go`, line 89-90:
```go
for i := 0; i < byteCount; i += 2 {
    u16s[i/2] = uint16(data[i]) | uint16(data[i+1])<<8  // Panics when i+1 >= len(data)
}
```

## Solution

set error when we get odd utf16 bytes

## Tests Added

- `TestReadUTF16LE_OddByteCount`: Verifies no panic with odd byte count
- `TestReadUTF16LE_SingleByte`: Verifies empty string for single byte input
- `TestReadUTF16LE_EvenByteCount`: Verifies normal case still works
- `TestReadUTF16LE_EmptyBuffer`: Verifies empty input handling
- `TestReadUTF16LE_SurrogatePair`: Verifies emoji/surrogate pair decoding

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/apache/fory/blob/main/CONTRIBUTING.md)
- [x] All tests pass (`go test -v ./...` in `go/fory`)
- [x] License headers are correct (hawkeye check passed)
- [x] PR title follows conventional commits format