### PR TITLE
fix(docs): adjusted sidebar position and fixed typos

### DIFF
--- a/docs/guide/cpp/basic-serialization.md
+++ b/docs/guide/cpp/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/cpp/configuration.md
+++ b/docs/guide/cpp/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -73,7 +73,7 @@ auto fory = Fory::builder()
     .build();
 ```
 
-## Configuration Options
+## Configuration
 
 ### xlang(bool)
 

--- a/docs/guide/csharp/basic-serialization.md
+++ b/docs/guide/csharp/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/csharp/configuration.md
+++ b/docs/guide/csharp/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/go/basic-serialization.md
+++ b/docs/guide/go/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 20
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/go/configuration.md
+++ b/docs/guide/go/configuration.md
@@ -50,7 +50,7 @@ f := fory.New(
 )
 ```
 
-## Configuration Options
+## Configuration
 
 ### WithTrackRef
 

--- a/docs/guide/java/advanced-features.md
+++ b/docs/guide/java/advanced-features.md
@@ -205,5 +205,5 @@ static {
 ## Related Topics
 
 - [Compression](compression.md) - Data compression options
-- [Configuration Options](configuration.md) - All ForyBuilder options
+- [Configuration](configuration.md) - All ForyBuilder options
 - [Cross-Language Serialization](cross-language.md) - XLANG mode

--- a/docs/guide/java/basic-serialization.md
+++ b/docs/guide/java/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -132,6 +132,6 @@ Object obj = fory.deserializeJavaObjectAndClass(bytes);
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - All ForyBuilder options
+- [Configuration](configuration.md) - All ForyBuilder options
 - [Type Registration](type-registration.md) - Class registration
 - [Troubleshooting](troubleshooting.md) - Common API usage issues

--- a/docs/guide/java/compression.md
+++ b/docs/guide/java/compression.md
@@ -132,5 +132,5 @@ CompressedArraySerializers.registerSerializers(fory);
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - All ForyBuilder options
+- [Configuration](configuration.md) - All ForyBuilder options
 - [Advanced Features](advanced-features.md) - Memory management

--- a/docs/guide/java/configuration.md
+++ b/docs/guide/java/configuration.md
@@ -1,6 +1,6 @@
 ---
-title: Configuration Options
-sidebar_position: 1
+title: Configuration
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/java/custom-serializers.md
+++ b/docs/guide/java/custom-serializers.md
@@ -656,4 +656,4 @@ When implementing custom map or collection serializers:
 
 - [Type Registration](type-registration.md) - Register serializers
 - [Schema Evolution](schema-evolution.md) - Compatible mode considerations
-- [Configuration Options](configuration.md) - Serialization options
+- [Configuration](configuration.md) - Serialization options

--- a/docs/guide/java/index.md
+++ b/docs/guide/java/index.md
@@ -188,7 +188,7 @@ ThreadSafeFory fory = Fory.builder()
 
 ## Next Steps
 
-- [Configuration Options](configuration.md) - Learn about ForyBuilder options
+- [Configuration](configuration.md) - Learn about ForyBuilder options
 - [Basic Serialization](basic-serialization.md) - Detailed serialization patterns
 - [Type Registration](type-registration.md) - Class registration and security
 - [Custom Serializers](custom-serializers.md) - Implement custom serializers

--- a/docs/guide/java/migration.md
+++ b/docs/guide/java/migration.md
@@ -115,6 +115,6 @@ fory.deserialize(buffer);
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - ForyBuilder options
+- [Configuration](configuration.md) - ForyBuilder options
 - [Schema Evolution](schema-evolution.md) - Handling class changes
 - [Troubleshooting](troubleshooting.md) - Common migration issues

--- a/docs/guide/java/schema-evolution.md
+++ b/docs/guide/java/schema-evolution.md
@@ -204,7 +204,7 @@ public class DeserializeIntoType {
 }
 ```
 
-## Configuration Options
+## Configuration
 
 | Option                    | Description                            | Default                   |
 | ------------------------- | -------------------------------------- | ------------------------- |
@@ -224,6 +224,6 @@ public class DeserializeIntoType {
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - All ForyBuilder options
+- [Configuration](configuration.md) - All ForyBuilder options
 - [Cross-Language Serialization](cross-language.md) - XLANG mode
 - [Troubleshooting](troubleshooting.md) - Common schema issues

--- a/docs/guide/java/troubleshooting.md
+++ b/docs/guide/java/troubleshooting.md
@@ -207,7 +207,7 @@ LoggerFactory.setLogLevel(LogLevel.DEBUG_LEVEL);
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - All ForyBuilder options
+- [Configuration](configuration.md) - All ForyBuilder options
 - [Schema Evolution](schema-evolution.md) - Compatible mode details
 - [Type Registration](type-registration.md) - Registration best practices
 - [Migration Guide](migration.md) - Upgrading Fory versions

--- a/docs/guide/java/type-registration.md
+++ b/docs/guide/java/type-registration.md
@@ -110,6 +110,6 @@ Fory fory = Fory.builder()
 
 ## Related Topics
 
-- [Configuration Options](configuration.md) - ForyBuilder security options
+- [Configuration](configuration.md) - ForyBuilder security options
 - [Custom Serializers](custom-serializers.md) - Register custom serializers
 - [Troubleshooting](troubleshooting.md) - Common registration issues

--- a/docs/guide/kotlin/fory-creation.md
+++ b/docs/guide/kotlin/fory-creation.md
@@ -89,9 +89,9 @@ val fory: ThreadSafeFory = Fory.builder()
 KotlinSerializers.registerSerializers(fory)
 ```
 
-## Configuration Options
+## Configuration
 
-All configuration options from Fory Java are available. See [Java Configuration Options](../java/configuration.md) for the complete list.
+All configuration options from Fory Java are available. See [Java Configuration](../java/configuration.md) for the complete list.
 
 Common options for Kotlin:
 

--- a/docs/guide/kotlin/index.md
+++ b/docs/guide/kotlin/index.md
@@ -93,7 +93,7 @@ fun main() {
 
 Fory Kotlin is built on top of Fory Java. Most configuration options, features, and concepts from Fory Java apply directly to Kotlin. Refer to the Java documentation for:
 
-- [Configuration Options](../java/configuration.md) - All ForyBuilder options
+- [Configuration](../java/configuration.md) - All ForyBuilder options
 - [Basic Serialization](../java/basic-serialization.md) - Serialization patterns and APIs
 - [Type Registration](../java/type-registration.md) - Class registration and security
 - [Schema Evolution](../java/schema-evolution.md) - Forward/backward compatibility

--- a/docs/guide/python/basic-serialization.md
+++ b/docs/guide/python/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/python/configuration.md
+++ b/docs/guide/python/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/rust/basic-serialization.md
+++ b/docs/guide/rust/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/rust/configuration.md
+++ b/docs/guide/rust/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,7 +41,7 @@ Allows independent schema evolution:
 let fory = Fory::default().compatible(true);
 ```
 
-## Configuration Options
+## Configuration
 
 ### Maximum Dynamic Object Nesting Depth
 

--- a/docs/guide/scala/fory-creation.md
+++ b/docs/guide/scala/fory-creation.md
@@ -114,9 +114,9 @@ object ForyHolder {
 }
 ```
 
-## Configuration Options
+## Configuration
 
-All configuration options from Fory Java are available. See [Java Configuration Options](../java/configuration.md) for the complete list.
+All configuration options from Fory Java are available. See [Java Configuration](../java/configuration.md) for the complete list.
 
 Common options for Scala:
 

--- a/docs/guide/scala/index.md
+++ b/docs/guide/scala/index.md
@@ -85,7 +85,7 @@ object ScalaExample {
 
 Fory Scala is built on top of Fory Java. Most configuration options, features, and concepts from Fory Java apply directly to Scala. Refer to the Java documentation for:
 
-- [Configuration Options](../java/configuration.md) - All ForyBuilder options
+- [Configuration](../java/configuration.md) - All ForyBuilder options
 - [Basic Serialization](../java/basic-serialization.md) - Serialization patterns and APIs
 - [Type Registration](../java/type-registration.md) - Class registration and security
 - [Schema Evolution](../java/schema-evolution.md) - Forward/backward compatibility

--- a/docs/guide/swift/basic-serialization.md
+++ b/docs/guide/swift/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/swift/configuration.md
+++ b/docs/guide/swift/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION


## Why?



## What does this PR do?

Changed the `sidebar_position` of Basic Serialization to 1
Replaced the `Configuration Option` typo to `Configuration`
(for all language guide)

## Related issues

Closes #3447 

## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


