### PR TITLE
feat(compiler): add gRPC flags to fory compiler

### DIFF
--- a/compiler/fory_compiler/cli.py
+++ b/compiler/fory_compiler/cli.py
@@ -385,13 +385,6 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         help="Generate gRPC service code (stubs, serialization traits, etc.)",
     )
 
-    parser.add_argument(
-        "--grpc-backend",
-        type=str,
-        default=None,
-        help="Specify gRPC backend (e.g., 'grpc++' for C++, 'grpcio' for Python). Defaults to standard backend for the language.",
-    )
-
     return parser.parse_args(args)
 
 
@@ -439,7 +432,6 @@ def compile_file(
     emit_fdl_path: Optional[Path] = None,
     resolve_cache: Optional[Dict[Path, Schema]] = None,
     grpc: bool = False,
-    grpc_backend: Optional[str] = None,
 ) -> bool:
     """Compile a single IDL file with import resolution.
 
@@ -502,7 +494,6 @@ def compile_file(
             package_override=package_override,
             go_nested_type_style=go_nested_type_style,
             grpc=grpc,
-            grpc_backend=grpc_backend,
         )
 
         generator_class = GENERATORS[lang]
@@ -534,7 +525,6 @@ def compile_file_recursive(
     resolve_cache: Dict[Path, Schema],
     go_module_root: Optional[Path],
     grpc: bool = False,
-    grpc_backend: Optional[str] = None,
 ) -> bool:
     file_path = file_path.resolve()
     if file_path in generated:
@@ -599,7 +589,6 @@ def compile_file_recursive(
             resolve_cache,
             go_module_root,
             grpc,
-            grpc_backend,
         ):
             stack.remove(file_path)
             return False
@@ -615,7 +604,6 @@ def compile_file_recursive(
         emit_fdl_path,
         resolve_cache,
         grpc,
-        grpc_backend,
     )
     if ok:
         generated.add(file_path)
@@ -705,7 +693,6 @@ def cmd_compile(args: argparse.Namespace) -> int:
                 resolve_cache,
                 None,
                 args.grpc,
-                args.grpc_backend,
             ):
                 success = False
         except ImportError as e:

--- a/compiler/fory_compiler/generators/base.py
+++ b/compiler/fory_compiler/generators/base.py
@@ -48,7 +48,6 @@ class GeneratorOptions:
     package_override: Optional[str] = None
     go_nested_type_style: Optional[str] = None
     grpc: bool = False
-    grpc_backend: Optional[str] = None
 
 
 class BaseGenerator(ABC):

--- a/compiler/fory_compiler/generators/base.py
+++ b/compiler/fory_compiler/generators/base.py
@@ -47,6 +47,8 @@ class GeneratorOptions:
     output_dir: Path
     package_override: Optional[str] = None
     go_nested_type_style: Optional[str] = None
+    grpc: bool = False
+    grpc_backend: Optional[str] = None
 
 
 class BaseGenerator(ABC):
@@ -70,6 +72,14 @@ class BaseGenerator(ABC):
     def generate(self) -> List[GeneratedFile]:
         """Generate code and return a list of generated files."""
         pass
+
+    def generate_services(self) -> List[GeneratedFile]:
+        """Generate service-related code (e.g. gRPC stubs).
+
+        Base implementation returns empty list. Subclasses should override
+        if they support service generation.
+        """
+        return []
 
     @abstractmethod
     def generate_type(self, field_type: FieldType, nullable: bool = False) -> str:


### PR DESCRIPTION
## Why?

For initializing stub generation for languages, compiler flags `--grpc` were required.
## What does this PR do?

### 1. fory_compiler/base.py

Update `GeneratorOptions` to include grpc (bool).
```python
@dataclass
class GeneratorOptions:
    """Options for code generation."""

    output_dir: Path
    package_override: Optional[str] = None
    go_nested_type_style: Optional[str] = None
    grpc: bool = False
```

Add generate_services(self) -> List[GeneratedFile] method to `BaseGenerator` (returns empty list by default).
```python
    def generate_services(self) -> List[GeneratedFile]:
        """Generate service-related code (e.g. gRPC stubs).

        Base implementation returns empty list. Subclasses should override
        if they support service generation.
        """
        return []
```

### 2. fory_compiler/cli.py

- Add --grpc flag (store_true).
- Update `compile_file` to: 
- - Pass flags to `GeneratorOptions`.
- - Call `generator.generate_services()` if --grpc is set.

```python
    parser.add_argument(
        "--grpc",
        action="store_true",
        help="Generate gRPC service code (stubs, serialization traits, etc.)",
    )
```
 
## Related issues

Closes #3271 

## Does this PR introduce any user-facing change?
- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
N/A