### PR TITLE
perf(ci): add Cargo caching to Rust CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
       - name: Run Rust CI
         run: python ./ci/run_ci.py rust
 
@@ -330,6 +334,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
       - name: Run Rust Xlang Test
         env:
           FORY_RUST_JAVA_CI: "1"


### PR DESCRIPTION
## Why?

The Rust CI currently takes approximately 3-5 minutes to complete. By adding Cargo dependency caching, we can reduce build times by caching compiled dependencies between runs.

## What does this PR do?

- Adds `Swatinem/rust-cache@v2` to the `rust` job in `.github/workflows/ci.yml`
- Adds `Swatinem/rust-cache@v2` to the `rust_xlang` job in `.github/workflows/ci.yml`
- Configures cache to use the `rust` workspace directory

## Related issues

Closes #2889

## Does this PR introduce any user-facing change?

No user-facing changes. This only affects CI execution time.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

**CI execution time comparison:**

| Job | Before (main) | After (with cache) | Improvement |
|-----|---------------|-------------------|-------------|
| Rust CI (ubuntu-latest) | 3m 13s | 2m 54s | ✅ **-19s** |
| Rust CI (macos-14) | 3m 02s | 2m 53s | ✅ **-9s** |
| Rust CI (macos-latest) | 3m 16s | 3m 22s | ⚠️ +6s |

**Cache details:**
- Cache size: ~14MB
- Cache includes: `~/.cargo/bin`, `~/.cargo/registry`, `~/.cargo/git`, `rust/target`
- Logs confirm: `Cache restored successfully` with full match
- Cache key format: `v0-rust-rust-Linux-x64-<env-hash>-<lockfile-hash>`

**Notes:**
- Ubuntu shows consistent improvement (~19s faster)
- macOS results are within normal variance range for GitHub Actions runners
- Cache prevents re-downloading and re-compiling Rust dependencies on subsequent runs