### PR TITLE
fix(go): add bound checking for refResolver and metaStringResolver reads

### DIFF
--- a/go/fory/meta_string_resolver.go
+++ b/go/fory/meta_string_resolver.go
@@ -124,7 +124,7 @@ func (r *MetaStringResolver) ReadMetaStringBytes(buf *ByteBuffer, ctxErr *Error)
 	length := int16(header >> 1)
 	if header&1 != 0 {
 		index := int(length) - 1
-		if index >= len(r.dynamicIDToEnumString) {
+		if index < 0 || index >= len(r.dynamicIDToEnumString) {
 			return nil, fmt.Errorf("invalid dynamic index: %d", index)
 		}
 		return r.dynamicIDToEnumString[index], nil

--- a/go/fory/meta_string_resolver_test.go
+++ b/go/fory/meta_string_resolver_test.go
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fory
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetaStringResolverNegativeIndexPanic reproduces the CRITICAL security bug 
+// in MetaStringResolver where a header of 1 triggers a -1 index panic.
+func TestMetaStringResolverNegativeIndexPanic(t *testing.T) {
+	resolver := NewMetaStringResolver()
+	buffer := NewByteBuffer(nil)
+	
+	// header = 1 means (header & 1 != 0) is true (it's a reference)
+	// and length = header >> 1 = 0.
+	// index = length - 1 = -1.
+	buffer.WriteVarUint32Small7(1)
+	buffer.SetReaderIndex(0)
+
+	var ctxErr Error
+	// This should NOT panic. The fix handles the negative index.
+	require.NotPanics(t, func() {
+		_, err := resolver.ReadMetaStringBytes(buffer, &ctxErr)
+		if err == nil {
+			t.Errorf("Expected error for negative index, got nil")
+		}
+	}, "MetaStringResolver should not panic on negative index")
+}
+
+// TestMetaStringResolverBoundaryRegression verifies that the smallest valid
+// dynamic index (resulting in index 0) still resolves correctly.
+func TestMetaStringResolverBoundaryRegression(t *testing.T) {
+	resolver := NewMetaStringResolver()
+	
+	// Add a string to the cache so len is 1
+	m := NewMetaStringBytes([]byte("test"), 123)
+	resolver.dynamicIDToEnumString = append(resolver.dynamicIDToEnumString, m)
+
+	// Craft a header that points to index 0
+	// header = (index + 1) << 1 | 1 
+	// For index 0: (0 + 1) << 1 | 1 = 3
+	buffer := NewByteBuffer(nil)
+	buffer.WriteVarUint32Small7(3) 
+	buffer.SetReaderIndex(0)
+
+	var ctxErr Error
+	result, err := resolver.ReadMetaStringBytes(buffer, &ctxErr)
+	require.NoError(t, err)
+	require.Equal(t, m, result, "Should correctly resolve the first dynamic string (index 0)")
+}

--- a/go/fory/meta_string_resolver_test.go
+++ b/go/fory/meta_string_resolver_test.go
@@ -18,16 +18,16 @@
 package fory
 
 import (
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
-// TestMetaStringResolverNegativeIndexPanic reproduces the CRITICAL security bug 
+// TestMetaStringResolverNegativeIndexPanic reproduces the CRITICAL security bug
 // in MetaStringResolver where a header of 1 triggers a -1 index panic.
 func TestMetaStringResolverNegativeIndexPanic(t *testing.T) {
 	resolver := NewMetaStringResolver()
 	buffer := NewByteBuffer(nil)
-	
+
 	// header = 1 means (header & 1 != 0) is true (it's a reference)
 	// and length = header >> 1 = 0.
 	// index = length - 1 = -1.
@@ -48,16 +48,16 @@ func TestMetaStringResolverNegativeIndexPanic(t *testing.T) {
 // dynamic index (resulting in index 0) still resolves correctly.
 func TestMetaStringResolverBoundaryRegression(t *testing.T) {
 	resolver := NewMetaStringResolver()
-	
+
 	// Add a string to the cache so len is 1
 	m := NewMetaStringBytes([]byte("test"), 123)
 	resolver.dynamicIDToEnumString = append(resolver.dynamicIDToEnumString, m)
 
 	// Craft a header that points to index 0
-	// header = (index + 1) << 1 | 1 
+	// header = (index + 1) << 1 | 1
 	// For index 0: (0 + 1) << 1 | 1 = 3
 	buffer := NewByteBuffer(nil)
-	buffer.WriteVarUint32Small7(3) 
+	buffer.WriteVarUint32Small7(3)
 	buffer.SetReaderIndex(0)
 
 	var ctxErr Error

--- a/go/fory/ref_resolver.go
+++ b/go/fory/ref_resolver.go
@@ -277,6 +277,9 @@ func (r *RefResolver) GetReadObject(refId int32) reflect.Value {
 	if refId < 0 {
 		return r.readObject
 	}
+	if int(refId) >= len(r.readObjects) {
+		return reflect.Value{}
+	}
 	return r.readObjects[refId]
 }
 

--- a/go/fory/ref_resolver_test.go
+++ b/go/fory/ref_resolver_test.go
@@ -189,7 +189,7 @@ func TestRefTrackingLargeCount(t *testing.T) {
 func TestRefResolverOOBPanic(t *testing.T) {
 	resolver := newRefResolver(true)
 	buffer := NewByteBuffer(nil)
-	
+
 	// Craft a buffer with RefFlag (-2) followed by a huge RefID (9999)
 	buffer.WriteInt8(RefFlag)
 	buffer.WriteVarUint32(9999)
@@ -207,7 +207,7 @@ func TestRefResolverOOBPanic(t *testing.T) {
 func TestRefResolverBoundaryRegression(t *testing.T) {
 	resolver := newRefResolver(true)
 	val := reflect.ValueOf("test")
-	
+
 	// Fill the resolver with 2 objects
 	id0, _ := resolver.PreserveRefId()
 	resolver.SetReadObject(id0, val)

--- a/go/fory/ref_resolver_test.go
+++ b/go/fory/ref_resolver_test.go
@@ -183,3 +183,38 @@ func TestRefTrackingLargeCount(t *testing.T) {
 		})
 	}
 }
+
+// TestRefResolverOOBPanic reproduces the CRITICAL security bug in RefResolver
+// where a huge refId in the buffer triggers an OOB panic.
+func TestRefResolverOOBPanic(t *testing.T) {
+	resolver := newRefResolver(true)
+	buffer := NewByteBuffer(nil)
+	
+	// Craft a buffer with RefFlag (-2) followed by a huge RefID (9999)
+	buffer.WriteInt8(RefFlag)
+	buffer.WriteVarUint32(9999)
+	buffer.SetReaderIndex(0)
+
+	var ctxErr Error
+	// This should NOT panic. The fix handles the invalid index gracefully.
+	require.NotPanics(t, func() {
+		resolver.ReadRefOrNull(buffer, &ctxErr)
+	}, "RefResolver.GetReadObject should not panic on OOB index")
+}
+
+// TestRefResolverBoundaryRegression verifies that valid boundary indices
+// (0 and len-1) still resolve correctly after the security fix.
+func TestRefResolverBoundaryRegression(t *testing.T) {
+	resolver := newRefResolver(true)
+	val := reflect.ValueOf("test")
+	
+	// Fill the resolver with 2 objects
+	id0, _ := resolver.PreserveRefId()
+	resolver.SetReadObject(id0, val)
+	id1, _ := resolver.PreserveRefId()
+	resolver.SetReadObject(id1, val)
+
+	// Verify boundary indices still work
+	require.Equal(t, val.String(), resolver.GetReadObject(0).String(), "Should resolve index 0")
+	require.Equal(t, val.String(), resolver.GetReadObject(1).String(), "Should resolve index len-1")
+}


### PR DESCRIPTION
## Why?
This PR addresses two critical security vulnerabilities in the Fory Go runtime.
Both issues stemmed from trusting integer values (references/indices) read directly from the wire. A maliciously crafted payload could provide an out-of-bounds index (either too large or negative), triggering a runtime panic. In a server environment, this would allow an attacker to perform a Denial of Service (DoS) attack by crashing the Go process with a single malicious packet.

## What does this PR do?

- Bounds Checking in `RefResolver`: added an upper-bound check in `GetReadObject` to ensure `refId` does not exceed the size of the `readObjects` slice.
- Bounds Checking in `MetaStringResolver`: added a lower-bound check in `ReadMetaStringBytes` to prevent negative index panics (e.g., when a header value of 1 is provided).
- Security & Regression Tests:
Added unit tests in `ref_resolver_test.go` and `meta_string_resolver_test.go` that specifically reproduce the OOB and negative-index panics.
- Added boundary regression tests to verify that valid edge cases (indices 0 and `len-1`) still function correctly.

## Related issues
Closes #3614 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark
N/A