### PR TITLE
fix(compiler): repair broken service example and add regression coverage

### DIFF
--- a/compiler/examples/service.fdl
+++ b/compiler/examples/service.fdl
@@ -15,17 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package demo.service;
+package demo.greeter;
 
 message HelloRequest {
     string name = 1;
 }
 
 message HelloReply {
-    string message = 1;
+    string reply = 1;
 }
 
 service Greeter {
     rpc SayHello (HelloRequest) returns (HelloReply);
 }
-

--- a/compiler/fory_compiler/tests/test_service_example.py
+++ b/compiler/fory_compiler/tests/test_service_example.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pathlib import Path
+
+from fory_compiler.cli import compile_file
+
+
+def test_service_example_compiles_for_java_and_python(tmp_path: Path):
+    example_path = Path(__file__).resolve().parents[2] / "examples" / "service.fdl"
+
+    java_out = tmp_path / "java"
+    python_out = tmp_path / "python"
+    ok = compile_file(
+        example_path,
+        {
+            "java": java_out,
+            "python": python_out,
+        },
+    )
+
+    assert ok is True
+    assert (java_out / "demo" / "greeter" / "HelloRequest.java").exists()
+    assert (java_out / "demo" / "greeter" / "HelloReply.java").exists()
+    assert (python_out / "demo_greeter.py").exists()

--- a/docs/compiler/compiler-guide.md
+++ b/docs/compiler/compiler-guide.md
@@ -136,7 +136,7 @@ foryc schema.fdl --package com.myapp.models
 foryc user.fdl order.fdl product.fdl --output ./generated
 ```
 
-**Compile a simple service schema (Java + Python):**
+**Compile a simple schema containing service definitions (Java + Python models):**
 
 ```bash
 foryc compiler/examples/service.fdl --java_out=./generated/java --python_out=./generated/python


### PR DESCRIPTION
## Why?

`compiler/examples/service.fdl` is currently broken as a runnable example.

I found this while bringing up the compiler locally and running the documented service example command from the compiler guide.

The example currently fails because:

1. the package name used `demo.service`, where `service` is a reserved FDL keyword
2. the reply field used `message` as an identifier, which is also a reserved keyword

So the documented example is not actually usable in its current form.

## What does this PR do?

- changes the example package from `demo.service` to `demo.greeter`
- renames the reply field from `message` to `reply`
- updates the compiler guide wording around this example
- adds a regression test that compiles the example for Java and Python outputs

## Related issues

- N/A

## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: `yes`
- [x] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [x] If `yes`, I can explain and defend all important changes without AI help.
- [x] If `yes`, I reviewed AI-assisted code changes line by line before submission.
- [x] If `yes`, I ran adequate human verification and recorded evidence.
- [x] If `yes`, I added or updated tests and docs where required.
- [x] If `yes`, I validated protocol or performance impacts with evidence when applicable.
- [x] If `yes`, I verified licensing and provenance compliance.

AI Usage Disclosure
- substantial_ai_assistance: yes
- scope: limited drafting assistance for code/test/doc edits and PR wording after manual reproduction and verification
- affected_files_or_subsystems: compiler example schema, compiler docs, compiler tests
- human_verification: manually reproduced the original failure on a clean `main` checkout, reviewed all changes line by line, then in my local compiler environment from `compiler/` ran `PYTHONPATH=. python3 -m pytest fory_compiler/tests/test_service_example.py -q` -> `1 passed`; also ran `PYTHONPATH=. python -m fory_compiler compile examples/service.fdl --java_out=/tmp/fory_service_example_java_pr1 --python_out=/tmp/fory_service_example_py_pr1` and verified generation succeeded
- performance_verification: N/A
- provenance_license_confirmation: Apache-2.0-compatible provenance confirmed; no incompatible third-party code introduced

## Does this PR introduce any user-facing change?

- This fixes a broken example and its documentation path, but it does not change a public API or binary protocol.
- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
