### PR TITLE
fix(java): Restore compact codec fixed width optimizations

### DIFF
--- a/java/fory-format/src/main/java/org/apache/fory/format/row/binary/CompactBinaryArray.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/row/binary/CompactBinaryArray.java
@@ -109,7 +109,7 @@ public class CompactBinaryArray extends BinaryArray {
       return super.getStruct(ordinal, field, extDataSlot);
     }
     if (extData[extDataSlot] == null) {
-      extData[extDataSlot] = DataTypes.createSchema(field);
+      extData[extDataSlot] = newSchema(field);
     }
     final BinaryRow row = newRow((Schema) extData[extDataSlot]);
     row.pointTo(getBuffer(), getOffset(ordinal), fixedWidth);

--- a/java/fory-format/src/main/java/org/apache/fory/format/type/ArrowSchemaConverter.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/type/ArrowSchemaConverter.java
@@ -66,6 +66,8 @@ public class ArrowSchemaConverter {
       return ArrowType.Utf8.INSTANCE;
     } else if (foryType instanceof DataTypes.BinaryType) {
       return ArrowType.Binary.INSTANCE;
+    } else if (foryType instanceof DataTypes.FixedWidthBinaryType) {
+      return new ArrowType.FixedSizeBinary(foryType.byteWidth());
     } else if (foryType instanceof DataTypes.DurationType) {
       return new ArrowType.Duration(TimeUnit.NANOSECOND);
     } else if (foryType instanceof DataTypes.TimestampType) {
@@ -183,6 +185,8 @@ public class ArrowSchemaConverter {
       return DataTypes.utf8();
     } else if (arrowType instanceof ArrowType.Binary) {
       return DataTypes.binary();
+    } else if (arrowType instanceof ArrowType.FixedSizeBinary) {
+      return DataTypes.fixedWidthBinary(((ArrowType.FixedSizeBinary) arrowType).getByteWidth());
     } else if (arrowType instanceof ArrowType.Duration) {
       return DataTypes.duration();
     } else if (arrowType instanceof ArrowType.Timestamp) {

--- a/java/fory-format/src/main/java/org/apache/fory/format/type/DataTypes.java
+++ b/java/fory-format/src/main/java/org/apache/fory/format/type/DataTypes.java
@@ -246,6 +246,19 @@ public class DataTypes {
     }
   }
 
+  /** Raw binary data (fixed-width). */
+  public static class FixedWidthBinaryType extends FixedWidthType {
+
+    private FixedWidthBinaryType(int byteSize) {
+      super(TYPE_BINARY, byteSize * 8);
+    }
+
+    @Override
+    public String name() {
+      return "fixedSizeBinary(" + byteWidth() + ")";
+    }
+  }
+
   // ============================================================================
   // Temporal types
   // ============================================================================
@@ -612,6 +625,10 @@ public class DataTypes {
 
   public static BinaryType binary() {
     return BinaryType.INSTANCE;
+  }
+
+  public static FixedWidthType fixedWidthBinary(int size) {
+    return new FixedWidthBinaryType(size);
   }
 
   public static DurationType duration() {

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/CompactCodecTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/CompactCodecTest.java
@@ -181,16 +181,13 @@ public class CompactCodecTest {
     row.pointTo(buffer, 0, buffer.size());
     final CompactUuidType deserializedBean = encoder.fromRow(row);
     assertEquals(bean1, deserializedBean);
-    // Note: Using binary() type which is variable-width, so size includes offset+size header (8
-    // bytes)
-    // plus the actual data (16 bytes) plus null bitmap (1 byte) plus alignment = 32 bytes
-    assertEquals(buffer.size(), 32);
+    assertEquals(buffer.size(), 17);
   }
 
   static class CompactUUIDCodec implements CustomCodec.MemoryBufferCodec<UUID> {
     @Override
     public Field getForyField(final String fieldName) {
-      return DataTypes.field(fieldName, DataTypes.binary());
+      return DataTypes.field(fieldName, DataTypes.fixedWidthBinary(16));
     }
 
     @Override
@@ -293,8 +290,7 @@ public class CompactCodecTest {
     row.pointTo(buffer, 0, buffer.size());
     final InlineNestedArrayType deserializedBean = encoder.fromRow(row);
     assertEquals(deserializedBean, bean1);
-    // Size is larger due to variable-width binary encoding for UUIDs
-    assertEquals(buffer.size(), 109);
+    assertEquals(buffer.size(), 88);
   }
 
   @Data
@@ -353,8 +349,7 @@ public class CompactCodecTest {
     row.pointTo(buffer, 0, buffer.size());
     final CompactMapType deserializedBean = encoder.fromRow(row);
     assertEquals(deserializedBean, bean1);
-    // Size is larger due to variable-width binary encoding for UUIDs
-    assertEquals(buffer.size(), 161);
+    assertEquals(buffer.size(), 109);
   }
 
   @Test

--- a/java/fory-format/src/test/java/org/apache/fory/format/encoder/CustomCodecTest.java
+++ b/java/fory-format/src/test/java/org/apache/fory/format/encoder/CustomCodecTest.java
@@ -212,7 +212,7 @@ public class CustomCodecTest {
 
     @Override
     public Field getForyField(final String fieldName) {
-      return DataTypes.field(fieldName, DataTypes.binary());
+      return DataTypes.field(fieldName, DataTypes.fixedWidthBinary(16));
     }
   }
 


### PR DESCRIPTION


## Why?

Restores compact codec fixed width binary optimizations

## Related issues

Fixes #3117 