### PR TITLE
fix(java): avoid deflater meta decompression hang on invalid input

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/exception/InvalidDataException.java
+++ b/java/fory-core/src/main/java/org/apache/fory/exception/InvalidDataException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.exception;
+
+/** Exception thrown when fory receives malformed or truncated input data. */
+public class InvalidDataException extends ForyException {
+
+  public InvalidDataException(String message) {
+    super(message);
+  }
+
+  public InvalidDataException(Throwable cause) {
+    super(cause);
+  }
+
+  public InvalidDataException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/fory-core/src/main/java/org/apache/fory/meta/DeflaterMetaCompressor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/DeflaterMetaCompressor.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
+import org.apache.fory.exception.InvalidDataException;
 
 /** A meta compressor based on {@link Deflater} compression algorithm. */
 public class DeflaterMetaCompressor implements MetaCompressor {
@@ -49,10 +50,22 @@ public class DeflaterMetaCompressor implements MetaCompressor {
     try {
       while (!inflater.finished()) {
         int decompressedSize = inflater.inflate(buffer);
-        outputStream.write(buffer, 0, decompressedSize);
+        if (decompressedSize > 0) {
+          outputStream.write(buffer, 0, decompressedSize);
+          continue;
+        }
+        if (inflater.needsDictionary()) {
+          throw new InvalidDataException("Invalid compressed metadata, dictionary is required.");
+        }
+        if (inflater.needsInput()) {
+          throw new InvalidDataException("Invalid compressed metadata, stream is truncated.");
+        }
+        throw new InvalidDataException("Invalid compressed metadata, inflater made no progress.");
       }
     } catch (DataFormatException e) {
-      throw new RuntimeException(e);
+      throw new InvalidDataException("Invalid compressed metadata format.", e);
+    } finally {
+      inflater.end();
     }
     return outputStream.toByteArray();
   }

--- a/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
+++ b/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
@@ -227,6 +227,7 @@ Args=--initialize-at-build-time=org.apache.fory.memory.MemoryBuffer,\
     org.apache.fory.config.Language,\
     org.apache.fory.config.LongEncoding,\
     org.apache.fory.config.UnknownEnumValueStrategy,\
+    org.apache.fory.exception.InvalidDataException,\
     org.apache.fory.logging.ForyLogger,\
     org.apache.fory.logging.LoggerFactory,\
     org.apache.fory.logging.LogLevel,\

--- a/java/fory-core/src/test/java/org/apache/fory/meta/DeflaterMetaCompressorTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/DeflaterMetaCompressorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.meta;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.apache.fory.exception.InvalidDataException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DeflaterMetaCompressorTest {
+  private final DeflaterMetaCompressor compressor = new DeflaterMetaCompressor();
+
+  @Test
+  public void testCompressDecompressRoundTrip() {
+    byte[] input = sampleInput();
+    byte[] compressed = compressor.compress(input, 0, input.length);
+    byte[] decompressed = compressor.decompress(compressed, 0, compressed.length);
+    assertEquals(decompressed, input);
+  }
+
+  @Test(timeOut = 5_000)
+  public void testDecompressTruncatedInputThrowsQuickly() {
+    byte[] compressed = compressor.compress(sampleInput(), 0, sampleInput().length);
+    byte[] truncated = Arrays.copyOf(compressed, compressed.length - 1);
+    InvalidDataException e =
+        Assert.expectThrows(
+            InvalidDataException.class,
+            () -> compressor.decompress(truncated, 0, truncated.length));
+    assertTrue(e.getMessage().contains("truncated"));
+  }
+
+  @Test(timeOut = 5_000)
+  public void testDecompressCorruptedInputThrows() {
+    byte[] compressed = compressor.compress(sampleInput(), 0, sampleInput().length);
+    byte[] corrupted = Arrays.copyOf(compressed, compressed.length);
+    corrupted[corrupted.length / 2] ^= 0x40;
+    InvalidDataException e =
+        Assert.expectThrows(
+            InvalidDataException.class,
+            () -> compressor.decompress(corrupted, 0, corrupted.length));
+    assertTrue(e.getMessage().contains("Invalid compressed metadata"));
+  }
+
+  private static byte[] sampleInput() {
+    return "0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"
+        .getBytes(StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a no-progress guard to `DeflaterMetaCompressor.decompress` so invalid/truncated deflate streams fail fast instead of spinning forever.
- Introduces `InvalidDataException` (subclass of `ForyException`) and raises it for malformed/truncated meta-compression input.
- Adds `DeflaterMetaCompressorTest` coverage for roundtrip + truncated/corrupt payload failures (with timeout guard).
- Registers `InvalidDataException` in `fory-core` `native-image.properties`.

## Why is this needed?
Issue #3471 reports an infinite loop (`inflate() == 0` while `finished() == false`) that can peg CPU at 100% for corrupt or truncated streams.

## Verification
- `cd java && mvn -T16 -pl fory-core test -Dtest=org.apache.fory.meta.DeflaterMetaCompressorTest`

Closes #3471
