### PR TITLE
feat(compiler): add helpers to generate unified gRPC service/method names

### DIFF
--- a/compiler/fory_compiler/generators/base.py
+++ b/compiler/fory_compiler/generators/base.py
@@ -30,6 +30,8 @@ from fory_compiler.ir.ast import (
     ListType,
     ArrayType,
     MapType,
+    RpcMethod,
+    Service,
 )
 from fory_compiler.ir.types import ARRAY_ELEMENT_KINDS
 
@@ -84,6 +86,18 @@ class BaseGenerator(ABC):
         if they support service generation.
         """
         return []
+
+    def get_grpc_service_name(self, service: Service) -> str:
+        """Get the gRPC service name."""
+        # e.g. for service `Greeter` defined in package `demo.greeter`, return `demo.greeter.Greeter`.
+        if self.package:
+            return f"{self.package}.{service.name}"
+        return service.name
+
+    def get_grpc_method_path(self, service: Service, method: RpcMethod) -> str:
+        """Get the gRPC method path."""
+        # e.g. for method `sayHello` defined in service `demo.greeter.Greeter, return `/demo.greeter.Greeter/SayHello`.
+        return f"/{self.get_grpc_service_name(service)}/{method.name}"
 
     @abstractmethod
     def generate_type(self, field_type: FieldType, nullable: bool = False) -> str:


### PR DESCRIPTION
## Why?

gRPC dispatches calls by the fully-qualified service name and method path, for example `demo.greeter.Greeter` and `/demo.greeter.Greeter/SayHello`. 

For generated gRPC code to interoperate across different languages, every language generator must generate these names from the same rule. 

Centralizing the helpers in `compiler/fory_compiler/generators/base.py` avoids redundancy logic in each language generator and make sure the generated names are the same.

## What does this PR do?

Add helpers to generate unified gRPC service/method names in `compiler/fory_compiler/generators/base.py`.

## Related issues

https://github.com/apache/fory/issues/3266

## AI Contribution Checklist

- [X] Substantial AI assistance was used in this PR: `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.
