### PR TITLE
refactor(rust): use absolute path in generated Rust code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ bazel-*
 **/.bazel_user_root/
 .whl
 python/.cache
-python/pyfory/__pycache__/
+__pycache__/
 python/dist
 python/build
 python/pyfory.egg-info

--- a/compiler/fory_compiler/generators/rust.py
+++ b/compiler/fory_compiler/generators/rust.py
@@ -55,17 +55,17 @@ class RustGenerator(BaseGenerator):
         PrimitiveKind.UINT16: "u16",
         PrimitiveKind.UINT32: "u32",
         PrimitiveKind.UINT64: "u64",
-        PrimitiveKind.FLOAT16: "Float16",
-        PrimitiveKind.BFLOAT16: "BFloat16",
+        PrimitiveKind.FLOAT16: "::fory::Float16",
+        PrimitiveKind.BFLOAT16: "::fory::BFloat16",
         PrimitiveKind.FLOAT32: "f32",
         PrimitiveKind.FLOAT64: "f64",
-        PrimitiveKind.STRING: "String",
-        PrimitiveKind.BYTES: "Vec<u8>",
-        PrimitiveKind.DATE: "chrono::NaiveDate",
-        PrimitiveKind.TIMESTAMP: "chrono::NaiveDateTime",
-        PrimitiveKind.DURATION: "chrono::Duration",
-        PrimitiveKind.DECIMAL: "fory::Decimal",
-        PrimitiveKind.ANY: "Box<dyn Any>",
+        PrimitiveKind.STRING: "::std::string::String",
+        PrimitiveKind.BYTES: "::std::vec::Vec<u8>",
+        PrimitiveKind.DATE: "::chrono::NaiveDate",
+        PrimitiveKind.TIMESTAMP: "::chrono::NaiveDateTime",
+        PrimitiveKind.DURATION: "::chrono::Duration",
+        PrimitiveKind.DECIMAL: "::fory::Decimal",
+        PrimitiveKind.ANY: "::std::boxed::Box<dyn ::std::any::Any>",
     }
 
     def generate(self) -> List[GeneratedFile]:
@@ -177,13 +177,15 @@ class RustGenerator(BaseGenerator):
     def generate_bytes_impl(self, type_name: str) -> List[str]:
         lines = []
         lines.append(f"impl {type_name} {{")
-        lines.append("    pub fn to_bytes(&self) -> Result<Vec<u8>, fory::Error> {")
+        lines.append(
+            "    pub fn to_bytes(&self) -> ::std::result::Result<::std::vec::Vec<u8>, ::fory::Error> {"
+        )
         lines.append("        let fory = detail::get_fory();")
         lines.append("        fory.serialize(self)")
         lines.append("    }")
         lines.append("")
         lines.append(
-            f"    pub fn from_bytes(data: &[u8]) -> Result<{type_name}, fory::Error> {{"
+            f"    pub fn from_bytes(data: &[u8]) -> ::std::result::Result<{type_name}, ::fory::Error> {{"
         )
         lines.append("        let fory = detail::get_fory();")
         lines.append("        fory.deserialize(data)")
@@ -194,42 +196,9 @@ class RustGenerator(BaseGenerator):
     def generate_module(self) -> GeneratedFile:
         """Generate a Rust module with all types."""
         lines = []
-        uses: Set[str] = set()
-
-        # Collect uses (including from nested types)
-        uses.add("use fory::Fory")
-        if any(not self.is_imported_type(message) for message in self.schema.messages):
-            uses.add("use fory::ForyStruct")
-        if any(not self.is_imported_type(enum) for enum in self.schema.enums) or any(
-            self.message_has_nested_enum(message)
-            for message in self.schema.messages
-            if not self.is_imported_type(message)
-        ):
-            uses.add("use fory::ForyEnum")
-        if any(not self.is_imported_type(union) for union in self.schema.unions) or any(
-            self.message_has_nested_union(message)
-            for message in self.schema.messages
-            if not self.is_imported_type(message)
-        ):
-            uses.add("use fory::ForyUnion")
-        uses.add("use std::sync::OnceLock")
-
-        for message in self.schema.messages:
-            if self.is_imported_type(message):
-                continue
-            self.collect_message_uses(message, uses)
-        for union in self.schema.unions:
-            if self.is_imported_type(union):
-                continue
-            self.collect_union_uses(union, uses)
 
         # License header
         lines.append(self.get_license_header("//"))
-        lines.append("")
-
-        # Uses
-        for use in sorted(uses):
-            lines.append(f"{use};")
         lines.append("")
 
         # Generate enums (top-level)
@@ -273,15 +242,6 @@ class RustGenerator(BaseGenerator):
             content="\n".join(lines),
         )
 
-    def collect_message_uses(self, message: Message, uses: Set[str]):
-        """Collect uses for a message and its nested types recursively."""
-        for field in message.fields:
-            self.collect_uses_for_field(field, uses)
-        for nested_msg in message.nested_messages:
-            self.collect_message_uses(nested_msg, uses)
-        for nested_union in message.nested_unions:
-            self.collect_union_uses(nested_union, uses)
-
     def message_has_nested_enum(self, message: Message) -> bool:
         if message.nested_enums:
             return True
@@ -297,13 +257,6 @@ class RustGenerator(BaseGenerator):
             self.message_has_nested_union(nested_msg)
             for nested_msg in message.nested_messages
         )
-
-    def collect_union_uses(self, union: Union, uses: Set[str]):
-        """Collect uses for a union and its cases."""
-        for field in union.fields:
-            if self.field_uses_pointer(field):
-                uses.add("use std::sync::Arc")
-            self.collect_uses(field.field_type, uses)
 
     def get_registration_type_name(
         self, name: str, parent_stack: Optional[List[Message]] = None
@@ -364,7 +317,9 @@ class RustGenerator(BaseGenerator):
         type_name = enum.name
 
         # Derive macros
-        lines.append("#[derive(ForyEnum, Debug, Clone, PartialEq, Eq, Hash, Default)]")
+        lines.append(
+            "#[derive(::fory::ForyEnum, Debug, Clone, PartialEq, Eq, Hash, Default)]"
+        )
         lines.append("#[repr(i32)]")
 
         lines.append(f"pub enum {type_name} {{")
@@ -396,7 +351,7 @@ class RustGenerator(BaseGenerator):
         comment = self.format_type_id_comment(union, "//")
         if comment:
             lines.append(comment)
-        derives = ["ForyUnion", "Debug"]
+        derives = ["::fory::ForyUnion", "Debug"]
         if not has_any:
             derives.extend(["Clone", "PartialEq"])
         lines.append(f"#[derive({', '.join(derives)})]")
@@ -411,7 +366,7 @@ class RustGenerator(BaseGenerator):
                 element_optional=field.element_optional,
                 element_ref=field.element_ref,
                 parent_stack=parent_stack,
-                pointer_type="Arc",
+                pointer_type="::std::sync::Arc",
             )
             lines.append(f"    #[fory(id = {field.number})]")
             payload_attr = self.get_payload_field_attr(field)
@@ -428,9 +383,11 @@ class RustGenerator(BaseGenerator):
         if union.fields:
             first_field = union.fields[0]
             first_variant = self.to_pascal_case(first_field.name)
-            lines.append(f"impl Default for {union.name} {{")
+            lines.append(f"impl ::std::default::Default for {union.name} {{")
             lines.append("    fn default() -> Self {")
-            lines.append(f"        Self::{first_variant}(Default::default())")
+            lines.append(
+                f"        Self::{first_variant}(::std::default::Default::default())"
+            )
             lines.append("    }")
             lines.append("}")
             lines.append("")
@@ -454,7 +411,7 @@ class RustGenerator(BaseGenerator):
         if comment:
             lines.append(comment)
         needs_safe_debug = self.message_needs_safe_debug(message)
-        derives = ["ForyStruct"]
+        derives = ["::fory::ForyStruct"]
         if not needs_safe_debug:
             derives.append("Debug")
         if not self.message_has_any(message):
@@ -524,9 +481,9 @@ class RustGenerator(BaseGenerator):
         """Generate a Debug impl that avoids recursive ref expansion."""
         lines: List[str] = []
         type_name = self.to_pascal_case(message.name)
-        lines.append(f"impl std::fmt::Debug for {type_name} {{")
+        lines.append(f"impl ::std::fmt::Debug for {type_name} {{")
         lines.append(
-            "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {"
+            "    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {"
         )
         if not message.fields:
             lines.append(
@@ -760,15 +717,15 @@ class RustGenerator(BaseGenerator):
         element_optional: bool = False,
         element_ref: bool = False,
         parent_stack: Optional[List[Message]] = None,
-        pointer_type: str = "Arc",
+        pointer_type: str = "::std::sync::Arc",
     ) -> str:
         """Generate Rust type string."""
         if isinstance(field_type, PrimitiveType):
             if field_type.kind == PrimitiveKind.ANY:
-                return "Box<dyn Any>"
+                return "::std::boxed::Box<dyn ::std::any::Any>"
             base_type = self.PRIMITIVE_MAP[field_type.kind]
             if nullable:
-                return f"Option<{base_type}>"
+                return f"::std::option::Option<{base_type}>"
             return base_type
 
         elif isinstance(field_type, NamedType):
@@ -781,7 +738,7 @@ class RustGenerator(BaseGenerator):
             if ref:
                 type_name = f"{pointer_type}<{type_name}>"
             if nullable:
-                type_name = f"Option<{type_name}>"
+                type_name = f"::std::option::Option<{type_name}>"
             return type_name
 
         elif isinstance(field_type, ListType):
@@ -794,11 +751,11 @@ class RustGenerator(BaseGenerator):
                 parent_stack=parent_stack,
                 pointer_type=pointer_type,
             )
-            list_type = f"Vec<{element_type}>"
+            list_type = f"::std::vec::Vec<{element_type}>"
             if ref:
                 list_type = f"{pointer_type}<{list_type}>"
             if nullable:
-                list_type = f"Option<{list_type}>"
+                list_type = f"::std::option::Option<{list_type}>"
             return list_type
 
         elif isinstance(field_type, ArrayType):
@@ -809,11 +766,11 @@ class RustGenerator(BaseGenerator):
                 parent_stack=parent_stack,
                 pointer_type=pointer_type,
             )
-            array_type = f"Vec<{element_type}>"
+            array_type = f"::std::vec::Vec<{element_type}>"
             if ref:
                 array_type = f"{pointer_type}<{array_type}>"
             if nullable:
-                array_type = f"Option<{array_type}>"
+                array_type = f"::std::option::Option<{array_type}>"
             return array_type
 
         elif isinstance(field_type, MapType):
@@ -831,11 +788,11 @@ class RustGenerator(BaseGenerator):
                 parent_stack=parent_stack,
                 pointer_type=pointer_type,
             )
-            map_type = f"HashMap<{key_type}, {value_type}>"
+            map_type = f"::std::collections::HashMap<{key_type}, {value_type}>"
             if ref:
                 map_type = f"{pointer_type}<{map_type}>"
             if nullable:
-                map_type = f"Option<{map_type}>"
+                map_type = f"::std::option::Option<{map_type}>"
             return map_type
 
         return "()"
@@ -867,60 +824,6 @@ class RustGenerator(BaseGenerator):
 
         return self.to_pascal_case(type_name)
 
-    def collect_uses(self, field_type: FieldType, uses: Set[str]):
-        """Collect required use statements for a field type."""
-        if isinstance(field_type, PrimitiveType):
-            if field_type.kind in (
-                PrimitiveKind.DATE,
-                PrimitiveKind.TIMESTAMP,
-                PrimitiveKind.DURATION,
-            ):
-                uses.add("use chrono")
-            if field_type.kind == PrimitiveKind.FLOAT16:
-                uses.add("use fory::Float16")
-            if field_type.kind == PrimitiveKind.BFLOAT16:
-                uses.add("use fory::BFloat16")
-            if field_type.kind == PrimitiveKind.ANY:
-                uses.add("use std::any::Any")
-
-        elif isinstance(field_type, NamedType):
-            pass  # No additional uses needed
-
-        elif isinstance(field_type, ListType):
-            self.collect_uses(field_type.element_type, uses)
-
-        elif isinstance(field_type, ArrayType):
-            self.collect_uses(field_type.element_type, uses)
-
-        elif isinstance(field_type, MapType):
-            uses.add("use std::collections::HashMap")
-            self.collect_uses(field_type.key_type, uses)
-            self.collect_uses(field_type.value_type, uses)
-
-    def collect_uses_for_field(self, field: Field, uses: Set[str]):
-        """Collect uses for a field, including ref tracking."""
-        if isinstance(field.field_type, ListType) and field.element_ref:
-            ref_options = field.element_ref_options
-            weak_ref = ref_options.get("weak_ref") is True
-        elif isinstance(field.field_type, MapType) and field.field_type.value_ref:
-            ref_options = field.field_type.value_ref_options
-            weak_ref = ref_options.get("weak_ref") is True
-        else:
-            ref_options = field.ref_options
-            weak_ref = ref_options.get("weak_ref") is True
-        pointer_type = self.get_pointer_type(ref_options, weak_ref)
-        if weak_ref and self.field_uses_pointer(field):
-            if pointer_type == "RcWeak":
-                uses.add("use fory::RcWeak")
-            else:
-                uses.add("use fory::ArcWeak")
-        elif self.field_uses_pointer(field):
-            if pointer_type == "Rc":
-                uses.add("use std::rc::Rc")
-            else:
-                uses.add("use std::sync::Arc")
-        self.collect_uses(field.field_type, uses)
-
     def field_uses_pointer(self, field: Field) -> bool:
         if field.ref:
             return True
@@ -934,15 +837,15 @@ class RustGenerator(BaseGenerator):
         """Determine pointer type for ref tracking based on field options."""
         thread_safe = ref_options.get("thread_safe_pointer")
         if thread_safe is False:
-            return "RcWeak" if weak_ref else "Rc"
-        return "ArcWeak" if weak_ref else "Arc"
+            return "::fory::RcWeak" if weak_ref else "::std::rc::Rc"
+        return "::fory::ArcWeak" if weak_ref else "::std::sync::Arc"
 
     def generate_registration(self) -> List[str]:
         """Generate the Fory registration function."""
         lines = []
 
         lines.append(
-            "pub fn register_types(fory: &mut Fory) -> Result<(), fory::Error> {"
+            "pub fn register_types(fory: &mut ::fory::Fory) -> ::std::result::Result<(), ::fory::Error> {"
         )
 
         # Register enums (top-level)
@@ -963,7 +866,7 @@ class RustGenerator(BaseGenerator):
                 continue
             self.generate_message_registration(lines, message, None)
 
-        lines.append("    Ok(())")
+        lines.append("    ::std::result::Result::Ok(())")
         lines.append("}")
 
         return lines
@@ -973,10 +876,12 @@ class RustGenerator(BaseGenerator):
         lines.append("mod detail {")
         lines.append("    use super::*;")
         lines.append("")
-        lines.append("    pub(super) fn get_fory() -> &'static Fory {")
-        lines.append("        static FORY: OnceLock<Fory> = OnceLock::new();")
+        lines.append("    pub(super) fn get_fory() -> &'static ::fory::Fory {")
+        lines.append(
+            "        static FORY: ::std::sync::OnceLock<::fory::Fory> = ::std::sync::OnceLock::new();"
+        )
         lines.append("        FORY.get_or_init(|| {")
-        lines.append("            let mut fory = Fory::builder()")
+        lines.append("            let mut fory = ::fory::Fory::builder()")
         lines.append("                .xlang(true)")
         lines.append("                .track_ref(true)")
         lines.append("                .compatible(true)")

--- a/compiler/fory_compiler/tests/test_generated_code.py
+++ b/compiler/fory_compiler/tests/test_generated_code.py
@@ -777,3 +777,40 @@ def test_go_generator_distinguishes_bytes_from_uint8_lists():
     go_output = render_files(generate_files(schema, GoGenerator))
     assert 'Payload []byte `fory:"id=1,type=bytes"`' in go_output
     assert 'Values []uint8 `fory:"id=2"`' in go_output
+
+
+def test_rust_generated_code_uses_absolute_paths():
+    schema = parse_fdl(
+        dedent(
+            """
+            package foo;
+
+            message String {
+                string value = 1;
+                list<string> items = 2;
+                map<string, string> labels = 3;
+                any payload = 4;
+                ref(weak=true) String parent = 5;
+            }
+
+            union Fory {
+                String text = 1;
+            }
+            """
+        )
+    )
+    rust_output = render_files(generate_files(schema, RustGenerator))
+    assert "use fory::" not in rust_output
+    assert "use std::" not in rust_output
+    assert "#[derive(::fory::ForyStruct" in rust_output
+    assert "#[derive(::fory::ForyUnion" in rust_output
+    assert "pub value: ::std::string::String," in rust_output
+    assert "pub items: ::std::vec::Vec<::std::string::String>," in rust_output
+    assert (
+        "pub labels: ::std::collections::HashMap<::std::string::String, ::std::string::String>,"
+        in rust_output
+    )
+    assert "pub payload: ::std::boxed::Box<dyn ::std::any::Any>," in rust_output
+    assert "pub parent: ::fory::ArcWeak<String>," in rust_output
+    assert "pub fn register_types(fory: &mut ::fory::Fory)" in rust_output
+    assert "static FORY: ::std::sync::OnceLock<::fory::Fory>" in rust_output

--- a/rust/fory-derive/src/fory_row.rs
+++ b/rust/fory-derive/src/fory_row.rs
@@ -35,7 +35,7 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
 
         quote! {
             let mut callback_info = struct_writer.write_start(#index);
-            <#ty as fory_core::row::Row<'a>>::write(&v.#ident, struct_writer.get_writer())?;
+            <#ty as ::fory_core::row::Row<'a>>::write(&v.#ident, struct_writer.get_writer())?;
             struct_writer.write_end(callback_info);
         }
     });
@@ -46,9 +46,9 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
         let getter_name: proc_macro2::Ident = syn::Ident::new(&format!("{ident}"), ident.span());
 
         quote! {
-            pub fn #getter_name(&self) -> <#ty as fory_core::row::Row<'a>>::ReadResult {
+            pub fn #getter_name(&self) -> <#ty as ::fory_core::row::Row<'a>>::ReadResult {
                 let bytes = self.struct_data.get_field_bytes(#index);
-                <#ty as fory_core::row::Row<'a>>::cast(bytes)
+                <#ty as ::fory_core::row::Row<'a>>::cast(bytes)
             }
         }
     });
@@ -59,25 +59,25 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         struct #getter<'a> {
-            struct_data: fory_core::row::StructViewer<'a>
+            struct_data: ::fory_core::row::StructViewer<'a>
         }
 
         impl<'a> #getter<'a> {
             #(#getter_exprs)*
         }
 
-        impl<'a> fory_core::row::Row<'a> for #name {
+        impl<'a> ::fory_core::row::Row<'a> for #name {
 
             type ReadResult = #getter<'a>;
 
-            fn write(v: &Self, writer: &mut fory_core::buffer::Writer) -> Result<(), fory_core::error::Error> {
-                let mut struct_writer = fory_core::row::StructWriter::new(#num_fields, writer);
+            fn write(v: &Self, writer: &mut ::fory_core::buffer::Writer) -> Result<(), ::fory_core::error::Error> {
+                let mut struct_writer = ::fory_core::row::StructWriter::new(#num_fields, writer);
                 #(#write_exprs);*;
                 Ok(())
             }
 
             fn cast(bytes: &'a [u8]) -> Self::ReadResult {
-                #getter{ struct_data: fory_core::row::StructViewer::new(bytes, #num_fields) }
+                #getter{ struct_data: ::fory_core::row::StructViewer::new(bytes, #num_fields) }
             }
         }
     };

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -86,7 +86,7 @@ fn gen_write_variant_elements(
             .filter_map(|(binding, ident)| match binding {
                 FieldBinding::Codec(binding) => Some(binding.write_value_with_mode(
                     quote! { #ident },
-                    quote! { fory_core::RefMode::NullOnly },
+                    quote! { ::fory_core::RefMode::NullOnly },
                     quote! { true },
                 )),
                 FieldBinding::Skipped(_) => None,
@@ -101,7 +101,7 @@ fn gen_write_single_payload(source_fields: &[SourceField<'_>], value: TokenStrea
         Ok(bindings) => match bindings.as_slice() {
             [FieldBinding::Codec(binding)] => binding.write_value_with_mode(
                 value,
-                quote! { fory_core::RefMode::Tracking },
+                quote! { ::fory_core::RefMode::Tracking },
                 quote! { true },
             ),
             [FieldBinding::Skipped(_)] => {
@@ -153,7 +153,7 @@ fn gen_read_variant_elements(
                         let index = serialized_index;
                         serialized_index += 1;
                         let read_value = binding.read_with_mode_expr(
-                            quote! { fory_core::RefMode::NullOnly },
+                            quote! { ::fory_core::RefMode::NullOnly },
                             quote! { true },
                         );
                         read_fields.push(quote! {
@@ -186,7 +186,7 @@ fn gen_read_single_payload(source_fields: &[SourceField<'_>]) -> TokenStream {
     match build_bindings(source_fields) {
         Ok(bindings) => match bindings.as_slice() {
             [FieldBinding::Codec(binding)] => binding
-                .read_with_mode_expr(quote! { fory_core::RefMode::Tracking }, quote! { true }),
+                .read_with_mode_expr(quote! { ::fory_core::RefMode::Tracking }, quote! { true }),
             [FieldBinding::Skipped(_)] => {
                 quote! { compile_error!("skip is not valid for union payload fields") }
             }
@@ -209,25 +209,25 @@ pub fn gen_actual_type_id(data_enum: &DataEnum) -> TokenStream {
         quote! {
             if xlang {
                 if register_by_name {
-                    fory_core::type_id::TypeId::NAMED_UNION as u32
+                    ::fory_core::type_id::TypeId::NAMED_UNION as u32
                 } else {
-                    fory_core::type_id::TypeId::TYPED_UNION as u32
+                    ::fory_core::type_id::TypeId::TYPED_UNION as u32
                 }
             } else {
-                fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, compatible)
+                ::fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, compatible)
             }
         }
     } else {
         quote! {
             let _ = xlang;
-            fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, compatible)
+            ::fory_core::serializer::enum_::actual_type_id(type_id, register_by_name, compatible)
         }
     }
 }
 
 pub fn gen_field_fields_info(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        Ok(Vec::new())
+        ::std::result::Result::Ok(::std::vec::Vec::new())
     }
 }
 
@@ -247,8 +247,8 @@ pub fn gen_variants_fields_info(enum_name: &syn::Ident, data_enum: &DataEnum) ->
                     quote! {
                         (
                             #variant_name.to_string(),
-                            std::any::TypeId::of::<#meta_type_ident>(),
-                            <#meta_type_ident as fory_core::serializer::enum_::NamedEnumVariantMetaTrait>::fory_fields_info(type_resolver)?
+                            ::std::any::TypeId::of::<#meta_type_ident>(),
+                            <#meta_type_ident as ::fory_core::serializer::enum_::NamedEnumVariantMetaTrait>::fory_fields_info(type_resolver)?
                         )
                     }
                 }
@@ -257,8 +257,8 @@ pub fn gen_variants_fields_info(enum_name: &syn::Ident, data_enum: &DataEnum) ->
                     quote! {
                         (
                             #variant_name.to_string(),
-                            std::any::TypeId::of::<()>(), // Placeholder type ID
-                            Vec::new()
+                            ::std::any::TypeId::of::<()>(), // Placeholder type ID
+                            ::std::vec::Vec::new()
                         )
                     }
                 }
@@ -267,7 +267,7 @@ pub fn gen_variants_fields_info(enum_name: &syn::Ident, data_enum: &DataEnum) ->
         .collect();
 
     quote! {
-        Ok(vec![
+        ::std::result::Result::Ok(::std::vec![
             #(#variant_info),*
         ])
     }
@@ -334,12 +334,12 @@ pub(crate) fn gen_named_variant_meta_type_impl_with_enum_name(
     quote! {
         struct #meta_type_ident;
 
-        impl fory_core::serializer::enum_::NamedEnumVariantMetaTrait for #meta_type_ident {
+        impl ::fory_core::serializer::enum_::NamedEnumVariantMetaTrait for #meta_type_ident {
             fn fory_get_sorted_field_names() -> &'static [&'static str] {
                 &[#(#field_name_literals),*]
             }
 
-            fn fory_fields_info(type_resolver: &fory_core::resolver::TypeResolver) -> Result<Vec<fory_core::meta::FieldInfo>, fory_core::error::Error> {
+            fn fory_fields_info(type_resolver: &::fory_core::resolver::TypeResolver) -> ::std::result::Result<::std::vec::Vec<::fory_core::meta::FieldInfo>, ::fory_core::error::Error> {
                 #fields_info_ts
             }
         }
@@ -348,7 +348,7 @@ pub(crate) fn gen_named_variant_meta_type_impl_with_enum_name(
 
 pub fn gen_write(_data_enum: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::write::<Self>(self, context, ref_mode, write_type_info)
+        ::fory_core::serializer::enum_::write::<Self>(self, context, ref_mode, write_type_info)
     }
 }
 
@@ -378,7 +378,7 @@ fn xlang_variant_branches(data_enum: &DataEnum, default_variant_value: u32) -> V
                             Self::#ident => {
                                 context.writer.write_var_u32(#tag_value);
                                 // Write null flag for unit variant (no value)
-                                context.writer.write_i8(fory_core::RefFlag::Null as i8);
+                                context.writer.write_i8(::fory_core::RefFlag::Null as i8);
                             }
                         }
                     } else {
@@ -562,7 +562,7 @@ fn rust_compatible_variant_write_branches(
                         Self::#ident { #(#field_idents),* } => {
                             context.writer.write_var_u32((#tag_value << 2) | 0b10);
                             // Write type meta inline using streaming protocol
-                            context.write_type_meta(std::any::TypeId::of::<#meta_type_ident>())?;
+                            context.write_type_meta(::std::any::TypeId::of::<#meta_type_ident>())?;
                             // Write fields same as struct
                             #(#write_fields)*
                         }
@@ -620,29 +620,29 @@ pub fn gen_write_type_info(data_enum: &DataEnum) -> TokenStream {
         // Union-compatible with data: write typed/named union type info in xlang mode
         quote! {
             if context.is_xlang() {
-                let rs_type_id = std::any::TypeId::of::<Self>();
-                context.write_any_type_info(fory_core::type_id::UNKNOWN, rs_type_id)?;
+                let rs_type_id = ::std::any::TypeId::of::<Self>();
+                context.write_any_type_info(::fory_core::type_id::UNKNOWN, rs_type_id)?;
                 Ok(())
             } else {
-                fory_core::serializer::enum_::write_type_info::<Self>(context)
+                ::fory_core::serializer::enum_::write_type_info::<Self>(context)
             }
         }
     } else {
         quote! {
-            fory_core::serializer::enum_::write_type_info::<Self>(context)
+            ::fory_core::serializer::enum_::write_type_info::<Self>(context)
         }
     }
 }
 
 pub fn gen_read(_: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::read::<Self>(context, ref_mode, read_type_info)
+        ::fory_core::serializer::enum_::read::<Self>(context, ref_mode, read_type_info)
     }
 }
 
 pub fn gen_read_with_type_info(_: &DataEnum) -> TokenStream {
     quote! {
-        fory_core::serializer::enum_::read::<Self>(context, ref_mode, false)
+        ::fory_core::serializer::enum_::read::<Self>(context, ref_mode, false)
     }
 }
 
@@ -674,9 +674,9 @@ pub fn gen_static_type_id(data_enum: &DataEnum) -> TokenStream {
         .any(|v| !matches!(v.fields, Fields::Unit));
 
     if is_union_compatible && has_data_variants {
-        quote! { fory_core::TypeId::UNION }
+        quote! { ::fory_core::TypeId::UNION }
     } else {
-        quote! { fory_core::TypeId::ENUM }
+        quote! { ::fory_core::TypeId::ENUM }
     }
 }
 
@@ -854,7 +854,7 @@ fn rust_compatible_variant_read_branches(
                             // Unit variant should have variant_type == 0b0
                             if variant_type != 0b0 {
                                 // Variant type mismatch: skip the data and use default
-                                use fory_core::serializer::skip::skip_enum_variant;
+                                use ::fory_core::serializer::skip::skip_enum_variant;
                                 skip_enum_variant(context, variant_type, &None)?;
                                 return Ok(#default_value);
                             }
@@ -880,7 +880,7 @@ fn rust_compatible_variant_read_branches(
                             // Unnamed variant should have variant_type == 0b1
                             if variant_type != 0b1 {
                                 // Variant type mismatch: skip the data and use default
-                                use fory_core::serializer::skip::skip_enum_variant;
+                                use ::fory_core::serializer::skip::skip_enum_variant;
                                 skip_enum_variant(context, variant_type, &None)?;
                                 return Ok(#default_value);
                             }
@@ -891,7 +891,7 @@ fn rust_compatible_variant_read_branches(
                             #(#read_fields;)*
 
                             // Skip any extra elements
-                            use fory_core::serializer::skip::skip_any_value;
+                            use ::fory_core::serializer::skip::skip_any_value;
                             for _ in #field_count..len {
                                 skip_any_value(context, true)?;
                             }
@@ -931,7 +931,7 @@ fn rust_compatible_variant_read_branches(
                             if variant_type != 0b10 {
                                 // Variant type mismatch: peer didn't write meta for non-named variant
                                 // Skip the data and use default
-                                use fory_core::serializer::skip::skip_enum_variant;
+                                use ::fory_core::serializer::skip::skip_enum_variant;
                                 skip_enum_variant(context, variant_type, &None)?;
                                 return Ok(#default_value);
                             }
@@ -1005,12 +1005,12 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
     let unknown_xlang_branch = if is_union_compatible && has_data_variants {
         quote! {
             _ => {
-                use fory_core::serializer::skip::skip_any_value;
+                use ::fory_core::serializer::skip::skip_any_value;
                 skip_any_value(context, true)?;
                 if context.is_compatible() {
                     Ok(#default_variant_construction)
                 } else {
-                    return Err(fory_core::error::Error::unknown_enum("unknown enum value"));
+                    return Err(::fory_core::error::Error::unknown_enum("unknown enum value"));
                 }
             }
         }
@@ -1021,7 +1021,7 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
                 if context.is_compatible() {
                     Ok(#default_variant_construction)
                 } else {
-                    return Err(fory_core::error::Error::unknown_enum("unknown enum value"));
+                    return Err(::fory_core::error::Error::unknown_enum("unknown enum value"));
                 }
             }
         }
@@ -1045,7 +1045,7 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
                     _ => {
                         // Unknown variant in compatible mode: skip the data and use default variant
                         // variant_type: 0b0 = Unit, 0b1 = Unnamed, 0b10 = Named
-                        use fory_core::serializer::skip::skip_enum_variant;
+                        use ::fory_core::serializer::skip::skip_enum_variant;
                         // For named variants, we don't have type_info yet, so pass None
                         // skip_enum_variant will read it from the stream
                         skip_enum_variant(context, variant_type, &None)?;
@@ -1056,7 +1056,7 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
                 let tag = context.reader.read_var_u32()?;
                 match tag {
                     #(#rust_variant_branches)*
-                    _ => return Err(fory_core::error::Error::unknown_enum("unknown enum value")),
+                    _ => return Err(::fory_core::error::Error::unknown_enum("unknown enum value")),
                 }
             }
         }
@@ -1079,19 +1079,19 @@ pub fn gen_read_type_info(data_enum: &DataEnum) -> TokenStream {
                 let type_info = context.read_any_type_info()?;
                 let remote_type_id = type_info.get_type_id();
                 if remote_type_id != expected_type_id {
-                    return Err(fory_core::error::Error::type_mismatch(
+                    return Err(::fory_core::error::Error::type_mismatch(
                         expected_type_id as u32,
                         remote_type_id as u32,
                     ));
                 }
                 Ok(())
             } else {
-                fory_core::serializer::enum_::read_type_info::<Self>(context)
+                ::fory_core::serializer::enum_::read_type_info::<Self>(context)
             }
         }
     } else {
         quote! {
-            fory_core::serializer::enum_::read_type_info::<Self>(context)
+            ::fory_core::serializer::enum_::read_type_info::<Self>(context)
         }
     }
 }

--- a/rust/fory-derive/src/object/field_codec.rs
+++ b/rust/fory-derive/src/object/field_codec.rs
@@ -50,7 +50,7 @@ impl<'a> ResolvedField<'a> {
         match &self.dispatch {
             FieldDispatch::Codec { codec_ty } => {
                 let value_ty = self.value_ty;
-                quote! { <#codec_ty as fory_core::serializer::codec::Codec<#value_ty>> }
+                quote! { <#codec_ty as ::fory_core::serializer::codec::Codec<#value_ty>> }
             }
             FieldDispatch::Serializer { .. } => {
                 quote! { compile_error!("serializer-dispatched field has no codec call") }
@@ -67,8 +67,8 @@ impl<'a> ResolvedField<'a> {
             FieldDispatch::Serializer { .. } => {
                 let ty = self.value_ty;
                 quote! {
-                    <#ty as fory_core::Serializer>::fory_reserved_space()
-                        + fory_core::type_id::SIZE_OF_REF_AND_TYPE
+                    <#ty as ::fory_core::Serializer>::fory_reserved_space()
+                        + ::fory_core::type_id::SIZE_OF_REF_AND_TYPE
                 }
             }
         }
@@ -92,7 +92,7 @@ impl<'a> ResolvedField<'a> {
                 let ty = self.value_ty;
                 if serializer_field_can_use_data_path(self.source.field) {
                     quote! {
-                        <#ty as fory_core::Serializer>::fory_write_data_generic(
+                        <#ty as ::fory_core::Serializer>::fory_write_data_generic(
                             #value,
                             context,
                             #has_generics
@@ -102,13 +102,13 @@ impl<'a> ResolvedField<'a> {
                     let ref_mode = serializer_ref_mode_for_field(self.source.field);
                     quote! {
                         let write_type_info = if context.is_compatible() {
-                            fory_core::serializer::util::field_need_write_type_info(
-                                <#ty as fory_core::Serializer>::fory_static_type_id()
+                            ::fory_core::serializer::util::field_need_write_type_info(
+                                <#ty as ::fory_core::Serializer>::fory_static_type_id()
                             )
                         } else {
-                            <#ty as fory_core::Serializer>::fory_is_polymorphic()
+                            <#ty as ::fory_core::Serializer>::fory_is_polymorphic()
                         };
-                        <#ty as fory_core::Serializer>::fory_write(
+                        <#ty as ::fory_core::Serializer>::fory_write(
                             #value,
                             context,
                             #ref_mode,
@@ -143,7 +143,7 @@ impl<'a> ResolvedField<'a> {
             FieldDispatch::Serializer { has_generics, .. } => {
                 let ty = self.value_ty;
                 quote! {
-                    <#ty as fory_core::Serializer>::fory_write(
+                    <#ty as ::fory_core::Serializer>::fory_write(
                         #value,
                         context,
                         #ref_mode,
@@ -168,19 +168,19 @@ impl<'a> ResolvedField<'a> {
                 let ty = self.value_ty;
                 if serializer_field_can_use_data_path(self.source.field) {
                     quote! {
-                        let #var = <#ty as fory_core::Serializer>::fory_read_data(context)?;
+                        let #var = <#ty as ::fory_core::Serializer>::fory_read_data(context)?;
                     }
                 } else {
                     let ref_mode = serializer_ref_mode_for_field(self.source.field);
                     quote! {
                         let read_type_info = if context.is_compatible() {
-                            fory_core::serializer::util::field_need_read_type_info(
-                                <#ty as fory_core::Serializer>::fory_static_type_id() as u32
+                            ::fory_core::serializer::util::field_need_read_type_info(
+                                <#ty as ::fory_core::Serializer>::fory_static_type_id() as u32
                             )
                         } else {
-                            <#ty as fory_core::Serializer>::fory_is_polymorphic()
+                            <#ty as ::fory_core::Serializer>::fory_is_polymorphic()
                         };
-                        let #var = <#ty as fory_core::Serializer>::fory_read(
+                        let #var = <#ty as ::fory_core::Serializer>::fory_read(
                             context,
                             #ref_mode,
                             read_type_info
@@ -206,7 +206,7 @@ impl<'a> ResolvedField<'a> {
             FieldDispatch::Serializer { .. } => {
                 let ty = self.value_ty;
                 quote! {
-                    <#ty as fory_core::Serializer>::fory_read(context, #ref_mode, #read_type_info)?
+                    <#ty as ::fory_core::Serializer>::fory_read(context, #ref_mode, #read_type_info)?
                 }
             }
         }
@@ -242,11 +242,11 @@ impl<'a> ResolvedField<'a> {
                     )? {
                         #var = Some(value);
                     } else {
-                        let read_ref_flag = fory_core::serializer::util::field_need_write_ref_into(
+                        let read_ref_flag = ::fory_core::serializer::util::field_need_write_ref_into(
                             remote_field_type.type_id,
                             remote_field_type.nullable,
                         );
-                        fory_core::serializer::skip::skip_field_value(context, remote_field_type, read_ref_flag)?;
+                        ::fory_core::serializer::skip::skip_field_value(context, remote_field_type, read_ref_flag)?;
                     }
                 }
             }
@@ -254,30 +254,30 @@ impl<'a> ResolvedField<'a> {
                 let ty = self.value_ty;
                 quote! {
                     let remote_field_type = &_field.field_type;
-                    if fory_core::serializer::codec::field_types_compatible(
+                    if ::fory_core::serializer::codec::field_types_compatible(
                         local_field_type,
                         remote_field_type,
                     ) {
                         let read_ref_mode =
-                            fory_core::serializer::codec::field_ref_mode(remote_field_type);
+                            ::fory_core::serializer::codec::field_ref_mode(remote_field_type);
                         let read_type_info = if context.is_compatible() {
-                            fory_core::serializer::util::field_need_read_type_info(
+                            ::fory_core::serializer::util::field_need_read_type_info(
                                 remote_field_type.type_id
                             )
                         } else {
-                            <#ty as fory_core::Serializer>::fory_is_polymorphic()
+                            <#ty as ::fory_core::Serializer>::fory_is_polymorphic()
                         };
-                        #var = Some(<#ty as fory_core::Serializer>::fory_read(
+                        #var = Some(<#ty as ::fory_core::Serializer>::fory_read(
                             context,
                             read_ref_mode,
                             read_type_info,
                         )?);
                     } else {
-                        let read_ref_flag = fory_core::serializer::util::field_need_write_ref_into(
+                        let read_ref_flag = ::fory_core::serializer::util::field_need_write_ref_into(
                             remote_field_type.type_id,
                             remote_field_type.nullable,
                         );
-                        fory_core::serializer::skip::skip_field_value(context, remote_field_type, read_ref_flag)?;
+                        ::fory_core::serializer::skip::skip_field_value(context, remote_field_type, read_ref_flag)?;
                     }
                 }
             }
@@ -291,7 +291,7 @@ impl<'a> ResolvedField<'a> {
             FieldDispatch::Codec { .. } => {
                 let call = self.codec_call();
                 quote! {
-                    fory_core::meta::FieldInfo::new_with_id(
+                    ::fory_core::meta::FieldInfo::new_with_id(
                         #field_id,
                         #name,
                         #call::field_type(type_resolver)?
@@ -300,7 +300,7 @@ impl<'a> ResolvedField<'a> {
             }
             FieldDispatch::Serializer { field_type, .. } => {
                 quote! {
-                    fory_core::meta::FieldInfo::new_with_id(
+                    ::fory_core::meta::FieldInfo::new_with_id(
                         #field_id,
                         #name,
                         #field_type
@@ -414,7 +414,7 @@ pub(crate) fn codec_type_for(
         };
         let inner_codec = codec_type_for(&inner, &inner_meta, false, false)?;
         return Ok(quote! {
-            fory_core::serializer::codec::OptionCodec<#inner, #inner_codec, #track_ref>
+            ::fory_core::serializer::codec::OptionCodec<#inner, #inner_codec, #track_ref>
         });
     }
 
@@ -444,7 +444,7 @@ pub(crate) fn codec_type_for(
                     return Err(syn::Error::new_spanned(ty, "bytes schema requires Vec<u8>"));
                 }
                 return Ok(quote! {
-                    fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref>
+                    ::fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref>
                 });
             }
             if meta.array {
@@ -456,7 +456,7 @@ pub(crate) fn codec_type_for(
                 }
                 let type_id = primitive_array_type_id_for_vec_element(elem_ty)?;
                 return Ok(quote! {
-                    fory_core::serializer::codec::PrimitiveArrayVecCodec<
+                    ::fory_core::serializer::codec::PrimitiveArrayVecCodec<
                         #elem_ty,
                         #type_id,
                         #nullable,
@@ -474,7 +474,7 @@ pub(crate) fn codec_type_for(
                     elem_meta.effective_ref(elem_class),
                 )?;
                 return Ok(quote! {
-                    fory_core::serializer::codec::VecCodec<#elem_ty, #elem_codec, #nullable, #track_ref>
+                    ::fory_core::serializer::codec::VecCodec<#elem_ty, #elem_codec, #nullable, #track_ref>
                 });
             }
             let elem_meta = meta.element_meta();
@@ -483,7 +483,7 @@ pub(crate) fn codec_type_for(
             let elem_track_ref = elem_meta.effective_ref(elem_class);
             let elem_codec = codec_type_for(elem_ty, &elem_meta, elem_nullable, elem_track_ref)?;
             return Ok(quote! {
-                fory_core::serializer::codec::VecCodec<#elem_ty, #elem_codec, #nullable, #track_ref>
+                ::fory_core::serializer::codec::VecCodec<#elem_ty, #elem_codec, #nullable, #track_ref>
             });
         }
         if name == "HashMap" {
@@ -535,11 +535,11 @@ pub(crate) fn codec_type_for(
                     || contains_exact_any_object(value_ty)
                 {
                     return Ok(quote! {
-                        fory_core::serializer::codec::HashMapCodec<#key_ty, #value_ty, #key_codec, #value_codec, #nullable, #track_ref>
+                        ::fory_core::serializer::codec::HashMapCodec<#key_ty, #value_ty, #key_codec, #value_codec, #nullable, #track_ref>
                     });
                 }
                 return Ok(quote! {
-                    fory_core::serializer::codec::MapSerializerCodec<
+                    ::fory_core::serializer::codec::MapSerializerCodec<
                         #ty,
                         #key_ty,
                         #value_ty,
@@ -573,7 +573,7 @@ pub(crate) fn codec_type_for(
                 value_meta.effective_ref(value_class),
             )?;
             return Ok(quote! {
-                fory_core::serializer::codec::HashMapCodec<#key_ty, #value_ty, #key_codec, #value_codec, #nullable, #track_ref>
+                ::fory_core::serializer::codec::HashMapCodec<#key_ty, #value_ty, #key_codec, #value_codec, #nullable, #track_ref>
             });
         }
         if name == "HashSet" {
@@ -617,11 +617,11 @@ pub(crate) fn codec_type_for(
                 elem_meta.effective_ref(elem_class),
             )?;
             return Ok(quote! {
-                fory_core::serializer::codec::CollectionSerializerCodec<
+                ::fory_core::serializer::codec::CollectionSerializerCodec<
                     #ty,
                     #elem_ty,
                     #elem_codec,
-                    { fory_core::type_id::TypeId::SET as u8 },
+                    { ::fory_core::type_id::TypeId::SET as u8 },
                     #nullable,
                     #track_ref
                 >
@@ -640,7 +640,7 @@ pub(crate) fn codec_type_for(
             )?;
             let type_id = serializer_backed_collection_type_id(&name);
             return Ok(quote! {
-                fory_core::serializer::codec::CollectionSerializerCodec<
+                ::fory_core::serializer::codec::CollectionSerializerCodec<
                     #ty,
                     #elem_ty,
                     #elem_codec,
@@ -670,7 +670,7 @@ pub(crate) fn codec_type_for(
                 value_meta.effective_ref(value_class),
             )?;
             return Ok(quote! {
-                fory_core::serializer::codec::MapSerializerCodec<
+                ::fory_core::serializer::codec::MapSerializerCodec<
                     #ty,
                     #key_ty,
                     #value_ty,
@@ -725,11 +725,11 @@ pub(crate) fn codec_type_for(
                 elem_meta.effective_ref(elem_class),
             )?;
             return Ok(quote! {
-                fory_core::serializer::codec::CollectionSerializerCodec<
+                ::fory_core::serializer::codec::CollectionSerializerCodec<
                     #ty,
                     #elem_ty,
                     #elem_codec,
-                    { fory_core::type_id::TypeId::LIST as u8 },
+                    { ::fory_core::type_id::TypeId::LIST as u8 },
                     #nullable,
                     #track_ref
                 >
@@ -738,13 +738,13 @@ pub(crate) fn codec_type_for(
     }
 
     if is_exact_any(ty, "Box") {
-        return Ok(quote! { fory_core::serializer::codec::AnyBoxCodec<#nullable, #track_ref> });
+        return Ok(quote! { ::fory_core::serializer::codec::AnyBoxCodec<#nullable, #track_ref> });
     }
     if is_exact_any(ty, "Rc") {
-        return Ok(quote! { fory_core::serializer::codec::AnyRcCodec<#nullable, #track_ref> });
+        return Ok(quote! { ::fory_core::serializer::codec::AnyRcCodec<#nullable, #track_ref> });
     }
     if is_exact_any(ty, "Arc") {
-        return Ok(quote! { fory_core::serializer::codec::AnyArcCodec<#nullable, #track_ref> });
+        return Ok(quote! { ::fory_core::serializer::codec::AnyArcCodec<#nullable, #track_ref> });
     }
 
     if let Some((_, trait_name)) = is_box_dyn_trait(ty) {
@@ -789,7 +789,7 @@ pub(crate) fn codec_type_for(
         return Ok(codec);
     }
 
-    Ok(quote! { fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref> })
+    Ok(quote! { ::fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref> })
 }
 
 fn is_vec_type(ty: &Type) -> bool {
@@ -807,9 +807,9 @@ fn integer_codec_type(
     match type_name.as_str() {
         "i32" => {
             let wire = match encoding {
-                IntEncoding::Fixed => quote! { { fory_core::type_id::TypeId::INT32 as u8 } },
+                IntEncoding::Fixed => quote! { { ::fory_core::type_id::TypeId::INT32 as u8 } },
                 IntEncoding::Varint => {
-                    quote! { { fory_core::type_id::TypeId::VARINT32 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::VARINT32 as u8 } }
                 }
                 IntEncoding::Tagged => {
                     return Some(quote! {
@@ -817,25 +817,25 @@ fn integer_codec_type(
                     });
                 }
             };
-            Some(quote! { fory_core::serializer::codec::I32Codec<#wire, #nullable, #track_ref> })
+            Some(quote! { ::fory_core::serializer::codec::I32Codec<#wire, #nullable, #track_ref> })
         }
         "i64" => {
             let wire = match encoding {
-                IntEncoding::Fixed => quote! { { fory_core::type_id::TypeId::INT64 as u8 } },
+                IntEncoding::Fixed => quote! { { ::fory_core::type_id::TypeId::INT64 as u8 } },
                 IntEncoding::Varint => {
-                    quote! { { fory_core::type_id::TypeId::VARINT64 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::VARINT64 as u8 } }
                 }
                 IntEncoding::Tagged => {
-                    quote! { { fory_core::type_id::TypeId::TAGGED_INT64 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::TAGGED_INT64 as u8 } }
                 }
             };
-            Some(quote! { fory_core::serializer::codec::I64Codec<#wire, #nullable, #track_ref> })
+            Some(quote! { ::fory_core::serializer::codec::I64Codec<#wire, #nullable, #track_ref> })
         }
         "u32" => {
             let wire = match encoding {
-                IntEncoding::Fixed => quote! { { fory_core::type_id::TypeId::UINT32 as u8 } },
+                IntEncoding::Fixed => quote! { { ::fory_core::type_id::TypeId::UINT32 as u8 } },
                 IntEncoding::Varint => {
-                    quote! { { fory_core::type_id::TypeId::VAR_UINT32 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::VAR_UINT32 as u8 } }
                 }
                 IntEncoding::Tagged => {
                     return Some(quote! {
@@ -843,19 +843,19 @@ fn integer_codec_type(
                     });
                 }
             };
-            Some(quote! { fory_core::serializer::codec::U32Codec<#wire, #nullable, #track_ref> })
+            Some(quote! { ::fory_core::serializer::codec::U32Codec<#wire, #nullable, #track_ref> })
         }
         "u64" => {
             let wire = match encoding {
-                IntEncoding::Fixed => quote! { { fory_core::type_id::TypeId::UINT64 as u8 } },
+                IntEncoding::Fixed => quote! { { ::fory_core::type_id::TypeId::UINT64 as u8 } },
                 IntEncoding::Varint => {
-                    quote! { { fory_core::type_id::TypeId::VAR_UINT64 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::VAR_UINT64 as u8 } }
                 }
                 IntEncoding::Tagged => {
-                    quote! { { fory_core::type_id::TypeId::TAGGED_UINT64 as u8 } }
+                    quote! { { ::fory_core::type_id::TypeId::TAGGED_UINT64 as u8 } }
                 }
             };
-            Some(quote! { fory_core::serializer::codec::U64Codec<#wire, #nullable, #track_ref> })
+            Some(quote! { ::fory_core::serializer::codec::U64Codec<#wire, #nullable, #track_ref> })
         }
         _ => {
             if meta.encoding.is_some() {
@@ -886,7 +886,9 @@ fn type_name_and_args(
 }
 
 fn vec_element_type_name(ty: &Type) -> Option<String> {
-    Some(ty.to_token_stream().to_string().replace(' ', ""))
+    type_name_and_args(ty)
+        .map(|(name, _)| name)
+        .or_else(|| Some(ty.to_token_stream().to_string().replace(' ', "")))
 }
 
 fn single_type_arg<'a>(
@@ -994,13 +996,13 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
 
     if let Type::Array(array) = ty {
         let type_id = get_type_id_by_type_ast(ty);
-        if fory_core::type_id::PRIMITIVE_ARRAY_TYPES.contains(&type_id) {
+        if ::fory_core::type_id::PRIMITIVE_ARRAY_TYPES.contains(&type_id) {
             return Ok(field_type_literal(type_id, nullable, track_ref, Vec::new()));
         }
         let elem_ty = array.elem.as_ref();
         let elem_type = nested_field_type_expr(elem_ty)?;
         return Ok(field_type_literal(
-            fory_core::type_id::TypeId::LIST as u32,
+            ::fory_core::type_id::TypeId::LIST as u32,
             nullable,
             track_ref,
             vec![elem_type],
@@ -1009,14 +1011,14 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
 
     if matches!(ty, Type::Tuple(_)) {
         return Ok(field_type_literal(
-            fory_core::type_id::TypeId::LIST as u32,
+            ::fory_core::type_id::TypeId::LIST as u32,
             nullable,
             track_ref,
             vec![quote! {
-                fory_core::meta::FieldType::new(
-                    fory_core::type_id::TypeId::UNKNOWN as u32,
+                ::fory_core::meta::FieldType::new(
+                    ::fory_core::type_id::TypeId::UNKNOWN as u32,
                     true,
-                    Vec::new(),
+                    ::std::vec::Vec::new(),
                 )
             }],
         ));
@@ -1028,7 +1030,7 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
                 let elem_ty = single_type_arg(args, ty, "Vec")?;
                 let elem_type = nested_field_type_expr(elem_ty)?;
                 return Ok(field_type_literal(
-                    fory_core::type_id::TypeId::LIST as u32,
+                    ::fory_core::type_id::TypeId::LIST as u32,
                     nullable,
                     track_ref,
                     vec![elem_type],
@@ -1038,7 +1040,7 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
                 let elem_ty = single_type_arg(args, ty, &name)?;
                 let elem_type = nested_field_type_expr(elem_ty)?;
                 return Ok(field_type_literal(
-                    fory_core::type_id::TypeId::LIST as u32,
+                    ::fory_core::type_id::TypeId::LIST as u32,
                     nullable,
                     track_ref,
                     vec![elem_type],
@@ -1048,7 +1050,7 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
                 let elem_ty = single_type_arg(args, ty, &name)?;
                 let elem_type = nested_field_type_expr(elem_ty)?;
                 return Ok(field_type_literal(
-                    fory_core::type_id::TypeId::SET as u32,
+                    ::fory_core::type_id::TypeId::SET as u32,
                     nullable,
                     track_ref,
                     vec![elem_type],
@@ -1059,7 +1061,7 @@ fn field_type_expr_for(ty: &Type, nullable: bool, track_ref: bool) -> syn::Resul
                 let key_type = nested_field_type_expr(key_ty)?;
                 let value_type = nested_field_type_expr(value_ty)?;
                 return Ok(field_type_literal(
-                    fory_core::type_id::TypeId::MAP as u32,
+                    ::fory_core::type_id::TypeId::MAP as u32,
                     nullable,
                     track_ref,
                     vec![key_type, value_type],
@@ -1079,7 +1081,7 @@ fn nested_field_type_expr(ty: &Type) -> syn::Result<TokenStream> {
     let track_ref = meta.effective_ref(class);
     let codec_ty = codec_type_for(ty, &meta, nullable, track_ref)?;
     Ok(quote! {
-        <#codec_ty as fory_core::serializer::codec::Codec<#ty>>::field_type(type_resolver)?
+        <#codec_ty as ::fory_core::serializer::codec::Codec<#ty>>::field_type(type_resolver)?
     })
 }
 
@@ -1090,30 +1092,30 @@ fn field_type_literal(
     generics: Vec<TokenStream>,
 ) -> TokenStream {
     quote! {
-        fory_core::meta::FieldType::new_with_ref(
+        ::fory_core::meta::FieldType::new_with_ref(
             #type_id,
             #nullable,
             #track_ref,
-            vec![#(#generics),*],
+            ::std::vec![#(#generics),*],
         )
     }
 }
 
 fn serializer_field_type_expr(ty: &Type, nullable: bool, track_ref: bool) -> TokenStream {
     quote! {
-        <fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref>
-            as fory_core::serializer::codec::Codec<#ty>>::field_type(type_resolver)?
+        <::fory_core::serializer::codec::SerializerCodec<#ty, #nullable, #track_ref>
+            as ::fory_core::serializer::codec::Codec<#ty>>::field_type(type_resolver)?
     }
 }
 
 fn serializer_ref_mode_for_field(field: &syn::Field) -> TokenStream {
     let (nullable, track_ref) = serializer_field_markers(field);
     if track_ref {
-        quote! { fory_core::RefMode::Tracking }
+        quote! { ::fory_core::RefMode::Tracking }
     } else if nullable {
-        quote! { fory_core::RefMode::NullOnly }
+        quote! { ::fory_core::RefMode::NullOnly }
     } else {
-        quote! { fory_core::RefMode::None }
+        quote! { ::fory_core::RefMode::None }
     }
 }
 
@@ -1135,23 +1137,27 @@ fn is_serializer_backed_collection(name: &str) -> bool {
 }
 
 fn primitive_array_type_id_for_vec_element(ty: &Type) -> syn::Result<TokenStream> {
-    let type_name = ty.to_token_stream().to_string().replace(' ', "");
+    let type_name = type_name_and_args(ty)
+        .map(|(name, _)| name)
+        .unwrap_or_else(|| ty.to_token_stream().to_string().replace(' ', ""));
     match type_name.as_str() {
-        "bool" => Ok(quote! { { fory_core::type_id::TypeId::BOOL_ARRAY as u8 } }),
-        "i8" => Ok(quote! { { fory_core::type_id::TypeId::INT8_ARRAY as u8 } }),
-        "i16" => Ok(quote! { { fory_core::type_id::TypeId::INT16_ARRAY as u8 } }),
-        "i32" => Ok(quote! { { fory_core::type_id::TypeId::INT32_ARRAY as u8 } }),
-        "i64" => Ok(quote! { { fory_core::type_id::TypeId::INT64_ARRAY as u8 } }),
-        "u8" => Ok(quote! { { fory_core::type_id::TypeId::UINT8_ARRAY as u8 } }),
-        "u16" => Ok(quote! { { fory_core::type_id::TypeId::UINT16_ARRAY as u8 } }),
-        "u32" => Ok(quote! { { fory_core::type_id::TypeId::UINT32_ARRAY as u8 } }),
-        "u64" => Ok(quote! { { fory_core::type_id::TypeId::UINT64_ARRAY as u8 } }),
-        "float16" | "Float16" => Ok(quote! { { fory_core::type_id::TypeId::FLOAT16_ARRAY as u8 } }),
-        "bfloat16" | "BFloat16" => {
-            Ok(quote! { { fory_core::type_id::TypeId::BFLOAT16_ARRAY as u8 } })
+        "bool" => Ok(quote! { { ::fory_core::type_id::TypeId::BOOL_ARRAY as u8 } }),
+        "i8" => Ok(quote! { { ::fory_core::type_id::TypeId::INT8_ARRAY as u8 } }),
+        "i16" => Ok(quote! { { ::fory_core::type_id::TypeId::INT16_ARRAY as u8 } }),
+        "i32" => Ok(quote! { { ::fory_core::type_id::TypeId::INT32_ARRAY as u8 } }),
+        "i64" => Ok(quote! { { ::fory_core::type_id::TypeId::INT64_ARRAY as u8 } }),
+        "u8" => Ok(quote! { { ::fory_core::type_id::TypeId::UINT8_ARRAY as u8 } }),
+        "u16" => Ok(quote! { { ::fory_core::type_id::TypeId::UINT16_ARRAY as u8 } }),
+        "u32" => Ok(quote! { { ::fory_core::type_id::TypeId::UINT32_ARRAY as u8 } }),
+        "u64" => Ok(quote! { { ::fory_core::type_id::TypeId::UINT64_ARRAY as u8 } }),
+        "float16" | "Float16" => {
+            Ok(quote! { { ::fory_core::type_id::TypeId::FLOAT16_ARRAY as u8 } })
         }
-        "f32" => Ok(quote! { { fory_core::type_id::TypeId::FLOAT32_ARRAY as u8 } }),
-        "f64" => Ok(quote! { { fory_core::type_id::TypeId::FLOAT64_ARRAY as u8 } }),
+        "bfloat16" | "BFloat16" => {
+            Ok(quote! { { ::fory_core::type_id::TypeId::BFLOAT16_ARRAY as u8 } })
+        }
+        "f32" => Ok(quote! { { ::fory_core::type_id::TypeId::FLOAT32_ARRAY as u8 } }),
+        "f64" => Ok(quote! { { ::fory_core::type_id::TypeId::FLOAT64_ARRAY as u8 } }),
         _ => Err(syn::Error::new_spanned(
             ty,
             "array requires a non-null number or bool Vec element type",
@@ -1161,8 +1167,8 @@ fn primitive_array_type_id_for_vec_element(ty: &Type) -> syn::Result<TokenStream
 
 fn serializer_backed_collection_type_id(name: &str) -> TokenStream {
     match name {
-        "BTreeSet" | "BinaryHeap" => quote! { { fory_core::type_id::TypeId::SET as u8 } },
-        _ => quote! { { fory_core::type_id::TypeId::LIST as u8 } },
+        "BTreeSet" | "BinaryHeap" => quote! { { ::fory_core::type_id::TypeId::SET as u8 } },
+        _ => quote! { { ::fory_core::type_id::TypeId::LIST as u8 } },
     }
 }
 
@@ -1270,7 +1276,7 @@ fn is_exact_any(ty: &Type, owner: &str) -> bool {
 }
 
 fn is_primitive_array_type(ty: &Type) -> bool {
-    fory_core::type_id::PRIMITIVE_ARRAY_TYPES.contains(&get_type_id_by_type_ast(ty))
+    ::fory_core::type_id::PRIMITIVE_ARRAY_TYPES.contains(&get_type_id_by_type_ast(ty))
 }
 
 pub(crate) fn default_expr_for_type(ty: &Type) -> TokenStream {
@@ -1279,8 +1285,8 @@ pub(crate) fn default_expr_for_type(ty: &Type) -> TokenStream {
         let trait_ident = format_ident!("{}", trait_name);
         return quote! {
             {
-                let wrapper = <#wrapper_ty as fory_core::ForyDefault>::fory_default();
-                std::rc::Rc::<dyn #trait_ident>::from(wrapper)
+                let wrapper = <#wrapper_ty as ::fory_core::ForyDefault>::fory_default();
+                ::std::rc::Rc::<dyn #trait_ident>::from(wrapper)
             }
         };
     }
@@ -1289,12 +1295,12 @@ pub(crate) fn default_expr_for_type(ty: &Type) -> TokenStream {
         let trait_ident = format_ident!("{}", trait_name);
         return quote! {
             {
-                let wrapper = <#wrapper_ty as fory_core::ForyDefault>::fory_default();
-                std::sync::Arc::<dyn #trait_ident>::from(wrapper)
+                let wrapper = <#wrapper_ty as ::fory_core::ForyDefault>::fory_default();
+                ::std::sync::Arc::<dyn #trait_ident>::from(wrapper)
             }
         };
     }
-    quote! { <#ty as fory_core::ForyDefault>::fory_default() }
+    quote! { <#ty as ::fory_core::ForyDefault>::fory_default() }
 }
 
 #[cfg(test)]

--- a/rust/fory-derive/src/object/misc.rs
+++ b/rust/fory-derive/src/object/misc.rs
@@ -38,18 +38,17 @@ fn hash(fields: &[&Field]) -> TokenStream {
         let ty = &field.ty;
         let name = super::util::get_field_name(field, idx);
         quote! {
-            (#name, <#ty as fory_core::serializer::Serializer>::fory_get_type_id())
+            (#name, <#ty as ::fory_core::serializer::Serializer>::fory_get_type_id())
         }
     });
 
     quote! {
         fn fory_hash() -> u32 {
-            use std::sync::Once;
             static mut name_hash: u32 = 0u32;
-            static name_hash_once: Once = Once::new();
+            static name_hash_once: ::std::sync::Once = ::std::sync::Once::new();
             unsafe {
                 name_hash_once.call_once(|| {
-                        name_hash = fory_core::meta::compute_struct_hash(vec![#(#props),*]);
+                        name_hash = ::fory_core::meta::compute_struct_hash(::std::vec![#(#props),*]);
                 });
                 name_hash
             }
@@ -59,16 +58,16 @@ fn hash(fields: &[&Field]) -> TokenStream {
 
 pub fn gen_actual_type_id() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::actual_type_id(type_id, register_by_name, compatible)
+        ::fory_core::serializer::struct_::actual_type_id(type_id, register_by_name, compatible)
     }
 }
 
 pub fn gen_actual_type_id_no_evolving() -> TokenStream {
     quote! {
         if register_by_name {
-            fory_core::type_id::TypeId::NAMED_STRUCT as u32
+            ::fory_core::type_id::TypeId::NAMED_STRUCT as u32
         } else {
-            fory_core::type_id::TypeId::STRUCT as u32
+            ::fory_core::type_id::TypeId::STRUCT as u32
         }
     }
 }
@@ -94,9 +93,9 @@ pub fn gen_field_fields_info(source_fields: &[SourceField<'_>]) -> TokenStream {
     let static_field_names = get_sort_fields_ts(&fields);
 
     quote! {
-        let mut field_infos: Vec<fory_core::meta::FieldInfo> = vec![#(#field_infos),*];
+        let mut field_infos: ::std::vec::Vec<::fory_core::meta::FieldInfo> = ::std::vec![#(#field_infos),*];
         let sorted_field_names = #static_field_names;
-        fory_core::meta::sort_fields(&mut field_infos, sorted_field_names)?;
-        Ok(field_infos)
+        ::fory_core::meta::sort_fields(&mut field_infos, sorted_field_names)?;
+        ::std::result::Result::Ok(field_infos)
     }
 }

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -80,7 +80,7 @@ pub(crate) fn assign_value(source_fields: &[SourceField<'_>]) -> Vec<TokenStream
 
 pub fn gen_read_type_info() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::read_type_info_fast::<Self>(context)
+        ::fory_core::serializer::struct_::read_type_info_fast::<Self>(context)
     }
 }
 
@@ -104,16 +104,16 @@ fn get_source_fields_loop_ts(source_fields: &[SourceField<'_>]) -> TokenStream {
                     );
                     let private_ident = &binding.private_ident;
                     quote! {
-                        fory_core::serializer::struct_::struct_before_read_field(
+                        ::fory_core::serializer::struct_::struct_before_read_field(
                             #struct_name_lit,
                             #field_name_lit,
                             context,
                         );
                         #base
-                        fory_core::serializer::struct_::struct_after_read_field(
+                        ::fory_core::serializer::struct_::struct_after_read_field(
                             #struct_name_lit,
                             #field_name_lit,
-                            (&#private_ident) as &dyn std::any::Any,
+                            (&#private_ident) as &dyn ::std::any::Any,
                             context,
                         );
                     }
@@ -168,9 +168,9 @@ pub fn gen_read_data(source_fields: &[SourceField<'_>]) -> TokenStream {
         // Read and check version hash when class version checking is enabled
         if context.is_check_struct_version() {
             let read_version = context.reader.read_i32()?;
-            let type_name = std::any::type_name::<Self>();
+            let type_name = ::std::any::type_name::<Self>();
             let local_version: i32 = #version_hash_ts;
-            fory_core::meta::TypeMeta::check_struct_version(read_version, local_version, type_name)?;
+            ::fory_core::meta::TypeMeta::check_struct_version(read_version, local_version, type_name)?;
         }
         #read_fields
         #self_construction
@@ -182,37 +182,37 @@ pub fn gen_read(_struct_ident: &Ident) -> TokenStream {
     // When the struct has generics (e.g., LeaderId<C>), using `Self` ensures the full
     // type with generics is used in the impl block.
     quote! {
-        let ref_flag = if ref_mode != fory_core::RefMode::None {
+        let ref_flag = if ref_mode != ::fory_core::RefMode::None {
             context.reader.read_i8()?
         } else {
-            fory_core::RefFlag::NotNullValue as i8
+            ::fory_core::RefFlag::NotNullValue as i8
         };
-        if ref_flag == (fory_core::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::RefFlag::RefValue as i8) {
+        if ref_flag == (::fory_core::RefFlag::NotNullValue as i8) || ref_flag == (::fory_core::RefFlag::RefValue as i8) {
             // For RefValueFlag with Tracking mode, reserve a ref_id to participate in ref tracking.
             // This is needed for xlang compatibility where all objects (not just Rc/Arc)
             // participate in reference tracking when ref tracking is enabled.
             // Only reserve for Tracking mode, not NullOnly mode.
-            if ref_flag == (fory_core::RefFlag::RefValue as i8) && ref_mode == fory_core::RefMode::Tracking {
+            if ref_flag == (::fory_core::RefFlag::RefValue as i8) && ref_mode == ::fory_core::RefMode::Tracking {
                 context.ref_reader.reserve_ref_id();
             }
             if context.is_compatible() {
                 let type_info = if read_type_info {
                     context.read_any_type_info()?
                 } else {
-                    let rs_type_id = std::any::TypeId::of::<Self>();
+                    let rs_type_id = ::std::any::TypeId::of::<Self>();
                     context.get_type_info(&rs_type_id)?
                 };
-                <Self as fory_core::StructSerializer>::fory_read_compatible(context, type_info)
+                <Self as ::fory_core::StructSerializer>::fory_read_compatible(context, type_info)
             } else {
                 if read_type_info {
-                    <Self as fory_core::Serializer>::fory_read_type_info(context)?;
+                    <Self as ::fory_core::Serializer>::fory_read_type_info(context)?;
                 }
-                <Self as fory_core::Serializer>::fory_read_data(context)
+                <Self as ::fory_core::Serializer>::fory_read_data(context)
             }
-        } else if ref_flag == (fory_core::RefFlag::Null as i8) {
-            Ok(<Self as fory_core::ForyDefault>::fory_default())
+        } else if ref_flag == (::fory_core::RefFlag::Null as i8) {
+            Ok(<Self as ::fory_core::ForyDefault>::fory_default())
         } else {
-            Err(fory_core::error::Error::invalid_ref(format!("Unknown ref flag, value:{ref_flag}")))
+            Err(::fory_core::error::Error::invalid_ref(format!("Unknown ref flag, value:{ref_flag}")))
         }
     }
 }
@@ -225,21 +225,21 @@ pub fn gen_read_with_type_info() -> TokenStream {
     // ) -> Result<Self, Error>
     // Note: We use `Self` instead of `#struct_ident` to correctly handle generic types.
     quote! {
-        let ref_flag = if ref_mode != fory_core::RefMode::None {
+        let ref_flag = if ref_mode != ::fory_core::RefMode::None {
             context.reader.read_i8()?
         } else {
-            fory_core::RefFlag::NotNullValue as i8
+            ::fory_core::RefFlag::NotNullValue as i8
         };
-        if ref_flag == (fory_core::RefFlag::NotNullValue as i8) || ref_flag == (fory_core::RefFlag::RefValue as i8) {
+        if ref_flag == (::fory_core::RefFlag::NotNullValue as i8) || ref_flag == (::fory_core::RefFlag::RefValue as i8) {
             if context.is_compatible() {
-                <Self as fory_core::StructSerializer>::fory_read_compatible(context, type_info)
+                <Self as ::fory_core::StructSerializer>::fory_read_compatible(context, type_info)
             } else {
-                <Self as fory_core::Serializer>::fory_read_data(context)
+                <Self as ::fory_core::Serializer>::fory_read_data(context)
             }
-        } else if ref_flag == (fory_core::RefFlag::Null as i8) {
-            Ok(<Self as fory_core::ForyDefault>::fory_default())
+        } else if ref_flag == (::fory_core::RefFlag::Null as i8) {
+            Ok(<Self as ::fory_core::ForyDefault>::fory_default())
         } else {
-            Err(fory_core::error::Error::invalid_ref(format!("Unknown ref flag, value:{ref_flag}")))
+            Err(::fory_core::error::Error::invalid_ref(format!("Unknown ref flag, value:{ref_flag}")))
         }
     }
 }
@@ -291,19 +291,19 @@ pub(crate) fn gen_read_compatible_with_construction(
         quote! {
             _ => {
                 let field_type = &_field.field_type;
-                let read_ref_flag = fory_core::serializer::util::field_need_write_ref_into(
+                let read_ref_flag = ::fory_core::serializer::util::field_need_write_ref_into(
                     field_type.type_id,
                     field_type.nullable,
                 );
                 let field_name = _field.field_name.as_str();
-                fory_core::serializer::struct_::struct_before_read_field(
+                ::fory_core::serializer::struct_::struct_before_read_field(
                     #struct_name_lit,
                     field_name,
                     context,
                 );
-                fory_core::serializer::skip::skip_field_value(context, &field_type, read_ref_flag)?;
-                let placeholder: &dyn std::any::Any = &();
-                fory_core::serializer::struct_::struct_after_read_field(
+                ::fory_core::serializer::skip::skip_field_value(context, &field_type, read_ref_flag)?;
+                let placeholder: &dyn ::std::any::Any = &();
+                ::fory_core::serializer::struct_::struct_after_read_field(
                     #struct_name_lit,
                     field_name,
                     placeholder,
@@ -315,11 +315,11 @@ pub(crate) fn gen_read_compatible_with_construction(
         quote! {
             _ => {
                 let field_type = &_field.field_type;
-                let read_ref_flag = fory_core::serializer::util::field_need_write_ref_into(
+                let read_ref_flag = ::fory_core::serializer::util::field_need_write_ref_into(
                     field_type.type_id,
                     field_type.nullable,
                 );
-                fory_core::serializer::skip::skip_field_value(context, field_type, read_ref_flag)?;
+                ::fory_core::serializer::skip::skip_field_value(context, field_type, read_ref_flag)?;
             }
         }
     };
@@ -352,21 +352,21 @@ pub(crate) fn gen_read_compatible_with_construction(
         quote! {
             let local_variant_type_info = context
                 .get_type_resolver()
-                .get_type_info(&std::any::TypeId::of::<#meta_type_ident>())
-                .map_err(|_| fory_core::Error::type_error(
+                .get_type_info(&::std::any::TypeId::of::<#meta_type_ident>())
+                .map_err(|_| ::fory_core::Error::type_error(
                     concat!("Local enum variant metadata not found for ", #variant_name_lit)
                 ))?;
             let local_variant_type_meta = local_variant_type_info.get_type_meta();
             let local_fields = local_variant_type_meta.get_field_infos();
 
-            let field_index_by_name: std::collections::HashMap<_, _> = local_fields
+            let field_index_by_name: ::std::collections::HashMap<_, _> = local_fields
                 .iter()
                 .enumerate()
                 .filter(|(_, f)| !f.field_name.is_empty())
                 .map(|(i, f)| (f.field_name.clone(), (i, f)))
                 .collect();
 
-            let field_index_by_id: std::collections::HashMap<_, _> = local_fields
+            let field_index_by_id: ::std::collections::HashMap<_, _> = local_fields
                 .iter()
                 .enumerate()
                 .filter(|(_, f)| f.field_id >= 0)
@@ -378,7 +378,7 @@ pub(crate) fn gen_read_compatible_with_construction(
                     field_index_by_id.get(&field.field_id).copied()
                 } else {
                     let snake_case_name =
-                        fory_core::util::to_snake_case(&field.field_name);
+                        ::fory_core::util::to_snake_case(&field.field_name);
                     field_index_by_name.get(&snake_case_name).copied()
                 };
 
@@ -414,14 +414,14 @@ pub(crate) fn gen_read_compatible_with_construction(
 
     quote! {
         let meta = context.get_type_resolver().get_type_meta_by_index_ref(
-            &std::any::TypeId::of::<Self>(),
-            <Self as fory_core::StructSerializer>::fory_type_index(),
+            &::std::any::TypeId::of::<Self>(),
+            <Self as ::fory_core::StructSerializer>::fory_type_index(),
         )?;
         let local_type_hash = meta.get_hash();
         let remote_meta = type_info.get_type_meta_ref();
         let remote_type_hash = remote_meta.get_hash();
         if remote_type_hash == local_type_hash {
-            return <Self as fory_core::Serializer>::fory_read_data(context);
+            return <Self as ::fory_core::Serializer>::fory_read_data(context);
         }
         #fields_binding
         #(#declare_ts)*

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -73,7 +73,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
                 actual_type_id_ts,
                 misc::gen_get_sorted_field_names(&fields),
                 misc::gen_field_fields_info(&source_fields),
-                quote! { Ok(Vec::new()) }, // No variants for structs
+                quote! { ::std::result::Result::Ok(::std::vec::Vec::new()) }, // No variants for structs
                 read::gen_read_compatible(&source_fields),
                 vec![], // No variant meta types for structs
             )
@@ -88,7 +88,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
                 derive_enum::gen_field_fields_info(s),
                 derive_enum::gen_variants_fields_info(name, s),
                 quote! {
-                    Err(fory_core::Error::not_allowed("`fory_read_compatible` should only be invoked at struct type"
+                    ::std::result::Result::Err(::fory_core::Error::not_allowed("`fory_read_compatible` should only be invoked at struct type"
                 ))
                 },
                 variant_meta_types,
@@ -121,7 +121,7 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
                 read::gen_read_data(&source_fields),
                 read::gen_read_type_info(),
                 write::gen_reserved_space(&source_fields),
-                quote! { fory_core::TypeId::STRUCT },
+                quote! { ::fory_core::TypeId::STRUCT },
             )
         }
         syn::Data::Enum(e) => (
@@ -144,14 +144,14 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
     let type_idx = misc::allocate_type_id();
 
     let gen = quote! {
-        use fory_core::ForyDefault as _;
+        use ::fory_core::ForyDefault as _;
 
         // Generate variant meta types for enums (must be at module scope)
         #(#enum_variant_meta_types)*
 
         #default_impl
 
-        impl #impl_generics fory_core::StructSerializer for #name #ty_generics #where_clause {
+        impl #impl_generics ::fory_core::StructSerializer for #name #ty_generics #where_clause {
             #[inline(always)]
             fn fory_type_index() -> u32 {
                 #type_idx
@@ -166,41 +166,41 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
                 #get_sorted_field_names_ts
             }
 
-            fn fory_fields_info(type_resolver: &fory_core::resolver::TypeResolver) -> Result<Vec<fory_core::meta::FieldInfo>, fory_core::error::Error> {
+            fn fory_fields_info(type_resolver: &::fory_core::resolver::TypeResolver) -> ::std::result::Result<::std::vec::Vec<::fory_core::meta::FieldInfo>, ::fory_core::error::Error> {
                 #fields_info_ts
             }
 
-            fn fory_variants_fields_info(type_resolver: &fory_core::resolver::TypeResolver) -> Result<Vec<(String, std::any::TypeId, Vec<fory_core::meta::FieldInfo>)>, fory_core::error::Error> {
+            fn fory_variants_fields_info(type_resolver: &::fory_core::resolver::TypeResolver) -> ::std::result::Result<::std::vec::Vec<(::std::string::String, ::std::any::TypeId, ::std::vec::Vec<::fory_core::meta::FieldInfo>)>, ::fory_core::error::Error> {
                 #variants_fields_info_ts
             }
 
             #[inline]
-            fn fory_read_compatible(context: &mut fory_core::ReadContext, type_info: std::rc::Rc<fory_core::TypeInfo>) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_compatible(context: &mut ::fory_core::ReadContext, type_info: ::std::rc::Rc<::fory_core::TypeInfo>) -> ::std::result::Result<Self, ::fory_core::error::Error> {
                 #read_compatible_ts
             }
         }
 
-        impl #impl_generics fory_core::Serializer for #name #ty_generics #where_clause {
+        impl #impl_generics ::fory_core::Serializer for #name #ty_generics #where_clause {
             #[inline(always)]
-            fn fory_get_type_id(type_resolver: &fory_core::resolver::TypeResolver) -> Result<fory_core::TypeId, fory_core::error::Error> {
+            fn fory_get_type_id(type_resolver: &::fory_core::resolver::TypeResolver) -> ::std::result::Result<::fory_core::TypeId, ::fory_core::error::Error> {
                 let type_id = type_resolver
-                    .get_type_id(&std::any::TypeId::of::<Self>(), #type_idx)
-                    .map_err(fory_core::error::Error::enhance_type_error::<Self>)?;
-                Ok(type_id)
+                    .get_type_id(&::std::any::TypeId::of::<Self>(), #type_idx)
+                    .map_err(::fory_core::error::Error::enhance_type_error::<Self>)?;
+                ::std::result::Result::Ok(type_id)
             }
 
             #[inline(always)]
-            fn fory_type_id_dyn(&self, type_resolver: &fory_core::resolver::TypeResolver) -> Result<fory_core::TypeId, fory_core::error::Error> {
+            fn fory_type_id_dyn(&self, type_resolver: &::fory_core::resolver::TypeResolver) -> ::std::result::Result<::fory_core::TypeId, ::fory_core::error::Error> {
                 Self::fory_get_type_id(type_resolver)
             }
 
             #[inline(always)]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn ::std::any::Any {
                 self
             }
 
             #[inline(always)]
-            fn fory_static_type_id() -> fory_core::TypeId
+            fn fory_static_type_id() -> ::fory_core::TypeId
             where
                 Self: Sized,
             {
@@ -213,37 +213,37 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
             }
 
             #[inline(always)]
-            fn fory_write(&self, context: &mut fory_core::WriteContext, ref_mode: fory_core::RefMode, write_type_info: bool, _: bool) -> Result<(), fory_core::error::Error> {
+            fn fory_write(&self, context: &mut ::fory_core::WriteContext, ref_mode: ::fory_core::RefMode, write_type_info: bool, _: bool) -> ::std::result::Result<(), ::fory_core::error::Error> {
                 #write_ts
             }
 
             #[inline]
-            fn fory_write_data(&self, context: &mut fory_core::WriteContext) -> Result<(), fory_core::error::Error> {
+            fn fory_write_data(&self, context: &mut ::fory_core::WriteContext) -> ::std::result::Result<(), ::fory_core::error::Error> {
                 #write_data_ts
             }
 
             #[inline(always)]
-            fn fory_write_type_info(context: &mut fory_core::WriteContext) -> Result<(), fory_core::error::Error> {
+            fn fory_write_type_info(context: &mut ::fory_core::WriteContext) -> ::std::result::Result<(), ::fory_core::error::Error> {
                 #write_type_info_ts
             }
 
             #[inline(always)]
-            fn fory_read(context: &mut fory_core::ReadContext, ref_mode: fory_core::RefMode, read_type_info: bool) -> Result<Self, fory_core::error::Error> {
+            fn fory_read(context: &mut ::fory_core::ReadContext, ref_mode: ::fory_core::RefMode, read_type_info: bool) -> ::std::result::Result<Self, ::fory_core::error::Error> {
                 #read_ts
             }
 
             #[inline(always)]
-            fn fory_read_with_type_info(context: &mut fory_core::ReadContext, ref_mode: fory_core::RefMode, type_info: std::rc::Rc<fory_core::TypeInfo>) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_with_type_info(context: &mut ::fory_core::ReadContext, ref_mode: ::fory_core::RefMode, type_info: ::std::rc::Rc<::fory_core::TypeInfo>) -> ::std::result::Result<Self, ::fory_core::error::Error> {
                 #read_with_type_info_ts
             }
 
             #[inline]
-            fn fory_read_data( context: &mut fory_core::ReadContext) -> Result<Self, fory_core::error::Error> {
+            fn fory_read_data( context: &mut ::fory_core::ReadContext) -> ::std::result::Result<Self, ::fory_core::error::Error> {
                 #read_data_ts
             }
 
             #[inline(always)]
-            fn fory_read_type_info(context: &mut fory_core::ReadContext) -> Result<(), fory_core::error::Error> {
+            fn fory_read_type_info(context: &mut ::fory_core::ReadContext) -> ::std::result::Result<(), ::fory_core::error::Error> {
                 #read_type_info_ts
             }
         }
@@ -292,12 +292,12 @@ fn generate_default_impl(
             if should_generate_default {
                 // User requested Default generation via #[fory(generate_default)]
                 quote! {
-                    impl #impl_generics fory_core::ForyDefault for #name #ty_generics #where_clause {
+                    impl #impl_generics ::fory_core::ForyDefault for #name #ty_generics #where_clause {
                         fn fory_default() -> Self {
                             #self_construction
                         }
                     }
-                    impl #impl_generics std::default::Default for #name #ty_generics #where_clause {
+                    impl #impl_generics ::std::default::Default for #name #ty_generics #where_clause {
                         fn default() -> Self {
                             Self::fory_default()
                         }
@@ -307,7 +307,7 @@ fn generate_default_impl(
                 // Default case: only generate ForyDefault, not Default
                 // This avoids conflicts with existing Default implementations
                 quote! {
-                   impl #impl_generics fory_core::ForyDefault for #name #ty_generics #where_clause {
+                   impl #impl_generics ::fory_core::ForyDefault for #name #ty_generics #where_clause {
                         fn fory_default() -> Self {
                             #self_construction
                         }
@@ -332,7 +332,7 @@ fn generate_default_impl(
                     syn::Fields::Unnamed(fields) => {
                         let defaults = fields.unnamed.iter().map(|f| {
                             let ty = &f.ty;
-                            quote! { <#ty as fory_core::ForyDefault>::fory_default() }
+                            quote! { <#ty as ::fory_core::ForyDefault>::fory_default() }
                         });
                         quote! { (#(#defaults),*) }
                     }
@@ -340,7 +340,7 @@ fn generate_default_impl(
                         let field_inits = fields.named.iter().map(|f| {
                             let ident = &f.ident;
                             let ty = &f.ty;
-                            quote! { #ident: <#ty as fory_core::ForyDefault>::fory_default() }
+                            quote! { #ident: <#ty as ::fory_core::ForyDefault>::fory_default() }
                         });
                         quote! { { #(#field_inits),* } }
                     }
@@ -350,7 +350,7 @@ fn generate_default_impl(
                     // User has #[derive(Default)] or #[default] attribute
                     // Only generate ForyDefault that delegates to Default
                     quote! {
-                        impl #impl_generics fory_core::ForyDefault for #name #ty_generics #where_clause {
+                        impl #impl_generics ::fory_core::ForyDefault for #name #ty_generics #where_clause {
                             fn fory_default() -> Self {
                                 Self::default()
                             }
@@ -359,13 +359,13 @@ fn generate_default_impl(
                 } else if should_generate_default {
                     // User requested Default generation via #[fory(generate_default)]
                     quote! {
-                        impl #impl_generics fory_core::ForyDefault for #name #ty_generics #where_clause {
+                        impl #impl_generics ::fory_core::ForyDefault for #name #ty_generics #where_clause {
                             fn fory_default() -> Self {
                                 Self::#variant_ident #field_defaults
                             }
                         }
 
-                        impl #impl_generics std::default::Default for #name #ty_generics #where_clause {
+                        impl #impl_generics ::std::default::Default for #name #ty_generics #where_clause {
                             fn default() -> Self {
                                 Self::#variant_ident #field_defaults
                             }
@@ -374,7 +374,7 @@ fn generate_default_impl(
                 } else {
                     // Default case: only generate ForyDefault, not Default
                     quote! {
-                        impl #impl_generics fory_core::ForyDefault for #name #ty_generics #where_clause {
+                        impl #impl_generics ::fory_core::ForyDefault for #name #ty_generics #where_clause {
                             fn fory_default() -> Self {
                                 Self::#variant_ident #field_defaults
                             }

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -211,8 +211,30 @@ type FieldGroups = (
     FieldGroup,
 );
 
+/// Extract the inner generic arguments from a type name while ignoring path qualifiers.
+///
+/// e.g., both `Vec<T>` and `::std::vec::Vec<T>` return `T` when `outer` is `Vec`.
+fn extract_generic_inner<'a>(s: &'a str, outer: &str) -> Option<&'a str> {
+    let generic_start = s.find('<')?;
+    let owner = s[..generic_start]
+        .rsplit("::")
+        .next()
+        .unwrap_or(&s[..generic_start]);
+    if owner != outer {
+        return None;
+    }
+    s[generic_start + 1..].strip_suffix('>')
+}
+
+/// Return the final path segment so absolute generated paths match the same runtime type names.
+///
+/// e.g., `::fory::Float16` and `Float16` both normalize to `Float16`.
+fn unqualified_type_name(ty: &str) -> &str {
+    ty.rsplit("::").next().unwrap_or(ty)
+}
+
 fn extract_option_inner(s: &str) -> Option<&str> {
-    s.strip_prefix("Option<")?.strip_suffix(">")
+    extract_generic_inner(s, "Option")
 }
 
 const PRIMITIVE_TYPE_NAMES: [&str; 17] = [
@@ -220,8 +242,12 @@ const PRIMITIVE_TYPE_NAMES: [&str; 17] = [
     "f64", "u8", "u16", "u32", "u64", "u128",
 ];
 
+fn is_primitive_type_name(ty: &str) -> bool {
+    PRIMITIVE_TYPE_NAMES.contains(&unqualified_type_name(ty))
+}
+
 fn get_primitive_type_id(ty: &str) -> u32 {
-    match ty {
+    match unqualified_type_name(ty) {
         "bool" => TypeId::BOOL as u32,
         "i8" => TypeId::INT8 as u32,
         "i16" => TypeId::INT16 as u32,
@@ -311,15 +337,23 @@ pub(crate) fn get_type_id_by_name(ty: &str) -> u32 {
     }
 
     // Check collection types
-    if ty.starts_with("Vec<") || ty.starts_with("VecDeque<") || ty.starts_with("LinkedList<") {
+    if extract_generic_inner(ty, "Vec").is_some()
+        || extract_generic_inner(ty, "VecDeque").is_some()
+        || extract_generic_inner(ty, "LinkedList").is_some()
+    {
         return TypeId::LIST as u32;
     }
 
-    if ty.starts_with("HashSet<") || ty.starts_with("BTreeSet<") || ty.starts_with("BinaryHeap<") {
+    if extract_generic_inner(ty, "HashSet").is_some()
+        || extract_generic_inner(ty, "BTreeSet").is_some()
+        || extract_generic_inner(ty, "BinaryHeap").is_some()
+    {
         return TypeId::SET as u32;
     }
 
-    if ty.starts_with("HashMap<") || ty.starts_with("BTreeMap<") {
+    if extract_generic_inner(ty, "HashMap").is_some()
+        || extract_generic_inner(ty, "BTreeMap").is_some()
+    {
         return TypeId::MAP as u32;
     }
 
@@ -493,7 +527,7 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
 
         // handle Option<Primitive> specially
         if let Some(inner) = extract_option_inner(&ty) {
-            if PRIMITIVE_TYPE_NAMES.contains(&inner) {
+            if is_primitive_type_name(inner) {
                 // Get base type ID and adjust for encoding attributes
                 let base_type_id = get_primitive_type_id(inner);
                 let type_id = adjust_type_id_for_encoding(base_type_id, &meta);
@@ -501,7 +535,7 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
             } else {
                 group_field(ident, sort_key, inner, false);
             }
-        } else if PRIMITIVE_TYPE_NAMES.contains(&ty.as_str()) {
+        } else if is_primitive_type_name(&ty) {
             group_field(ident, sort_key, &ty, true);
         } else {
             group_field(ident, sort_key, &ty, false);
@@ -644,8 +678,8 @@ fn adjust_type_id_for_encoding(base_type_id: u32, meta: &super::field_meta::Fory
 }
 
 fn array_type_id_for_vec_name(ty: &str) -> Option<u32> {
-    let elem = ty.strip_prefix("Vec<")?.strip_suffix('>')?;
-    match elem {
+    let elem = extract_generic_inner(ty, "Vec")?;
+    match unqualified_type_name(elem) {
         "bool" => Some(TypeId::BOOL_ARRAY as u32),
         "i8" => Some(TypeId::INT8_ARRAY as u32),
         "i16" => Some(TypeId::INT16_ARRAY as u32),
@@ -873,10 +907,10 @@ pub(crate) fn gen_struct_version_hash_ts(fields: &[&Field]) -> TokenStream {
     quote! {
         {
             const VERSION_HASH: i32 = #version_hash;
-            if fory_core::util::ENABLE_FORY_DEBUG_OUTPUT {
+            if ::fory_core::util::ENABLE_FORY_DEBUG_OUTPUT {
                 println!(
                     "[rust][fory-debug] struct {} version fingerprint=\"{}\" hash={}",
-                    std::any::type_name::<Self>(),
+                    ::std::any::type_name::<Self>(),
                     #fingerprint,
                     VERSION_HASH
                 );

--- a/rust/fory-derive/src/object/write.rs
+++ b/rust/fory-derive/src/object/write.rs
@@ -44,7 +44,7 @@ pub fn gen_reserved_space(source_fields: &[SourceField<'_>]) -> TokenStream {
 
 pub fn gen_write_type_info() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::write_type_info_fast::<Self>(context)
+        ::fory_core::serializer::struct_::write_type_info_fast::<Self>(context)
     }
 }
 
@@ -73,17 +73,17 @@ pub fn gen_write_data(source_fields: &[SourceField<'_>]) -> TokenStream {
                         proc_macro2::Span::call_site(),
                     );
                     Some(quote! {
-                        fory_core::serializer::struct_::struct_before_write_field(
+                        ::fory_core::serializer::struct_::struct_before_write_field(
                             #struct_name_lit,
                             #field_name_lit,
-                            (&#value_ts) as &dyn std::any::Any,
+                            (&#value_ts) as &dyn ::std::any::Any,
                             context,
                         );
                         #base
-                        fory_core::serializer::struct_::struct_after_write_field(
+                        ::fory_core::serializer::struct_::struct_after_write_field(
                             #struct_name_lit,
                             #field_name_lit,
-                            (&#value_ts) as &dyn std::any::Any,
+                            (&#value_ts) as &dyn ::std::any::Any,
                             context,
                         );
                     })
@@ -108,6 +108,6 @@ pub fn gen_write_data(source_fields: &[SourceField<'_>]) -> TokenStream {
 
 pub fn gen_write() -> TokenStream {
     quote! {
-        fory_core::serializer::struct_::write::<Self>(self, context, ref_mode, write_type_info)
+        ::fory_core::serializer::struct_::write::<Self>(self, context, ref_mode, write_type_info)
     }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Apache Fory™.**

**If this is your first time opening a PR on fory, you can refer to [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fory™** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fory/blob/main/CONTRIBUTING.md).

    - Apache Fory™ has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Why?

For generated Rust code, it would be better to use absolute paths like `::std::option::Option` instead of `Option`. 
On the one hand, this follows common practice in [procedural macros](https://doc.rust-lang.org/reference/procedural-macros.html#r-macro.proc.hygiene) and prost; on the other hand, this will keep Fory/runtime/std/core references out of the generated code's local namespace, so IDL-defined names such as `String`, `Vec` won't collide with the generator-owned types.

## What does this PR do?

- Use absolute paths across the Rust code generator and derived macros.
- Remove collecting uses logic in the Rust code generator like
  https://github.com/apache/fory/blob/b4441d0ac55ba0dc89eb4a311966daa58074b9fc/compiler/fory_compiler/generators/rust.py#L199-L215

## Related issues

N/A.

## AI Contribution Checklist

<!-- Full requirements and disclosure template:
https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs -->

- [ ] Substantial AI assistance was used in this PR: no
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.

<!-- If substantial AI assistance = `yes`, paste the completed checklist and disclosure block here, including the final ai_review summary and screenshot evidence from both fresh reviewers on the current PR diff or current HEAD after the latest code changes. -->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fory/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
