### PR TITLE
feat(ci): add bazel downloads retry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,13 @@
 # Must be first. Enables build:windows, build:linux, build:macos, build:freebsd, build:openbsd
 build --enable_platform_specific_config
 
+# The maximum number of attempts to retry a download error. The default value is 5
+common --experimental_repository_downloader_retries=10
+# The maximum number of attempts for http downloads. The default value is 8.
+common --http_connector_attempts=16
+# Scale all timeouts related to http downloads by the given factor. The default value is 1.0.
+common --http_timeout_scaling=2.0
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python
@@ -55,4 +62,3 @@ build:x86_64 --copt=-mbmi2
 
 # ARM64-specific optimizations (if any needed in the future)
 build:arm64 --copt=-march=armv8-a
-


### PR DESCRIPTION


## Why?

Bazel downloads should retry in case of network issues.

## What does this PR do?

Actually, Bazel 8.2.1 (the version Fory currently uses) **already** supports downloads retrying **by default**. Check `--experimental_repository_downloader_retries`, `--http_connector_attempts` and `--http_timeout_scaling` in the [doc](https://bazel.build/versions/8.2.0/reference/command-line-reference).

I just manually doubled these values in .bazelrc

## Related issues

Closes https://github.com/apache/fory/issues/3491.



## AI Contribution Checklist

No.

## Does this PR introduce any user-facing change?

No.

## Benchmark

No.