### PR TITLE
chore(java): Update Spotless and Checkstyle to allow building with JDK25

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -220,7 +220,6 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -1090,7 +1090,7 @@ public final class Fory implements BaseFory {
       case ClassResolver.HASHMAP_ID:
         copy = hashMapSerializer.copy((HashMap) obj);
         break;
-        // todo: add fastpath for other types.
+      // todo: add fastpath for other types.
       default:
         copy = copyObject(obj, typeInfo.getSerializer());
     }

--- a/java/fory-core/src/main/java/org/apache/fory/util/MurmurHash3.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/MurmurHash3.java
@@ -92,10 +92,10 @@ public final class MurmurHash3 {
     switch (len & 0x03) {
       case 3:
         k1 = (data[roundedEnd + 2] & 0xff) << 16;
-        // fallthrough
+      // fallthrough
       case 2:
         k1 |= (data[roundedEnd + 1] & 0xff) << 8;
-        // fallthrough
+      // fallthrough
       case 1:
         k1 |= (data[roundedEnd] & 0xff);
         k1 *= c1;

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/Encoders.java
@@ -152,7 +152,7 @@ public class Encoders {
    *
    * @param token TypeToken instance which explicit specified the type.
    * @param <T> T is a array type, can be a nested list type.
-   * @return
+   * @return the array encoder
    */
   public static <T extends Collection<?>> ArrayEncoder<T> arrayEncoder(TypeRef<T> token) {
     return arrayEncoder(token, null);
@@ -170,7 +170,7 @@ public class Encoders {
    *
    * @param token TypeToken instance which explicit specified the type.
    * @param <T> T is a array type, can be a nested list type.
-   * @return
+   * @return the map encoder
    */
   public static <T extends Map> MapEncoder<T> mapEncoder(TypeRef<T> token) {
     return mapEncoder(token, null);
@@ -180,7 +180,7 @@ public class Encoders {
    * The underlying implementation uses array, only supported {@link Map} format, because generic
    * type such as List is erased to simply List, so a bean class input param is required.
    *
-   * @return
+   * @return the map encoder
    */
   @SuppressWarnings("unchecked")
   public static <T extends Map, K, V> MapEncoder<T> mapEncoder(

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -73,7 +73,7 @@
     <janino.version>3.1.12</janino.version>
     <commons_codec.version>1.13</commons_codec.version>
     <fory.java.rootdir>${basedir}</fory.java.rootdir>
-    <maven-spotless-plugin.version>2.41.1</maven-spotless-plugin.version>
+    <maven-spotless-plugin.version>3.3.0</maven-spotless-plugin.version>
     <lombok.version>1.18.38</lombok.version>
   </properties>
 
@@ -224,14 +224,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.29</version>
-          </dependency>
-        </dependencies>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -245,7 +238,6 @@
         <configuration>
           <configLocation>${fory.java.rootdir}/checkstyle.xml</configLocation>
           <suppressionsLocation>${fory.java.rootdir}/checkstyle-suppressions.xml</suppressionsLocation>
-          <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <failOnViolation>true</failOnViolation>
@@ -261,8 +253,8 @@
         <configuration>
           <java>
             <googleJavaFormat>
-              <!-- 1.19.1 support JDK21 -->
-              <version>1.19.1</version>
+              <!-- 1.35 support JDK25 -->
+              <version>1.35.0</version>
               <style>GOOGLE</style>
             </googleJavaFormat>
           </java>


### PR DESCRIPTION
## Why?

Spotless fails when run in JDK25:
```
Execution default-cli of goal com.diffplug.spotless:spotless-maven-plugin:2.41.1:apply failed: An API incompatibility was encountered while executing com.diffplug.spotless:spotless-maven-plugin:2.41.1:apply: java.lang.NoSuchMethodError: 'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
```

## What does this PR do?

Updates build plugins to newer versions with JDK25 support