### PR TITLE
feat(c++): add sanitizer configuration in bazel build and CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,3 +56,16 @@ build:x86_64 --copt=-mbmi2
 # ARM64-specific optimizations (if any needed in the future)
 build:arm64 --copt=-march=armv8-a
 
+# AddressSanitizer
+build:asan --strip=never
+build:asan --copt=-fsanitize=address
+build:asan --copt=-g
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --linkopt=-fsanitize=address
+
+# UndefinedBehaviorSanitizer
+build:ubsan --strip=never
+build:ubsan --copt=-fsanitize=alignment,bool,bounds,bounds-strict,builtin,enum,integer-divide-by-zero,object-size,pointer-overflow,return,shift,signed-integer-overflow,unreachable,vla-bound,vptr
+build:ubsan --copt=-g
+build:ubsan --copt=-fno-omit-frame-pointer
+build:ubsan --linkopt=-fsanitize=alignment,bool,bounds,bounds-strict,builtin,enum,integer-divide-by-zero,object-size,pointer-overflow,return,shift,signed-integer-overflow,unreachable,vla-bound,vptr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,69 @@ jobs:
             bazel-out/*/testlogs/**/*.xml
           if-no-files-found: ignore
 
+  cpp_sanitizers:
+    name: C++ Sanitizer (${{ matrix.sanitizer }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sanitizer: [asan, ubsan]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip'
+      - name: Cache Bazel binary
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/bin/bazel
+            ~/.local/bin/bazel
+          key: bazel-binary-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}
+          restore-keys: |
+            bazel-binary-${{ runner.os }}-${{ runner.arch }}-
+      - name: Cache Bazel repository cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel/_bazel_*/*/external
+          key: bazel-repo-sanitizer-${{ runner.os }}-${{ runner.arch }}-py311-${{ hashFiles('WORKSPACE', '.bazelrc', 'bazel/**') }}
+          restore-keys: |
+            bazel-repo-sanitizer-${{ runner.os }}-${{ runner.arch }}-py311-
+      - name: Cache Bazel build outputs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel
+          key: bazel-build-cpp-sanitizer-${{ runner.os }}-${{ runner.arch }}-${{ matrix.sanitizer }}-${{ hashFiles('cpp/**', 'BUILD', 'WORKSPACE', '.bazelrc') }}
+      - name: Install Bazel and C++ deps
+        run: python ./ci/run_ci.py cpp --install-deps-only
+      - name: Run C++ ${{ matrix.sanitizer }} tests
+        run: |
+          ARCH="$(uname -m)"
+          BAZEL_CONFIGS="--config=${{ matrix.sanitizer }}"
+          if [[ -x ~/bin/bazel ]]; then
+            BAZEL_BIN=~/bin/bazel
+          elif [[ -x ~/.local/bin/bazel ]]; then
+            BAZEL_BIN=~/.local/bin/bazel
+          else
+            echo "bazel not found in ~/bin or ~/.local/bin"
+            exit 1
+          fi
+          if [[ "${ARCH}" == "x86_64" || "${ARCH}" == "amd64" ]]; then
+            BAZEL_CONFIGS="--config=x86_64 ${BAZEL_CONFIGS}"
+          fi
+          ${BAZEL_BIN} test --cache_test_results=no ${BAZEL_CONFIGS} $(${BAZEL_BIN} query //cpp/...)
+      - name: Upload Bazel Test Logs (${{ matrix.sanitizer }})
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: bazel-test-logs-${{ matrix.sanitizer }}
+          path: |
+            bazel-out/*/testlogs/**/*.log
+            bazel-out/*/testlogs/**/*.xml
+          if-no-files-found: ignore
+
   cpp_xlang:
     name: C++ Xlang Test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ FORY_CSHARP_JAVA_CI=1 ENABLE_FORY_DEBUG_OUTPUT=1 mvn -T16 test -Dtest=org.apache
 - All commands must be executed within the `cpp` directory.
 - Fory c++ use c++ 17, you must not use features from higher version of C++.
 - Bazel uses bzlmod (`MODULE.bazel`); prefer Bazel 8+.
+- For Bazel C++ tests, detect machine architecture and **only** add `--config=x86_64` on `x86_64`/`amd64`; on `arm64`/`aarch64`, do not enable this config.
 - When you updated the code, use `clang-format` to update the code
 - When invoking a method that returns `Result`, always use `FORY_TRY` unless in a control flow context.
 - Wrap error checks with `FORY_PREDICT_FALSE` for branch prediction optimization.

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -341,9 +341,16 @@ case $1 in
       "$ROOT"/ci/deploy.sh install_pyarrow
       export PATH=~/bin:$PATH
       echo "bazel version: $(bazel version)"
+      ARCH="$(uname -m)"
+      BAZEL_TEST_CONFIG=""
+      case "${ARCH}" in
+        x86_64|amd64)
+          BAZEL_TEST_CONFIG="--config=x86_64"
+          ;;
+      esac
       set +e
       echo "Executing fory c++ tests"
-      bazel test $(bazel query //...)
+      bazel test ${BAZEL_TEST_CONFIG} $(bazel query //...)
       testcode=$?
       if [[ $testcode -ne 0 ]]; then
         echo "Executing fory c++ tests failed"


### PR DESCRIPTION


## Why?

Close https://github.com/apache/fory/issues/1203

## What does this PR do?

- Add ASan and UBSan integration in `.bazelrc`.
- I noticed that directly running `bazel test $(bazel query //cpp/...)` triggers compilation errors because the `--config=x86_64` flag is not provided. In the new CI Python script `run_ci.py`, the `cpp.py` task invoked by it indeed contains a check for this flag:
  https://github.com/apache/fory/blob/af6e8b25e8c2d188cba2d99ccb276c47ec6c9c31/ci/tasks/cpp.py#L40-L41
  The `run_ci.sh` script does not contain this check. Although this script appears to no longer be used, I still added the corresponding flag check there.
Similarly, I also added documentation about this flag in `AGENTS.md`.

- In `ci.yml`, I added a new job to enable tests with sanitizers in CI. Currently, this job only runs on ubuntu-latest.

## Related issues

https://github.com/apache/fory/issues/1203


## Benchmark


I believe this feature only introduces extra burden during testing.