### PR TITLE
fix(dart): use getUint32 for correctly encoding u64 value

### DIFF
--- a/dart/packages/fory/lib/src/buffer.dart
+++ b/dart/packages/fory/lib/src/buffer.dart
@@ -402,7 +402,7 @@ final class Buffer {
   /// Reads an unsigned 64-bit integer written by [writeTaggedUint64].
   int readTaggedUint64() {
     final readIndex = _readerIndex;
-    final first = _view.getInt32(readIndex, Endian.little);
+    final first = _view.getUint32(readIndex, Endian.little);
     if ((first & 1) == 0) {
       _readerIndex = readIndex + 4;
       return first >>> 1;

--- a/dart/packages/fory/lib/src/codegen/generated_support.dart
+++ b/dart/packages/fory/lib/src/codegen/generated_support.dart
@@ -345,7 +345,7 @@ final class GeneratedReadCursor {
 
   int readTaggedUint64() {
     final readIndex = _offset;
-    final first = _view.getInt32(readIndex, Endian.little);
+    final first = _view.getUint32(readIndex, Endian.little);
     if ((first & 1) == 0) {
       _offset = readIndex + 4;
       return first >>> 1;

--- a/dart/packages/fory/test/buffer_test.dart
+++ b/dart/packages/fory/test/buffer_test.dart
@@ -1,4 +1,6 @@
+import 'dart:typed_data';
 import 'package:fory/fory.dart';
+import 'package:fory/src/codegen/generated_support.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -26,6 +28,31 @@ void main() {
       expect(buffer.readVarUint32(), equals(300));
       expect(buffer.readVarInt64(), equals(-17));
       expect(buffer.readVarUint64(), equals(9000));
+    });
+
+    test('tagged uint64 sign extension regression', () {
+      final buffer = Buffer();
+      final testValue = 0x7FFFFFFF;
+
+      buffer.writeTaggedUint64(testValue);
+      buffer.wrap(buffer.toBytes());
+
+      final result = buffer.readTaggedUint64();
+
+      expect(result, equals(testValue));
+    });
+
+    test('GeneratedReadCursor tagged uint64 sign extension regression', () {
+      final buffer = Buffer();
+      final testValue = 0x7FFFFFFF;
+
+      buffer.writeTaggedUint64(testValue);
+      buffer.wrap(buffer.toBytes());
+
+      final cursor = GeneratedReadCursor.start(buffer);
+      final result = cursor.readTaggedUint64();
+
+      expect(result, equals(testValue));
     });
   });
 }


### PR DESCRIPTION
## Why?
`getInt32` treats the top bit as a sign bit. For large values where that bit is set (0xFFFFFFFE), the number comes back negative. Even though >>> is unsigned shift, it is shifting the already-corrupted signed value, garbage in, garbage out.
## What does this PR do?
Use `getUint32` instead.
`getUint32` has no sign bit, so all 32 bits are treated as magnitude.
## Related issues
N/A


## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


