### PR TITLE
test(cpp): optimize float16 sign symmetry test for ASAN

### DIFF
--- a/cpp/fory/util/float16_test.cc
+++ b/cpp/fory/util/float16_test.cc
@@ -307,13 +307,31 @@ TEST(Float16FromFloatTest, IntegerAndUlpRegressionCases) {
 }
 
 TEST(Float16FromFloatTest, SignSymmetryForNonNaNBitPatterns) {
-  for (uint32_t bits = 0; bits < 0xFFFFFFFFu; bits += 104729u) {
-    const float value = bits_to_float(bits);
-    if (std::isnan(value)) {
-      continue;
+  auto test_range = [](uint32_t start, uint32_t end, uint32_t step) {
+    for (uint32_t bits = start; bits < end; bits += step) {
+      const float value = bits_to_float(bits);
+      if (!std::isnan(value)) {
+        ExpectSignSymmetry(value);
+      }
     }
-    ExpectSignSymmetry(value);
+  };
+
+  test_range(0x00000000u, 0x00800000u, 4099u);
+
+  test_range(0x33000000u, 0x38800000u, 1031u);
+  test_range(0x00800000u, 0x33000000u, 200003u);
+
+  for (uint32_t exp = 113; exp <= 142; ++exp) {
+    const uint32_t base = exp << 23;
+    test_range(base, base + 64u, 1u);
+    test_range(base + 0x007FFF00u, base + 0x00800000u, 1u);
   }
+
+  test_range(0x38800000u, 0x47800000u, 50021u);
+
+  test_range(0x47800000u, 0x7F800000u, 100003u);
+
+  ExpectSignSymmetry(bits_to_float(0x7F800000u));
 }
 
 TEST(Float16Test, FromBitsRoundTrip) {


### PR DESCRIPTION
**Optimize float16 sign symmetry test to fix ASAN slow down**




## Why?



## What does this PR do?
The `SignSymmetryForNonNaNBitPatterns` test was doing a massive brute-force scan across ~41k float32 patterns. Under ASAN, the heavy memory instrumentation caused this single test to take ~246 seconds.
Instead of scanning the whole range, this rewrites the test to just densely sample the actual critical boundaries (subnormals, underflow/overflow thresholds, and normal bins). We get the exact same edge-case coverage, but the test now finishes in just **~13ms**.


## Related issues
fix: #3524


## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
normal build:
<img width="1125" height="650" alt="Screenshot From 2026-03-30 21-54-21" src="https://github.com/user-attachments/assets/da74ac5a-8739-45eb-b385-30bc494ecebc" />
asan build:
<img width="1106" height="883" alt="Screenshot From 2026-03-30 21-55-36" src="https://github.com/user-attachments/assets/43eed5c6-f5c3-4fc9-aed4-07d43a39b650" />


ASAN runtime down from 246s to 13ms!  
