### PR TITLE
feat(go): update float16 array/slice logic in createSerializer

### DIFF
--- a/go/fory/type_resolver.go
+++ b/go/fory/type_resolver.go
@@ -1708,6 +1708,10 @@ func (r *TypeResolver) createSerializer(type_ reflect.Type, mapInStruct bool) (s
 			// []byte uses byteSliceSerializer
 			return byteSliceSerializer{}, nil
 		case reflect.Uint16:
+			// Check for fory.Float16 (aliased to uint16)
+			if elem == float16Type {
+				return float16SliceSerializer{}, nil
+			}
 			return uint16SliceSerializer{}, nil
 		case reflect.Uint32:
 			return uint32SliceSerializer{}, nil
@@ -1756,8 +1760,7 @@ func (r *TypeResolver) createSerializer(type_ reflect.Type, mapInStruct bool) (s
 			return int32ArraySerializer{arrayType: type_}, nil
 		case reflect.Uint16:
 			// Check for fory.Float16 (aliased to uint16)
-			// Check name first to avoid slow PkgPath call
-			if elem.Name() == "Float16" && (elem.PkgPath() == "github.com/apache/fory/go/fory/float16" || strings.HasSuffix(elem.PkgPath(), "/float16")) {
+			if elem == float16Type {
 				return float16ArraySerializer{arrayType: type_}, nil
 			}
 			return uint16ArraySerializer{arrayType: type_}, nil

--- a/go/fory/type_test.go
+++ b/go/fory/type_test.go
@@ -18,9 +18,11 @@
 package fory
 
 import (
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/apache/fory/go/fory/float16"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypeResolver(t *testing.T) {
@@ -60,5 +62,91 @@ func TestTypeResolver(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, test.typeInfo, typeStr)
 		require.Equal(t, test.type_, type_)
+	}
+}
+
+func TestCreateSerializerSliceTypes(t *testing.T) {
+	fory := NewFory()
+	r := newTypeResolver(fory)
+
+	tests := []struct {
+		sliceType              reflect.Type
+		expectedSerializerType reflect.Type
+	}{
+		{reflect.TypeOf([]bool{}), reflect.TypeOf(boolSliceSerializer{})},
+		{reflect.TypeOf([]int8{}), reflect.TypeOf(int8SliceSerializer{})},
+		{reflect.TypeOf([]int16{}), reflect.TypeOf(int16SliceSerializer{})},
+		{reflect.TypeOf([]int32{}), reflect.TypeOf(int32SliceSerializer{})},
+		{reflect.TypeOf([]int64{}), reflect.TypeOf(int64SliceSerializer{})},
+		{reflect.TypeOf([]float32{}), reflect.TypeOf(float32SliceSerializer{})},
+		{reflect.TypeOf([]float64{}), reflect.TypeOf(float64SliceSerializer{})},
+		{reflect.TypeOf([]int{}), reflect.TypeOf(intSliceSerializer{})},
+		{reflect.TypeOf([]uint{}), reflect.TypeOf(uintSliceSerializer{})},
+		{reflect.TypeOf([]uint16{}), reflect.TypeOf(uint16SliceSerializer{})},
+		{reflect.TypeOf([]float16.Float16{}), reflect.TypeOf(float16SliceSerializer{})},
+		{reflect.TypeOf([]uint32{}), reflect.TypeOf(uint32SliceSerializer{})},
+		{reflect.TypeOf([]uint64{}), reflect.TypeOf(uint64SliceSerializer{})},
+		{reflect.TypeOf([]string{}), reflect.TypeOf(stringSliceSerializer{})},
+	}
+
+	for _, test := range tests {
+		serializer, err := r.createSerializer(test.sliceType, false)
+		if err != nil {
+			t.Fatalf("Failed to create serializer for %s: %v", test.sliceType, err)
+		}
+
+		if reflect.TypeOf(serializer) != test.expectedSerializerType {
+			t.Errorf("For type %s, expected serializer of type %s, got %T", test.sliceType, test.expectedSerializerType, serializer)
+		}
+	}
+}
+
+func TestCreateSerializerArrayTypes(t *testing.T) {
+	fory := NewFory()
+	r := newTypeResolver(fory)
+
+	var expectedIntArraySerializerType reflect.Type
+	if reflect.TypeOf(int(0)).Size() == 8 {
+		expectedIntArraySerializerType = reflect.TypeOf(int64ArraySerializer{})
+	} else {
+		expectedIntArraySerializerType = reflect.TypeOf(int32ArraySerializer{})
+	}
+
+	var expectedUintArraySerializerType reflect.Type
+	if reflect.TypeOf(uint(0)).Size() == 8 {
+		expectedUintArraySerializerType = reflect.TypeOf(uint64ArraySerializer{})
+	} else {
+		expectedUintArraySerializerType = reflect.TypeOf(uint32ArraySerializer{})
+	}
+
+	tests := []struct {
+		arrayType              reflect.Type
+		expectedSerializerType reflect.Type
+	}{
+		{reflect.TypeOf([4]bool{}), reflect.TypeOf(boolArraySerializer{})},
+		{reflect.TypeOf([4]int8{}), reflect.TypeOf(int8ArraySerializer{})},
+		{reflect.TypeOf([4]int16{}), reflect.TypeOf(int16ArraySerializer{})},
+		{reflect.TypeOf([4]int32{}), reflect.TypeOf(int32ArraySerializer{})},
+		{reflect.TypeOf([4]int64{}), reflect.TypeOf(int64ArraySerializer{})},
+		{reflect.TypeOf([4]float32{}), reflect.TypeOf(float32ArraySerializer{})},
+		{reflect.TypeOf([4]float64{}), reflect.TypeOf(float64ArraySerializer{})},
+		{reflect.TypeOf([4]int{}), expectedIntArraySerializerType},
+		{reflect.TypeOf([4]uint{}), expectedUintArraySerializerType},
+		{reflect.TypeOf([4]byte{}), reflect.TypeOf(uint8ArraySerializer{})},
+		{reflect.TypeOf([4]uint16{}), reflect.TypeOf(uint16ArraySerializer{})},
+		{reflect.TypeOf([4]float16.Float16{}), reflect.TypeOf(float16ArraySerializer{})},
+		{reflect.TypeOf([4]uint32{}), reflect.TypeOf(uint32ArraySerializer{})},
+		{reflect.TypeOf([4]uint64{}), reflect.TypeOf(uint64ArraySerializer{})},
+	}
+
+	for _, test := range tests {
+		serializer, err := r.createSerializer(test.arrayType, false)
+		if err != nil {
+			t.Fatalf("Failed to create serializer for %s: %v", test.arrayType, err)
+		}
+
+		if reflect.TypeOf(serializer) != test.expectedSerializerType {
+			t.Errorf("For type %s, expected serializer of type %s, got %T", test.arrayType, test.expectedSerializerType, serializer)
+		}
 	}
 }


### PR DESCRIPTION


## Why?

To handle `float16` arrays and slices in a cleaner way during serialization and deserialization in the Go.

## What does this PR do?

- Modified the `createSerializer` function in `go/fory/type_resolver.go` to correctly return `float16SliceSerializer` for `reflect.Slice` of `float16` and `float16ArraySerializer` for `reflect.Array` of `float16`. 
- Added tests in `type_test.go` to validate this behavior.

## Related issues



#3235 implementation for `float16` support
#3310 `bfloat` implementation that aligns with this PR

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

