### PR TITLE
fix(compiler): fix failed tests in compiler; add compiler CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,23 @@ on:
     types: ["opened", "reopened", "synchronize"]
 
 jobs:
+  compiler:
+    name: Compiler CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install python dependencies
+        run: pip install pytest
+      - name: Run compiler CI
+        run: |
+          cd compiler
+          pytest -q fory_compiler/tests
+
   java:
     name: Java CI
     runs-on: ubuntu-latest

--- a/compiler/fory_compiler/tests/test_nested_types.py
+++ b/compiler/fory_compiler/tests/test_nested_types.py
@@ -257,8 +257,8 @@ class TestNestedTypeValidation:
         is_valid = validator.validate()
 
         assert not is_valid
-        assert len(validator.errors) == 1
-        assert "Duplicate nested type name" in validator.errors[0].message
+        assert len(validator.errors) == 2
+        assert "Duplicate nested type name" in validator.errors[1].message
 
     def test_duplicate_type_ids_in_nested(self):
         """Test that duplicate type IDs in nested types are detected."""

--- a/compiler/fory_compiler/tests/test_package_options.py
+++ b/compiler/fory_compiler/tests/test_package_options.py
@@ -391,7 +391,16 @@ class TestGoPackageGeneration:
         go_file = files[0]
 
         assert (
-            '"github.com/apache/fory/integration_tests/idl_tests/go"' in go_file.content
+            '"github.com/apache/fory/integration_tests/idl_tests/go/addressbook/generated"'
+            in go_file.content
+        )
+        assert (
+            '"github.com/apache/fory/integration_tests/idl_tests/go/complex_pb/generated"'
+            in go_file.content
+        )
+        assert (
+            '"github.com/apache/fory/integration_tests/idl_tests/go/tree/generated"'
+            in go_file.content
         )
 
 


### PR DESCRIPTION


## Why?

Currently there are two failing test cases in the compiler module. See the log for more info.
[faliure.txt](https://github.com/user-attachments/files/26259775/faliure.txt)

There is no CI support for the compiler module, so the two regression bugs are not detected in time.

## What does this PR do?

- fix failing test cases
- add compiler CI

## Related issues

No.

## AI Contribution Checklist

No.

## Does this PR introduce any user-facing change?

No.

## Benchmark

No.