### PR TITLE
DRAFT: Ruby xlang buffer + core encodings prototype

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,50 @@
+# Apache Fory Ruby (prototype)
+
+This folder is a small, work-in-progress ruby prototype for Apache Fory’s xlang wire format.
+
+It’s not a usable Ruby runtime yet. The goal is simply to show early progress on the lowest-level building blocks (buffer + integer/string header encodings) and to keep those pieces covered by tests.
+
+## What’s included
+
+- A growable byte `Buffer` with separate read/write cursors
+- Encoding helpers needed by the xlang spec:
+  - little-endian fixed-width ints
+  - `varuint64` / `varint64` (ZigZag)
+  - `TAGGED_INT64` (the xlang “signed hybrid int64”)
+  - `VarUint36Small` for string headers
+  - UTF-8 string header: `(byte_length << 2) | encoding_type`
+- Tests that cover:
+  - round-trips
+  - truncated/malformed inputs
+  - a few golden-byte fixtures (assert exact encoded bytes for selected values)
+
+## Spec notes
+
+This prototype follows the in-repo reference spec:
+- `docs/specification/xlang_serialization_spec.md`
+
+A couple of details that are easy to get wrong (and are explicitly tested here):
+
+- **VarUint36Small**: if `< 0x80`, it’s a single byte; otherwise it falls back to standard `varuint64`.
+- **TAGGED_INT64**:
+  - 4-byte form for values in `[-2^30, 2^30-1]`: write `int32_le(value << 1)`
+  - 9-byte form otherwise: write `0x01` followed by `int64_le(value)`
+- **String encoding ids** used in headers: LATIN1=0, UTF16=1, UTF8=2.
+
+If another runtime turns out to be the canonical reference for a particular corner case, this prototype should be adjusted to match it.
+
+## What’s intentionally not included
+
+- type system / serializers
+- reference tracking
+- TypeDef / meta share
+- collections, structs, enums
+- cross-language interop fixtures (likely a later step)
+
+## Run tests
+
+From the repo root:
+
+- `cd ruby && ruby -Ilib:test test/**/*_test.rb`
+
+This keeps the prototype lightweight (no gem packaging step needed yet).

--- a/ruby/lib/fory.rb
+++ b/ruby/lib/fory.rb
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prototype entrypoint.
+
+require_relative "fory/buffer"
+require_relative "fory/encoding"

--- a/ruby/lib/fory/buffer.rb
+++ b/ruby/lib/fory/buffer.rb
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Fory
+  # growable byte buffer with independent read/write cursors.
+  # this is a prototype-level implementation to support encoding work.
+  class Buffer
+    class Error < StandardError; end
+    class UnderflowError < Error; end
+
+    attr_reader :read_pos, :write_pos
+
+    def initialize(initial_capacity = 64)
+      raise ArgumentError, "initial_capacity must be >= 0" if initial_capacity < 0
+
+      @bytes = String.new(capacity: initial_capacity, encoding: ::Encoding::BINARY)
+      @read_pos = 0
+      @write_pos = 0
+    end
+
+    def self.wrap(bytes)
+      buf = new(0)
+      buf.replace_bytes(bytes)
+      buf
+    end
+
+    def replace_bytes(bytes)
+      @bytes = bytes.dup.force_encoding(::Encoding::BINARY)
+      @read_pos = 0
+      @write_pos = @bytes.bytesize
+      self
+    end
+
+    def bytes
+      @bytes.byteslice(0, @write_pos)
+    end
+
+    def remaining
+      @write_pos - @read_pos
+    end
+
+    def reset_read!
+      @read_pos = 0
+    end
+
+    def clear!
+      @read_pos = 0
+      @write_pos = 0
+      self
+    end
+
+    def ensure_capacity(extra)
+      needed = @write_pos + extra
+      return if needed <= @bytes.bytesize
+
+      new_size = [@bytes.bytesize, 1].max
+      new_size *= 2 while new_size < needed
+      @bytes << "\x00" * (new_size - @bytes.bytesize)
+    end
+
+    def write_bytes(str)
+      str = str.dup.force_encoding(::Encoding::BINARY)
+      ensure_capacity(str.bytesize)
+      @bytes.setbyte(@write_pos, str.getbyte(0)) if str.bytesize == 1
+      @bytes[@write_pos, str.bytesize] = str
+      @write_pos += str.bytesize
+      self
+    end
+
+    def read_bytes(n)
+      raise ArgumentError, "n must be >= 0" if n < 0
+      raise UnderflowError, "need #{n} bytes, have #{remaining}" if remaining < n
+
+      out = @bytes.byteslice(@read_pos, n)
+      @read_pos += n
+      out
+    end
+
+    def write_uint8(v)
+      ensure_capacity(1)
+      @bytes.setbyte(@write_pos, v & 0xFF)
+      @write_pos += 1
+      self
+    end
+
+    def read_uint8
+      raise UnderflowError, "need 1 byte, have #{remaining}" if remaining < 1
+
+      b = @bytes.getbyte(@read_pos)
+      @read_pos += 1
+      b
+    end
+
+    def write_int8(v)
+      write_uint8(v)
+    end
+
+    def read_int8
+      v = read_uint8
+      v >= 0x80 ? v - 0x100 : v
+    end
+
+    def write_int16_le(v)
+      ensure_capacity(2)
+      @bytes.setbyte(@write_pos, v & 0xFF)
+      @bytes.setbyte(@write_pos + 1, (v >> 8) & 0xFF)
+      @write_pos += 2
+      self
+    end
+
+    def read_int16_le
+      b0 = read_uint8
+      b1 = read_uint8
+      v = b0 | (b1 << 8)
+      v >= 0x8000 ? v - 0x10000 : v
+    end
+
+    def write_int32_le(v)
+      ensure_capacity(4)
+      @bytes.setbyte(@write_pos, v & 0xFF)
+      @bytes.setbyte(@write_pos + 1, (v >> 8) & 0xFF)
+      @bytes.setbyte(@write_pos + 2, (v >> 16) & 0xFF)
+      @bytes.setbyte(@write_pos + 3, (v >> 24) & 0xFF)
+      @write_pos += 4
+      self
+    end
+
+    def read_int32_le
+      b0 = read_uint8
+      b1 = read_uint8
+      b2 = read_uint8
+      b3 = read_uint8
+      v = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+      v >= 0x8000_0000 ? v - 0x1_0000_0000 : v
+    end
+
+    def write_int64_le(v)
+      ensure_capacity(8)
+      8.times do |i|
+        @bytes.setbyte(@write_pos + i, (v >> (8 * i)) & 0xFF)
+      end
+      @write_pos += 8
+      self
+    end
+
+    def read_int64_le
+      bytes = read_bytes(8).bytes
+      v = 0
+      bytes.each_with_index { |b, i| v |= (b << (8 * i)) }
+      # interpret as signed 64-bit
+      v >= 0x8000_0000_0000_0000 ? v - 0x1_0000_0000_0000_0000 : v
+    end
+  end
+end

--- a/ruby/lib/fory/encoding.rb
+++ b/ruby/lib/fory/encoding.rb
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Fory
+  module Encoding
+    class Error < StandardError; end
+    class MalformedError < Error; end
+    class TruncatedError < Error; end
+
+    module_function
+
+    def zigzag_encode_i64(n)
+      ((n << 1) ^ (n >> 63)) & 0xFFFF_FFFF_FFFF_FFFF
+    end
+
+    def zigzag_decode_i64(u)
+      ((u >> 1) ^ -(u & 1))
+    end
+
+    def write_varuint64(buf, value)
+      v = value & 0xFFFF_FFFF_FFFF_FFFF
+      while v >= 0x80
+        buf.write_uint8((v & 0x7F) | 0x80)
+        v >>= 7
+      end
+      buf.write_uint8(v)
+    end
+
+    def read_varuint64(buf, max_bytes: 10)
+      shift = 0
+      result = 0
+      i = 0
+      while i < max_bytes
+        raise TruncatedError, "truncated varuint" if buf.remaining < 1
+        b = buf.read_uint8
+        result |= ((b & 0x7F) << shift)
+        return result if (b & 0x80) == 0
+        shift += 7
+        i += 1
+      end
+      raise MalformedError, "varuint too long"
+    end
+
+    def write_varint64(buf, value)
+      write_varuint64(buf, zigzag_encode_i64(value))
+    end
+
+    def read_varint64(buf)
+      zigzag_decode_i64(read_varuint64(buf))
+    end
+
+
+    def write_tagged_int64(buf, value)
+      if value >= -1_073_741_824 && value <= 1_073_741_823
+        buf.write_int32_le(value << 1)
+      else
+        buf.write_uint8(0x01)
+        buf.write_int64_le(value)
+      end
+    end
+
+    def read_tagged_int64(buf)
+      raise TruncatedError, "truncated tagged int64" if buf.remaining < 4
+
+      b0 = buf.read_uint8
+      b1 = buf.read_uint8
+      b2 = buf.read_uint8
+      b3 = buf.read_uint8
+      u32 = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+
+      if (u32 & 1) == 0
+        i32 = u32 >= 0x8000_0000 ? u32 - 0x1_0000_0000 : u32
+        (i32 >> 1)
+      else
+        raise TruncatedError, "truncated tagged int64" if buf.remaining < 5
+        buf.instance_variable_set(:@read_pos, buf.read_pos - 3)
+        buf.read_int64_le
+      end
+    end
+
+    def write_varuint36_small(buf, value)
+      raise ArgumentError, "value must be >= 0" if value < 0
+      raise ArgumentError, "value too large for varuint36" if value > 0xFFFF_FFFFF
+
+      if value < 0x80
+        buf.write_uint8(value)
+      else
+        write_varuint64(buf, value)
+      end
+    end
+
+    def read_varuint36_small(buf)
+      raise TruncatedError, "truncated varuint36" if buf.remaining < 1
+
+      b0 = buf.read_uint8
+      if (b0 & 0x80) == 0
+        v = b0
+      else
+        buf.instance_variable_set(:@read_pos, buf.read_pos - 1)
+        v = read_varuint64(buf)
+      end
+
+      raise MalformedError, "varuint36 overflow" if v > 0xFFFF_FFFFF
+      v
+    end
+
+    UTF8 = 2
+
+    def write_string_utf8_header(buf, byte_length)
+      header = (byte_length << 2) | UTF8
+      write_varuint36_small(buf, header)
+    end
+
+    def read_string_header(buf)
+      header = read_varuint36_small(buf)
+      encoding = header & 0x3
+      byte_length = header >> 2
+      [byte_length, encoding]
+    end
+  end
+end

--- a/ruby/test/buffer_test.rb
+++ b/ruby/test/buffer_test.rb
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "test_helper"
+
+class BufferTest < Minitest::Test
+  def test_le_roundtrip
+    buf = Fory::Buffer.new
+    buf.write_int8(-1)
+    buf.write_int16_le(-2)
+    buf.write_int32_le(-3)
+    buf.write_int64_le(-4)
+
+    buf.reset_read!
+    assert_equal(-1, buf.read_int8)
+    assert_equal(-2, buf.read_int16_le)
+    assert_equal(-3, buf.read_int32_le)
+    assert_equal(-4, buf.read_int64_le)
+  end
+
+  def test_underflow
+    buf = Fory::Buffer.wrap("\x01")
+    buf.read_uint8
+    assert_raises(Fory::Buffer::UnderflowError) { buf.read_uint8 }
+  end
+
+  def test_grows
+    buf = Fory::Buffer.new(0)
+    100.times { buf.write_uint8(0xAA) }
+    assert_equal(100, buf.bytes.bytesize)
+  end
+end

--- a/ruby/test/encoding_test.rb
+++ b/ruby/test/encoding_test.rb
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "test_helper"
+
+class EncodingTest < Minitest::Test
+  def test_varuint64_roundtrip
+    values = [0, 1, 127, 128, 300, 16_384, 2**32 - 1, 2**63 - 1]
+    values.each do |v|
+      buf = Fory::Buffer.new
+      Fory::Encoding.write_varuint64(buf, v)
+      buf.reset_read!
+      assert_equal(v, Fory::Encoding.read_varuint64(buf))
+    end
+  end
+
+  def test_varint64_roundtrip
+    values = [0, 1, -1, 63, -64, 64, -65, 2**31, -(2**31), 2**63 - 1, -(2**63)]
+    values.each do |v|
+      buf = Fory::Buffer.new
+      Fory::Encoding.write_varint64(buf, v)
+      buf.reset_read!
+      assert_equal(v, Fory::Encoding.read_varint64(buf))
+    end
+  end
+
+  def test_varuint_malformed_too_long
+    buf = Fory::Buffer.wrap("\x80" * 10)
+    assert_raises(Fory::Encoding::MalformedError) { Fory::Encoding.read_varuint64(buf, max_bytes: 3) }
+  end
+
+  def test_varuint_truncated
+    buf = Fory::Buffer.wrap("\x80")
+    assert_raises(Fory::Encoding::TruncatedError) { Fory::Encoding.read_varuint64(buf) }
+  end
+
+  def test_tagged_int64_roundtrip
+    values = [
+      -1_073_741_825, -1_073_741_824, -32_768, -129, -128, -1, 0, 1, 127, 128,
+      1_073_741_823, 1_073_741_824,
+      -(2**63), (2**63) - 1
+    ]
+    values.each do |v|
+      buf = Fory::Buffer.new
+      Fory::Encoding.write_tagged_int64(buf, v)
+      buf.reset_read!
+      assert_equal(v, Fory::Encoding.read_tagged_int64(buf))
+    end
+  end
+
+  def test_varuint36_small_roundtrip
+    values = [0, 1, 127, 128, 16_384, 0xFFFF_FFFFF]
+    values.each do |v|
+      buf = Fory::Buffer.new
+      Fory::Encoding.write_varuint36_small(buf, v)
+      buf.reset_read!
+      assert_equal(v, Fory::Encoding.read_varuint36_small(buf))
+    end
+  end
+
+  def test_varuint36_small_truncated
+    # First byte indicates multi-byte varint but no continuation bytes.
+    buf = Fory::Buffer.wrap("\x80")
+    assert_raises(Fory::Encoding::TruncatedError) { Fory::Encoding.read_varuint36_small(buf) }
+  end
+
+  def test_string_header
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_string_utf8_header(buf, 123)
+    buf.reset_read!
+    len, enc = Fory::Encoding.read_string_header(buf)
+    assert_equal(123, len)
+    assert_equal(Fory::Encoding::UTF8, enc)
+  end
+
+  def test_varuint36_small_golden
+    cases = {
+      0 => ["00"],
+      1 => ["01"],
+      127 => ["7F"],
+      128 => ["80", "01"],
+      16_384 => ["80", "80", "01"],
+    }
+
+    cases.each do |value, expected_hex|
+      buf = Fory::Buffer.new
+      Fory::Encoding.write_varuint36_small(buf, value)
+      assert_equal(expected_hex, buf.bytes.bytes.map { |b| "%02X" % b })
+
+      buf.reset_read!
+      assert_equal(value, Fory::Encoding.read_varuint36_small(buf))
+    end
+  end
+
+  def test_tagged_int64_golden
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_tagged_int64(buf, 1)
+    assert_equal(["02", "00", "00", "00"], buf.bytes.bytes.map { |b| "%02X" % b })
+
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_tagged_int64(buf, 1_073_741_824)
+    assert_equal(
+      ["01", "00", "00", "00", "40", "00", "00", "00", "00"],
+      buf.bytes.bytes.map { |b| "%02X" % b }
+    )
+  end
+
+  def test_string_header_golden_utf8
+
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_string_utf8_header(buf, 0)
+    assert_equal(["02"], buf.bytes.bytes.map { |b| "%02X" % b })
+
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_string_utf8_header(buf, 1)
+    assert_equal(["06"], buf.bytes.bytes.map { |b| "%02X" % b })
+
+    buf = Fory::Buffer.new
+    Fory::Encoding.write_string_utf8_header(buf, 128)
+    assert_equal(["82", "04"], buf.bytes.bytes.map { |b| "%02X" % b })
+  end
+end

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift File.expand_path("..", __dir__)
+
+require "minitest/autorun"
+require "fory"


### PR DESCRIPTION
# Apache Fory Ruby (prototype)

This folder is a small, work-in-progress ruby prototype for Apache Fory’s xlang wire format.

It’s not a usable Ruby runtime yet. The goal is simply to show early progress on the lowest-level building blocks (buffer + integer/string header encodings) and to keep those pieces covered by tests.

## What’s included

- A growable byte `Buffer` with separate read/write cursors
- Encoding helpers needed by the xlang spec:
  - little-endian fixed-width ints
  - `varuint64` / `varint64` (ZigZag)
  - `TAGGED_INT64` (the xlang “signed hybrid int64”)
  - `VarUint36Small` for string headers
  - UTF-8 string header: `(byte_length << 2) | encoding_type`
- Tests that cover:
  - round-trips
  - truncated/malformed inputs
  - a few golden-byte fixtures (assert exact encoded bytes for selected values)

## Spec notes

This prototype follows the in-repo reference spec:
- `docs/specification/xlang_serialization_spec.md`

A couple of details that are easy to get wrong (and are explicitly tested here):

- **VarUint36Small**: if `< 0x80`, it’s a single byte; otherwise it falls back to standard `varuint64`.
- **TAGGED_INT64**:
  - 4-byte form for values in `[-2^30, 2^30-1]`: write `int32_le(value << 1)`
  - 9-byte form otherwise: write `0x01` followed by `int64_le(value)`
- **String encoding ids** used in headers: LATIN1=0, UTF16=1, UTF8=2.

If another runtime turns out to be the canonical reference for a particular corner case, this prototype should be adjusted to match it.

## What’s intentionally not included

- type system / serializers
- reference tracking
- TypeDef / meta share
- collections, structs, enums
- cross-language interop fixtures (likely a later step)

## Run tests

From the repo root:

- `cd ruby && ruby -Ilib:test test/**/*_test.rb`

