### PR TITLE
fix(go): added pre-allocation bounds checks for slices and strings

### DIFF
--- a/go/fory/slice_primitive.go
+++ b/go/fory/slice_primitive.go
@@ -695,7 +695,7 @@ func ReadByteSlice(buf *ByteBuffer, err *Error) []byte {
 	if size == 0 {
 		return make([]byte, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -720,7 +720,7 @@ func ReadBoolSlice(buf *ByteBuffer, err *Error) []bool {
 	if size == 0 {
 		return make([]bool, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -745,7 +745,7 @@ func ReadInt8Slice(buf *ByteBuffer, err *Error) []int8 {
 	if size == 0 {
 		return make([]int8, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -777,7 +777,7 @@ func ReadInt16Slice(buf *ByteBuffer, err *Error) []int16 {
 	if length == 0 {
 		return make([]int16, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -815,7 +815,7 @@ func ReadInt32Slice(buf *ByteBuffer, err *Error) []int32 {
 	if length == 0 {
 		return make([]int32, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -853,7 +853,7 @@ func ReadInt64Slice(buf *ByteBuffer, err *Error) []int64 {
 	if length == 0 {
 		return make([]int64, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -891,7 +891,7 @@ func ReadUint16Slice(buf *ByteBuffer, err *Error) []uint16 {
 	if length == 0 {
 		return make([]uint16, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -929,7 +929,7 @@ func ReadUint32Slice(buf *ByteBuffer, err *Error) []uint32 {
 	if length == 0 {
 		return make([]uint32, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -967,7 +967,7 @@ func ReadUint64Slice(buf *ByteBuffer, err *Error) []uint64 {
 	if length == 0 {
 		return make([]uint64, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -1005,7 +1005,7 @@ func ReadFloat32Slice(buf *ByteBuffer, err *Error) []float32 {
 	if length == 0 {
 		return make([]float32, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -1043,7 +1043,7 @@ func ReadFloat64Slice(buf *ByteBuffer, err *Error) []float64 {
 	if length == 0 {
 		return make([]float64, 0)
 	}
-	if size > buf.writerIndex-buf.readerIndex {
+	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 		return nil
 	}
@@ -1181,7 +1181,7 @@ func ReadIntSlice(buf *ByteBuffer, err *Error) []int {
 		if length == 0 {
 			return make([]int, 0)
 		}
-		if size > buf.writerIndex-buf.readerIndex {
+		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 			return nil
 		}
@@ -1200,7 +1200,7 @@ func ReadIntSlice(buf *ByteBuffer, err *Error) []int {
 		if length == 0 {
 			return make([]int, 0)
 		}
-		if size > buf.writerIndex-buf.readerIndex {
+		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 			return nil
 		}
@@ -1254,7 +1254,7 @@ func ReadUintSlice(buf *ByteBuffer, err *Error) []uint {
 		if length == 0 {
 			return make([]uint, 0)
 		}
-		if size > buf.writerIndex-buf.readerIndex {
+		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 			return nil
 		}
@@ -1273,7 +1273,7 @@ func ReadUintSlice(buf *ByteBuffer, err *Error) []uint {
 		if length == 0 {
 			return make([]uint, 0)
 		}
-		if size > buf.writerIndex-buf.readerIndex {
+		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
 			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
 			return nil
 		}

--- a/go/fory/slice_primitive.go
+++ b/go/fory/slice_primitive.go
@@ -695,12 +695,11 @@ func ReadByteSlice(buf *ByteBuffer, err *Error) []byte {
 	if size == 0 {
 		return make([]byte, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+	raw := buf.ReadBinary(size, err)
+	if err.HasError() {
 		return nil
 	}
 	result := make([]byte, size)
-	raw := buf.ReadBinary(size, err)
 	copy(result, raw)
 	return result
 }
@@ -720,12 +719,11 @@ func ReadBoolSlice(buf *ByteBuffer, err *Error) []bool {
 	if size == 0 {
 		return make([]bool, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+	raw := buf.ReadBinary(size, err)
+	if err.HasError() {
 		return nil
 	}
 	result := make([]bool, size)
-	raw := buf.ReadBinary(size, err)
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
 	return result
 }
@@ -745,12 +743,11 @@ func ReadInt8Slice(buf *ByteBuffer, err *Error) []int8 {
 	if size == 0 {
 		return make([]int8, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+	raw := buf.ReadBinary(size, err)
+	if err.HasError() {
 		return nil
 	}
 	result := make([]int8, size)
-	raw := buf.ReadBinary(size, err)
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
 	return result
 }
@@ -777,20 +774,21 @@ func ReadInt16Slice(buf *ByteBuffer, err *Error) []int16 {
 	if length == 0 {
 		return make([]int16, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]int16, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]int16, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]int16, length)
 		for i := 0; i < length; i++ {
 			result[i] = buf.ReadInt16(err)
 		}
+		return result
 	}
-	return result
 }
 
 // WriteInt32Slice writes []int32 to buffer using ARRAY protocol
@@ -815,20 +813,21 @@ func ReadInt32Slice(buf *ByteBuffer, err *Error) []int32 {
 	if length == 0 {
 		return make([]int32, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]int32, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]int32, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]int32, length)
 		for i := 0; i < length; i++ {
 			result[i] = buf.ReadInt32(err)
 		}
+		return result
 	}
-	return result
 }
 
 // WriteInt64Slice writes []int64 to buffer using ARRAY protocol
@@ -853,20 +852,21 @@ func ReadInt64Slice(buf *ByteBuffer, err *Error) []int64 {
 	if length == 0 {
 		return make([]int64, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]int64, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]int64, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]int64, length)
 		for i := 0; i < length; i++ {
 			result[i] = buf.ReadInt64(err)
 		}
+		return result
 	}
-	return result
 }
 
 // WriteUint16Slice writes []uint16 to buffer using ARRAY protocol
@@ -891,20 +891,21 @@ func ReadUint16Slice(buf *ByteBuffer, err *Error) []uint16 {
 	if length == 0 {
 		return make([]uint16, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]uint16, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]uint16, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]uint16, length)
 		for i := 0; i < length; i++ {
 			result[i] = uint16(buf.ReadInt16(err))
 		}
+		return result
 	}
-	return result
 }
 
 // WriteUint32Slice writes []uint32 to buffer using ARRAY protocol
@@ -929,20 +930,21 @@ func ReadUint32Slice(buf *ByteBuffer, err *Error) []uint32 {
 	if length == 0 {
 		return make([]uint32, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]uint32, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]uint32, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]uint32, length)
 		for i := 0; i < length; i++ {
 			result[i] = uint32(buf.ReadInt32(err))
 		}
+		return result
 	}
-	return result
 }
 
 // WriteUint64Slice writes []uint64 to buffer using ARRAY protocol
@@ -967,20 +969,21 @@ func ReadUint64Slice(buf *ByteBuffer, err *Error) []uint64 {
 	if length == 0 {
 		return make([]uint64, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]uint64, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]uint64, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]uint64, length)
 		for i := 0; i < length; i++ {
 			result[i] = uint64(buf.ReadInt64(err))
 		}
+		return result
 	}
-	return result
 }
 
 // WriteFloat32Slice writes []float32 to buffer using ARRAY protocol
@@ -1005,20 +1008,21 @@ func ReadFloat32Slice(buf *ByteBuffer, err *Error) []float32 {
 	if length == 0 {
 		return make([]float32, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]float32, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]float32, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]float32, length)
 		for i := 0; i < length; i++ {
 			result[i] = buf.ReadFloat32(err)
 		}
+		return result
 	}
-	return result
 }
 
 // WriteFloat64Slice writes []float64 to buffer using ARRAY protocol
@@ -1043,20 +1047,21 @@ func ReadFloat64Slice(buf *ByteBuffer, err *Error) []float64 {
 	if length == 0 {
 		return make([]float64, 0)
 	}
-	if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-		return nil
-	}
-	result := make([]float64, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
+		if err.HasError() {
+			return nil
+		}
+		result := make([]float64, length)
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+		return result
 	} else {
+		result := make([]float64, length)
 		for i := 0; i < length; i++ {
 			result[i] = buf.ReadFloat64(err)
 		}
+		return result
 	}
-	return result
 }
 
 // ============================================================================
@@ -1181,39 +1186,41 @@ func ReadIntSlice(buf *ByteBuffer, err *Error) []int {
 		if length == 0 {
 			return make([]int, 0)
 		}
-		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-			return nil
-		}
-		result := make([]int, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
+			if err.HasError() {
+				return nil
+			}
+			result := make([]int, length)
 			copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+			return result
 		} else {
+			result := make([]int, length)
 			for i := 0; i < length; i++ {
 				result[i] = int(buf.ReadInt64(err))
 			}
+			return result
 		}
-		return result
 	} else {
 		length := size / 4
 		if length == 0 {
 			return make([]int, 0)
 		}
-		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-			return nil
-		}
-		result := make([]int, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
+			if err.HasError() {
+				return nil
+			}
+			result := make([]int, length)
 			copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+			return result
 		} else {
+			result := make([]int, length)
 			for i := 0; i < length; i++ {
 				result[i] = int(buf.ReadInt32(err))
 			}
+			return result
 		}
-		return result
 	}
 }
 
@@ -1254,39 +1261,41 @@ func ReadUintSlice(buf *ByteBuffer, err *Error) []uint {
 		if length == 0 {
 			return make([]uint, 0)
 		}
-		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-			return nil
-		}
-		result := make([]uint, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
+			if err.HasError() {
+				return nil
+			}
+			result := make([]uint, length)
 			copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+			return result
 		} else {
+			result := make([]uint, length)
 			for i := 0; i < length; i++ {
 				result[i] = uint(buf.ReadInt64(err))
 			}
+			return result
 		}
-		return result
 	} else {
 		length := size / 4
 		if length == 0 {
 			return make([]uint, 0)
 		}
-		if buf.reader == nil && size > buf.writerIndex-buf.readerIndex {
-			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
-			return nil
-		}
-		result := make([]uint, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
+			if err.HasError() {
+				return nil
+			}
+			result := make([]uint, length)
 			copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
+			return result
 		} else {
+			result := make([]uint, length)
 			for i := 0; i < length; i++ {
 				result[i] = uint(buf.ReadInt32(err))
 			}
+			return result
 		}
-		return result
 	}
 }
 

--- a/go/fory/slice_primitive.go
+++ b/go/fory/slice_primitive.go
@@ -695,6 +695,10 @@ func ReadByteSlice(buf *ByteBuffer, err *Error) []byte {
 	if size == 0 {
 		return make([]byte, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]byte, size)
 	raw := buf.ReadBinary(size, err)
 	copy(result, raw)
@@ -716,6 +720,10 @@ func ReadBoolSlice(buf *ByteBuffer, err *Error) []bool {
 	if size == 0 {
 		return make([]bool, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]bool, size)
 	raw := buf.ReadBinary(size, err)
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(&result[0])), size), raw)
@@ -736,6 +744,10 @@ func ReadInt8Slice(buf *ByteBuffer, err *Error) []int8 {
 	size := buf.ReadLength(err)
 	if size == 0 {
 		return make([]int8, 0)
+	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
 	}
 	result := make([]int8, size)
 	raw := buf.ReadBinary(size, err)
@@ -764,6 +776,10 @@ func ReadInt16Slice(buf *ByteBuffer, err *Error) []int16 {
 	length := size / 2
 	if length == 0 {
 		return make([]int16, 0)
+	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
 	}
 	result := make([]int16, length)
 	if isLittleEndian {
@@ -799,6 +815,10 @@ func ReadInt32Slice(buf *ByteBuffer, err *Error) []int32 {
 	if length == 0 {
 		return make([]int32, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]int32, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
@@ -832,6 +852,10 @@ func ReadInt64Slice(buf *ByteBuffer, err *Error) []int64 {
 	length := size / 8
 	if length == 0 {
 		return make([]int64, 0)
+	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
 	}
 	result := make([]int64, length)
 	if isLittleEndian {
@@ -867,6 +891,10 @@ func ReadUint16Slice(buf *ByteBuffer, err *Error) []uint16 {
 	if length == 0 {
 		return make([]uint16, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]uint16, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
@@ -900,6 +928,10 @@ func ReadUint32Slice(buf *ByteBuffer, err *Error) []uint32 {
 	length := size / 4
 	if length == 0 {
 		return make([]uint32, 0)
+	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
 	}
 	result := make([]uint32, length)
 	if isLittleEndian {
@@ -935,6 +967,10 @@ func ReadUint64Slice(buf *ByteBuffer, err *Error) []uint64 {
 	if length == 0 {
 		return make([]uint64, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]uint64, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
@@ -969,6 +1005,10 @@ func ReadFloat32Slice(buf *ByteBuffer, err *Error) []float32 {
 	if length == 0 {
 		return make([]float32, 0)
 	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
+	}
 	result := make([]float32, length)
 	if isLittleEndian {
 		raw := buf.ReadBinary(size, err)
@@ -1002,6 +1042,10 @@ func ReadFloat64Slice(buf *ByteBuffer, err *Error) []float64 {
 	length := size / 8
 	if length == 0 {
 		return make([]float64, 0)
+	}
+	if size > buf.writerIndex-buf.readerIndex {
+		*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+		return nil
 	}
 	result := make([]float64, length)
 	if isLittleEndian {
@@ -1137,6 +1181,10 @@ func ReadIntSlice(buf *ByteBuffer, err *Error) []int {
 		if length == 0 {
 			return make([]int, 0)
 		}
+		if size > buf.writerIndex-buf.readerIndex {
+			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+			return nil
+		}
 		result := make([]int, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
@@ -1151,6 +1199,10 @@ func ReadIntSlice(buf *ByteBuffer, err *Error) []int {
 		length := size / 4
 		if length == 0 {
 			return make([]int, 0)
+		}
+		if size > buf.writerIndex-buf.readerIndex {
+			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+			return nil
 		}
 		result := make([]int, length)
 		if isLittleEndian {
@@ -1202,6 +1254,10 @@ func ReadUintSlice(buf *ByteBuffer, err *Error) []uint {
 		if length == 0 {
 			return make([]uint, 0)
 		}
+		if size > buf.writerIndex-buf.readerIndex {
+			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+			return nil
+		}
 		result := make([]uint, length)
 		if isLittleEndian {
 			raw := buf.ReadBinary(size, err)
@@ -1216,6 +1272,10 @@ func ReadUintSlice(buf *ByteBuffer, err *Error) []uint {
 		length := size / 4
 		if length == 0 {
 			return make([]uint, 0)
+		}
+		if size > buf.writerIndex-buf.readerIndex {
+			*err = BufferOutOfBoundError(buf.readerIndex, size, buf.writerIndex)
+			return nil
 		}
 		result := make([]uint, length)
 		if isLittleEndian {

--- a/go/fory/slice_primitive_test.go
+++ b/go/fory/slice_primitive_test.go
@@ -466,3 +466,14 @@ func TestReadInt32Slice_OOM_Bug(t *testing.T) {
 	assert.True(t, err.HasError(), "Expected an error due to out of bounds buffer")
 	assert.Equal(t, 0, len(result), "Expected an empty slice due to missing data")
 }
+
+func TestReadBoolSliceWrappedBuffer(t *testing.T) {
+	payload := NewByteBuffer(nil)
+	WriteBoolSlice(payload, []bool{true, false})
+
+	err := &Error{}
+	result := ReadBoolSlice(NewByteBuffer(payload.Bytes()), err)
+
+	assert.False(t, err.HasError(), "Expected wrapped buffer reads to use the serialized payload")
+	assert.Equal(t, []bool{true, false}, result)
+}

--- a/go/fory/slice_primitive_test.go
+++ b/go/fory/slice_primitive_test.go
@@ -451,3 +451,18 @@ func TestUint64Slice(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func TestReadInt32Slice_OOM_Bug(t *testing.T) {
+	// We claim a size of 40,000 bytes, but provide no actual data.
+	buf := NewByteBuffer(nil)
+	buf.WriteLength(40000)
+
+	// Reset reader index so we can read what we just wrote
+	buf.SetReaderIndex(0)
+
+	err := &Error{}
+	result := ReadInt32Slice(buf, err)
+
+	assert.True(t, err.HasError(), "Expected an error due to out of bounds buffer")
+	assert.Equal(t, 0, len(result), "Expected an empty slice due to missing data")
+}

--- a/go/fory/string.go
+++ b/go/fory/string.go
@@ -71,6 +71,9 @@ func readString(buf *ByteBuffer, err *Error) string {
 // Specific encoding read methods
 func readLatin1(buf *ByteBuffer, size int, err *Error) string {
 	data := buf.ReadBinary(size, err)
+	if err.HasError() {
+		return ""
+	}
 	// Latin1 bytes need to be converted to UTF-8
 	// Each Latin1 byte is a single Unicode code point (0-255)
 	runes := make([]rune, size)

--- a/go/fory/string_test.go
+++ b/go/fory/string_test.go
@@ -89,3 +89,15 @@ func TestReadUTF16LE_SurrogatePair(t *testing.T) {
 	require.False(t, err.HasError())
 	require.Equal(t, "🎉", result)
 }
+
+func TestReadLatin1_OOM_Bug(t *testing.T) {
+	// We claim a massive size of 10,000 bytes, but provide an empty buffer.
+	buf := NewByteBuffer(nil)
+
+	err := &Error{}
+	// readLatin1 doesn't read the length itself, it takes it as an argument
+	result := readLatin1(buf, 10000, err)
+
+	require.True(t, err.HasError(), "Expected an error due to out of bounds buffer")
+	require.Equal(t, "", result, "Expected an empty string due to missing data")
+}


### PR DESCRIPTION
## Why?

The code immediately allocated bytes based on the untrusted size. If any user sent a size of 2 billion but only actually sent 5 bytes of data, the server would instantly try to allocate 2GB of RAM. If many such requests were sent, the server would run out of memory (OOM) and crash.

## What does this PR do?
Add check which ensures we never allocate memory for data that hasn't actually arrived yet. It forces the allocation to be bounded by the physical size of the data we have already received and verified.

## Related issues
Closes #3617 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark