### PR TITLE
feat(go): improve test coverage for int slice primitive serializers

### DIFF
--- a/go/fory/slice_primitive_test.go
+++ b/go/fory/slice_primitive_test.go
@@ -19,7 +19,6 @@ package fory
 
 import (
 	"math"
-	"strconv"
 	"testing"
 
 	"github.com/apache/fory/go/fory/float16"
@@ -72,10 +71,7 @@ func TestIntSlice(t *testing.T) {
 	f := NewFory()
 
 	t.Run("int_slice_large_numbers", func(t *testing.T) {
-		slice := []int{1, -2, 3, -4, 2147483647, -2147483648} // Example with large int32 values
-		if strconv.IntSize == 64 {
-			slice = []int{1, -2, 3, -4, math.MaxInt64, math.MinInt64} // For int64
-		}
+		slice := []int{1, -2, 3, -4, math.MaxInt, math.MinInt}
 		data, err := f.Serialize(slice)
 		assert.NoError(t, err)
 
@@ -113,10 +109,7 @@ func TestUintSlice(t *testing.T) {
 	f := NewFory()
 
 	t.Run("uint_slice_large_numbers", func(t *testing.T) {
-		slice := []uint{1, 2, 3, 4, 4294967295} // Example with large uint32 values
-		if strconv.IntSize == 64 {
-			slice = []uint{1, 2, 3, 4, math.MaxUint64} // For uint64
-		}
+		slice := []uint{1, 2, 3, 4, math.MaxUint}
 		data, err := f.Serialize(slice)
 		assert.NoError(t, err)
 

--- a/go/fory/slice_primitive_test.go
+++ b/go/fory/slice_primitive_test.go
@@ -18,6 +18,8 @@
 package fory
 
 import (
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/apache/fory/go/fory/float16"
@@ -60,6 +62,354 @@ func TestFloat16Slice(t *testing.T) {
 		assert.NoError(t, err)
 
 		var result []float16.Float16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestIntSlice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("int_slice_large_numbers", func(t *testing.T) {
+		slice := []int{1, -2, 3, -4, 2147483647, -2147483648} // Example with large int32 values
+		if strconv.IntSize == 64 {
+			slice = []int{1, -2, 3, -4, math.MaxInt64, math.MinInt64} // For int64
+		}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("int_slice_empty", func(t *testing.T) {
+		slice := []int{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("int_slice_nil", func(t *testing.T) {
+		var slice []int = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestUintSlice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("uint_slice_large_numbers", func(t *testing.T) {
+		slice := []uint{1, 2, 3, 4, 4294967295} // Example with large uint32 values
+		if strconv.IntSize == 64 {
+			slice = []uint{1, 2, 3, 4, math.MaxUint64} // For uint64
+		}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("uint_slice_empty", func(t *testing.T) {
+		slice := []uint{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("uint_slice_nil", func(t *testing.T) {
+		var slice []uint = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestInt8Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("int8_slice_large_numbers", func(t *testing.T) {
+		slice := []int8{1, -2, 3, -4, math.MaxInt8, math.MinInt8}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int8
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("int8_slice_empty", func(t *testing.T) {
+		slice := []int8{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int8
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("int8_slice_nil", func(t *testing.T) {
+		var slice []int8 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int8
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestInt16Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("int16_slice_large_numbers", func(t *testing.T) {
+		slice := []int16{1, -2, 3, -4, math.MaxInt16, math.MinInt16}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("int16_slice_empty", func(t *testing.T) {
+		slice := []int16{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("int16_slice_nil", func(t *testing.T) {
+		var slice []int16 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestInt32Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("int32_slice_large_numbers", func(t *testing.T) {
+		slice := []int32{1, -2, 3, -4, math.MaxInt32, math.MinInt32}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("int32_slice_empty", func(t *testing.T) {
+		slice := []int32{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("int32_slice_nil", func(t *testing.T) {
+		var slice []int32 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestInt64Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("int64_slice_large_numbers", func(t *testing.T) {
+		slice := []int64{1, -2, 3, -4, math.MaxInt64, math.MinInt64}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int64
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("int64_slice_empty", func(t *testing.T) {
+		slice := []int64{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int64
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("int64_slice_nil", func(t *testing.T) {
+		var slice []int64 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []int64
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestUint16Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("uint16_slice_large_numbers", func(t *testing.T) {
+		slice := []uint16{1, 2, 3, 4, math.MaxUint16}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("uint16_slice_empty", func(t *testing.T) {
+		slice := []uint16{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("uint16_slice_nil", func(t *testing.T) {
+		var slice []uint16 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint16
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestUint32Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("uint32_slice_large_numbers", func(t *testing.T) {
+		slice := []uint32{1, 2, 3, 4, math.MaxUint32}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("uint32_slice_empty", func(t *testing.T) {
+		slice := []uint32{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("uint32_slice_nil", func(t *testing.T) {
+		var slice []uint32 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint32
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestUint64Slice(t *testing.T) {
+	f := NewFory()
+
+	t.Run("uint64_slice_large_numbers", func(t *testing.T) {
+		slice := []uint64{1, 2, 3, 4, math.MaxUint64}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint64
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("uint64_slice_empty", func(t *testing.T) {
+		slice := []uint64{}
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint64
+		err = f.Deserialize(data, &result)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("uint64_slice_nil", func(t *testing.T) {
+		var slice []uint64 = nil
+		data, err := f.Serialize(slice)
+		assert.NoError(t, err)
+
+		var result []uint64
 		err = f.Deserialize(data, &result)
 		assert.NoError(t, err)
 		assert.Nil(t, result)


### PR DESCRIPTION


## Why?

Improve test coverage and robustness for Go int slice primitive serializers.

## What does this PR do?

Added new test cases for `int`, `uint`, `int8`, `int16`, `int32`, `int64`, `uint16`, `uint32`, `uint64` slice serializers in `go/fory/slice_primitive_test.go`. Tests include large number serialization/deserialization scenarios.

## Related issues



@chaokunyang in https://github.com/apache/fory/pull/3311#discussion_r2780480615

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?