### PR TITLE
fix(java): Fix EnumSetSerializer for enums with overriding methods

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
@@ -658,6 +658,9 @@ public class CollectionSerializers {
       } else {
         elemClass = object.iterator().next().getClass();
       }
+      if (!elemClass.isEnum()) {
+        elemClass = elemClass.getEnclosingClass();
+      }
       fory.getClassResolver().writeClassAndUpdateCache(buffer, elemClass);
       Serializer serializer = fory.getClassResolver().getSerializer(elemClass);
       buffer.writeVarUint32Small7(object.size());

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
@@ -343,6 +343,35 @@ public class CollectionSerializersTest extends ForyTestBase {
     copyCheck(fory, EnumSet.of(TestEnum.A, TestEnum.B));
   }
 
+  enum TestEnumWithMethods {
+    A {
+      @Override
+      public void foo() {
+        System.out.println("A");
+      }
+    },
+    B,
+    C {
+      @Override
+      public void foo() {}
+    },
+    D;
+
+    public void foo() {
+      System.out.println("default");
+    }
+  }
+
+  @Test
+  public void tesEnumSetSerializerWithMethods() {
+    serDe(getJavaFory(), EnumSet.noneOf(TestEnumWithMethods.class));
+    serDe(getJavaFory(), EnumSet.of(TestEnumWithMethods.A));
+    serDe(getJavaFory(), EnumSet.of(TestEnumWithMethods.B));
+    serDe(getJavaFory(), EnumSet.of(TestEnumWithMethods.A, TestEnumWithMethods.B));
+    serDe(getJavaFory(), EnumSet.of(TestEnumWithMethods.A, TestEnumWithMethods.C));
+    serDe(getJavaFory(), EnumSet.allOf(TestEnumWithMethods.class));
+  }
+
   @Test
   public void tesBitSetSerializer() {
     serDe(getJavaFory(), BitSet.valueOf(LongStream.range(0, 2).toArray()));


### PR DESCRIPTION


## Why?

Fix `EnumSetSerializers` for enums that have overriding methods in vairants:

```java
  enum TestEnumWithMethods {
    A {
      @Override
      public void foo() {
          System.out.println("A");
      }
    },
    B,
    C {
      @Override
      public void foo() {
      }
    },
    D;

    public void foo() {
        System.out.println("default");
    }
  }
```

## What does this PR do?

`EnumSetSerializer` now correctly unwraps types of variants that extend base enum type. Doing it this way instead of writing class of variant and unwrapping it in read prevents writing additional classes for enum variants.

## Related issues

- Fixes #3306

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [x] Does this PR introduce any binary protocol compatibility change?

This PR changes class of contained enum that `EnumSetSerializer` writes. Instead of writing class of enum variant if this variant extends base enum class it always writes class of base enum. This however does not break any existing code since previously `EnumSet`s of classes with overriding methods could not be deserialized at all

## Benchmark

