### PR TITLE
chore(java): Clean up Javadoc warnings, and fail the build if any new ones are introduced

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
@@ -52,8 +52,8 @@ public @interface ForyField {
    * Field tag ID for schema evolution mode.
    *
    * <ul>
-   *   <li>When >= 0: Uses this numeric ID instead of field name string for compact encoding
-   *   <li>When -1 (default): Uses field name with meta string encoding
+   *   <li>When {@code >= 0}: Uses this numeric ID instead of field name string for compact encoding
+   *   <li>When {@code -1} (default): Uses field name with meta string encoding
    * </ul>
    *
    * <p>Must be unique within the class (except -1) and stable across versions.

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Int32Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Int32Type.java
@@ -41,10 +41,10 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Int32Type(compress = true)  // Uses varint encoding (default)
+ *   {@literal @}Int32Type(compress = true)  // Uses varint encoding (default)
  *   int compactId;
  *
- *   @Int32Type(compress = false) // Uses fixed 4-byte encoding
+ *   {@literal @}Int32Type(compress = false) // Uses fixed 4-byte encoding
  *   int fixedId;
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Int64Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Int64Type.java
@@ -43,13 +43,13 @@ import org.apache.fory.config.LongEncoding;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Int64Type(encoding = LongEncoding.VARINT64)  // Variable-length (default)
+ *   {@literal @}Int64Type(encoding = LongEncoding.VARINT64)  // Variable-length (default)
  *   long compactId;
  *
- *   @Int64Type(encoding = LongEncoding.FIXED_INT64)     // Fixed 8-byte
+ *   {@literal @}Int64Type(encoding = LongEncoding.FIXED_INT64)     // Fixed 8-byte
  *   long fixedTimestamp;
  *
- *   @Int64Type(encoding = LongEncoding.TAGGED_INT64) // Tagged encoding
+ *   {@literal @}Int64Type(encoding = LongEncoding.TAGGED_INT64) // Tagged encoding
  *   long taggedValue;
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Int8ArrayType.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Int8ArrayType.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Int8ArrayType
+ *   {@literal @}Int8ArrayType
  *   byte[] data;  // Will be serialized as signed 8-bit array
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint16ArrayType.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint16ArrayType.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint16ArrayType
+ *   {@literal @}Uint16ArrayType
  *   short[] ports;  // Will be serialized as unsigned 16-bit array
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint16Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint16Type.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint16Type
+ *   {@literal @}Uint16Type
  *   int port;  // Will be serialized as unsigned 16-bit [0, 65535]
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint32ArrayType.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint32ArrayType.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint32ArrayType
+ *   {@literal @}Uint32ArrayType
  *   int[] counts;  // Will be serialized as unsigned 32-bit array
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint32Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint32Type.java
@@ -50,10 +50,10 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint32Type(compress = true)  // Uses varuint encoding (default)
+ *   {@literal @}Uint32Type(compress = true)  // Uses varuint encoding (default)
  *   long compactCount;
  *
- *   @Uint32Type(compress = false) // Uses fixed 4-byte encoding
+ *   {@literal @}Uint32Type(compress = false) // Uses fixed 4-byte encoding
  *   long fixedCount;
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint64ArrayType.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint64ArrayType.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint64ArrayType
+ *   {@literal @}Uint64ArrayType
  *   long[] timestamps;  // Will be serialized as unsigned 64-bit array
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint64Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint64Type.java
@@ -55,13 +55,13 @@ import org.apache.fory.config.LongEncoding;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint64Type(encoding = LongEncoding.VARINT64)  // Variable-length (default)
+ *   {@literal @}Uint64Type(encoding = LongEncoding.VARINT64)  // Variable-length (default)
  *   long compactId;
  *
- *   @Uint64Type(encoding = LongEncoding.FIXED_INT64)     // Fixed 8-byte
+ *   {@literal @}Uint64Type(encoding = LongEncoding.FIXED_INT64)     // Fixed 8-byte
  *   long fixedTimestamp;
  *
- *   @Uint64Type(encoding = LongEncoding.TAGGED_INT64) // Tagged encoding
+ *   {@literal @}Uint64Type(encoding = LongEncoding.TAGGED_INT64) // Tagged encoding
  *   long taggedValue;
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint8ArrayType.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint8ArrayType.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint8ArrayType
+ *   {@literal @}Uint8ArrayType
  *   byte[] data;  // Will be serialized as unsigned 8-bit array
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/Uint8Type.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/Uint8Type.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public class MyStruct {
- *   @Uint8Type
+ *   {@literal @}Uint8Type
  *   short flags;  // Will be serialized as unsigned 8-bit [0, 255]
  * }
  * }</pre>

--- a/java/fory-core/src/main/java/org/apache/fory/codegen/Expression.java
+++ b/java/fory-core/src/main/java/org/apache/fory/codegen/Expression.java
@@ -85,8 +85,8 @@ import org.apache.fory.util.function.SerializableTriFunction;
 public interface Expression {
 
   /**
-   * Returns the Class<?> of the result of evaluating this expression. It is invalid to query the
-   * type of unresolved expression (i.e., when `resolved` == false).
+   * Returns the type of the result of evaluating this expression. It is invalid to query the type
+   * of unresolved expression (i.e., when `resolved` == false).
    */
   TypeRef<?> type();
 
@@ -845,6 +845,7 @@ public interface Expression {
       return new ExprCode(codeBuilder.toString(), null, null);
     }
 
+    @Override
     public String toString() {
       return String.format("SetField(%s, %s, %s)", targetObject, fieldName, fieldValue);
     }

--- a/java/fory-core/src/main/java/org/apache/fory/collection/ForyObjectMap.java
+++ b/java/fory-core/src/main/java/org/apache/fory/collection/ForyObjectMap.java
@@ -118,7 +118,7 @@ public class ForyObjectMap<K, V> {
   }
 
   /**
-   * Returns an index >= 0 and <= {@link #mask} for the specified {@code item}.
+   * Returns an {@code index >= 0 and <= mask} for the specified {@code item}.
    *
    * <p>The default implementation uses Fibonacci hashing on the item's {@link Object#hashCode()}:
    * the hashcode is multiplied by a long constant (2 to the 64th, divided by the golden ratio) then
@@ -134,6 +134,8 @@ public class ForyObjectMap<K, V> {
    * event that most hashcodes are Fibonacci numbers, if keys provide poor or incorrect hashcodes,
    * or to simplify hashing if keys provide high quality hashcodes and don't need Fibonacci hashing:
    * {@code return item.hashCode() & mask;}
+   *
+   * @see #mask
    */
   protected int place(K item) {
     return (int) (item.hashCode() * MASK_NUMBER >>> shift);
@@ -351,6 +353,7 @@ public class ForyObjectMap<K, V> {
     }
   }
 
+  @Override
   public int hashCode() {
     int h = size;
     K[] keyTable = this.keyTable;
@@ -368,6 +371,7 @@ public class ForyObjectMap<K, V> {
     return h;
   }
 
+  @Override
   public boolean equals(Object obj) {
     if (obj == this) {
       return true;
@@ -403,6 +407,7 @@ public class ForyObjectMap<K, V> {
     return toString(separator, false);
   }
 
+  @Override
   public String toString() {
     return toString(", ", true);
   }

--- a/java/fory-core/src/main/java/org/apache/fory/collection/LongMap.java
+++ b/java/fory-core/src/main/java/org/apache/fory/collection/LongMap.java
@@ -125,7 +125,7 @@ public class LongMap<V> {
   }
 
   /**
-   * Returns an index >= 0 and <= {@link #mask} for the specified {@code item}.
+   * Returns an {@code index >= 0 and <= mask} for the specified {@code item}.
    *
    * <p>The default implementation uses Fibonacci hashing on the item's {@link Object#hashCode()}:
    * the hashcode is multiplied by a long constant (2 to the 64th, divided by the golden ratio) then
@@ -141,6 +141,8 @@ public class LongMap<V> {
    * event that most hashcodes are Fibonacci numbers, if keys provide poor or incorrect hashcodes,
    * or to simplify hashing if keys provide high quality hashcodes and don't need Fibonacci hashing:
    * {@code return item.hashCode() & mask;}
+   *
+   * @see #mask
    */
   protected int place(long item) {
     return (int) (item * MASK_NUMBER >>> shift);
@@ -344,6 +346,7 @@ public class LongMap<V> {
     }
   }
 
+  @Override
   public String toString() {
     if (size == 0) {
       return "[]";

--- a/java/fory-core/src/main/java/org/apache/fory/collection/ObjectArray.java
+++ b/java/fory-core/src/main/java/org/apache/fory/collection/ObjectArray.java
@@ -96,7 +96,7 @@ public final class ObjectArray<T> {
 
   /**
    * Set all object array elements to null. This method is faster than {@link Arrays#fill} for large
-   * arrays (> 128).
+   * arrays ({@code > 128}).
    */
   public static void clearObjectArray(Object[] objects, int start, int size) {
     if (size < COPY_THRESHOLD) {

--- a/java/fory-core/src/main/java/org/apache/fory/config/LongEncoding.java
+++ b/java/fory-core/src/main/java/org/apache/fory/config/LongEncoding.java
@@ -26,9 +26,9 @@ package org.apache.fory.config;
 public enum LongEncoding {
   /**
    * Fory Tagged int64 Encoding:
-   * <li>If long is in [0xc0000000, 0x3fffffff], encode as 4 bytes int: `| little-endian: ((int)
-   *     value) << 1 |`
-   * <li>Otherwise write as 9 bytes: `| 0b1 | little-endian 8bytes long |`.
+   * <li>If long is in [0xc0000000, 0x3fffffff], encode as 4 bytes int: {@code | little-endian:
+   *     ((int) value) << 1 |}
+   * <li>Otherwise write as 9 bytes: {@code | 0b1 | little-endian 8bytes long |}.
    *
    *     <p>Faster than {@link #VARINT}, but compression is not good as {@link #VARINT} such as for
    *     ints in short range.
@@ -38,8 +38,8 @@ public enum LongEncoding {
    * Fory Progressive Variable-length Long Encoding:
    * <li>positive long format: first bit in every byte indicate whether has next byte, then next
    *     byte should be read util first bit is unset.
-   * <li>Negative number will be converted to positive number by ` (v << 1) ^ (v >> 63)` to reduce
-   *     cost of small negative numbers.
+   * <li>Negative number will be converted to positive number by {@code (v << 1) ^ (v >> 63)} to
+   *     reduce cost of small negative numbers.
    */
   VARINT,
   /** Write long as little endian 8bytes, no compression. */

--- a/java/fory-core/src/main/java/org/apache/fory/memory/BitUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/BitUtils.java
@@ -30,8 +30,8 @@ public class BitUtils {
   /**
    * Sets the bit at the specified index to {@code true}.
    *
-   * <p>Every byte is set form right to left(the least significant -> the most significant): 1L <<
-   * bitIndex
+   * <p>Every byte is set from right to left(the least significant → the most significant): {@code
+   * 1L << bitIndex}.
    */
   public static void set(MemoryBuffer bitmapBuffer, int baseOffset, int index) {
     final int byteIndex = baseOffset + (index >> 3);
@@ -140,7 +140,7 @@ public class BitUtils {
   /**
    * Given a bitmap buffer, count the number of bits that are not set.
    *
-   * <p>Every byte is set form right to left: 0xFF << remainder
+   * <p>Every byte is set from right to left: {@code 0xFF << remainder}
    *
    * @return number of bits not set.
    */

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -1209,8 +1209,8 @@ public final class MemoryBuffer {
 
   /**
    * Write signed long using fory Tagged(Small long as int) encoding. If long is in [0xc0000000,
-   * 0x3fffffff], encode as 4 bytes int: | little-endian: ((int) value) << 1 |; Otherwise write as 9
-   * bytes: | 0b1 | little-endian 8bytes long |
+   * 0x3fffffff], encode as 4 bytes int: {@code | little-endian: ((int) value) << 1 |}; Otherwise
+   * write as 9 bytes: {@code | 0b1 | little-endian 8bytes long |}.
    */
   public int writeTaggedInt64(long value) {
     ensure(writerIndex + 9);
@@ -1219,8 +1219,8 @@ public final class MemoryBuffer {
 
   /**
    * Write unsigned long using fory Tagged(Small long as int) encoding. If long is in [0,
-   * 0x7fffffff], encode as 4 bytes int: | little-endian: ((int) value) << 1 |; Otherwise write as 9
-   * bytes: | 0b1 | little-endian 8bytes long |
+   * 0x7fffffff], encode as 4 bytes int: {@code | little-endian: ((int) value) << 1 |}; Otherwise
+   * write as 9 bytes: {@code | 0b1 | little-endian 8bytes long |}.
    */
   public int writeTaggedUint64(long value) {
     ensure(writerIndex + 9);

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/RefMode.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/RefMode.java
@@ -30,7 +30,7 @@ import org.apache.fory.annotation.CodegenInvoke;
  *   <li>{@link #NULL_ONLY} - Field is nullable but no ref tracking. Write null flag (-3) for null,
  *       or not-null flag (-1) then data.
  *   <li>{@link #TRACKING} - Ref tracking enabled (implies nullable). Write ref flag: -3 for null,
- *       -1 for first occurrence (then data), or ref id (>=0) for subsequent references.
+ *       -1 for first occurrence (then data), or ref id (&gt;=0) for subsequent references.
  * </ul>
  */
 public enum RefMode {

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/RefResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/RefResolver.java
@@ -80,8 +80,9 @@ public interface RefResolver {
   int preserveRefId(int refId);
 
   /**
-   * Preserve and return a `refId` which is `>=` {@link Fory#NOT_NULL_VALUE_FLAG} if the value is
-   * not null. If the value is referencable value, the `refId` will be {@link #preserveRefId}.
+   * Preserve and return a {@code refId} which is {@code >=} {@link Fory#NOT_NULL_VALUE_FLAG} if the
+   * value is not null. If the value is referencable value, the {@code refId} will be {@link
+   * #preserveRefId}.
    */
   int tryPreserveRefId(MemoryBuffer buffer);
 

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -383,8 +383,8 @@ public abstract class TypeResolver {
 
   /**
    * Writes shared class metadata using the meta-share protocol. Protocol: If class already written,
-   * writes (index << 1) | 1 (reference). If new class, writes (index << 1) followed by TypeDef
-   * bytes.
+   * writes {@code (index << 1) | 1} (reference). If new class, writes {@code (index << 1)} followed
+   * by TypeDef bytes.
    *
    * <p>This method is shared between XtypeResolver and ClassResolver.
    */
@@ -1276,7 +1276,7 @@ public abstract class TypeResolver {
   /**
    * Gets the sort key for a field descriptor.
    *
-   * <p>If the field has a {@link ForyField} annotation with id >= 0, returns the id as a string.
+   * <p>If the field has a {@link ForyField} annotation with id &gt;= 0, returns the id as a string.
    * Otherwise, returns the snake_case field name. This ensures fields are sorted by tag ID when
    * configured, matching the fingerprint computation order.
    *

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/MetaSharedLayerSerializerBase.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/MetaSharedLayerSerializerBase.java
@@ -118,7 +118,7 @@ public abstract class MetaSharedLayerSerializerBase<T> extends AbstractObjectSer
    * Populate field index map and field types array in the serializer's field order. This is used by
    * ObjectStreamSerializer to build fieldIndexMap and putFieldTypes in the correct order.
    *
-   * @param fieldIndexMap map to populate with field name -> index
+   * @param fieldIndexMap map to populate with field name → index
    * @param fieldTypes array to populate with field types (must be pre-allocated with getNumFields()
    *     size)
    */

--- a/java/fory-core/src/main/java/org/apache/fory/type/Types.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Types.java
@@ -220,7 +220,7 @@ public class Types {
   /** One dimensional float64 array. */
   public static final int FLOAT64_ARRAY = 56;
 
-  /** Bound value for range checks (types with id >= BOUND are not internal types). */
+  /** Bound value for range checks (types with id &gt;= BOUND are not internal types). */
   public static final int BOUND = 64;
 
   public static final int INVALID_USER_TYPE_ID = -1;

--- a/java/fory-core/src/main/java/org/apache/fory/util/MurmurHash3.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/MurmurHash3.java
@@ -26,7 +26,7 @@ package org.apache.fory.util;
  * to this file.
  *
  * <p>This java port is faster than guava and consistent cross-language for all seeds, see <a
- * href="https://yonik.com/murmurhash3-for-java/>murmurhash3-for-java</a>
+ * href="https://yonik.com/murmurhash3-for-java/">murmurhash3-for-java</a>
  */
 public final class MurmurHash3 {
 

--- a/java/fory-core/src/main/java/org/apache/fory/util/StringEncodingUtils.java
+++ b/java/fory-core/src/main/java/org/apache/fory/util/StringEncodingUtils.java
@@ -423,8 +423,8 @@ public class StringEncodingUtils {
   }
 
   /**
-   * Fast scan to check if UTF-8 data fits in Latin1 encoding (all code points <= 0xFF). This is a
-   * read-only pass optimized for cache locality.
+   * Fast scan to check if UTF-8 data fits in Latin1 encoding (all code points {@code <= 0xFF}).
+   * This is a read-only pass optimized for cache locality.
    */
   public static boolean isUTF8WithinLatin1(byte[] src, int offset, int length) {
     final int end = offset + length;

--- a/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/encoder/BaseBinaryEncoderBuilder.java
@@ -546,7 +546,8 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
   /**
    * Return an expression to serialize opaque <code>inputObject</code> as binary using <code>fory
    * </code>. When deserialization, using fory to deserialize sliced MemoryBuffer. See {@link
-   * BinaryUtils#getElemAccessMethodName(TypeRef)}, {@link Getters#getBuffer(int)}
+   * BinaryUtils#getElemAccessMethodName(TypeRef,TypeResolutionContext)}, {@link
+   * Getters#getBuffer(int)}
    */
   protected Expression serializeForObject(
       Expression ordinal, Expression writer, Expression inputObject) {
@@ -907,7 +908,8 @@ public abstract class BaseBinaryEncoderBuilder extends CodecBuilder {
 
   /**
    * Using fory to deserialize sliced MemoryBuffer. see {@link
-   * BinaryUtils#getElemAccessMethodName(TypeRef)}, {@link Getters#getBuffer(int)}
+   * BinaryUtils#getElemAccessMethodName(TypeRef,TypeResolutionContext)}, {@link
+   * Getters#getBuffer(int)}
    */
   protected Expression deserializeForObject(Expression value, TypeRef<?> typeRef) {
     return new Invoke(foryRef, "deserialize", typeRef, value);

--- a/java/fory-format/src/main/java/org/apache/fory/format/row/binary/BinaryArray.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/row/binary/BinaryArray.java
@@ -38,8 +38,9 @@ import org.apache.fory.memory.Platform;
 import org.apache.fory.util.Preconditions;
 
 /**
- * Each array has four parts(8-byte aligned): [numElements][validity bits][values or
- * offset&length][variable length portion]
+ * Each array has four parts(8-byte aligned):
+ *
+ * <p>{@code [numElements][validity bits][values or offset&length][variable length portion]}
  *
  * <p>numElements is int, but use 8-byte to align
  *

--- a/java/fory-simd/pom.xml
+++ b/java/fory-simd/pom.xml
@@ -73,7 +73,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
         <configuration>
           <argLine>--add-modules=jdk.incubator.vector</argLine>
         </configuration>
@@ -83,6 +82,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <!-- Turn this on once https://github.com/apache/maven-javadoc-plugin/issues/1310 is resolved -->
+          <failOnWarnings>false</failOnWarnings>
           <additionalOptions>
             <additionalOption>--add-modules=jdk.incubator.vector</additionalOption>
           </additionalOptions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -170,6 +170,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.0.1</version>
           <executions>
@@ -185,6 +190,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.5.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -215,11 +225,6 @@
           <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -237,7 +242,7 @@
             <id>validate</id>
             <phase>validate</phase>
             <goals>
-              <!-- test in ci only or manually invoke the gaol -->
+              <!-- test in ci only or manually invoke the goal -->
               <!-- <goal>check</goal> -->
             </goals>
           </execution>
@@ -271,7 +276,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -288,6 +292,7 @@
           <detectJavaApiLink>false</detectJavaApiLink>
           <detectLinks>false</detectLinks>
           <detectOfflineLinks>false</detectOfflineLinks>
+          <failOnWarnings>true</failOnWarnings>
           <bottom>
             Copyright © 2023-2025, The Apache Software Foundation. Apache Fory™, Fory™, and Apache
             are either registered trademarks or trademarks of the Apache Software Foundation.


### PR DESCRIPTION
## Why?

Javadoc build currently emits many warnings, which are lost in build output and ignored.

## What does this PR do?

Fix the ones that are there, and turn on fail mode, so future warnings cannot be introduced.
