### PR TITLE
fix(javascript): preserve getTypeInfo in regenerated read serializer

### DIFF
--- a/javascript/packages/core/lib/typeResolver.ts
+++ b/javascript/packages/core/lib/typeResolver.ts
@@ -293,6 +293,7 @@ export default class TypeResolver {
     const serializer = this.generateReadSerializer(typeInfo);
     return this.registerSerializer(typeInfo, {
       getHash: serializer.getHash,
+      getTypeInfo: serializer.getTypeInfo,
       read: serializer.read,
       readNoRef: serializer.readNoRef,
       readRef: serializer.readRef,

--- a/javascript/test/typemeta.test.ts
+++ b/javascript/test/typemeta.test.ts
@@ -241,6 +241,18 @@ describe("typemeta", () => {
     expect(reader.deserialize(localBytes)).toEqual({ value: 123 });
   });
 
+  test("regenerated read serializers keep getTypeInfo", () => {
+    const fory = new Fory({ compatible: true });
+    const serializer = (fory as any).typeResolver.regenerateReadSerializer(
+      Type.struct({ namespace: "example", typeName: "repro_struct" }, {
+        value: Type.int32(),
+      }),
+    );
+
+    expect(typeof serializer.getTypeInfo).toBe("function");
+    expect(serializer.getTypeInfo().named).toBe("example$repro_struct");
+  });
+
   test("caches regenerated compatible readers for alternating nested schemas", () => {
     const stringWriterFory = new Fory({ compatible: true });
     const boolWriterFory = new Fory({ compatible: true });


### PR DESCRIPTION
## Why?

`TypeResolver.regenerateReadSerializer()` returned a partial serializer object that missed `getTypeInfo`.

When runtime paths later call `original.getTypeInfo()` (for example in `ReadContext` type-meta regeneration flow), it can throw:

```text
TypeError: original.getTypeInfo is not a function
```

## What does this PR do?

- Add `getTypeInfo: serializer.getTypeInfo` when registering the regenerated serializer in `javascript/packages/core/lib/typeResolver.ts`.
- Keep regenerated serializer interface consistent with normal serializer instances.

Minimal reproduction:

```js
const core = require("./javascript/packages/core/dist/index.js");
const Fory = core.default;
const { Type } = core;

const fory = new Fory({ compatible: true });
const serializer = fory.typeResolver.regenerateReadSerializer(
  Type.struct({ namespace: "demo", typeName: "repro_struct" }, {
    id: Type.int32(),
  }),
);

console.log(typeof serializer.getTypeInfo); // before: undefined, after: function
serializer.getTypeInfo();
```

## Related issues

Fixes #3668

## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: `no`
- [x] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [x] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

N/A (bug fix, no protocol/perf-path behavior change expected).