### PR TITLE
feat: add basic maven plugin for fory compiler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,15 +214,15 @@ sudo flamegraph.pl out.folded > out.svg
 
 ```bash
 bazel run :refresh_compile_commands
-```
+```  
 
 ## How to use Jetbrains IDEA IDE for Java Development
 
-Apache Fory™ Java development is based on Java 11+, and different modules are built with different Java versions.
+Apache Fory™ Java development is based on Java 11+, and different modules may be build using different Java versions.
 
 For example, the `fory-core` module is built with Java 8, and the `fory-format` module is built with Java 11.
 
-To use Jetbrains IDEA IDE for Java Development, you need to configure the project SDK and module SDK to using JDK 11+.
+To use JetBrains IDEA IDE for Java Development, you need to configure the project SDK and module SDK to using JDK 11+.
 
 And due to the usage of `sun.misc.Unsafe` API, which is not visible in Java 11+, you need to configure java compiler with `--releaese` option disabled.
 

--- a/java/fory-compiler-maven-plugin/pom.xml
+++ b/java/fory-compiler-maven-plugin/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.fory</groupId>
+    <artifactId>fory-compiler-maven-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Fory Compiler Maven Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.9.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.6.4</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java/fory-compiler-maven-plugin/src/main/java/org/apache/fory/plugin/ForyMojo.java
+++ b/java/fory-compiler-maven-plugin/src/main/java/org/apache/fory/plugin/ForyMojo.java
@@ -1,0 +1,14 @@
+package org.apache.fory.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+@Mojo(name = "compile")
+public class ForyMojo extends AbstractMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        getLog().info("🔥 Fory Compiler Plugin is running...");
+    }
+}


### PR DESCRIPTION
## What
Added a basic Maven plugin for Fory compiler.

## Why
To enable integration of Fory compiler with Maven builds.

## Changes
- Created Maven plugin module
- Added basic Mojo implementation
- Added required dependencies in pom.xml

## Notes
This is an initial version and can be extended further.