### PR TITLE
feat(xlang): simplify xlang field ordering

### DIFF
--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -1874,41 +1874,16 @@ template <typename T> struct CompileTimeFieldHelpers {
            tid == static_cast<uint32_t>(TypeId::TAGGED_UINT64);
   }
 
-  /// Check if a type ID is an internal (built-in, final) type for group 2.
-  /// Internal types are STRING, DURATION, TIMESTAMP, DATE, DECIMAL,
-  /// BINARY, ARRAY, and primitive arrays. Java xlang DescriptorGrouper excludes
-  /// enums from finals (line 897 in XtypeResolver). Excludes: ENUM (13-14),
-  /// STRUCT (15-18), EXT (19-20), LIST (21), SET (22), MAP (23)
-  static constexpr bool is_internal_type_id(uint32_t tid) {
-    return tid == static_cast<uint32_t>(TypeId::STRING) ||
-           (tid >= static_cast<uint32_t>(TypeId::DURATION) &&
-            tid <= static_cast<uint32_t>(TypeId::BINARY)) ||
-           tid == static_cast<uint32_t>(TypeId::ARRAY) ||
-           (tid >= static_cast<uint32_t>(TypeId::BOOL_ARRAY) &&
-            tid <= static_cast<uint32_t>(TypeId::FLOAT64_ARRAY));
-  }
-
   static constexpr int group_rank(size_t index) {
     if constexpr (FieldCount == 0) {
-      return 6;
+      return 3;
     } else {
       uint32_t tid = type_ids[index];
       bool nullable = nullable_flags[index];
       if (is_primitive_type_id(tid)) {
         return nullable ? 1 : 0;
       }
-      // Check LIST/SET/MAP BEFORE is_internal_type_id since they fall
-      // within the internal type range (STRING=12 to DECIMAL=27) but
-      // need their own groups for proper field ordering.
-      if (tid == static_cast<uint32_t>(TypeId::LIST))
-        return 3;
-      if (tid == static_cast<uint32_t>(TypeId::SET))
-        return 4;
-      if (tid == static_cast<uint32_t>(TypeId::MAP))
-        return 5;
-      if (is_internal_type_id(tid))
-        return 2;
-      return 6;
+      return 2;
     }
   }
 
@@ -1916,6 +1891,12 @@ template <typename T> struct CompileTimeFieldHelpers {
     if (field_ids[lhs] >= 0 && field_ids[rhs] >= 0 &&
         field_ids[lhs] != field_ids[rhs]) {
       return field_ids[lhs] < field_ids[rhs] ? -1 : 1;
+    }
+    if (field_ids[lhs] >= 0 && field_ids[rhs] < 0) {
+      return -1;
+    }
+    if (field_ids[lhs] < 0 && field_ids[rhs] >= 0) {
+      return 1;
     }
     size_t lhs_len = identifier_lengths[lhs];
     size_t rhs_len = identifier_lengths[rhs];
@@ -1963,17 +1944,6 @@ template <typename T> struct CompileTimeFieldHelpers {
           return sa > sb;
         if (a_tid != b_tid)
           return a_tid < b_tid; // type_id ascending
-        int cmp = compare_identifier(a, b);
-        if (cmp != 0) {
-          return cmp < 0;
-        }
-        return Names[a] < Names[b];
-      }
-
-      if (ga == 2) {
-        // Internal types (STRING, etc.): sort by type_id ascending, then name
-        if (a_tid != b_tid)
-          return a_tid < b_tid;
         int cmp = compare_identifier(a, b);
         if (cmp != 0) {
           return cmp < 0;

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -1250,33 +1250,6 @@ template <typename T> struct CompileTimeFieldHelpers {
   static inline constexpr auto ptrs = FieldDescriptor::ptrs();
   using FieldPtrs = decltype(ptrs);
 
-  template <size_t... Indices>
-  static constexpr bool any_field_has_id(std::index_sequence<Indices...>) {
-    if constexpr (sizeof...(Indices) == 0) {
-      return false;
-    } else {
-      return ((::fory::detail::GetFieldConfigEntry<T, Indices>::has_id) || ...);
-    }
-  }
-
-  template <size_t... Indices>
-  static constexpr bool all_fields_have_id(std::index_sequence<Indices...>) {
-    if constexpr (sizeof...(Indices) == 0) {
-      return true;
-    } else {
-      return ((::fory::detail::GetFieldConfigEntry<T, Indices>::has_id) && ...);
-    }
-  }
-
-  static constexpr bool any_id_mode_field =
-      any_field_has_id(std::make_index_sequence<FieldCount>{});
-  static constexpr bool all_id_mode_fields =
-      all_fields_have_id(std::make_index_sequence<FieldCount>{});
-
-  static_assert(!any_id_mode_field || all_id_mode_fields,
-                "FORY_STRUCT must use exactly one identity mode: either all "
-                "fields use fory::F(id), or no fields use ids.");
-
   template <size_t Index> static constexpr uint32_t field_type_id() {
     if constexpr (FieldCount == 0) {
       return 0;
@@ -1353,11 +1326,14 @@ template <typename T> struct CompileTimeFieldHelpers {
       if constexpr (::fory::detail::has_field_config_v<T>) {
         constexpr int16_t config_id =
             ::fory::detail::GetFieldConfigEntry<T, Index>::id;
-        if constexpr (config_id >= 0) {
+        if constexpr (::fory::detail::GetFieldConfigEntry<T, Index>::has_id) {
+          static_assert(config_id >= 0, "Fory field id must be non-negative");
           return config_id;
         }
       }
       if constexpr (is_fory_field_v<RawFieldType>) {
+        static_assert(RawFieldType::tag_id >= 0,
+                      "Fory field id must be non-negative");
         return RawFieldType::tag_id;
       }
       // No tag ID defined

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -1032,6 +1032,25 @@ TEST(StructComprehensiveTest,
                            {make_test_field_type(TypeId::UINT32)}))};
   TypeMeta::assign_field_ids(&local_type, name_remote);
   EXPECT_EQ(name_remote[0].field_id, -1);
+
+  TypeMeta mixed_local;
+  mixed_local.field_infos = {
+      make_test_field_info("tagged", 3, make_test_field_type(TypeId::STRING)),
+      make_test_field_info("alpha", -1, make_test_field_type(TypeId::BINARY)),
+      make_test_field_info("beta", -1, make_test_field_type(TypeId::VARINT32))};
+  std::vector<FieldInfo> mixed_remote = {
+      make_test_field_info("alpha", -1, make_test_field_type(TypeId::BINARY)),
+      make_test_field_info("tagged", 3, make_test_field_type(TypeId::STRING)),
+      make_test_field_info("beta", -1, make_test_field_type(TypeId::VARINT32))};
+  TypeMeta::assign_field_ids(&mixed_local, mixed_remote);
+  EXPECT_EQ(mixed_remote[0].field_id, 1);
+  EXPECT_EQ(mixed_remote[1].field_id, 0);
+  EXPECT_EQ(mixed_remote[2].field_id, 2);
+
+  std::vector<FieldInfo> untagged_remote_for_tagged_local = {
+      make_test_field_info("tagged", -1, make_test_field_type(TypeId::STRING))};
+  TypeMeta::assign_field_ids(&mixed_local, untagged_remote_for_tagged_local);
+  EXPECT_EQ(untagged_remote_for_tagged_local[0].field_id, -1);
 }
 
 TEST(StructComprehensiveTest, OptionalFieldsAllEmpty) {

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -117,6 +117,22 @@ struct TaggedGroupedOrderStruct {
               (int_value, fory::F(10).varint()));
 };
 
+struct MixedFieldIdentityStruct {
+  std::string beta_value;
+  std::string tagged_value;
+  std::string alpha_value;
+  int32_t count;
+
+  bool operator==(const MixedFieldIdentityStruct &other) const {
+    return beta_value == other.beta_value &&
+           tagged_value == other.tagged_value &&
+           alpha_value == other.alpha_value && count == other.count;
+  }
+
+  FORY_STRUCT(MixedFieldIdentityStruct, beta_value, (tagged_value, fory::F(3)),
+              alpha_value, (count, fory::F(2).varint()));
+};
+
 class PrivateFieldsStruct {
 public:
   PrivateFieldsStruct() = default;
@@ -522,6 +538,7 @@ inline void register_all_test_types(Fory &fory) {
   fory.register_struct<PartialMapAnnotatedStruct>(type_id++);
   fory.register_struct<OptionalNestedAnnotatedStruct>(type_id++);
   fory.register_struct<ListArrayAnnotatedStruct>(type_id++);
+  fory.register_struct<MixedFieldIdentityStruct>(type_id++);
   fory.register_struct<OptionalFieldsStruct>(type_id++);
   fory.register_struct<EnumStruct>(type_id++);
   fory.register_struct<UserProfile>(type_id++);
@@ -912,6 +929,26 @@ TEST(StructComprehensiveTest, TaggedFieldsKeepGroupedPayloadOrder) {
   ASSERT_EQ(fields.size(), 2);
   EXPECT_EQ(fields[0].field_id, 10);
   EXPECT_EQ(fields[1].field_id, 1);
+}
+
+TEST(StructComprehensiveTest, MixedFieldIdentifiersUseProtocolOrder) {
+  MixedFieldIdentityStruct obj{"beta", "tagged", "alpha", 7};
+  test_roundtrip(obj);
+
+  auto fory =
+      Fory::builder().xlang(true).compatible(true).track_ref(false).build();
+  ASSERT_TRUE(fory.register_struct<MixedFieldIdentityStruct>(607).ok());
+  ASSERT_TRUE(fory.serialize(obj).ok());
+  TypeMeta meta =
+      fory.type_resolver().clone_struct_meta<MixedFieldIdentityStruct>();
+  const auto &fields = meta.get_field_infos();
+  ASSERT_EQ(fields.size(), 4);
+  EXPECT_EQ(fields[0].field_id, 2);
+  EXPECT_EQ(fields[1].field_id, 3);
+  EXPECT_EQ(fields[2].field_name, "alpha_value");
+  EXPECT_EQ(fields[2].field_id, -1);
+  EXPECT_EQ(fields[3].field_name, "beta_value");
+  EXPECT_EQ(fields[3].field_id, -1);
 }
 
 TEST(StructComprehensiveTest, NonPrimitiveFieldsSortByFieldIdentifier) {

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -914,6 +914,24 @@ TEST(StructComprehensiveTest, TaggedFieldsKeepGroupedPayloadOrder) {
   EXPECT_EQ(fields[1].field_id, 1);
 }
 
+TEST(StructComprehensiveTest, NonPrimitiveFieldsSortByFieldIdentifier) {
+  auto fields = TypeMeta::sort_field_infos({
+      make_test_field_info("string_value", 20,
+                           make_test_field_type(TypeId::STRING)),
+      make_test_field_info("map_value", 10, make_test_field_type(TypeId::MAP)),
+      make_test_field_info("custom_value", -1,
+                           make_test_field_type(TypeId::NAMED_STRUCT)),
+      make_test_field_info("binary_value", -1,
+                           make_test_field_type(TypeId::BINARY)),
+  });
+
+  ASSERT_EQ(fields.size(), 4);
+  EXPECT_EQ(fields[0].field_name, "map_value");
+  EXPECT_EQ(fields[1].field_name, "string_value");
+  EXPECT_EQ(fields[2].field_name, "binary_value");
+  EXPECT_EQ(fields[3].field_name, "custom_value");
+}
+
 TEST(StructComprehensiveTest,
      FieldTypeCompatibleFingerprintNormalizesEncoding) {
   FieldType fixed_i32 = make_test_field_type(TypeId::INT32);

--- a/cpp/fory/serialization/type_resolver.cc
+++ b/cpp/fory/serialization/type_resolver.cc
@@ -939,6 +939,12 @@ int compare_field_sort_key(const FieldInfo &a, const FieldInfo &b) {
   if (a.field_id >= 0 && b.field_id >= 0 && a.field_id != b.field_id) {
     return a.field_id < b.field_id ? -1 : 1;
   }
+  if (a.field_id >= 0 && b.field_id < 0) {
+    return -1;
+  }
+  if (a.field_id < 0 && b.field_id >= 0) {
+    return 1;
+  }
   std::string a_key = field_sort_key_text(a);
   std::string b_key = field_sort_key_text(b);
   if (a_key != b_key) {
@@ -974,51 +980,21 @@ bool numeric_sorter(const FieldInfo &a, const FieldInfo &b) {
   return compare_field_sort_key(a, b) < 0;
 }
 
-// Type then identity sorter (for internal type fields like STRING).
-// Sorts by: type_id (ascending), then numeric field ID or field name.
-bool type_then_name_sorter(const FieldInfo &a, const FieldInfo &b) {
-  if (a.field_type.type_id != b.field_type.type_id) {
-    return a.field_type.type_id < b.field_type.type_id;
-  }
-  return compare_field_sort_key(a, b) < 0;
-}
-
-// Identity sorter (for list/set/map/other fields).
+// Identity sorter (for non-primitive fields).
 // Sorts by numeric field ID when present, otherwise field name.
 bool name_sorter(const FieldInfo &a, const FieldInfo &b) {
   return compare_field_sort_key(a, b) < 0;
-}
-
-// Check if a type ID is a "final" type for field group 2 in field ordering.
-// Final types are STRING, DURATION, TIMESTAMP, DATE, DECIMAL, BINARY,
-// ARRAY, and primitive arrays.
-// These are types with fixed serializers that don't need type info written.
-// Excludes: ENUM (13-14), STRUCT (15-18), EXT (19-20), LIST (21), SET (22), MAP
-// (23) Note: LIST/SET/MAP are checked separately before this function is
-// called.
-bool is_final_type_for_grouping(uint32_t type_id) {
-  return type_id == static_cast<uint32_t>(TypeId::STRING) ||
-         (type_id >= static_cast<uint32_t>(TypeId::DURATION) &&
-          type_id <= static_cast<uint32_t>(TypeId::BINARY)) ||
-         type_id == static_cast<uint32_t>(TypeId::ARRAY) ||
-         (type_id >= static_cast<uint32_t>(TypeId::BOOL_ARRAY) &&
-          type_id <= static_cast<uint32_t>(TypeId::FLOAT64_ARRAY));
 }
 
 } // anonymous namespace
 
 std::vector<FieldInfo>
 TypeMeta::sort_field_infos(std::vector<FieldInfo> fields) {
-  // Group fields according to xlang spec. Field IDs are identity metadata for
-  // fingerprints and compatible matching; they do not replace the physical
-  // grouped payload order.
+  // Group fields according to xlang spec. Non-primitives intentionally share
+  // one identifier-sorted tail group regardless of type ID.
   std::vector<FieldInfo> primitive_fields;
   std::vector<FieldInfo> nullable_primitive_fields;
-  std::vector<FieldInfo> internal_type_fields;
-  std::vector<FieldInfo> list_fields;
-  std::vector<FieldInfo> set_fields;
-  std::vector<FieldInfo> map_fields;
-  std::vector<FieldInfo> other_fields;
+  std::vector<FieldInfo> non_primitive_fields;
 
   for (auto &field : fields) {
     uint32_t type_id = field.field_type.type_id;
@@ -1030,16 +1006,8 @@ TypeMeta::sort_field_infos(std::vector<FieldInfo> fields) {
       } else {
         primitive_fields.push_back(std::move(field));
       }
-    } else if (type_id == static_cast<uint32_t>(TypeId::LIST)) {
-      list_fields.push_back(std::move(field));
-    } else if (type_id == static_cast<uint32_t>(TypeId::SET)) {
-      set_fields.push_back(std::move(field));
-    } else if (type_id == static_cast<uint32_t>(TypeId::MAP)) {
-      map_fields.push_back(std::move(field));
-    } else if (is_final_type_for_grouping(type_id)) {
-      internal_type_fields.push_back(std::move(field));
     } else {
-      other_fields.push_back(std::move(field));
+      non_primitive_fields.push_back(std::move(field));
     }
   }
 
@@ -1047,12 +1015,8 @@ TypeMeta::sort_field_infos(std::vector<FieldInfo> fields) {
   std::sort(primitive_fields.begin(), primitive_fields.end(), numeric_sorter);
   std::sort(nullable_primitive_fields.begin(), nullable_primitive_fields.end(),
             numeric_sorter);
-  std::sort(internal_type_fields.begin(), internal_type_fields.end(),
-            type_then_name_sorter);
-  std::sort(list_fields.begin(), list_fields.end(), name_sorter);
-  std::sort(set_fields.begin(), set_fields.end(), name_sorter);
-  std::sort(map_fields.begin(), map_fields.end(), name_sorter);
-  std::sort(other_fields.begin(), other_fields.end(), name_sorter);
+  std::sort(non_primitive_fields.begin(), non_primitive_fields.end(),
+            name_sorter);
 
   // Combine sorted groups
   std::vector<FieldInfo> sorted;
@@ -1063,16 +1027,8 @@ TypeMeta::sort_field_infos(std::vector<FieldInfo> fields) {
                 std::make_move_iterator(nullable_primitive_fields.begin()),
                 std::make_move_iterator(nullable_primitive_fields.end()));
   sorted.insert(sorted.end(),
-                std::make_move_iterator(internal_type_fields.begin()),
-                std::make_move_iterator(internal_type_fields.end()));
-  sorted.insert(sorted.end(), std::make_move_iterator(list_fields.begin()),
-                std::make_move_iterator(list_fields.end()));
-  sorted.insert(sorted.end(), std::make_move_iterator(set_fields.begin()),
-                std::make_move_iterator(set_fields.end()));
-  sorted.insert(sorted.end(), std::make_move_iterator(map_fields.begin()),
-                std::make_move_iterator(map_fields.end()));
-  sorted.insert(sorted.end(), std::make_move_iterator(other_fields.begin()),
-                std::make_move_iterator(other_fields.end()));
+                std::make_move_iterator(non_primitive_fields.begin()),
+                std::make_move_iterator(non_primitive_fields.end()));
 
   return sorted;
 }

--- a/cpp/fory/serialization/type_resolver.cc
+++ b/cpp/fory/serialization/type_resolver.cc
@@ -1055,34 +1055,6 @@ void TypeMeta::assign_field_ids(const TypeMeta *local_type,
       local_field_id_map.emplace(local_fields[i].field_id, i);
     }
   }
-  const bool local_uses_field_ids = !local_field_id_map.empty();
-  bool remote_uses_field_ids = false;
-  for (const auto &remote_field : remote_fields) {
-    if (remote_field.field_id >= 0) {
-      remote_uses_field_ids = true;
-      break;
-    }
-  }
-
-  if (local_uses_field_ids || remote_uses_field_ids) {
-    for (auto &remote_field : remote_fields) {
-      size_t local_index = static_cast<size_t>(-1);
-      if (local_uses_field_ids && remote_field.field_id >= 0) {
-        auto id_it = local_field_id_map.find(remote_field.field_id);
-        if (id_it != local_field_id_map.end() &&
-            field_types_compatible_top_level(
-                local_fields[id_it->second].field_type,
-                remote_field.field_type)) {
-          local_index = id_it->second;
-        }
-      }
-      remote_field.field_id = local_index == static_cast<size_t>(-1)
-                                  ? -1
-                                  : static_cast<int16_t>(local_index);
-    }
-    return;
-  }
-
   // Track which local fields have already been matched so that each
   // local field is bound to at most one remote field when we fall
   // back to type-based matching.
@@ -1092,31 +1064,45 @@ void TypeMeta::assign_field_ids(const TypeMeta *local_type,
   for (auto &remote_field : remote_fields) {
     size_t local_index = static_cast<size_t>(-1);
 
-    // 1) Try exact name + type match first (fast path for same-language
-    //    schemas and most C++-only cases).
-    if (local_index == static_cast<size_t>(-1)) {
+    if (remote_field.field_id >= 0) {
+      auto id_it = local_field_id_map.find(remote_field.field_id);
+      if (id_it != local_field_id_map.end() && !used[id_it->second] &&
+          field_types_compatible_top_level(
+              local_fields[id_it->second].field_type,
+              remote_field.field_type)) {
+        local_index = id_it->second;
+      }
+    } else {
+      // 1) Try exact name + type match first (fast path for same-language
+      //    schemas and most C++-only cases). A local tag-ID field's identifier
+      //    is the tag ID, not the field name, so it must not match an untagged
+      //    remote field by name in a mixed schema.
       auto it = local_field_index_map.find(remote_field.field_name);
       if (it != local_field_index_map.end()) {
         size_t idx = it->second;
         const FieldInfo &local_field = local_fields[idx];
-        if (field_types_compatible_top_level(local_field.field_type,
+        if (local_field.field_id < 0 &&
+            field_types_compatible_top_level(local_field.field_type,
                                              remote_field.field_type)) {
           local_index = idx;
         }
       }
-    }
 
-    // 2) Fallback: match by type signature and position when field names
-    //    are not available or differ across languages.
-    if (local_index == static_cast<size_t>(-1)) {
-      for (size_t i = 0; i < local_fields.size(); ++i) {
-        if (used[i]) {
-          continue;
-        }
-        if (field_types_compatible_top_level(local_fields[i].field_type,
-                                             remote_field.field_type)) {
-          local_index = i;
-          break;
+      // 2) Fallback: match by type signature and position when field names
+      //    are not available or differ across languages. Keep this fallback
+      //    within name-based fields so a mixed schema does not switch into a
+      //    global tag-ID mode or bind an untagged field to a tagged local
+      //    field.
+      if (local_index == static_cast<size_t>(-1)) {
+        for (size_t i = 0; i < local_fields.size(); ++i) {
+          if (used[i] || local_fields[i].field_id >= 0) {
+            continue;
+          }
+          if (field_types_compatible_top_level(local_fields[i].field_type,
+                                               remote_field.field_type)) {
+            local_index = i;
+            break;
+          }
         }
       }
     }

--- a/cpp/fory/serialization/type_resolver.h
+++ b/cpp/fory/serialization/type_resolver.h
@@ -1204,7 +1204,8 @@ constexpr int16_t compute_field_id() {
   if constexpr (::fory::detail::has_field_config_v<T>) {
     constexpr int16_t config_id =
         ::fory::detail::GetFieldConfigEntry<T, Index>::id;
-    if constexpr (config_id >= 0) {
+    if constexpr (::fory::detail::GetFieldConfigEntry<T, Index>::has_id) {
+      static_assert(config_id >= 0, "Fory field id must be non-negative");
       return config_id;
     }
   }

--- a/csharp/src/Fory.Generator/AnalyzerReleases.Unshipped.md
+++ b/csharp/src/Fory.Generator/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@ Rule ID | Category | Severity | Notes
 FORY001 | Fory | Error | Generic types are not supported by ForyObject generator
 FORY002 | Fory | Error | Missing parameterless constructor
 FORY003 | Fory | Error | Unsupported Field encoding
+FORY004 | Fory | Error | Invalid Fory field id

--- a/csharp/src/Fory.Generator/ForyObjectGenerator.cs
+++ b/csharp/src/Fory.Generator/ForyObjectGenerator.cs
@@ -2255,13 +2255,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
         TypeClassification classification = resolution.Classification;
         int group = classification.IsPrimitive
             ? (isOptional ? 2 : 1)
-            : classification.IsMap
-                ? 5
-                : classification.IsCollection
-                    ? 4
-                    : classification.IsBuiltIn
-                        ? 3
-                        : 6;
+            : 3;
 
         int index = int.MaxValue;
         Location? sourceLocation = memberSymbol.Locations.FirstOrDefault(loc => loc.IsInSource);
@@ -2712,11 +2706,6 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             .ThenBy(m =>
             {
                 if (m.Group is 1 or 2)
-                {
-                    return (int)m.Classification.TypeId;
-                }
-
-                if (m.Group is 3 or 5)
                 {
                     return (int)m.Classification.TypeId;
                 }

--- a/csharp/src/Fory.Generator/ForyObjectGenerator.cs
+++ b/csharp/src/Fory.Generator/ForyObjectGenerator.cs
@@ -55,6 +55,14 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor InvalidFieldId = new(
+        id: "FORY004",
+        title: "Invalid Fory field id",
+        messageFormat: "Member '{0}' uses an invalid [ForyField] id; field ids must be non-negative and no greater than short.MaxValue",
+        category: "Fory",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         IncrementalValuesProvider<TypeModel?> typeModels = context.SyntaxProvider
@@ -81,6 +89,16 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
         {
             if (maybeModel is null)
             {
+                continue;
+            }
+
+            if (!maybeModel.Diagnostics.IsDefaultOrEmpty)
+            {
+                foreach (Diagnostic diagnostic in maybeModel.Diagnostics)
+                {
+                    context.ReportDiagnostic(diagnostic);
+                }
+
                 continue;
             }
 
@@ -2116,7 +2134,8 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
                 serializerName,
                 DeclKind.Enum,
                 ImmutableArray<MemberModel>.Empty,
-                ImmutableArray<MemberModel>.Empty);
+                ImmutableArray<MemberModel>.Empty,
+                ImmutableArray<Diagnostic>.Empty);
         }
 
         DeclKind kind = typeSymbol.TypeKind switch
@@ -2136,6 +2155,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             return null;
         }
 
+        List<Diagnostic> diagnostics = [];
         List<MemberModel> members = [];
         foreach (ISymbol member in typeSymbol.GetMembers())
         {
@@ -2151,7 +2171,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                MemberModel? parsedField = BuildMemberModel(field.Name, field.Type, field, MemberDeclKind.Field);
+                MemberModel? parsedField = BuildMemberModel(field.Name, field.Type, field, MemberDeclKind.Field, diagnostics);
                 if (parsedField is not null)
                 {
                     members.Add(parsedField);
@@ -2182,7 +2202,8 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
                     property.Name,
                     property.Type,
                     property,
-                    MemberDeclKind.Property);
+                    MemberDeclKind.Property,
+                    diagnostics);
                 if (parsedProperty is not null)
                 {
                     members.Add(parsedProperty);
@@ -2195,14 +2216,15 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             .ToImmutableArray();
         ImmutableArray<MemberModel> sorted = SortMembers(ordered);
 
-        return new TypeModel(typeName, serializerName, kind, ordered, sorted);
+        return new TypeModel(typeName, serializerName, kind, ordered, sorted, diagnostics.ToImmutableArray());
     }
 
     private static MemberModel? BuildMemberModel(
         string name,
         ITypeSymbol memberType,
         ISymbol memberSymbol,
-        MemberDeclKind memberDeclKind)
+        MemberDeclKind memberDeclKind,
+        List<Diagnostic> diagnostics)
     {
         (bool isOptional, ITypeSymbol unwrappedType) = UnwrapNullable(memberType);
         short? fieldId = null;
@@ -2216,7 +2238,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             }
 
             if (attribute.ConstructorArguments.Length == 1 &&
-                TryGetNonNegativeShort(attribute.ConstructorArguments[0], out short ctorFieldId))
+                TryGetFieldId(attribute.ConstructorArguments[0], memberSymbol, diagnostics, out short ctorFieldId))
             {
                 fieldId = ctorFieldId;
             }
@@ -2225,7 +2247,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             {
                 if (string.Equals(namedArg.Key, "Id", StringComparison.Ordinal))
                 {
-                    if (TryGetNonNegativeShort(namedArg.Value, out short parsedFieldId))
+                    if (TryGetFieldId(namedArg.Value, memberSymbol, diagnostics, out short parsedFieldId))
                     {
                         fieldId = parsedFieldId;
                     }
@@ -2635,7 +2657,11 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
         };
     }
 
-    private static bool TryGetNonNegativeShort(TypedConstant value, out short fieldId)
+    private static bool TryGetFieldId(
+        TypedConstant value,
+        ISymbol memberSymbol,
+        List<Diagnostic> diagnostics,
+        out short fieldId)
     {
         fieldId = default;
         object? raw = value.Value;
@@ -2671,6 +2697,10 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             case ulong v:
                 if (v > (ulong)short.MaxValue)
                 {
+                    diagnostics.Add(Diagnostic.Create(
+                        InvalidFieldId,
+                        memberSymbol.Locations.FirstOrDefault(),
+                        memberSymbol.Name));
                     return false;
                 }
 
@@ -2682,6 +2712,10 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
 
         if (numeric < 0 || numeric > short.MaxValue)
         {
+            diagnostics.Add(Diagnostic.Create(
+                InvalidFieldId,
+                memberSymbol.Locations.FirstOrDefault(),
+                memberSymbol.Name));
             return false;
         }
 
@@ -3500,13 +3534,15 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
             string serializerName,
             DeclKind kind,
             ImmutableArray<MemberModel> members,
-            ImmutableArray<MemberModel> sortedMembers)
+            ImmutableArray<MemberModel> sortedMembers,
+            ImmutableArray<Diagnostic> diagnostics)
         {
             TypeName = typeName;
             SerializerName = serializerName;
             Kind = kind;
             Members = members;
             SortedMembers = sortedMembers;
+            Diagnostics = diagnostics;
         }
 
         public string TypeName { get; }
@@ -3514,6 +3550,7 @@ public sealed class ForyObjectGenerator : IIncrementalGenerator
         public DeclKind Kind { get; }
         public ImmutableArray<MemberModel> Members { get; }
         public ImmutableArray<MemberModel> SortedMembers { get; }
+        public ImmutableArray<Diagnostic> Diagnostics { get; }
     }
 
     private sealed class MemberModel

--- a/csharp/tests/Fory.Tests/Fory.Tests.csproj
+++ b/csharp/tests/Fory.Tests/Fory.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -24,5 +25,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Fory\Fory.csproj" />
     <ProjectReference Include="..\..\src\Fory.Generator\Fory.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Fory.Generator\Fory.Generator.csproj" ReferenceOutputAssembly="true" />
   </ItemGroup>
 </Project>

--- a/csharp/tests/Fory.Tests/ForyGeneratorTests.cs
+++ b/csharp/tests/Fory.Tests/ForyGeneratorTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Immutable;
+using Apache.Fory.Generator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Apache.Fory.Tests;
+
+public sealed class ForyGeneratorTests
+{
+    [Fact]
+    public void NegativeForyFieldIdReportsDiagnostic()
+    {
+        const string source = """
+            using Apache.Fory;
+
+            namespace GeneratedDiagnostics;
+
+            [ForyObject]
+            public sealed class InvalidFieldId
+            {
+                [ForyField(-1)]
+                public int Value { get; set; }
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(source);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ForyObjectGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation output, out ImmutableArray<Diagnostic> diagnostics);
+
+        ImmutableArray<Diagnostic> generatorDiagnostics = driver.GetRunResult().Diagnostics;
+        Assert.Contains(generatorDiagnostics.Concat(diagnostics), diagnostic => diagnostic.Id == "FORY004");
+        Assert.DoesNotContain(output.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Id != "FORY004");
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        IEnumerable<MetadataReference> platformReferences =
+            ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        MetadataReference foryReference =
+            MetadataReference.CreateFromFile(typeof(ForyObjectAttribute).Assembly.Location);
+
+        return CSharpCompilation.Create(
+            "ForyGeneratorDiagnostics",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.CSharp12))],
+            platformReferences.Append(foryReference),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
+++ b/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
@@ -71,6 +71,20 @@ public sealed class FieldOrder
 }
 
 [ForyObject]
+public sealed class NonPrimitiveFieldOrder
+{
+    [ForyField(20)]
+    public string StringValue { get; set; } = string.Empty;
+
+    [ForyField(10)]
+    public Dictionary<string, int> MapValue { get; set; } = [];
+
+    public byte[] BinaryValue { get; set; } = [];
+    public Address CustomValue { get; set; } = new();
+    public int IntValue { get; set; }
+}
+
+[ForyObject]
 public sealed class SchemaNumbers
 {
     [ForyField(Type = typeof(S.Fixed<S.UInt32>))]
@@ -919,6 +933,20 @@ public sealed class ForyRuntimeTests
         Assert.Equal(value.A, second);
         Assert.Equal(value.C, third);
         Assert.Equal(value.Z, fourth);
+    }
+
+    [Fact]
+    public void TypeMetaFieldsOrderNonPrimitivesByFieldIdentifier()
+    {
+        TypeResolver resolver = new();
+        List<string> fieldNames = resolver.GetTypeInfo<NonPrimitiveFieldOrder>()
+            .TypeMetaFields(false)
+            .Select(field => field.FieldName)
+            .ToList();
+
+        Assert.Equal(
+            ["int_value", "map_value", "string_value", "binary_value", "custom_value"],
+            fieldNames);
     }
 
     [Fact]

--- a/dart/packages/fory-test/lib/entity/xlang_test_manual.dart
+++ b/dart/packages/fory-test/lib/entity/xlang_test_manual.dart
@@ -111,6 +111,8 @@ const GeneratedFieldType _refOverrideElementFieldType = GeneratedFieldType(
 
 const List<GeneratedFieldInfo> _refOverrideContainerForyFieldInfo =
     <GeneratedFieldInfo>[
+  // Keep this manual fixture in the same protocol order as generated structs:
+  // all fields are non-primitive, so field identifiers order the wire payload.
   GeneratedFieldInfo(
     name: 'listField',
     identifier: 'list_field',
@@ -118,19 +120,6 @@ const List<GeneratedFieldInfo> _refOverrideContainerForyFieldInfo =
     fieldType: GeneratedFieldType(
       type: List,
       typeId: TypeIds.list,
-      nullable: false,
-      ref: false,
-      dynamic: null,
-      arguments: <GeneratedFieldType>[_refOverrideElementFieldType],
-    ),
-  ),
-  GeneratedFieldInfo(
-    name: 'setField',
-    identifier: 'set_field',
-    id: null,
-    fieldType: GeneratedFieldType(
-      type: Set,
-      typeId: TypeIds.set,
       nullable: false,
       ref: false,
       dynamic: null,
@@ -158,6 +147,19 @@ const List<GeneratedFieldInfo> _refOverrideContainerForyFieldInfo =
         ),
         _refOverrideElementFieldType,
       ],
+    ),
+  ),
+  GeneratedFieldInfo(
+    name: 'setField',
+    identifier: 'set_field',
+    id: null,
+    fieldType: GeneratedFieldType(
+      type: Set,
+      typeId: TypeIds.set,
+      nullable: false,
+      ref: false,
+      dynamic: null,
+      arguments: <GeneratedFieldType>[_refOverrideElementFieldType],
     ),
   ),
 ];
@@ -198,8 +200,8 @@ final class _RefOverrideContainerForySerializer
   void write(WriteContext context, RefOverrideContainer value) {
     final fields = _writeFields(context);
     writeGeneratedStructFieldInfoValue(context, fields[0], value.listField);
-    writeGeneratedStructFieldInfoValue(context, fields[1], value.setField);
-    writeGeneratedStructFieldInfoValue(context, fields[2], value.mapField);
+    writeGeneratedStructFieldInfoValue(context, fields[1], value.mapField);
+    writeGeneratedStructFieldInfoValue(context, fields[2], value.setField);
   }
 
   @override
@@ -210,13 +212,13 @@ final class _RefOverrideContainerForySerializer
       readGeneratedStructFieldInfoValue(context, fields[0], value.listField),
       value.listField,
     );
-    value.setField = _readRefOverrideContainerSetField(
-      readGeneratedStructFieldInfoValue(context, fields[1], value.setField),
-      value.setField,
-    );
     value.mapField = _readRefOverrideContainerMapField(
-      readGeneratedStructFieldInfoValue(context, fields[2], value.mapField),
+      readGeneratedStructFieldInfoValue(context, fields[1], value.mapField),
       value.mapField,
+    );
+    value.setField = _readRefOverrideContainerSetField(
+      readGeneratedStructFieldInfoValue(context, fields[2], value.setField),
+      value.setField,
     );
     return value;
   }
@@ -241,15 +243,15 @@ final class _RefOverrideContainerForySerializer
           );
           break;
         case 1:
-          value.setField = _readRefOverrideContainerSetField(
-            readGeneratedCompatibleStructField(context, layout, index),
-            value.setField,
-          );
-          break;
-        case 2:
           value.mapField = _readRefOverrideContainerMapField(
             readGeneratedCompatibleStructField(context, layout, index),
             value.mapField,
+          );
+          break;
+        case 2:
+          value.setField = _readRefOverrideContainerSetField(
+            readGeneratedCompatibleStructField(context, layout, index),
+            value.setField,
           );
           break;
         default:

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -166,7 +166,15 @@ final class ForyGenerator extends Generator {
     final idValue = reader?.peek('id');
     final nullableValue = reader?.peek('nullable');
     final dynamicValue = reader?.peek('dynamic');
-    final fieldId = idValue == null || idValue.isNull ? null : idValue.intValue;
+    final rawFieldId =
+        idValue == null || idValue.isNull ? null : idValue.intValue;
+    if (rawFieldId != null && rawFieldId < 0) {
+      throw InvalidGenerationSourceError(
+        'Fory field id must be non-negative.',
+        element: field,
+      );
+    }
+    final fieldId = rawFieldId;
     final nullable = nullableValue == null || nullableValue.isNull
         ? _isNullable(field.type)
         : nullableValue.boolValue;
@@ -180,9 +188,8 @@ final class ForyGenerator extends Generator {
       name: field.displayName,
       type: field.type,
       displayType: _typeCodeString(field.type),
-      identifier: fieldId != null && fieldId >= 0
-          ? '$fieldId'
-          : _toSnakeCase(field.displayName),
+      identifier:
+          fieldId != null ? '$fieldId' : _toSnakeCase(field.displayName),
       id: fieldId,
       nullable: nullable,
       ref: ref,

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -2111,10 +2111,7 @@ GeneratedFieldType(
   List<_GeneratedFieldSpec> _sortFields(List<_GeneratedFieldSpec> fields) {
     final primitiveFields = <_GeneratedFieldSpec>[];
     final boxedPrimitiveFields = <_GeneratedFieldSpec>[];
-    final builtInFields = <_GeneratedFieldSpec>[];
-    final collectionFields = <_GeneratedFieldSpec>[];
-    final mapFields = <_GeneratedFieldSpec>[];
-    final otherFields = <_GeneratedFieldSpec>[];
+    final nonPrimitiveFields = <_GeneratedFieldSpec>[];
 
     for (final field in fields) {
       if (_isPrimitiveTypeId(field.fieldType.typeId)) {
@@ -2123,32 +2120,19 @@ GeneratedFieldType(
         } else {
           primitiveFields.add(field);
         }
-      } else if (field.fieldType.typeId == TypeIds.list ||
-          field.fieldType.typeId == TypeIds.set) {
-        collectionFields.add(field);
-      } else if (field.fieldType.typeId == TypeIds.map) {
-        mapFields.add(field);
-      } else if (_isBuiltInTypeId(field.fieldType.typeId)) {
-        builtInFields.add(field);
       } else {
-        otherFields.add(field);
+        nonPrimitiveFields.add(field);
       }
     }
 
     primitiveFields.sort(_comparePrimitiveFields);
     boxedPrimitiveFields.sort(_comparePrimitiveFields);
-    builtInFields.sort(_compareNonPrimitiveFields);
-    collectionFields.sort(_compareNonPrimitiveFields);
-    mapFields.sort(_compareNonPrimitiveFields);
-    otherFields.sort(_compareOtherFields);
+    nonPrimitiveFields.sort(_compareOtherFields);
 
     return <_GeneratedFieldSpec>[
       ...primitiveFields,
       ...boxedPrimitiveFields,
-      ...builtInFields,
-      ...collectionFields,
-      ...mapFields,
-      ...otherFields,
+      ...nonPrimitiveFields,
     ];
   }
 
@@ -2166,21 +2150,6 @@ GeneratedFieldType(
     if (sizeCompare != 0) {
       return sizeCompare;
     }
-    final typeCompare = left.fieldType.typeId - right.fieldType.typeId;
-    if (typeCompare != 0) {
-      return typeCompare;
-    }
-    final keyCompare = _compareFieldIdentity(left, right);
-    if (keyCompare != 0) {
-      return keyCompare;
-    }
-    return left.name.compareTo(right.name);
-  }
-
-  int _compareNonPrimitiveFields(
-    _GeneratedFieldSpec left,
-    _GeneratedFieldSpec right,
-  ) {
     final typeCompare = left.fieldType.typeId - right.fieldType.typeId;
     if (typeCompare != 0) {
       return typeCompare;
@@ -2211,6 +2180,12 @@ GeneratedFieldType(
       if (idCompare != 0) {
         return idCompare;
       }
+    }
+    if (leftId != null && leftId >= 0 && (rightId == null || rightId < 0)) {
+      return -1;
+    }
+    if ((leftId == null || leftId < 0) && rightId != null && rightId >= 0) {
+      return 1;
     }
     final keyCompare = left.identifier.compareTo(right.identifier);
     if (keyCompare != 0) {

--- a/dart/packages/fory/lib/src/resolver/type_resolver.dart
+++ b/dart/packages/fory/lib/src/resolver/type_resolver.dart
@@ -214,6 +214,33 @@ bool _fieldTypeUsesNestedTypeDefinitions(FieldType fieldType) {
   return false;
 }
 
+void _validateFieldInfo(FieldInfo field) {
+  final id = field.id;
+  if (id != null && id < 0) {
+    throw ArgumentError('Field id for ${field.name} must be non-negative.');
+  }
+}
+
+List<FieldInfo> _validateFieldInfos(Iterable<FieldInfo> fields) {
+  final validated = <FieldInfo>[];
+  final usedIds = <int, String>{};
+  for (final field in fields) {
+    _validateFieldInfo(field);
+    final id = field.id;
+    if (id != null) {
+      final existing = usedIds[id];
+      if (existing != null && existing != field.name) {
+        throw ArgumentError(
+          'Duplicate field id $id for fields $existing and ${field.name}.',
+        );
+      }
+      usedIds[id] = field.name;
+    }
+    validated.add(field);
+  }
+  return List<FieldInfo>.unmodifiable(validated);
+}
+
 final class TypeResolver {
   final Config config;
   final WireTypeMetaEncoder _wireTypeMetaEncoder = const WireTypeMetaEncoder();
@@ -311,9 +338,7 @@ final class TypeResolver {
     final encodedTypeName =
         typeName == null ? null : typeNameMetaString(typeName);
     final normalizedFields = registrationKind == RegistrationKind.struct
-        ? List<FieldInfo>.unmodifiable(
-            List<FieldInfo>.from(fields),
-          )
+        ? _validateFieldInfos(fields)
         : const <FieldInfo>[];
     final typeDef = _buildTypeDef(
       kind: registrationKind,

--- a/dart/packages/fory/lib/src/util/hash_util.dart
+++ b/dart/packages/fory/lib/src/util/hash_util.dart
@@ -203,16 +203,21 @@ String schemaFingerprint(TypeDef typeDef) {
     ..sort((left, right) {
       final leftId = left.id;
       final rightId = right.id;
-      if (leftId != null && rightId != null) {
+      if ((leftId != null && leftId < 0) || (rightId != null && rightId < 0)) {
+        throw ArgumentError('Field id must be non-negative.');
+      }
+      final leftHasId = leftId != null;
+      final rightHasId = rightId != null;
+      if (leftHasId && rightHasId) {
         final result = leftId.compareTo(rightId);
         return result == 0
             ? left.identifier.compareTo(right.identifier)
             : result;
       }
-      if (leftId != null) {
+      if (leftHasId) {
         return -1;
       }
-      if (rightId != null) {
+      if (rightHasId) {
         return 1;
       }
       return left.identifier.compareTo(right.identifier);

--- a/dart/packages/fory/test/runtime_validation_test.dart
+++ b/dart/packages/fory/test/runtime_validation_test.dart
@@ -128,6 +128,17 @@ class SchemaVersionV2 {
   int count = 0;
 }
 
+@ForyStruct()
+class DuplicateFieldIdOrder {
+  DuplicateFieldIdOrder();
+
+  @ForyField(id: 1)
+  String first = '';
+
+  @ForyField(id: 1)
+  String second = '';
+}
+
 void _registerValidationTypes(Fory fory) {
   RuntimeValidationTestFory.register(
     fory,
@@ -201,6 +212,26 @@ Object _nestedList(int depth) {
 
 void main() {
   group('field options', () {
+    test('duplicate generated field ids are rejected during registration', () {
+      final fory = Fory();
+
+      expect(
+        () => RuntimeValidationTestFory.register(
+          fory,
+          DuplicateFieldIdOrder,
+          namespace: 'validation',
+          typeName: 'DuplicateFieldIdOrder',
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.toString(),
+            'message',
+            contains('Duplicate field id 1'),
+          ),
+        ),
+      );
+    });
+
     test('skip fields stay local only after round trip', () {
       final fory = Fory();
       _registerValidationTypes(fory);

--- a/docs/guide/cpp/field-configuration.md
+++ b/docs/guide/cpp/field-configuration.md
@@ -46,16 +46,17 @@ or add virtual dispatch on the serialization path.
 FORY_STRUCT(DataV2, id, (timestamp, fory::F().tagged()), version);
 ```
 
-`fory::F(id)` uses id-mode field identity:
+`fory::F(id)` uses explicit id-based field identity. IDs must be
+non-negative:
 
 ```cpp
 FORY_STRUCT(DataV2, (id, fory::F(0)), (timestamp, fory::F(1).tagged()),
             (version, fory::F(2)));
 ```
 
-A struct must use exactly one identity mode. If any field uses `fory::F(id)`,
-every field in that `FORY_STRUCT` must use `fory::F(id)`. Mixed name/id mode is a
-compile-time error.
+Fields without explicit IDs still use their snake_case field names. Explicit
+IDs sort before name-based fields within the same protocol field group, so a
+single `FORY_STRUCT` may mix `fory::F(id)`, `fory::F()`, and bare fields.
 
 ## Scalar Encoding
 

--- a/docs/guide/csharp/field-configuration.md
+++ b/docs/guide/csharp/field-configuration.md
@@ -23,7 +23,7 @@ This page covers field-level serializer configuration for C# generated serialize
 
 ## `[ForyObject]` and `[ForyField]`
 
-Use `[ForyObject]` to enable source-generated serializers. Use `[ForyField]` to assign an optional stable field id or to override the Fory schema type used for a field.
+Use `[ForyObject]` to enable source-generated serializers. Use `[ForyField]` to assign an optional stable non-negative field id or to override the Fory schema type used for a field.
 
 ```csharp
 using Apache.Fory;

--- a/docs/guide/go/struct-tags.md
+++ b/docs/guide/go/struct-tags.md
@@ -336,7 +336,7 @@ type User struct {
 | ---------- | ------- | ------------------------ |
 | `nullable` | `false` | Use pointer types (`*T`) |
 | `ref`      | `false` | Add `fory:"ref"` tag     |
-| `id`       | `-1`    | Add `fory:"id=N"` tag    |
+| `id`       | omitted | Add `fory:"id=N"` tag    |
 
 ## Best Practices
 

--- a/docs/guide/go/troubleshooting.md
+++ b/docs/guide/go/troubleshooting.md
@@ -211,10 +211,10 @@ f2 := fory.New(fory.WithTrackRef(true))  // Must match!
 
 **Common causes**:
 
-1. **Invalid tag ID**: ID must be >= -1
+1. **Invalid tag ID**: ID must be non-negative
 
 ```go
-// Wrong: negative ID (other than -1)
+// Wrong: negative ID
 type Bad struct {
     Field int `fory:"id=-5"`
 }

--- a/docs/guide/java/field-configuration.md
+++ b/docs/guide/java/field-configuration.md
@@ -84,7 +84,7 @@ public class User {
 
 | Parameter  | Type      | Default | Description                            |
 | ---------- | --------- | ------- | -------------------------------------- |
-| `id`       | `int`     | `-1`    | Field tag ID (-1 = use field name)     |
+| `id`       | `int`     | omitted | Non-negative field tag ID              |
 | `nullable` | `boolean` | `false` | Whether the field can be null          |
 | `ref`      | `boolean` | `false` | Enable reference tracking              |
 | `dynamic`  | `Dynamic` | `AUTO`  | Control polymorphism for struct fields |
@@ -117,7 +117,7 @@ public class User {
 **Notes**:
 
 - IDs must be unique within a class
-- IDs must be >= 0 (use -1 to use field name encoding, which is the default)
+- IDs must be >= 0
 - If not specified, field name is used in metadata (larger overhead)
 
 **Without field IDs** (field names used in metadata):

--- a/docs/guide/java/field-configuration.md
+++ b/docs/guide/java/field-configuration.md
@@ -84,7 +84,7 @@ public class User {
 
 | Parameter  | Type      | Default | Description                            |
 | ---------- | --------- | ------- | -------------------------------------- |
-| `id`       | `int`     | omitted | Non-negative field tag ID              |
+| `id`       | `int`     | `-1`    | Non-negative field tag ID, or no ID    |
 | `nullable` | `boolean` | `false` | Whether the field can be null          |
 | `ref`      | `boolean` | `false` | Enable reference tracking              |
 | `dynamic`  | `Dynamic` | `AUTO`  | Control polymorphism for struct fields |
@@ -117,8 +117,9 @@ public class User {
 **Notes**:
 
 - IDs must be unique within a class
-- IDs must be >= 0
-- If not specified, field name is used in metadata (larger overhead)
+- IDs must be >= 0 when configured
+- If not specified, the annotation default `-1` is ignored and field name is used in metadata
+  (larger overhead)
 
 **Without field IDs** (field names used in metadata):
 

--- a/docs/guide/python/field-configuration.md
+++ b/docs/guide/python/field-configuration.md
@@ -72,7 +72,7 @@ class User:
 
 | Parameter         | Type     | Default   | Description                          |
 | ----------------- | -------- | --------- | ------------------------------------ |
-| `id`              | `int`    | `-1`      | Field tag ID (-1 = use field name)   |
+| `id`              | `int`    | omitted   | Non-negative field tag ID            |
 | `nullable`        | `bool`   | `False`   | Whether the field can be null        |
 | `ref`             | `bool`   | `False`   | Enable reference tracking            |
 | `ignore`          | `bool`   | `False`   | Exclude field from serialization     |
@@ -103,7 +103,7 @@ class User:
 **Notes**:
 
 - IDs must be unique within a class
-- IDs must be >= 0 (use -1 to use field name encoding, which is the default)
+- IDs must be >= 0
 - If not specified, field name is used in metadata (larger overhead)
 
 **Without field IDs** (field names used in metadata):

--- a/docs/guide/rust/field-configuration.md
+++ b/docs/guide/rust/field-configuration.md
@@ -83,7 +83,7 @@ struct User {
 **Notes**:
 
 - IDs must be unique within a struct
-- IDs must be >= 0 (use -1 to explicitly opt-out of tag ID encoding)
+- IDs must be non-negative
 - If not specified, field name is used in metadata (larger overhead)
 
 ### Skipping Fields (`skip`)
@@ -317,7 +317,7 @@ struct Bad {
 // Error: invalid id value
 #[derive(ForyStruct)]
 struct Bad2 {
-    #[fory(id = -2)]  // Compile error: id must be >= -1
+    #[fory(id = -1)]  // Compile error: id must be non-negative
     field: String,
 }
 

--- a/docs/specification/java_serialization_spec.md
+++ b/docs/specification/java_serialization_spec.md
@@ -19,563 +19,667 @@ license: |
   limitations under the License.
 ---
 
-## Spec overview
+## Scope
 
-Apache Fory Java serialization is a dynamic binary format for Java object graphs. It supports
-shared references, circular references, polymorphism, and optional schema evolution. The format is
-stream friendly: shared type metadata is written inline when needed and there is no meta start
-offset.
+This document specifies the Apache Fory Java native binary format: the format
+used by Java when `withXlang(false)` is configured. The format is optimized for
+Java object graphs, Java collection implementations, Java primitive arrays,
+Java class registration, Java serialization hooks, and optional schema
+evolution.
 
-The Java native format is an extension of the xlang wire format and reuses the same core framing
-and encodings; see `docs/specification/xlang_serialization_spec.md` for the shared baseline.
+Java native mode and xlang mode share low-level building blocks such as
+little-endian numeric payloads, variable-length integer encodings, reference
+flags, meta string encodings, and TypeDef/ClassDef concepts. They are different
+wire formats. In Java native mode, only the scalar type IDs from `BOOL` through
+`STRING` are shared with xlang. Collection, map, struct, array, enum, and
+native Java implementation type IDs are Java native IDs unless this document
+explicitly says otherwise.
 
-Overall layout:
+See [Xlang Serialization Format](xlang_serialization_spec.md) for the
+cross-language format.
 
-```
-| fory header | object ref meta | object type meta | object value data |
-```
+## Stream Layout
 
-All data is encoded in little endian byte order. When running on a big endian platform, array
-serializers swap byte order on write/read so the on-wire layout remains little endian.
+A Java native stream contains one header byte followed by one or more root
+objects. Each root object is encoded as a normal object slot:
 
-## Fory header
+```text
+| header | root_0 | root_1 | ... |
 
-Java native serialization writes a one byte bitmap header. The header layout mirrors the xlang
-bitmap and uses the same flag bits.
-
-```
-|     6 bits    | 1 bit | 1 bit |
-+---------------+-------+-------+
-| reserved      |  oob  | xlang |
-```
-
-- xlang flag: bit 0, set when serialization uses xlang format and clear for Java native format.
-- oob flag: bit 1, set when `BufferCallback` is not null.
-- reserved bits: bits 2-7, must be zero.
-
-The header is always a single byte; no language ID is written.
-
-## Reference meta
-
-Reference tracking uses the same flags as the xlang specification.
-
-| Flag                | Byte Value | Description                                                                                              |
-| ------------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
-| NULL FLAG           | `-3`       | Object is null. No further bytes are written for this object.                                            |
-| REF FLAG            | `-2`       | Object was already serialized. Followed by unsigned varint32 reference ID.                               |
-| NOT_NULL VALUE FLAG | `-1`       | Object is non-null but reference tracking is disabled for this type. Object data follows immediately.    |
-| REF VALUE FLAG      | `0`        | Object is referencable and this is its first occurrence. Object data follows. Assigns next reference ID. |
-
-When reference tracking is disabled globally or for a specific field/type, only `NULL FLAG` and
-`NOT_NULL VALUE FLAG` are used.
-
-## Type system and type IDs
-
-Java native serialization uses the unified type ID layout shared with xlang:
-
-```
-full_type_id = (user_type_id << 8) | internal_type_id
+root:
+| reference flag | [type metadata] | [value payload] |
 ```
 
-- `internal_type_id` is the low 8 bits describing the kind (enum/struct/ext, named variants, or a
-  built-in type).
-- `user_type_id` is the numeric registration ID (0-based) for user-defined enum/struct/ext types.
-- Named types use `NAMED_*` internal IDs and carry names in metadata rather than embedding a user
-  ID.
+All multi-byte fixed-width values are little endian. A big-endian Java runtime
+must still write and read little-endian payloads.
 
-### Shared internal type IDs (0-63)
+The stream is stateful. Type metadata, class definitions, and object references
+are assigned indexes as they are first encountered and may be referenced later
+in the same stream.
 
-Java native mode shares the xlang internal IDs for all values below 64. IDs `0~56` are defined by
-the xlang spec, while `57~63` are reserved for future internal use. These IDs are stable across
-languages.
+## Header
 
-See the internal type ID table in
-[Xlang Serialization Format](xlang_serialization_spec.md#internal-type-id-table).
-Java shares all IDs `< 64`, with `57~63` reserved for future internal use.
+The header is a single byte:
 
-### Java native built-in type IDs
-
-Java native serialization assigns Java-specific built-ins starting at
-`Types.BOUND + 5` (`Types.BOUND` is 64; 5 IDs are reserved for future use).
-Type IDs in `0~56` are shared with xlang; `57~63` are reserved; `64+` are only
-valid in Java native mode.
-
-| Type ID | Name                       | Description                    |
-| ------- | -------------------------- | ------------------------------ |
-| 69      | VOID_ID                    | java.lang.Void                 |
-| 70      | CHAR_ID                    | java.lang.Character            |
-| 71      | PRIMITIVE_VOID_ID          | void                           |
-| 72      | PRIMITIVE_BOOL_ID          | boolean                        |
-| 73      | PRIMITIVE_INT8_ID          | byte                           |
-| 74      | PRIMITIVE_CHAR_ID          | char                           |
-| 75      | PRIMITIVE_INT16_ID         | short                          |
-| 76      | PRIMITIVE_INT32_ID         | int                            |
-| 77      | PRIMITIVE_FLOAT32_ID       | float                          |
-| 78      | PRIMITIVE_INT64_ID         | long                           |
-| 79      | PRIMITIVE_FLOAT64_ID       | double                         |
-| 80      | PRIMITIVE_BOOLEAN_ARRAY_ID | boolean[]                      |
-| 81      | PRIMITIVE_BYTE_ARRAY_ID    | byte[]                         |
-| 82      | PRIMITIVE_CHAR_ARRAY_ID    | char[]                         |
-| 83      | PRIMITIVE_SHORT_ARRAY_ID   | short[]                        |
-| 84      | PRIMITIVE_INT_ARRAY_ID     | int[]                          |
-| 85      | PRIMITIVE_FLOAT_ARRAY_ID   | float[]                        |
-| 86      | PRIMITIVE_LONG_ARRAY_ID    | long[]                         |
-| 87      | PRIMITIVE_DOUBLE_ARRAY_ID  | double[]                       |
-| 88      | STRING_ARRAY_ID            | String[]                       |
-| 89      | OBJECT_ARRAY_ID            | Object[]                       |
-| 90      | ARRAYLIST_ID               | java.util.ArrayList            |
-| 91      | HASHMAP_ID                 | java.util.HashMap              |
-| 92      | HASHSET_ID                 | java.util.HashSet              |
-| 93      | CLASS_ID                   | java.lang.Class                |
-| 94      | EMPTY_OBJECT_ID            | empty object stub              |
-| 95      | LAMBDA_STUB_ID             | lambda stub                    |
-| 96      | JDK_PROXY_STUB_ID          | JDK proxy stub                 |
-| 97      | REPLACE_STUB_ID            | writeReplace/readResolve stub  |
-| 98      | NONEXISTENT_META_SHARED_ID | meta-shared unknown class stub |
-
-### Registration and named types
-
-User-defined enum/struct/ext types can be registered by numeric ID or by name.
-
-- Numeric registration: `full_type_id = (user_id << 8) | internal_type_id`.
-- Name registration: type meta uses namespace and type name (see below).
-- Unregistered types are encoded as named types using namespace = package name and type name =
-  simple class name.
-
-Named type selection rules for unregistered types:
-
-- enum -> NAMED_ENUM
-- struct-like serializers -> NAMED_STRUCT (or NAMED_COMPATIBLE_STRUCT in compatible mode)
-- all other custom serializers -> NAMED_EXT
-
-## Type meta encoding
-
-Every value is written with a type ID followed by optional type metadata:
-
-1. Write `type_id` using varuint32 small7 encoding.
-2. For `NAMED_ENUM`, `NAMED_STRUCT`, `NAMED_EXT`, `NAMED_COMPATIBLE_STRUCT`:
-   - If meta share is enabled: write shared class meta (streaming format).
-   - Otherwise: write namespace and type name as meta strings.
-3. For `COMPATIBLE_STRUCT`:
-   - If meta share is enabled: write shared class meta (streaming format).
-   - Otherwise: no extra meta (type ID is sufficient).
-4. All other types: no extra meta.
-
-### Shared class meta (streaming)
-
-When meta share is enabled, Java uses the streaming shared meta protocol and writes TypeDef
-bytes inline on first use.
-
-```
-| varuint32: index_marker | [class def bytes if new] |
-
-index_marker = (index << 1) | flag
-flag = 1 -> reference
-flag = 0 -> new type
+```text
+| bits 7..2 reserved | bit 1 out-of-band | bit 0 xlang |
 ```
 
-- If `flag == 1`, this is a reference to a previously written type. No class def bytes follow.
-- If `flag == 0`, this is a new type definition and class def bytes are written inline.
+- `xlang` must be `0` for Java native mode.
+- `out-of-band` is `1` when a `BufferCallback` is configured.
+- Reserved bits must be `0`.
 
-The index is assigned sequentially in the order types are first encountered.
+Java native mode does not write a language ID after the header.
 
-## Schema modes
+## Reference Slots
 
-Java native serialization supports two schema modes:
+Objects, nullable fields, and reference-tracked fields use the standard Fory
+reference slot. The first byte is signed:
 
-- Schema consistent (compatible mode disabled): fields are serialized in a fixed order and no
-  ClassDef is required. Type meta uses `STRUCT` or `NAMED_STRUCT` for user-defined classes.
-- Schema evolution (compatible mode enabled): fields are serialized with schema evolution metadata
-  (ClassDef). Type meta uses `COMPATIBLE_STRUCT` or `NAMED_COMPATIBLE_STRUCT`.
+| Flag                  | Byte | Payload that follows                                             |
+| --------------------- | ---- | ---------------------------------------------------------------- |
+| `NULL_FLAG`           | `-3` | No payload. The slot value is `null`.                            |
+| `REF_FLAG`            | `-2` | `varuint32` reference ID of an earlier object.                   |
+| `NOT_NULL_VALUE_FLAG` | `-1` | Value payload. No reference ID is assigned for this occurrence.  |
+| `REF_VALUE_FLAG`      | `0`  | Value payload. Assign the next reference ID before reading data. |
 
-## ClassDef format (compatible mode)
+When reference tracking is disabled for a slot, writers use only `NULL_FLAG`
+and `NOT_NULL_VALUE_FLAG`.
 
-ClassDef is the schema evolution metadata encoded for compatible structs. It is written inline
-when shared meta is enabled, or referenced by index when already seen.
+Primitive field fast paths do not wrap non-null primitive values in a reference
+slot. Boxed primitives and other nullable values use the slot selected by field
+metadata.
 
-### Binary layout
+## Type Metadata
 
+Dynamic object slots write type metadata before the value payload. Type metadata
+identifies the serializer and, when needed, carries class names or ClassDef
+metadata.
+
+```text
+| varuint32 type_id | [type-specific metadata] |
 ```
-| 8 bytes header | [varuint32 extra size] | class meta bytes |
+
+Registered Java classes, Java native built-ins, and Fory internal serializers
+use numeric type IDs. Unregistered classes or classes registered by name carry
+name metadata. Schema-evolution classes may carry a ClassDef.
+
+### Native Type ID Ranges
+
+| Range    | Meaning                                                            |
+| -------- | ------------------------------------------------------------------ |
+| `0`      | `UNKNOWN`, used in metadata for dynamic or object-typed positions. |
+| `1..21`  | Shared scalar IDs from `BOOL` through `STRING`.                    |
+| `22..63` | Reserved in Java native mode for the xlang internal ID range.      |
+| `64..68` | Reserved for future Java native internal IDs.                      |
+| `69..98` | Java native built-ins listed below.                                |
+| `99+`    | User and runtime class IDs assigned by the Java `ClassResolver`.   |
+
+The shared scalar IDs are:
+
+| ID  | Name            | Java value domain                       |
+| --- | --------------- | --------------------------------------- |
+| 1   | `BOOL`          | boolean values in xlang metadata        |
+| 2   | `INT8`          | signed 8-bit integer metadata           |
+| 3   | `INT16`         | signed 16-bit integer metadata          |
+| 4   | `INT32`         | fixed-width signed 32-bit metadata      |
+| 5   | `VARINT32`      | variable-width signed 32-bit metadata   |
+| 6   | `INT64`         | fixed-width signed 64-bit metadata      |
+| 7   | `VARINT64`      | variable-width signed 64-bit metadata   |
+| 8   | `TAGGED_INT64`  | tagged signed 64-bit metadata           |
+| 9   | `UINT8`         | unsigned 8-bit metadata                 |
+| 10  | `UINT16`        | unsigned 16-bit metadata                |
+| 11  | `UINT32`        | fixed-width unsigned 32-bit metadata    |
+| 12  | `VAR_UINT32`    | variable-width unsigned 32-bit metadata |
+| 13  | `UINT64`        | fixed-width unsigned 64-bit metadata    |
+| 14  | `VAR_UINT64`    | variable-width unsigned 64-bit metadata |
+| 15  | `TAGGED_UINT64` | tagged unsigned 64-bit metadata         |
+| 16  | `FLOAT8`        | reserved 8-bit float metadata           |
+| 17  | `FLOAT16`       | half precision float metadata           |
+| 18  | `BFLOAT16`      | bfloat16 metadata                       |
+| 19  | `FLOAT32`       | 32-bit floating point metadata          |
+| 20  | `FLOAT64`       | 64-bit floating point metadata          |
+| 21  | `STRING`        | Java `String`                           |
+
+Java native built-ins start at ID `69`:
+
+| ID  | Name                         | Java type or serializer owner            |
+| --- | ---------------------------- | ---------------------------------------- |
+| 69  | `VOID_ID`                    | `java.lang.Void`                         |
+| 70  | `CHAR_ID`                    | `java.lang.Character`                    |
+| 71  | `PRIMITIVE_VOID_ID`          | `void`                                   |
+| 72  | `PRIMITIVE_BOOL_ID`          | `boolean`                                |
+| 73  | `PRIMITIVE_INT8_ID`          | `byte`                                   |
+| 74  | `PRIMITIVE_CHAR_ID`          | `char`                                   |
+| 75  | `PRIMITIVE_INT16_ID`         | `short`                                  |
+| 76  | `PRIMITIVE_INT32_ID`         | `int`                                    |
+| 77  | `PRIMITIVE_FLOAT32_ID`       | `float`                                  |
+| 78  | `PRIMITIVE_INT64_ID`         | `long`                                   |
+| 79  | `PRIMITIVE_FLOAT64_ID`       | `double`                                 |
+| 80  | `PRIMITIVE_BOOLEAN_ARRAY_ID` | `boolean[]`                              |
+| 81  | `PRIMITIVE_BYTE_ARRAY_ID`    | `byte[]`                                 |
+| 82  | `PRIMITIVE_CHAR_ARRAY_ID`    | `char[]`                                 |
+| 83  | `PRIMITIVE_SHORT_ARRAY_ID`   | `short[]`                                |
+| 84  | `PRIMITIVE_INT_ARRAY_ID`     | `int[]`                                  |
+| 85  | `PRIMITIVE_FLOAT_ARRAY_ID`   | `float[]`                                |
+| 86  | `PRIMITIVE_LONG_ARRAY_ID`    | `long[]`                                 |
+| 87  | `PRIMITIVE_DOUBLE_ARRAY_ID`  | `double[]`                               |
+| 88  | `STRING_ARRAY_ID`            | `String[]`                               |
+| 89  | `OBJECT_ARRAY_ID`            | `Object[]` and object array serializers  |
+| 90  | `ARRAYLIST_ID`               | `java.util.ArrayList`                    |
+| 91  | `HASHMAP_ID`                 | `java.util.HashMap`                      |
+| 92  | `HASHSET_ID`                 | `java.util.HashSet`                      |
+| 93  | `CLASS_ID`                   | `java.lang.Class`                        |
+| 94  | `EMPTY_OBJECT_ID`            | Empty-object serializer                  |
+| 95  | `LAMBDA_STUB_ID`             | Lambda replacement stub                  |
+| 96  | `JDK_PROXY_STUB_ID`          | JDK proxy replacement stub               |
+| 97  | `REPLACE_STUB_ID`            | `writeReplace`/`readResolve` replacement |
+| 98  | `NONEXISTENT_META_SHARED_ID` | Unknown class placeholder                |
+
+### Registered, Named, and Unregistered Classes
+
+Java native mode supports three class identity forms:
+
+- ID registration: the type ID is the registered numeric class ID.
+- Name registration: the type metadata carries namespace and type name strings.
+- Unregistered class: the type metadata carries the package name as namespace
+  and the simple Java class name as type name.
+
+Class registration is the fastest and most compact form. Name-based forms are
+used when stable names are required or class registration is disabled.
+
+### Meta Sharing
+
+When meta sharing is enabled, class metadata is written once and referenced by a
+stream-local index:
+
+```text
+| varuint32 marker | [class definition bytes if new] |
+
+marker = (index << 1) | flag
+flag = 0: new definition, class definition bytes follow
+flag = 1: reference to an earlier definition
 ```
 
-Header layout (lower bits on the right):
+Indexes are assigned in first-use order.
 
+## Schema Modes
+
+Java native mode has two object schema modes.
+
+### Schema-Consistent Mode
+
+Schema-consistent mode is used when compatible mode is disabled. The writer and
+reader must have matching fields and field order. No per-object ClassDef is
+required for ordinary registered classes. Field values are written directly in
+protocol order.
+
+### Compatible Mode
+
+Compatible mode writes ClassDef metadata for struct-like classes. Readers match
+local fields against remote ClassDef fields by identifier, read matching fields,
+and skip unknown fields using the remote field type metadata. Compatible mode is
+the Java native schema-evolution path.
+
+## Field Order
+
+Java native object serializers use the same deterministic field-order
+categories as the current xlang protocol:
+
+1. Primitive non-nullable numeric and boolean scalar fields.
+2. Primitive nullable numeric and boolean scalar fields, including boxed Java
+   primitive wrappers.
+3. Non-primitive fields.
+
+Primitive groups keep the primitive comparator:
+
+1. Fixed-width primitive encodings before compressed or variable-width
+   primitive encodings.
+2. Larger primitive width before smaller primitive width.
+3. Internal primitive type ID ascending.
+4. Field identifier.
+
+Non-primitive fields sort directly by field identifier. Non-primitive type ID,
+serializer kind, collection kind, map kind, and Java implementation class do not
+participate in field order.
+
+Field identifiers are selected as follows:
+
+- If a field has an explicit non-negative `@ForyField(id = ...)`, that numeric
+  ID is the field identifier.
+- Otherwise, the Java field name converted to snake_case is the field
+  identifier.
+- Negative annotation values are not valid field IDs. The annotation default
+  value `-1` means no explicit ID and is ignored for identifier selection.
+
+Identifier comparison is:
+
+1. If both fields have explicit IDs, compare IDs numerically.
+2. If only one field has an explicit ID, the ID-based field sorts before the
+   name-based field.
+3. If neither field has an explicit ID, compare snake_case names
+   lexicographically.
+4. If identifiers are equal, use deterministic tie-breakers such as declaring
+   class and original field name. Untagged fields with the same snake_case
+   identifier in the same class are invalid. A child field that hides an
+   inherited field with the same Java field name keeps only the nearest field in
+   xlang TypeDef metadata because the inherited field has no distinct untagged
+   identifier.
+
+Generated serializers may keep separate internal descriptor groups for
+primitive, collection, map, built-in, and user-defined serializers so they can
+emit specialized fast paths. Those internal groups are an implementation detail
+and must not change wire field order.
+
+## ClassDef Encoding
+
+Compatible mode and meta sharing encode Java class definitions as TypeDef
+records. A TypeDef has an 8-byte header followed by class metadata bytes:
+
+```text
+| 8-byte header | [varuint32 extra_size] | class metadata bytes |
 ```
-| 52-bit hash | 3 bits reserved | 1 bit compress | 8-bit size |
+
+Header bits:
+
+```text
+| 52-bit hash | 3 reserved bits | 1 compress bit | 8 size bits |
 ```
 
-- size: lower 8 bits. If size equals the mask (0xFF), write extra size as varuint32 and add it.
-- compress: bit 8, set when class meta bytes are compressed.
-- reserved: bits 9-11 are reserved for future use and must be zero.
-- hash: 52 stored hash bits derived from MurmurHash3 x64_128 seed 47 over
-  `class meta bytes || header_low12_le`. `header_low12_le` is two little-endian bytes containing
-  the low 12 header bits (size, compress, and reserved bits); the upper four bits of the second
-  byte are zero. Take lane 0 of the 128-bit MurmurHash3 result as a signed int64, left-shift it by
-  12 with two's-complement 64-bit wraparound, apply signed absolute value (leaving `INT64_MIN`
-  unchanged), then mask with `0xfffffffffffff000`. The final header is the masked hash bits OR-ed
-  with the low 12 header bits.
+- `size`: the lower 8 bits. If the value is `0xff`, read `extra_size` as
+  `varuint32` and add it to `0xff`.
+- `compress`: set when class metadata bytes are compressed by the configured
+  meta compressor.
+- `reserved`: must be zero.
+- `hash`: 52 bits derived from MurmurHash3 x64_128 seed 47 over
+  `class_metadata_bytes || header_low12_le`. `header_low12_le` is the low 12
+  header bits encoded as two little-endian bytes with the upper four bits of the
+  second byte clear. Take lane 0 of the MurmurHash3 result, left-shift it by 12
+  with signed 64-bit wraparound, apply signed absolute value, and mask with
+  `0xfffffffffffff000`.
 
-### Class meta bytes
+### Class Metadata Body
 
-Class meta encodes a linearized class hierarchy (from parent to leaf) and field metadata:
-
-```
-| root_kind_and_num_classes | class_layer_0 | class_layer_1 | ... |
+```text
+| root_kind_and_layer_count | class_layer_0 | class_layer_1 | ... |
 
 class_layer:
-| num_fields << 1 | registered_flag | [type_id if registered] |
-| namespace | type_name | field_infos |
+| varuint32 class_header | [registered type IDs or names] | field_info... |
 ```
 
-- `root_kind_and_num_classes` stores the root TypeDef kind in the high four bits and
-  `(num_layers - 1)` in the low four bits.
-  - Root kind codes are `STRUCT=0`, `COMPATIBLE_STRUCT=1`, `NAMED_STRUCT=2`,
-    `NAMED_COMPATIBLE_STRUCT=3`, `ENUM=4`, `NAMED_ENUM=5`, `EXT=6`, `NAMED_EXT=7`,
-    `TYPED_UNION=8`, and `NAMED_UNION=9`.
-  - Kind codes `10-14` are reserved and `15` is an extended-kind escape rejected until defined.
-  - If the low four bits equal `0b1111`, read an extra varuint32 small7 and add it.
-  - The actual number of layers is `num_classes + 1`.
-- `registered_flag` is 1 if the class is registered by numeric ID.
-- If registered by ID, the one-byte class type ID follows. For user-registered ID kinds, the
-  user type ID follows as varuint32.
-- If registered by name or unregistered, namespace and type name are written as meta strings.
+`root_kind_and_layer_count` stores the root TypeDef kind in the high four bits
+and `(num_layers - 1)` in the low four bits. If the low four bits are `0b1111`,
+read an extra `varuint32` and add it to `15`.
 
-### Field info
+Root kind codes:
 
-Each field uses a compact header followed by its name bytes (omitted when TAG_ID is used) and its
-type info:
+| Code  | Kind                                         |
+| ----- | -------------------------------------------- |
+| 0     | `STRUCT`                                     |
+| 1     | `COMPATIBLE_STRUCT`                          |
+| 2     | `NAMED_STRUCT`                               |
+| 3     | `NAMED_COMPATIBLE_STRUCT`                    |
+| 4     | `ENUM`                                       |
+| 5     | `NAMED_ENUM`                                 |
+| 6     | `EXT`                                        |
+| 7     | `NAMED_EXT`                                  |
+| 8     | `TYPED_UNION`                                |
+| 9     | `NAMED_UNION`                                |
+| 10-14 | Reserved                                     |
+| 15    | Extended-kind escape, rejected until defined |
 
-```
-| field_header | [field_name_bytes] | field_type |
+`class_header = (num_fields << 1) | registered_flag`.
+
+- If `registered_flag == 1`, write the class type ID as one byte. For
+  user-registered `ENUM`, `STRUCT`, `COMPATIBLE_STRUCT`, `EXT`, and
+  `TYPED_UNION`, write the user type ID as `varuint32`.
+- If `registered_flag == 0`, write namespace and type name as meta strings.
+
+Class layers are encoded from parent to leaf. Field lists inside each layer use
+the field order defined above.
+
+### Field Info
+
+Each field is encoded as:
+
+```text
+| field_header | [extended_name_or_id_size] | [field name bytes] | field_type |
 ```
 
 `field_header` bits:
 
-- bit 0: trackingRef
-- bit 1: nullable
-- bits 2-3: field name encoding
-- bits 4-6: name length (len-1), or tag ID when TAG_ID is used; value 7 indicates extended length
-- bit 7: reserved (0)
+| Bits | Meaning                                          |
+| ---- | ------------------------------------------------ |
+| 0    | `trackingRef`                                    |
+| 1    | `nullable`                                       |
+| 2..3 | field name encoding                              |
+| 4..6 | encoded name length minus one, or compact tag ID |
+| 7    | reserved, must be zero                           |
 
-Field name encoding:
+Field name encodings:
 
-- 0: UTF8
-- 1: ALL_TO_LOWER_SPECIAL
-- 2: LOWER_UPPER_DIGIT_SPECIAL
-- 3: TAG_ID (field name omitted, tag ID stored in size field)
+| Code | Encoding                             |
+| ---- | ------------------------------------ |
+| 0    | UTF-8                                |
+| 1    | all-to-lower special encoding        |
+| 2    | lower/upper/digit special encoding   |
+| 3    | tag ID; field name bytes are omitted |
 
-If length is extended (size==7), an extra varuint32 small7 storing `(len-1) - 7` follows.
+For name encodings, bits `4..6` store `encoded_length - 1` when it is less than
+`7`. If the value is `7`, read an extra `varuint32` and add it to `7`.
 
-### Field type encoding
+For tag ID encoding, bits `4..6` store the numeric field ID when it is less than
+`7`. If the value is `7`, read an extra `varuint32` and add it to `7`. Field IDs
+must be non-negative. Duplicate field IDs in one TypeDef are invalid.
 
-Field types are encoded with a type tag and optional nested type info. For nested types, the header
-includes nullable/trackingRef flags in the low bits.
-Top-level field types use the tag only (no flags).
+### Field Type
+
+Field types describe how compatible readers read or skip the field payload.
+Top-level field types write only the type tag. Nested field types store
+`nullable` and `trackingRef` in the low bits:
+
+```text
+nested_field_type_header = (type_tag << 2) | (nullable << 1) | trackingRef
+```
 
 Type tags:
 
-| Tag | Field type                                |
-| --- | ----------------------------------------- |
-| 0   | Object (ObjectFieldType)                  |
-| 1   | Map (MapFieldType)                        |
-| 2   | Collection/List/Set (CollectionFieldType) |
-| 3   | Array (ArrayFieldType)                    |
-| 4   | Enum (EnumFieldType)                      |
-| 5+  | Registered type (RegisteredFieldType)     |
+| Tag | Field type                  | Payload                          |
+| --- | --------------------------- | -------------------------------- |
+| 0   | Object/dynamic              | none                             |
+| 1   | Map                         | key field type, value field type |
+| 2   | Collection/List/Set         | element field type               |
+| 3   | Java array                  | dimensions, component field type |
+| 4   | Enum                        | none                             |
+| 5+  | Registered or built-in type | `tag - 5` is the type ID         |
 
-Encoding rules:
+## Meta Strings
 
-- ObjectFieldType: write tag 0.
-- MapFieldType: write tag 1, then key type, then value type.
-- CollectionFieldType: write tag 2, then element type.
-- ArrayFieldType: write tag 3, then dimensions, then component type.
-- EnumFieldType: write tag 4.
-- RegisteredFieldType: write tag `5 + type_id`.
+Namespaces, type names, and field names use the meta string encodings defined
+by the xlang specification. A meta string header stores the byte length and
+encoding kind; extended lengths are written as `varuint32`.
 
-For nested types, nullable/trackingRef flags are stored in the low bits of the header as
-`(type_tag << 2) | (nullable << 1) | tracking_ref`.
+Package and namespace names use UTF-8, all-to-lower special encoding, or
+lower/upper/digit special encoding. Type names use UTF-8,
+lower/upper/digit special encoding, first-to-lower special encoding, or
+all-to-lower special encoding. Field names use the field-info encoding table
+above.
 
-## Meta string encoding
+## Primitive Values
 
-Namespace, type names, and field names use the same meta string encodings as the xlang spec.
+Primitive values are written without type metadata when the field serializer is
+known statically:
 
-### Package and type names
+| Java type | Payload                                                                     |
+| --------- | --------------------------------------------------------------------------- |
+| `boolean` | one byte: `0` or `1`                                                        |
+| `byte`    | one signed byte                                                             |
+| `char`    | two-byte UTF-16 code unit, little endian                                    |
+| `short`   | two-byte signed integer, little endian                                      |
+| `int`     | fixed int32 little endian, or ZigZag varint32 when configured               |
+| `long`    | fixed int64 little endian, ZigZag varint64, or tagged int64 when configured |
+| `float`   | IEEE 754 binary32, little endian                                            |
+| `double`  | IEEE 754 binary64, little endian                                            |
 
-Header format:
+Boxed primitives use the same value payload after the selected null/reference
+slot.
 
-```
-| 6 bits size | 2 bits encoding |
-```
+## String Values
 
-- size is the byte length of the encoded name.
-- if size == 63, write extra length `(size - 63)` as varuint32 small7.
+Java strings are encoded as:
 
-Encodings:
+```text
+| varuint36_small7 header | bytes |
 
-- Package name: UTF8, ALL_TO_LOWER_SPECIAL, LOWER_UPPER_DIGIT_SPECIAL
-- Type name: UTF8, LOWER_UPPER_DIGIT_SPECIAL, FIRST_TO_LOWER_SPECIAL, ALL_TO_LOWER_SPECIAL
-
-### Field names
-
-Field name encoding is described in the ClassDef field header section. When using TAG_ID, the
-field name bytes are omitted and the tag ID is stored in the size field.
-
-### Encoding algorithms
-
-See the xlang specification for encoding algorithms and tables:
-`docs/specification/xlang_serialization_spec.md#meta-string`.
-
-## Value encodings
-
-This section describes the byte layouts for common built-in serializers used in Java native
-serialization. Custom serializers (EXT) may define additional formats but must still follow the
-reference and type meta rules described above.
-
-### Primitives
-
-- boolean: 1 byte (0x00 or 0x01).
-- byte: 1 byte.
-- short: 2 bytes little endian.
-- char: 2 bytes little endian (UTF-16 code unit).
-- int:
-  - fixed: 4 bytes little endian.
-  - varint: signed varint32 (ZigZag) when `compressInt` is enabled.
-- long:
-  - fixed: 8 bytes little endian.
-  - varint: signed varint64 (ZigZag) when `longEncoding=VARINT`.
-  - tagged: tagged int64 when `longEncoding=TAGGED`.
-- float: IEEE 754 float32, little endian.
-- double: IEEE 754 float64, little endian.
-
-Varint encodings follow the xlang spec:
-`docs/specification/xlang_serialization_spec.md#unsigned-varint32`.
-
-### String
-
-Strings are encoded as:
-
-```
-| varuint36_small: (num_bytes << 2) | coder | string bytes |
+header = (num_bytes << 2) | coder
 ```
 
-- coder: 2-bit value
-  - 0: LATIN1
-  - 1: UTF16
-  - 2: UTF8
-- num_bytes: byte length of the encoded string payload.
+`coder` values:
 
-UTF16 is encoded as little endian 2-byte code units.
+| Value | Encoding             |
+| ----- | -------------------- |
+| 0     | Latin-1              |
+| 1     | UTF-16 little endian |
+| 2     | UTF-8                |
 
-### Enum
+`num_bytes` is the byte length of the encoded payload.
 
-- If `serializeEnumByName` is enabled: write enum name as a meta string.
-- Otherwise: write an enum tag as varuint32 small7.
-  - By default the tag is the declaration ordinal.
-  - If the enum configures `@ForyEnumId`, write the configured stable id instead. Java supports
-    annotating exactly one id field, exactly one zero-argument id getter, or every enum constant
-    with explicit tag values.
+## Enum Values
 
-### Binary (byte[])
+Enum value payload depends on configuration:
 
-Primitive byte arrays are encoded as:
+- Ordinal mode writes the enum ordinal as `varuint32`.
+- `@ForyEnumId` mode writes the configured non-negative enum tag as
+  `varuint32`.
+- Name mode writes the enum constant name as a meta string.
 
-```
-| varuint32: num_bytes | raw bytes |
-```
+`@ForyEnumId` may be declared on enum constants, on one integer field, or on one
+zero-argument integer getter, according to the Java API contract. Duplicate or
+negative enum tags are invalid.
 
-### Primitive arrays
+## Arrays
 
-Primitive arrays write a byte-length prefix followed by the little-endian primitive payload unless
-compression is enabled:
+### Primitive Arrays
 
-```
-| varuint32: byte_length | raw bytes |
-```
+Primitive arrays write a length prefix and contiguous little-endian element
+payload:
 
-- `compressIntArray`: int[] encoded as `| varuint32: length | varint32... |`.
-- `compressLongArray`: long[] encoded as `| varuint32: length | varint64/tagged... |`.
-
-### Object arrays
-
-Object arrays encode length and a monomorphic flag:
-
-```
-| varuint32_small7: (length << 1) | mono_flag |
+```text
+| varuint32 byte_length | raw element bytes |
 ```
 
-- If `mono_flag == 1`, all elements share a known component serializer. Each element uses ref
-  flags and the component serializer writes the value.
-- If `mono_flag == 0`, each element uses ref flags and writes its own class info and data.
+Compressed `int[]` and `long[]` arrays use element count followed by compressed
+elements:
 
-### Collections (List/Set)
+```text
+int[] compressed:
+| varuint32 length | varint32... |
 
-Collections encode length and a one-byte elements header:
-
-```
-| varuint32_small7: length | elements_header | [elem_class_info] | elements... |
-```
-
-`elements_header` bits (see `CollectionFlags`):
-
-- bit 0: TRACKING_REF
-- bit 1: HAS_NULL
-- bit 2: IS_DECL_ELEMENT_TYPE
-- bit 3: IS_SAME_TYPE
-
-If `IS_SAME_TYPE` is set and `IS_DECL_ELEMENT_TYPE` is not set, the element class info is written
-once before the elements. Element values then follow with either ref flags (if TRACKING_REF) or
-per-element null flags (if HAS_NULL).
-
-If `IS_SAME_TYPE` is not set, each element is written with its own class info and data (and
-optionally ref flags).
-
-#### Child collection subclasses
-
-Optimized serializers for subclasses of supported JDK collection implementations write subclass
-field layers before element payloads:
-
-```
-| varuint32_small7: length | [comparator_ref] | varuint32_small7: num_class_layers |
-| class_layer_fields... | [elements_header | elem_class_info | elements...] |
+long[] compressed:
+| varuint32 length | varint64 or tagged_int64... |
 ```
 
-- `comparator_ref` is present only for sorted-set and priority-queue subclasses.
-- `num_class_layers` is the exact number of subclass-owned field layers written after the collection
-  header and before the element payload.
-- Readers must reject a payload whose `num_class_layers` does not match the local serializer's layer
-  count. These serializers do not carry per-layer class identity in the value payload, so mismatched
-  layers cannot be skipped safely.
+`byte[]` is the binary serializer and writes `varuint32 length` followed by raw
+bytes.
 
-### Maps
+### Object Arrays
 
-Maps encode entry count and then a sequence of chunks. Each chunk groups entries that share key
-and value types.
+Object arrays write the array length and an element type mode:
 
-```
-| varuint32_small7: size | chunk_1 | chunk_2 | ... |
-
-chunk (non-null entries):
-| header | chunk_size | [key_class_info] | [value_class_info] | entries... |
+```text
+| varuint32_small7 (length << 1 | monomorphic_flag) |
+| [shared element class metadata] |
+| element slots... |
 ```
 
-`header` bits (see `MapFlags`):
+- If `monomorphic_flag == 1`, all non-null elements use the same element
+  serializer. The shared element class metadata is written once.
+- If `monomorphic_flag == 0`, each non-null element writes its own type
+  metadata.
 
-- bit 0: TRACKING_KEY_REF
-- bit 1: KEY_HAS_NULL
-- bit 2: KEY_DECL_TYPE
-- bit 3: TRACKING_VALUE_REF
-- bit 4: VALUE_HAS_NULL
-- bit 5: VALUE_DECL_TYPE
+Each nullable or reference-tracked element is still represented by a reference
+slot before its element payload.
 
-If `KEY_DECL_TYPE` or `VALUE_DECL_TYPE` is unset, the corresponding class info is written once at
-the start of the chunk. `chunk_size` is a single byte (1..255) and `MAX_CHUNK_SIZE` is 255.
+## Collections
 
-#### Null key/value entries
+Java collection serializers write collection size, element flags, optional
+shared element type metadata, and element payloads:
 
-Entries with null key or null value are encoded as special single-entry chunks without a
-`chunk_size` byte:
-
-- null key, non-null value: `NULL_KEY_VALUE_DECL_TYPE*` flags, then value payload
-- null value, non-null key: `NULL_VALUE_KEY_DECL_TYPE*` flags, then key payload
-- null key and null value: `KV_NULL` header only
-
-These chunks always represent exactly one entry.
-
-`EnumMap` has an EnumMap-owned one-byte payload mode before its map payload:
-
-- `0`: normal payload, then `varuint32_small7` size, key enum class info, and the map chunks above.
-- `1`: Java-serialized empty `EnumMap` payload. Android uses this mode when an empty map has no
-  public key from which to derive the enum class. Readers on Android and JVM must accept both modes.
-
-#### Child map subclasses
-
-Optimized serializers for subclasses of supported JDK map implementations write subclass field
-layers before map entry chunks:
-
-```
-| varuint32_small7: size | [comparator_ref] | varuint32_small7: num_class_layers |
-| class_layer_fields... | [chunk_1 | chunk_2 | ...] |
+```text
+| varuint32_small7 size | elements_header | [element type metadata] | elements... |
 ```
 
-- `comparator_ref` is present only for sorted-map subclasses.
-- `num_class_layers` is the exact number of subclass-owned field layers written after the map header
-  and before the entry chunks.
-- Readers must reject a payload whose `num_class_layers` does not match the local serializer's layer
-  count. These serializers do not carry per-layer class identity in the value payload, so mismatched
-  layers cannot be skipped safely.
+`elements_header` bits:
 
-### JDK collection/map wrappers and views
+| Bit | Meaning                               |
+| --- | ------------------------------------- |
+| 0   | Element reference tracking is enabled |
+| 1   | At least one element may be null      |
+| 2   | Declared element type is used         |
+| 3   | All non-null elements share one type  |
 
-Java native mode may use specialized serializers for JDK collection/map wrappers and views. These
-serializers do not introduce a new collection/map protocol branch; they write ordinary object,
-collection, or map payloads in serializer-owned value slots.
+When all non-null elements share a type and the declared element type is not
+used, the shared element type metadata is written once before element payloads.
+Otherwise each non-null element writes its own type metadata. Null and reference
+flags follow the reference-slot rules.
 
-- Unmodifiable and synchronized wrappers keep the outer wrapper type metadata. The wrapper value
-  payload is the wrapped source collection or map written as a normal referencable object. Android
-  writers use public source implementations for that payload: `ArrayList`, `HashSet`, `TreeSet`,
-  `HashMap`, or `TreeMap`. Readers rewrap the source through `Collections.unmodifiable*` or
-  `Collections.synchronized*`.
-- Recognized sublist view classes keep their outer sublist type metadata and use a
-  serializer-local one-byte payload mode. Mode `0` writes visible elements as a normal collection
-  payload. Mode `1` writes view metadata as `offset`, `size`, and source list reference. Android
-  writers use mode `0`; JVM writers may use mode `1` when the view fields match the supported JDK
-  shape. Readers on Android and JVM must accept both modes.
-- `Collections.newSetFromMap` writes a backing-map payload. Android writers use `HashMap` backing
-  type metadata.
-- Immutable JDK collection serializers keep ordinary list/set/map payload semantics. Android readers
-  materialize public unmodifiable containers when JDK internal immutable constructors are not
-  available.
+### Collection Subclasses
 
-Xlang mode uses the xlang collection/map protocol and does not encode Java wrapper or view internals.
+Specialized serializers for supported JDK collection subclasses write
+subclass-owned field layers before the element payload:
 
-### Objects and structs
-
-Object values are encoded as:
-
-```
-| ref meta | type meta | field data |
+```text
+| varuint32_small7 size |
+| [comparator reference for sorted/priority collections] |
+| varuint32_small7 num_class_layers |
+| class_layer_fields... |
+| elements_header | [element type metadata] | elements... |
 ```
 
-Field data is written by the serializer selected by the class info. For standard object
-serialization:
+`num_class_layers` is the exact number of subclass field layers encoded in the
+payload. Readers must reject a payload whose layer count does not match the
+local serializer because the value payload does not carry enough layer identity
+to skip a mismatched subclass layout.
 
-- Fields are sorted deterministically using `DescriptorGrouper` order:
-  primitives, boxed primitives, built-ins, collections, maps, then other fields, with names sorted
-  within each category.
-- For compatible mode, `MetaSharedSerializer` uses ClassDef field metadata to read and skip
-  unknown fields.
-- For each field, the serializer uses field metadata (nullable, trackingRef, polymorphic) to decide
-  whether to write ref flags and/or type meta before the field value.
+## Maps
 
-### Throwable values
+Maps write entry count followed by one or more chunks. Each chunk groups entries
+with compatible key and value metadata:
 
-`Throwable` subclasses use a specialized payload that preserves stack trace, cause, message,
-suppressed exceptions, and subclass-owned fields:
-
-```
-| stack_trace_ref | cause_ref | message_string_ref |
-| varuint32: suppressed_count | suppressed_ref... |
-| varuint32: extra_field_count | extra_field_name/value... |
-| varuint32_small7: num_class_layers | class_layer_fields... |
+```text
+| varuint32_small7 size | chunk... |
 ```
 
-- `extra_field_count` is reserved for serializer-owned extension fields and is currently written as
-  zero.
-- `num_class_layers` is the exact number of `Throwable` subclass field layers written after the
-  built-in Throwable state.
-- Readers must reject a payload whose `num_class_layers` does not match the local serializer's layer
-  count. The Throwable value payload does not carry per-layer class identity, so mismatched layers
-  cannot be skipped safely.
+Non-null chunks:
 
-### Extensions (EXT)
+```text
+| header | uint8 chunk_size | [key type metadata] | [value type metadata] | entries... |
+```
 
-Extension types are encoded by their registered serializer. Type meta is still written before the
-value as described above. The serializer is responsible for the value layout.
+`chunk_size` is in `1..255`.
 
-## Out-of-band buffers
+`header` bits:
 
-When a `BufferCallback` is provided, the oob flag is set in the header and serializers may emit
-buffer references instead of inline bytes (for example, large primitive arrays). The out-of-band
-buffer protocol is specific to the callback implementation; the main stream only contains
-references to those buffers.
+| Bit | Meaning                             |
+| --- | ----------------------------------- |
+| 0   | Key reference tracking is enabled   |
+| 1   | Chunk may contain null keys         |
+| 2   | Declared key type is used           |
+| 3   | Value reference tracking is enabled |
+| 4   | Chunk may contain null values       |
+| 5   | Declared value type is used         |
+
+Null key or null value entries are encoded as single-entry special chunks
+without a `chunk_size` byte:
+
+- null key and non-null value: special null-key header, then value payload.
+- non-null key and null value: special null-value header, then key payload.
+- null key and null value: `KV_NULL` header only.
+
+`EnumMap` writes one serializer-owned payload mode byte before its normal map
+payload:
+
+- `0`: normal payload follows.
+- `1`: Java-serialized empty `EnumMap` payload.
+
+### Map Subclasses
+
+Specialized serializers for supported JDK map subclasses write subclass-owned
+field layers before entry chunks:
+
+```text
+| varuint32_small7 size |
+| [comparator reference for sorted maps] |
+| varuint32_small7 num_class_layers |
+| class_layer_fields... |
+| chunk... |
+```
+
+Readers must reject mismatched `num_class_layers` for the same reason as
+collection subclasses.
+
+## JDK Wrappers and Views
+
+Java native mode has serializers for selected JDK wrappers and views:
+
+- Unmodifiable and synchronized collection/map wrappers keep the wrapper type
+  metadata and write the wrapped source collection or map as a normal object
+  payload.
+- Recognized sublist views keep the sublist type metadata and write one
+  serializer-owned mode byte. Mode `0` writes visible elements as a collection
+  payload. Mode `1` writes view offset, size, and source list reference.
+- `Collections.newSetFromMap` writes the backing map payload.
+- Immutable JDK collection serializers keep list, set, or map payload
+  semantics and materialize an equivalent immutable or unmodifiable container
+  on read.
+
+Android and JVM implementations may choose different concrete public backing
+types for wrapper payloads, but the serializer-owned payload modes above define
+the wire shape.
+
+## Struct and Object Payloads
+
+Struct-like object payloads contain field values in protocol field order. The
+selected serializer owns the exact field fast path:
+
+```text
+| field_0 payload | field_1 payload | ... |
+```
+
+For each field, field metadata decides whether the field writes a primitive
+payload directly, a nullable slot, a reference-tracked slot, type metadata, or a
+specialized collection/map/array payload.
+
+Compatible-mode readers use the remote ClassDef field list to map fields by
+identifier. Unknown fields are skipped using their remote field type metadata.
+
+Generated serializers may split large generated methods and hoist serializers,
+field offsets, collection metadata, or map metadata. Those generated-code
+decisions must preserve the same object payload order.
+
+## Throwable Payloads
+
+`Throwable` serializers preserve standard Java throwable state and
+subclass-owned fields:
+
+```text
+| stack_trace_ref | cause_ref | message_ref |
+| varuint32 suppressed_count | suppressed_ref... |
+| varuint32 extra_field_count | extra_field_name/value... |
+| varuint32_small7 num_class_layers |
+| class_layer_fields... |
+```
+
+`extra_field_count` is reserved for serializer-owned extension fields and is
+currently written as zero. `num_class_layers` must match the local throwable
+serializer layout on read.
+
+## Replacement and Java Serialization Hooks
+
+Java native mode supports serializer-owned handling for Java object replacement
+and Java serialization hooks:
+
+- `writeReplace`/`readResolve` values use replacement metadata and payloads
+  owned by the replacement serializer.
+- JDK proxy and lambda stubs use their registered native stub IDs.
+- Types that require Java Object Serialization compatibility may be delegated to
+  serializers that reproduce the required Java semantics inside a Fory object
+  slot.
+
+These serializers still obey the stream header, reference slot, and type
+metadata rules in this document.
+
+## Unknown Classes
+
+When meta sharing is enabled and a reader does not have a local class for a
+remote ClassDef, Java may materialize an unknown-class placeholder using
+`NONEXISTENT_META_SHARED_ID`. The placeholder stores enough field data to
+preserve and copy the unknown value according to the unknown-class serializer.
+It does not make the unknown Java class available to user code.
+
+## Out-of-Band Buffers
+
+When the header out-of-band bit is set, serializers may write references to
+external buffers instead of writing all bytes inline. The callback defines the
+external buffer transport. The main stream remains a valid Fory stream
+containing references to those buffers at serializer-owned payload positions.

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -1473,8 +1473,9 @@ For every field, compute a stable identifier used for ordering:
 - Otherwise, use the field name converted to `snake_case`.
 
 Configured tag IDs must be non-negative. A negative configured tag ID is invalid; languages may
-use a negative value only as an internal sentinel for "no tag ID configured", which falls back to
-the `snake_case` field name. Tag IDs must be unique within a type; duplicate tag IDs are invalid.
+use a negative value only as a default or internal sentinel for "no tag ID configured", which falls
+back to the `snake_case` field name and is not a tag ID. Tag IDs must be unique within a type;
+duplicate tag IDs are invalid.
 
 Field identifiers compare as follows:
 

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -646,8 +646,8 @@ Field names:
 
 Field order:
 
-Field order is implementation-defined. Decoders must match fields by name or tag ID rather than
-position. Fory uses a stable grouping and sorting order to produce deterministic TypeDefs.
+TypeDef field lists use the same ordering defined in [Field order](#field-order). Compatible
+decoders must still match fields by name or tag ID rather than relying only on position.
 
 ## Meta String
 
@@ -1469,10 +1469,18 @@ language-specific helper classes.
 
 For every field, compute a stable identifier used for ordering:
 
-- If a tag ID is configured (e.g., `@ForyField(id=...)`), use the tag ID as a decimal string.
+- If a non-negative tag ID is configured (e.g., `@ForyField(id=...)`), use the tag ID.
 - Otherwise, use the field name converted to `snake_case`.
 
 Tag IDs must be unique within a type; duplicate tag IDs are invalid.
+
+Field identifiers compare as follows:
+
+1. If both fields have tag IDs, compare the IDs numerically.
+2. If only one field has a tag ID, the tagged field sorts first.
+3. If neither field has a tag ID, compare the `snake_case` names lexicographically.
+4. If fields still compare equal, use deterministic language-local tie-breakers such as declaring
+   class name, original field name, or original field index.
 
 ##### Step 2: Group assignment
 
@@ -1480,13 +1488,9 @@ Assign each field to exactly one group in the following order:
 
 1. **Primitive (non-nullable)**: primitive or boxed numeric/boolean types with `nullable=false`.
 2. **Primitive (nullable)**: primitive or boxed numeric/boolean types with `nullable=true`.
-3. **Built-in (non-container)**: internal type IDs that are not user-defined and not UNKNOWN,
-   excluding collections and maps (for example: STRING, TIME types, UNION/TYPED_UNION/NAMED_UNION,
-   primitive arrays).
-4. **Collection**: list/set/object-array fields. Non-primitive arrays are treated as LIST for
-   ordering purposes.
-5. **Map**: map fields.
-6. **Other**: user-defined enum/struct/ext and UNKNOWN types.
+3. **Non-primitive**: every other field, including strings, time/date/duration/decimal/binary
+   values, unions, primitive arrays, collections, maps, enums, structs, ext/user-defined types,
+   UNKNOWN fields, object arrays, and all other non-primitive schemas.
 
 ##### Step 3: Intra-group ordering
 
@@ -1498,16 +1502,11 @@ Within each group, apply the following sort keys in order until a difference is 
    types (`VARINT32`, `VAR_UINT32`, `VARINT64`, `VAR_UINT64`, `TAGGED_INT64`, `TAGGED_UINT64`).
 2. **Primitive size** (descending): 8-byte > 4-byte > 2-byte > 1-byte.
 3. **Internal type ID** (ascending) as a tie-breaker for equal sizes.
-4. **Field identifier** (lexicographic ascending).
+4. **Field identifier** using the comparator from Step 1.
 
-**Built-in / Collection / Map groups (3-5):**
+**Non-primitive group (3):**
 
-1. **Internal type ID** (ascending).
-2. **Field identifier** (lexicographic ascending).
-
-**Other group (6):**
-
-1. **Field identifier** (lexicographic ascending).
+1. **Field identifier** using the comparator from Step 1.
 
 If two fields still compare equal after the rules above, preserve a deterministic order by
 comparing declaring class name and then the original field name. This tie-breaker should be
@@ -1517,8 +1516,9 @@ reachable only in invalid schemas (e.g., duplicate tag IDs).
 
 - The ordering above is used for serialization order and TypeDef field lists. Schema hashes use
   the field identifier ordering described in the schema hash section.
-- Collection/map normalization is required so peers with different concrete types (e.g.,
-  `List` vs `Collection`) still agree on ordering.
+- Non-primitive type IDs and codec categories must not affect field order. Implementations may keep
+  internal categories to preserve optimized serializers and generated code paths, but the categories
+  are not ordering keys.
 - The compressed numeric rule is critical for cross-language consistency: compressed integer
   fields are always placed after all fixed-width integer fields.
 
@@ -1535,7 +1535,7 @@ MurmurHash3 x64_128 of the struct fingerprint string:
 
 - For each field, build `<field_id_or_name>,<field_type_fingerprint>;`.
 - Field identifier is the tag ID if present, otherwise the snake_case field name.
-- Sort by field identifier lexicographically before concatenation.
+- Sort by the field identifier comparator from [Field order](#field-order) before concatenation.
 - `field_type_fingerprint` is recursive:
   - Leaf: `<type_id>,<ref>,<nullable>`
   - `LIST` / `SET`: `<type_id>,<ref>,<nullable>[<element_fingerprint>]`

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -1472,7 +1472,9 @@ For every field, compute a stable identifier used for ordering:
 - If a non-negative tag ID is configured (e.g., `@ForyField(id=...)`), use the tag ID.
 - Otherwise, use the field name converted to `snake_case`.
 
-Tag IDs must be unique within a type; duplicate tag IDs are invalid.
+Configured tag IDs must be non-negative. A negative configured tag ID is invalid; languages may
+use a negative value only as an internal sentinel for "no tag ID configured", which falls back to
+the `snake_case` field name. Tag IDs must be unique within a type; duplicate tag IDs are invalid.
 
 Field identifiers compare as follows:
 

--- a/go/fory/codegen/parser.go
+++ b/go/fory/codegen/parser.go
@@ -83,6 +83,7 @@ func hasGenerateComment(commentGroup *ast.CommentGroup) bool {
 // extractStructInfo extracts metadata from a struct type
 func extractStructInfo(name string, structType *types.Struct) (*StructInfo, error) {
 	var fields []*FieldInfo
+	usedTagIDs := make(map[int]string)
 
 	for i := 0; i < structType.NumFields(); i++ {
 		field := structType.Field(i)
@@ -90,13 +91,19 @@ func extractStructInfo(name string, structType *types.Struct) (*StructInfo, erro
 			continue // Skip unexported fields
 		}
 
-		fieldInfo, err := analyzeField(field, i)
+		fieldInfo, err := analyzeField(field, structType.Tag(i), i)
 		if err != nil {
 			return nil, fmt.Errorf("analyzing field %s: %w", field.Name(), err)
 		}
 
 		if fieldInfo == nil {
 			continue // Skip unsupported fields
+		}
+		if fieldInfo.HasTagID {
+			if existing, ok := usedTagIDs[fieldInfo.TagID]; ok {
+				return nil, fmt.Errorf("duplicate field id %d for fields %s and %s", fieldInfo.TagID, existing, fieldInfo.GoName)
+			}
+			usedTagIDs[fieldInfo.TagID] = fieldInfo.GoName
 		}
 
 		fields = append(fields, fieldInfo)

--- a/go/fory/codegen/utils.go
+++ b/go/fory/codegen/utils.go
@@ -372,7 +372,7 @@ func sortFields(fields []*FieldInfo) {
 
 		// Within same group, apply group-specific sorting
 		switch group1 {
-		case groupPrimitive:
+		case groupPrimitive, groupNullablePrimitive:
 			// Primitive fields: larger size first, smaller later, variable size last
 			// When same size, sort by type id
 			// When same size and type id, sort by snake case field name
@@ -404,16 +404,7 @@ func sortFields(fields []*FieldInfo) {
 			// Finally by name
 			return f1.SnakeName < f2.SnakeName
 
-		case groupInternalBuiltin, groupListSet, groupMap:
-			// Built-in or collection types: sort by type id then name only.
-			// Java does NOT sort by nullable flag for these types.
-			if f1.TypeID != f2.TypeID {
-				return getTypeIDValue(f1.TypeID) < getTypeIDValue(f2.TypeID)
-			}
-			return f1.SnakeName < f2.SnakeName
-
-		case groupOther:
-			// Other fields: sort by snake case field name only
+		case groupNonPrimitive:
 			return f1.SnakeName < f2.SnakeName
 
 		default:
@@ -427,42 +418,20 @@ func sortFields(fields []*FieldInfo) {
 // This matches reflection's field ordering in field_info.go:
 // primitives → built-in non-container → list/set → map → other
 const (
-	groupPrimitive       = 0 // primitive and nullable primitive fields
-	groupInternalBuiltin = 1 // built-in non-container types sorted by typeId then name
-	groupListSet         = 2 // LIST/SET sorted by typeId then name
-	groupMap             = 3 // MAP sorted by typeId then name
-	groupOther           = 4 // structs, enums, and unknown types - sorted by name
+	groupPrimitive         = 0 // non-nullable primitive fields
+	groupNullablePrimitive = 1 // nullable primitive fields
+	groupNonPrimitive      = 2 // every non-primitive field sorted by identifier
 )
 
 // getFieldGroup categorizes a field into its sorting group
 func getFieldGroup(field *FieldInfo) int {
-	// Primitive fields, including nullable primitives.
 	if field.IsPrimitive {
+		if field.Nullable {
+			return groupNullablePrimitive
+		}
 		return groupPrimitive
 	}
-	typeID := field.TypeID
-	if typeID == "LIST" || typeID == "SET" {
-		return groupListSet
-	}
-	if typeID == "MAP" {
-		return groupMap
-	}
-	// Unknown or user-defined types go to "other"
-	switch typeID {
-	case "UNKNOWN",
-		"NAMED_STRUCT",
-		"NAMED_COMPATIBLE_STRUCT",
-		"STRUCT",
-		"COMPATIBLE_STRUCT",
-		"EXT",
-		"NAMED_EXT",
-		"ENUM",
-		"NAMED_ENUM",
-		"INTERFACE":
-		return groupOther
-	}
-	// Everything else is a built-in type (STRING/BINARY/arrays/TIMESTAMP/etc.)
-	return groupInternalBuiltin
+	return groupNonPrimitive
 }
 
 // getStructNames extracts struct names from StructInfo slice

--- a/go/fory/codegen/utils.go
+++ b/go/fory/codegen/utils.go
@@ -20,7 +20,10 @@ package codegen
 import (
 	"fmt"
 	"go/types"
+	"reflect"
 	"sort"
+	"strconv"
+	"strings"
 	"unicode"
 
 	"github.com/apache/fory/go/fory"
@@ -37,6 +40,8 @@ type FieldInfo struct {
 	IsOptional    bool       // Whether it's a fory optional.Optional[T]
 	Nullable      bool       // Whether the field can be null (pointer types)
 	TypeID        string     // Fory TypeID for sorting
+	TagID         int        // Explicit non-negative fory tag ID when HasTagID is true
+	HasTagID      bool       // Whether TagID is an explicit wire field identifier
 	PrimitiveSize int        // Size for primitive type sorting
 	OptionalElem  types.Type // Element type for optional.Optional[T]
 }
@@ -401,22 +406,21 @@ func sortFields(fields []*FieldInfo) {
 				return getTypeIDValue(f1.TypeID) < getTypeIDValue(f2.TypeID)
 			}
 
-			// Finally by name
-			return f1.SnakeName < f2.SnakeName
+			// Finally by field identifier
+			return lessFieldInfoIdentifier(f1, f2)
 
 		case groupNonPrimitive:
-			return f1.SnakeName < f2.SnakeName
+			return lessFieldInfoIdentifier(f1, f2)
 
 		default:
-			// Fallback: sort by name
-			return f1.SnakeName < f2.SnakeName
+			return lessFieldInfoIdentifier(f1, f2)
 		}
 	})
 }
 
 // Field group constants for sorting.
 // This matches reflection's field ordering in field_info.go:
-// primitives → built-in non-container → list/set → map → other
+// non-nullable primitives → nullable primitives → non-primitives
 const (
 	groupPrimitive         = 0 // non-nullable primitive fields
 	groupNullablePrimitive = 1 // nullable primitive fields
@@ -434,6 +438,24 @@ func getFieldGroup(field *FieldInfo) int {
 	return groupNonPrimitive
 }
 
+func lessFieldInfoIdentifier(f1, f2 *FieldInfo) bool {
+	f1HasTag := f1.HasTagID
+	f2HasTag := f2.HasTagID
+	if f1HasTag && f2HasTag {
+		if f1.TagID != f2.TagID {
+			return f1.TagID < f2.TagID
+		}
+	} else if f1HasTag {
+		return true
+	} else if f2HasTag {
+		return false
+	}
+	if f1.SnakeName != f2.SnakeName {
+		return f1.SnakeName < f2.SnakeName
+	}
+	return f1.GoName < f2.GoName
+}
+
 // getStructNames extracts struct names from StructInfo slice
 func getStructNames(structs []*StructInfo) []string {
 	names := make([]string, len(structs))
@@ -444,7 +466,7 @@ func getStructNames(structs []*StructInfo) []string {
 }
 
 // analyzeField analyzes a struct field and creates FieldInfo
-func analyzeField(field *types.Var, index int) (*FieldInfo, error) {
+func analyzeField(field *types.Var, structTag string, index int) (*FieldInfo, error) {
 	fieldType := field.Type()
 	goName := field.Name()
 	snakeName := toSnakeCase(goName)
@@ -474,6 +496,10 @@ func analyzeField(field *types.Var, index int) (*FieldInfo, error) {
 	isPointer := false
 	typeID := getTypeID(fieldType)
 	primitiveSize := getPrimitiveSize(fieldType)
+	tagID, hasTagID, err := parseGeneratedFieldTagID(structTag)
+	if err != nil {
+		return nil, err
+	}
 
 	// Handle pointer types
 	if ptr, ok := fieldType.(*types.Pointer); ok {
@@ -494,7 +520,44 @@ func analyzeField(field *types.Var, index int) (*FieldInfo, error) {
 		IsOptional:    isOptional,
 		Nullable:      isPointer || isOptional, // Pointer and optional types are nullable in xlang mode
 		TypeID:        typeID,
+		TagID:         tagID,
+		HasTagID:      hasTagID,
 		PrimitiveSize: primitiveSize,
 		OptionalElem:  optionalElem,
 	}, nil
+}
+
+func parseGeneratedFieldTagID(structTag string) (int, bool, error) {
+	if structTag == "" {
+		return 0, false, nil
+	}
+	foryTag, ok := reflect.StructTag(structTag).Lookup("fory")
+	if !ok || foryTag == "-" {
+		return 0, false, nil
+	}
+	tagID := 0
+	seenID := false
+	for _, part := range strings.Split(foryTag, ",") {
+		part = strings.TrimSpace(part)
+		if part == "id" {
+			return 0, false, fmt.Errorf("field id requires a value")
+		}
+		idText, ok := strings.CutPrefix(part, "id=")
+		if !ok {
+			continue
+		}
+		if seenID {
+			return 0, false, fmt.Errorf("duplicate field id tag")
+		}
+		seenID = true
+		parsedTagID, err := strconv.Atoi(idText)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid field id %q", idText)
+		}
+		if parsedTagID < 0 {
+			return 0, false, fmt.Errorf("field id must be non-negative")
+		}
+		tagID = parsedTagID
+	}
+	return tagID, seenID, nil
 }

--- a/go/fory/codegen/utils_test.go
+++ b/go/fory/codegen/utils_test.go
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package codegen
+
+import (
+	"go/token"
+	"go/types"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSortFieldsUsesTagIDs(t *testing.T) {
+	fields := []*FieldInfo{
+		{
+			GoName:    "StringValue",
+			SnakeName: "string_value",
+			TypeID:    "STRING",
+			TagID:     2,
+			HasTagID:  true,
+		},
+		{
+			GoName:    "MapValue",
+			SnakeName: "map_value",
+			TypeID:    "MAP",
+			TagID:     1,
+			HasTagID:  true,
+		},
+		{
+			GoName:    "CustomValue",
+			SnakeName: "custom_value",
+			TypeID:    "NAMED_STRUCT",
+		},
+		{
+			GoName:        "IntValue",
+			SnakeName:     "int_value",
+			TypeID:        "VARINT32",
+			TagID:         10,
+			HasTagID:      true,
+			IsPrimitive:   true,
+			PrimitiveSize: 4,
+		},
+	}
+
+	sortFields(fields)
+
+	names := make([]string, len(fields))
+	for i, field := range fields {
+		names[i] = field.GoName
+	}
+	want := []string{"IntValue", "MapValue", "StringValue", "CustomValue"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("unexpected field order: got %v, want %v", names, want)
+	}
+}
+
+func TestExtractStructInfoRejectsDuplicateTagIDs(t *testing.T) {
+	structType := types.NewStruct(
+		[]*types.Var{
+			types.NewField(token.NoPos, nil, "First", types.Typ[types.String], false),
+			types.NewField(token.NoPos, nil, "Second", types.Typ[types.String], false),
+		},
+		[]string{`fory:"id=1"`, `fory:"id=1"`},
+	)
+
+	_, err := extractStructInfo("DuplicateTagID", structType)
+	if err == nil || !strings.Contains(err.Error(), "duplicate field id 1") {
+		t.Fatalf("expected duplicate field id error, got %v", err)
+	}
+}
+
+func TestExtractStructInfoRejectsNegativeTagIDs(t *testing.T) {
+	structType := types.NewStruct(
+		[]*types.Var{
+			types.NewField(token.NoPos, nil, "Name", types.Typ[types.String], false),
+		},
+		[]string{`fory:"id=-1"`},
+	)
+
+	_, err := extractStructInfo("NegativeTagID", structType)
+	if err == nil || !strings.Contains(err.Error(), "field id must be non-negative") {
+		t.Fatalf("expected negative field id error, got %v", err)
+	}
+}
+
+func TestExtractStructInfoRejectsMalformedTagIDs(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tag     string
+		message string
+	}{
+		{
+			name:    "MissingValue",
+			tag:     `fory:"id"`,
+			message: "field id requires a value",
+		},
+		{
+			name:    "DuplicateKey",
+			tag:     `fory:"id=1,id=2"`,
+			message: "duplicate field id tag",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			structType := types.NewStruct(
+				[]*types.Var{
+					types.NewField(token.NoPos, nil, "Name", types.Typ[types.String], false),
+				},
+				[]string{test.tag},
+			)
+
+			_, err := extractStructInfo(test.name, structType)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("expected %q error, got %v", test.message, err)
+			}
+		})
+	}
+}

--- a/go/fory/field_info.go
+++ b/go/fory/field_info.go
@@ -565,7 +565,8 @@ type FieldFingerprintInfo struct {
 //
 //	Each field contributes:
 //	"<field_id_or_name>,<type_id>,<ref>,<nullable>[<nested_type_fingerprint>];"
-//	Fields are sorted by numeric tag ID when tags are present, otherwise by field name.
+//	Fields with tag IDs sort first by numeric tag ID, followed by name-based fields sorted by
+//	snake_case name.
 //
 // Field Components:
 //   - field_id_or_name: Tag ID as string if configured (e.g., "0", "1"), otherwise snake_case field name
@@ -608,6 +609,12 @@ func ComputeStructFingerprint(fields []FieldFingerprintInfo) string {
 	sort.Slice(fieldsWithKeys, func(i, j int) bool {
 		if fieldsWithKeys[i].hasFieldID && fieldsWithKeys[j].hasFieldID {
 			return fieldsWithKeys[i].fieldID < fieldsWithKeys[j].fieldID
+		}
+		if fieldsWithKeys[i].hasFieldID {
+			return true
+		}
+		if fieldsWithKeys[j].hasFieldID {
+			return false
 		}
 		return fieldsWithKeys[i].sortKey < fieldsWithKeys[j].sortKey
 	})

--- a/go/fory/field_info.go
+++ b/go/fory/field_info.go
@@ -230,27 +230,17 @@ func GroupFields(fields []FieldInfo) FieldGroup {
 		}
 	}
 
-	// Sort remainingFields: nullable primitives first (by primitiveComparator),
-	// then built-in scalar types (typeId, name), then lists, sets, maps,
-	// then primitive arrays and other fields by sort key.
+	// Sort remainingFields: nullable primitives keep primitive ordering, and every
+	// non-primitive field is ordered directly by field identifier.
 	sort.SliceStable(g.RemainingFields, func(i, j int) bool {
 		fi, fj := &g.RemainingFields[i], &g.RemainingFields[j]
 		catI, catJ := getFieldCategory(fi), getFieldCategory(fj)
 		if catI != catJ {
 			return catI < catJ
 		}
-		// Within nullable primitives category, use primitiveComparator logic
 		if catI == 0 {
 			return comparePrimitiveFields(fi, fj)
 		}
-		// Within built-in scalar or collection categories, sort by typeId then sort key.
-		if catI == 1 || catI == 2 || catI == 3 {
-			if fi.Meta.TypeId != fj.Meta.TypeId {
-				return fi.Meta.TypeId < fj.Meta.TypeId
-			}
-			return lessFieldSortKey(fi, fj)
-		}
-		// Other categories (struct, enum, etc.): sort by sort key
 		return lessFieldSortKey(fi, fj)
 	})
 
@@ -327,32 +317,12 @@ func isEnumField(field *FieldInfo) bool {
 
 // getFieldCategory returns the category for sorting remainingFields:
 // 0: nullable primitives (sorted by primitiveComparator)
-// 1: internal built-in non-container types, including primitive arrays (sorted by typeId, then sort key)
-// 2: list/set collections (sorted by typeId, then sort key)
-// 3: map collections (sorted by typeId, then sort key)
-// 4: struct, enum, and all other types (sorted by sort key)
+// 1: every non-primitive field (sorted by field identifier)
 func getFieldCategory(field *FieldInfo) int {
 	if isPrimitiveFieldGroupType(field.Meta.TypeId) &&
 		(isNullableFixedSizePrimitive(field.DispatchId) || isNullableVarintPrimitive(field.DispatchId)) {
 		return 0
 	}
-	typeId := field.Meta.TypeId
-	if typeId == UNKNOWN {
-		return 4
-	}
-	if isUserDefinedType(typeId) {
-		return 4
-	}
-	if typeId == LIST || typeId == SET {
-		return 2
-	}
-	if typeId == MAP {
-		return 3
-	}
-	if isPrimitiveArrayType(typeId) {
-		return 1
-	}
-	// Internal built-in non-container types: sorted by typeId, then sort key.
 	return 1
 }
 
@@ -743,6 +713,12 @@ func lessTripleSortKey(a, b triple) bool {
 	if a.tagID >= 0 && b.tagID >= 0 && a.tagID != b.tagID {
 		return a.tagID < b.tagID
 	}
+	if a.tagID >= 0 && b.tagID < 0 {
+		return true
+	}
+	if a.tagID < 0 && b.tagID >= 0 {
+		return false
+	}
 	aText := a.getSortKeyText()
 	bText := b.getSortKeyText()
 	if aText != bText {
@@ -764,6 +740,12 @@ func lessFieldSortKey(a, b *FieldInfo) bool {
 	bTagID := getFieldTagID(b)
 	if aTagID >= 0 && bTagID >= 0 && aTagID != bTagID {
 		return aTagID < bTagID
+	}
+	if aTagID >= 0 && bTagID < 0 {
+		return true
+	}
+	if aTagID < 0 && bTagID >= 0 {
+		return false
 	}
 	aText := getFieldSortKeyText(a)
 	bText := getFieldSortKeyText(b)
@@ -808,10 +790,10 @@ func sortFields(
 	}
 	// Ordering:
 	// 1) primitives (nullable=false), 2) primitives (nullable=true),
-	// 3) built-in non-container, 4) list/set, 5) map, 6) user-defined/unknown
+	// 3) every non-primitive field, sorted directly by field identifier.
 	// primitives = non-nullable primitive types (int, long, etc.)
 	// boxed = nullable boxed types (Integer, Long, etc. which are pointers in Go)
-	var primitives, boxed, listSet, maps, otherInternalTypeFields []triple
+	var primitives, boxed, nonPrimitives []triple
 
 	for _, t := range typeTriples {
 		switch {
@@ -822,22 +804,12 @@ func sortFields(
 			} else {
 				primitives = append(primitives, t)
 			}
-		case isPrimitiveArrayType(t.typeID):
-			// Primitive arrays are built-in non-container types in xlang field ordering.
-			otherInternalTypeFields = append(otherInternalTypeFields, t)
-		case isListType(t.typeID), isSetType(t.typeID):
-			// LIST, SET: collection group
-			listSet = append(listSet, t)
-		case isMapType(t.typeID):
-			// MAP: map group
-			maps = append(maps, t)
 		case isUserDefinedType(t.typeID):
 			userDefined = append(userDefined, t)
 		case t.typeID == UNKNOWN:
 			others = append(others, t)
 		default:
-			// STRING, BINARY, and other internal types (category 1 in reflection)
-			otherInternalTypeFields = append(otherInternalTypeFields, t)
+			nonPrimitives = append(nonPrimitives, t)
 		}
 	}
 	// Sort primitives (non-nullable) - same logic as boxed
@@ -870,40 +842,20 @@ func sortFields(
 	}
 	sortPrimitiveSlice(primitives)
 	sortPrimitiveSlice(boxed)
-	// Sort internal types (STRING, BINARY, LIST, SET, MAP) by typeId then name only.
-	// Java does NOT sort by nullable flag for these types.
-	sortByTypeIDThenName := func(s []triple) {
-		sort.Slice(s, func(i, j int) bool {
-			if s[i].typeID != s[j].typeID {
-				return s[i].typeID < s[j].typeID
-			}
-			return lessTripleSortKey(s[i], s[j])
-		})
-	}
 	sortTuple := func(s []triple) {
 		sort.Slice(s, func(i, j int) bool {
 			return lessTripleSortKey(s[i], s[j])
 		})
 	}
-	sortByTypeIDThenName(otherInternalTypeFields)
-	sortByTypeIDThenName(listSet)
-	sortByTypeIDThenName(maps)
-	// Merge primitive arrays, user-defined types, and unknown types into the same
-	// sort-key-ordered tail group.
-	otherGroup := make([]triple, 0, len(userDefined)+len(others))
-	otherGroup = append(otherGroup, userDefined...)
-	otherGroup = append(otherGroup, others...)
-	sortTuple(otherGroup)
+	nonPrimitives = append(nonPrimitives, userDefined...)
+	nonPrimitives = append(nonPrimitives, others...)
+	sortTuple(nonPrimitives)
 
-	// Order: primitives, boxed, built-in non-container, list/set, map, other (by name)
-	// This aligns with GroupFields' getFieldCategory sorting and spec ordering.
+	// Order: primitives, boxed primitives, then all non-primitives by field identifier.
 	all := make([]triple, 0, len(fieldNames))
 	all = append(all, primitives...)
 	all = append(all, boxed...)
-	all = append(all, otherInternalTypeFields...) // STRING, BINARY, time, unions, etc.
-	all = append(all, listSet...)
-	all = append(all, maps...)
-	all = append(all, otherGroup...)
+	all = append(all, nonPrimitives...)
 
 	outSer := make([]Serializer, len(all))
 	outNam := make([]string, len(all))

--- a/go/fory/field_spec.go
+++ b/go/fory/field_spec.go
@@ -501,6 +501,9 @@ func parseFieldTag(field reflect.StructField) (parsedFieldTag, error) {
 			if err != nil {
 				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag id=%q on field %s", value, field.Name)
 			}
+			if id < 0 {
+				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag id=%d on field %s: id must be non-negative", id, field.Name)
+			}
 			parsed.idSet = true
 			parsed.tagID = id
 		case "nullable":

--- a/go/fory/struct_test.go
+++ b/go/fory/struct_test.go
@@ -539,7 +539,7 @@ func TestTaggedFieldsKeepGroupedPayloadOrder(t *testing.T) {
 	structSer.fieldGroup.ForEachField(func(field *FieldInfo) {
 		fieldNames = append(fieldNames, field.Meta.Name)
 	})
-	require.Equal(t, []string{"flag", "count", "string_two", "string_ten", "duration"}, fieldNames)
+	require.Equal(t, []string{"flag", "count", "string_two", "duration", "string_ten"}, fieldNames)
 
 	typeDef, err := buildTypeDef(f, reflect.ValueOf(TaggedSortStruct{}))
 	require.NoError(t, err)

--- a/go/fory/tag.go
+++ b/go/fory/tag.go
@@ -60,15 +60,13 @@ func validateForyTags(t reflect.Type) error {
 			continue
 		}
 		if parsed.idSet {
-			if parsed.tagID < TagIDUseFieldName {
-				return InvalidTagErrorf("invalid fory tag id=%d on field %s: id must be >= -1", parsed.tagID, field.Name)
+			if parsed.tagID < 0 {
+				return InvalidTagErrorf("invalid fory tag id=%d on field %s: id must be non-negative", parsed.tagID, field.Name)
 			}
-			if parsed.tagID >= 0 {
-				if existing, ok := tagIDs[parsed.tagID]; ok {
-					return InvalidTagErrorf("duplicate fory tag id=%d on fields %s and %s", parsed.tagID, existing, field.Name)
-				}
-				tagIDs[parsed.tagID] = field.Name
+			if existing, ok := tagIDs[parsed.tagID]; ok {
+				return InvalidTagErrorf("duplicate fory tag id=%d on fields %s and %s", parsed.tagID, existing, field.Name)
 			}
+			tagIDs[parsed.tagID] = field.Name
 		}
 	}
 	return nil

--- a/go/fory/tag_test.go
+++ b/go/fory/tag_test.go
@@ -213,6 +213,18 @@ func TestGroupFieldsUsesFlatOrderForFullyTaggedStructs(t *testing.T) {
 	require.Equal(t, "long_value", group.RemainingFields[2].Meta.Name)
 }
 
+func TestSortFieldsOrdersNonPrimitivesByFieldIdentifier(t *testing.T) {
+	fieldNames := []string{"string_value", "map_value", "custom_value", "list_value", "int_value"}
+	serializers := make([]Serializer, len(fieldNames))
+	typeIDs := []TypeId{STRING, MAP, NAMED_STRUCT, LIST, VARINT32}
+	nullables := []bool{false, false, false, false, false}
+	tagIDs := []int{20, 10, TagIDUseFieldName, TagIDUseFieldName, 30}
+
+	_, sortedNames := sortFields(nil, fieldNames, serializers, typeIDs, nullables, tagIDs)
+
+	require.Equal(t, []string{"int_value", "map_value", "string_value", "custom_value", "list_value"}, sortedNames)
+}
+
 func TestParseFieldSpecRejectsInvalidTags(t *testing.T) {
 	type DuplicateKeys struct {
 		Value int32 `fory:"id=0,id=1"`

--- a/go/fory/tag_test.go
+++ b/go/fory/tag_test.go
@@ -225,6 +225,15 @@ func TestSortFieldsOrdersNonPrimitivesByFieldIdentifier(t *testing.T) {
 	require.Equal(t, []string{"int_value", "map_value", "string_value", "custom_value", "list_value"}, sortedNames)
 }
 
+func TestComputeStructFingerprintOrdersTagIdsBeforeNames(t *testing.T) {
+	fingerprint := ComputeStructFingerprint([]FieldFingerprintInfo{
+		{FieldID: TagIDUseFieldName, FieldName: "a_name", TypeID: STRING},
+		{FieldID: 2, FieldName: "tagged", TypeID: MAP},
+	})
+
+	require.Equal(t, "2,24,0,0;a_name,21,0,0;", fingerprint)
+}
+
 func TestParseFieldSpecRejectsInvalidTags(t *testing.T) {
 	type DuplicateKeys struct {
 		Value int32 `fory:"id=0,id=1"`
@@ -291,13 +300,15 @@ func TestValidateForyTagsStrict(t *testing.T) {
 		Field2 string `fory:"id=0,ignore"`
 	}
 	type InvalidID struct {
-		Field1 string `fory:"id=-2"`
+		Field1 string `fory:"id=-1"`
 	}
 
 	require.NoError(t, validateForyTags(reflect.TypeOf(Valid{})))
 	require.NoError(t, validateForyTags(reflect.TypeOf(IgnoredDuplicate{})))
 	require.Error(t, validateForyTags(reflect.TypeOf(DuplicateIDs{})))
-	require.Error(t, validateForyTags(reflect.TypeOf(InvalidID{})))
+	err := validateForyTags(reflect.TypeOf(InvalidID{}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "id must be non-negative")
 }
 
 func TestShouldIncludeField(t *testing.T) {

--- a/go/fory/tests/xlang/xlang_test_main.go
+++ b/go/fory/tests/xlang/xlang_test_main.go
@@ -251,7 +251,7 @@ type OneFieldStruct struct {
 // String field structs for schema evolution tests
 type EmptyStruct struct{}
 
-// F1 has @ForyField(id = -1, nullable = true) in Java
+// F1 has @ForyField(nullable = true) in Java
 type OneStringFieldStruct struct {
 	F1 *string `fory:"nullable"`
 }

--- a/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
+++ b/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
@@ -1067,7 +1067,7 @@ public final class ForyStructProcessor extends AbstractProcessor {
     }
     Map<? extends ExecutableElement, ? extends AnnotationValue> values =
         elements.getElementValuesWithDefaults(mirror);
-    int id = -1;
+    int id = Integer.MIN_VALUE;
     boolean nullable = !field.asType().getKind().isPrimitive();
     boolean ref = false;
     String dynamic = "AUTO";
@@ -1084,6 +1084,9 @@ public final class ForyStructProcessor extends AbstractProcessor {
       } else if ("dynamic".equals(name)) {
         dynamic = String.valueOf(value);
       }
+    }
+    if (id < 0 && id != Integer.MIN_VALUE) {
+      throw new InvalidStructException("@ForyField id must be non-negative", field);
     }
     return new ForyFieldMeta(true, id, nullable, ref, dynamic);
   }
@@ -1176,7 +1179,8 @@ public final class ForyStructProcessor extends AbstractProcessor {
   }
 
   private static final class ForyFieldMeta {
-    static final ForyFieldMeta NONE = new ForyFieldMeta(false, -1, false, false, "AUTO");
+    static final ForyFieldMeta NONE =
+        new ForyFieldMeta(false, Integer.MIN_VALUE, false, false, "AUTO");
 
     final boolean hasForyField;
     final int id;

--- a/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
+++ b/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
@@ -1067,7 +1067,7 @@ public final class ForyStructProcessor extends AbstractProcessor {
     }
     Map<? extends ExecutableElement, ? extends AnnotationValue> values =
         elements.getElementValuesWithDefaults(mirror);
-    int id = Integer.MIN_VALUE;
+    int id = -1;
     boolean nullable = !field.asType().getKind().isPrimitive();
     boolean ref = false;
     String dynamic = "AUTO";
@@ -1085,8 +1085,9 @@ public final class ForyStructProcessor extends AbstractProcessor {
         dynamic = String.valueOf(value);
       }
     }
-    if (id < 0 && id != Integer.MIN_VALUE) {
-      throw new InvalidStructException("@ForyField id must be non-negative", field);
+    if (id < -1) {
+      throw new InvalidStructException(
+          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID", field);
     }
     return new ForyFieldMeta(true, id, nullable, ref, dynamic);
   }
@@ -1179,8 +1180,7 @@ public final class ForyStructProcessor extends AbstractProcessor {
   }
 
   private static final class ForyFieldMeta {
-    static final ForyFieldMeta NONE =
-        new ForyFieldMeta(false, Integer.MIN_VALUE, false, false, "AUTO");
+    static final ForyFieldMeta NONE = new ForyFieldMeta(false, -1, false, false, "AUTO");
 
     final boolean hasForyField;
     final int id;

--- a/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/StaticSerializerSourceWriter.java
+++ b/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/StaticSerializerSourceWriter.java
@@ -86,12 +86,8 @@ final class StaticSerializerSourceWriter {
       builder.append("  private static final boolean FORY_STRUCT_DEBUG = true;\n");
     }
     builder.append("  private static final List<Descriptor> DESCRIPTORS = buildDescriptors();\n\n");
-    builder.append("  private final SerializationFieldInfo[] buildInFields;\n");
-    builder.append("  private final int[] buildInFieldIds;\n");
-    builder.append("  private final SerializationFieldInfo[] containerFields;\n");
-    builder.append("  private final int[] containerFieldIds;\n");
-    builder.append("  private final SerializationFieldInfo[] otherFields;\n");
-    builder.append("  private final int[] otherFieldIds;\n");
+    builder.append("  private final SerializationFieldInfo[] allFields;\n");
+    builder.append("  private final int[] allFieldIds;\n");
     builder.append("  private final SerializationFieldInfo[] fieldsById;\n");
     builder.append("  private final int classVersionHash;\n");
     builder.append("  private final boolean sameSchemaCompatible;\n\n");
@@ -161,12 +157,8 @@ final class StaticSerializerSourceWriter {
 
   private void writeConstructorBody(String fieldGroupsExpression, String sameSchemaExpression) {
     builder.append("    FieldGroups fieldGroups = ").append(fieldGroupsExpression).append(";\n");
-    builder.append("    this.buildInFields = fieldGroups.buildInFields;\n");
-    builder.append("    this.buildInFieldIds = localFieldIds(buildInFields, DESCRIPTORS);\n");
-    builder.append("    this.containerFields = fieldGroups.containerFields;\n");
-    builder.append("    this.containerFieldIds = localFieldIds(containerFields, DESCRIPTORS);\n");
-    builder.append("    this.otherFields = fieldGroups.userTypeFields;\n");
-    builder.append("    this.otherFieldIds = localFieldIds(otherFields, DESCRIPTORS);\n");
+    builder.append("    this.allFields = fieldGroups.allFields;\n");
+    builder.append("    this.allFieldIds = localFieldIds(allFields, DESCRIPTORS);\n");
     builder.append("    this.fieldsById = new SerializationFieldInfo[DESCRIPTORS.size()];\n");
     builder.append("    SerializationFieldInfo[] allFields = fieldGroups.allFields;\n");
     builder.append("    int[] allFieldIds = localFieldIds(allFields, DESCRIPTORS);\n");
@@ -188,9 +180,7 @@ final class StaticSerializerSourceWriter {
     builder.append("    if (typeResolver.checkClassVersion()) {\n");
     builder.append("      buffer.writeInt32(classVersionHash);\n");
     builder.append("    }\n");
-    builder.append("    writeBuildInFields(writeContext, value);\n");
-    builder.append("    writeContainerFields(writeContext, value);\n");
-    builder.append("    writeOtherFields(writeContext, value);\n");
+    builder.append("    writeFields(writeContext, value);\n");
     builder.append("  }\n\n");
     builder.append("  @Override\n");
     builder
@@ -226,9 +216,7 @@ final class StaticSerializerSourceWriter {
             .append(";\n");
       }
       builder.append("    Object[] values = new Object[DESCRIPTORS.size()];\n");
-      builder.append("    readBuildInRecordFields(readContext, values);\n");
-      builder.append("    readContainerRecordFields(readContext, values);\n");
-      builder.append("    readOtherRecordFields(readContext, values);\n");
+      builder.append("    readRecordFields(readContext, values);\n");
       for (SourceField field : struct.fields) {
         builder
             .append("    field")
@@ -243,19 +231,14 @@ final class StaticSerializerSourceWriter {
     } else {
       builder.append("    ").append(struct.typeName).append(" value = newBean();\n");
       builder.append("    readContext.reference(value);\n");
-      builder.append("    readBuildInFields(readContext, value);\n");
-      builder.append("    readContainerFields(readContext, value);\n");
-      builder.append("    readOtherFields(readContext, value);\n");
+      builder.append("    readFields(readContext, value);\n");
       builder.append("    return value;\n");
     }
     builder.append("  }\n\n");
   }
 
   private void writeWriteGroups() {
-    writeWriteGroup("BuildIn", "buildInFields", "buildInFieldIds", "writeBuildInFieldValue");
-    writeWriteGroup(
-        "Container", "containerFields", "containerFieldIds", "writeContainerFieldValue");
-    writeWriteGroup("Other", "otherFields", "otherFieldIds", "writeOtherFieldValue");
+    writeWriteGroup("", "allFields", "allFieldIds", "writeFieldValue");
   }
 
   private void writeWriteGroup(
@@ -266,7 +249,7 @@ final class StaticSerializerSourceWriter {
         .append("Fields(WriteContext writeContext, ")
         .append(struct.typeName)
         .append(" value) {\n");
-    if (groupName.equals("BuildIn") && hasDirectWriteField()) {
+    if (hasDirectWriteField()) {
       builder.append("    MemoryBuffer buffer = writeContext.getBuffer();\n");
     }
     builder.append("    for (int i = 0; i < ").append(fieldsName).append(".length; i++) {\n");
@@ -275,7 +258,7 @@ final class StaticSerializerSourceWriter {
     for (SourceField field : struct.fields) {
       builder.append("        case ").append(field.id).append(":\n");
       appendDebugWrite("before", "fieldInfo", 10);
-      if (groupName.equals("BuildIn") && canEmitDirectWriteField(field)) {
+      if (canEmitDirectWriteField(field)) {
         appendDirectWrite(field);
       } else {
         builder
@@ -300,15 +283,9 @@ final class StaticSerializerSourceWriter {
 
   private void writeReadGroups() {
     if (struct.record) {
-      writeReadRecordGroup("BuildIn", "buildInFields", "buildInFieldIds", "readBuildInFieldValue");
-      writeReadRecordGroup(
-          "Container", "containerFields", "containerFieldIds", "readContainerFieldValue");
-      writeReadRecordGroup("Other", "otherFields", "otherFieldIds", "readOtherFieldValue");
+      writeReadRecordGroup("", "allFields", "allFieldIds", "readFieldValue");
     } else {
-      writeReadBeanGroup("BuildIn", "buildInFields", "buildInFieldIds", "readBuildInFieldValue");
-      writeReadBeanGroup(
-          "Container", "containerFields", "containerFieldIds", "readContainerFieldValue");
-      writeReadBeanGroup("Other", "otherFields", "otherFieldIds", "readOtherFieldValue");
+      writeReadBeanGroup("", "allFields", "allFieldIds", "readFieldValue");
     }
   }
 
@@ -320,13 +297,13 @@ final class StaticSerializerSourceWriter {
         .append("Fields(ReadContext readContext, ")
         .append(struct.typeName)
         .append(" value) {\n");
-    if (groupName.equals("BuildIn") && hasDirectReadField()) {
+    if (hasDirectReadField()) {
       builder.append("    MemoryBuffer buffer = readContext.getBuffer();\n");
     }
     builder.append("    for (int i = 0; i < ").append(fieldsName).append(".length; i++) {\n");
     builder.append("      SerializationFieldInfo fieldInfo = ").append(fieldsName).append("[i];\n");
     appendDebugRead("before", "fieldInfo", 6);
-    if (!(groupName.equals("BuildIn") && hasDirectReadField())) {
+    if (!hasDirectReadField()) {
       builder
           .append("      Object fieldValue = ")
           .append(helperName)
@@ -336,11 +313,11 @@ final class StaticSerializerSourceWriter {
     builder.append("      switch (").append(idsName).append("[i]) {\n");
     for (SourceField field : struct.fields) {
       builder.append("        case ").append(field.id).append(":\n");
-      if (groupName.equals("BuildIn") && canEmitDirectReadField(field)) {
+      if (canEmitDirectReadField(field)) {
         appendDirectRead(field);
       } else {
         String fieldValueName = "fieldValue" + field.id;
-        if (groupName.equals("BuildIn") && hasDirectReadField()) {
+        if (hasDirectReadField()) {
           builder
               .append("          Object ")
               .append(fieldValueName)

--- a/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
+++ b/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
@@ -240,12 +240,15 @@ public class ForyStructProcessorTest {
                 + "import org.apache.fory.annotation.ForyField;\n"
                 + "import org.apache.fory.annotation.ForyStruct;\n"
                 + "@ForyStruct public class NegativeIdStruct {\n"
-                + "  @ForyField(id = -1) public int value;\n"
+                + "  @ForyField(id = -2) public int value;\n"
                 + "  public NegativeIdStruct() {}\n"
                 + "}\n");
     Assert.assertFalse(result.success);
     Assert.assertTrue(
-        result.diagnostics().contains("@ForyField id must be non-negative"), result.diagnostics());
+        result
+            .diagnostics()
+            .contains("@ForyField id must be -1 (no tag ID) or a non-negative tag ID"),
+        result.diagnostics());
   }
 
   @Test

--- a/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
+++ b/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
@@ -232,6 +232,23 @@ public class ForyStructProcessorTest {
   }
 
   @Test
+  public void testNegativeForyFieldIdFailsCompilation() throws Exception {
+    CompilationResult result =
+        compile(
+            "test.NegativeIdStruct",
+            "package test;\n"
+                + "import org.apache.fory.annotation.ForyField;\n"
+                + "import org.apache.fory.annotation.ForyStruct;\n"
+                + "@ForyStruct public class NegativeIdStruct {\n"
+                + "  @ForyField(id = -1) public int value;\n"
+                + "  public NegativeIdStruct() {}\n"
+                + "}\n");
+    Assert.assertFalse(result.success);
+    Assert.assertTrue(
+        result.diagnostics().contains("@ForyField id must be non-negative"), result.diagnostics());
+  }
+
+  @Test
   public void testInvalidScalarAnnotationCarrierFailsCompilation() throws Exception {
     CompilationResult result =
         compile(

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
@@ -53,12 +53,12 @@ public @interface ForyField {
    *
    * <ul>
    *   <li>When {@code >= 0}: Uses this numeric ID instead of field name string for compact encoding
-   *   <li>When {@code -1} (default): Uses field name with meta string encoding
+   *   <li>When omitted: Uses field name with meta string encoding
    * </ul>
    *
-   * <p>Must be unique within the class (except -1) and stable across versions.
+   * <p>Configured IDs must be non-negative, unique within the class, and stable across versions.
    */
-  int id() default -1;
+  int id() default Integer.MIN_VALUE;
 
   /**
    * Whether this field can be null. When set to false (default), Fory skips writing the null flag

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
@@ -53,12 +53,14 @@ public @interface ForyField {
    *
    * <ul>
    *   <li>When {@code >= 0}: Uses this numeric ID instead of field name string for compact encoding
-   *   <li>When omitted: Uses field name with meta string encoding
+   *   <li>When {@code -1} (default): No tag ID is configured; uses field name with meta string
+   *       encoding
    * </ul>
    *
-   * <p>Configured IDs must be non-negative, unique within the class, and stable across versions.
+   * <p>Configured tag IDs are values {@code >= 0}; they must be unique within the class and stable
+   * across versions. Values below {@code -1} are invalid.
    */
-  int id() default Integer.MIN_VALUE;
+  int id() default -1;
 
   /**
    * Whether this field can be null. When set to false (default), Fory skips writing the null flag

--- a/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
@@ -275,7 +275,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     return fory.getJITContext().asyncVisitFory(f -> function.apply(f.getTypeResolver()));
   }
 
-  private boolean needWriteRef(TypeRef<?> type) {
+  protected boolean needWriteRef(TypeRef<?> type) {
     return typeResolver(r -> r.needToWriteRef(type));
   }
 
@@ -518,9 +518,9 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
           elementType = TypeAnnotationUtils.getPrimitiveListElementTypeRef(descriptor);
         }
         action =
-            serializeForCollection(buffer, inputObject, typeRef, serializer, false, elementType);
+            serializeForCollection(buffer, inputObject, typeRef, serializer, true, elementType);
       } else if (useMapSerialization(typeRef)) {
-        action = serializeForMap(buffer, inputObject, typeRef, serializer, false);
+        action = serializeForMap(buffer, inputObject, typeRef, serializer, true);
       } else {
         action = serializeForNotNullObjectForField(inputObject, buffer, descriptor, serializer);
       }
@@ -2268,9 +2268,13 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
           serializer = getPrimitiveListCollectionSerializer(cls);
           elementType = TypeAnnotationUtils.getPrimitiveListElementTypeRef(descriptor);
         }
-        obj = deserializeForCollection(buffer, typeRef, serializer, null, elementType);
+        InvokeHint invokeHint = new InvokeHint(true, buffer);
+        invokeHint.add(serializer);
+        obj = deserializeForCollection(buffer, typeRef, serializer, invokeHint, elementType);
       } else if (useMapSerialization(typeRef)) {
-        obj = deserializeForMap(buffer, typeRef, serializer, null);
+        InvokeHint invokeHint = new InvokeHint(true, buffer);
+        invokeHint.add(serializer);
+        obj = deserializeForMap(buffer, typeRef, serializer, invokeHint);
       } else {
         if (serializer != null) {
           return read(serializer, buffer, OBJECT_TYPE);

--- a/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleLayerCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleLayerCodecBuilder.java
@@ -244,18 +244,7 @@ public class CompatibleLayerCodecBuilder extends ObjectCodecBuilder {
     deserializeReadGroup(
         objectCodecOptimizer.boxedReadGroups, numGroups, expressions, bean, buffer);
     deserializeReadGroup(
-        objectCodecOptimizer.buildInReadGroups, numGroups, expressions, bean, buffer);
-    for (Descriptor descriptor :
-        objectCodecOptimizer.descriptorGrouper.getCollectionDescriptors()) {
-      expressions.add(
-          deserializeGroup(java.util.Collections.singletonList(descriptor), bean, buffer, false));
-    }
-    for (Descriptor descriptor : objectCodecOptimizer.descriptorGrouper.getMapDescriptors()) {
-      expressions.add(
-          deserializeGroup(java.util.Collections.singletonList(descriptor), bean, buffer, false));
-    }
-    deserializeReadGroup(
-        objectCodecOptimizer.otherReadGroups, numGroups, expressions, bean, buffer);
+        objectCodecOptimizer.nonPrimitiveReadGroups, numGroups, expressions, bean, buffer);
     expressions.add(new Expression.Return(bean));
     return expressions;
   }

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
@@ -37,7 +37,6 @@ import static org.apache.fory.type.TypeUtils.getRawType;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -178,16 +177,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
     addGroupExpressions(
         objectCodecOptimizer.boxedWriteGroups, numGroups, expressions, bean, buffer);
     addGroupExpressions(
-        objectCodecOptimizer.buildInWriteGroups, numGroups, expressions, bean, buffer);
-    for (Descriptor descriptor :
-        objectCodecOptimizer.descriptorGrouper.getCollectionDescriptors()) {
-      expressions.add(serializeGroup(Collections.singletonList(descriptor), bean, buffer, false));
-    }
-    for (Descriptor d : objectCodecOptimizer.descriptorGrouper.getMapDescriptors()) {
-      expressions.add(serializeGroup(Collections.singletonList(d), bean, buffer, false));
-    }
-    addGroupExpressions(
-        objectCodecOptimizer.otherWriteGroups, numGroups, expressions, bean, buffer);
+        objectCodecOptimizer.nonPrimitiveWriteGroups, numGroups, expressions, bean, buffer);
     return expressions;
   }
 
@@ -208,10 +198,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
 
   protected int getNumGroups(ObjectCodecOptimizer objectCodecOptimizer) {
     return objectCodecOptimizer.boxedWriteGroups.size()
-        + objectCodecOptimizer.buildInWriteGroups.size()
-        + objectCodecOptimizer.otherWriteGroups.size()
-        + objectCodecOptimizer.descriptorGrouper.getCollectionDescriptors().size()
-        + objectCodecOptimizer.descriptorGrouper.getMapDescriptors().size();
+        + objectCodecOptimizer.nonPrimitiveWriteGroups.size();
   }
 
   private Expression serializeGroup(
@@ -575,15 +562,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
     deserializeReadGroup(
         objectCodecOptimizer.boxedReadGroups, numGroups, expressions, bean, buffer);
     deserializeReadGroup(
-        objectCodecOptimizer.buildInReadGroups, numGroups, expressions, bean, buffer);
-    for (Descriptor d : objectCodecOptimizer.descriptorGrouper.getCollectionDescriptors()) {
-      expressions.add(deserializeGroup(Collections.singletonList(d), bean, buffer, false));
-    }
-    for (Descriptor d : objectCodecOptimizer.descriptorGrouper.getMapDescriptors()) {
-      expressions.add(deserializeGroup(Collections.singletonList(d), bean, buffer, false));
-    }
-    deserializeReadGroup(
-        objectCodecOptimizer.otherReadGroups, numGroups, expressions, bean, buffer);
+        objectCodecOptimizer.nonPrimitiveReadGroups, numGroups, expressions, bean, buffer);
     if (isRecord) {
       if (recordCtrAccessible) {
         assert bean instanceof FieldsCollector;

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
@@ -687,7 +687,8 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
   }
 
   private boolean needsGeneratedReadFieldMethod(Descriptor descriptor) {
-    return !isMonomorphic(descriptor)
+    return !hasFewFields()
+        && !isMonomorphic(descriptor)
         && !useCollectionSerialization(descriptor)
         && !useMapSerialization(descriptor.getTypeRef());
   }

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
@@ -191,9 +191,13 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
       if (group.isEmpty()) {
         continue;
       }
-      boolean inline = group.size() == 1 && numGroups < 10;
+      boolean inline = hasFewFields() || (group.size() == 1 && numGroups < 10);
       expressions.add(serializeGroup(group, bean, buffer, inline));
     }
+  }
+
+  protected boolean hasFewFields() {
+    return objectCodecOptimizer.descriptorGrouper.getNumDescriptors() < 6;
   }
 
   protected int getNumGroups(ObjectCodecOptimizer objectCodecOptimizer) {
@@ -320,7 +324,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
           throw new IllegalStateException("Unsupported dispatchId: " + dispatchId);
         }
       }
-      if (numPrimitiveFields < 4) {
+      if (hasFewFields() || numPrimitiveFields < 4) {
         expressions.add(groupExpressions);
       } else {
         expressions.add(
@@ -476,7 +480,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
         // int/long are sorted in the last.
         addIncWriterIndexExpr(groupExpressions, buffer, acc);
       }
-      if (numPrimitiveFields < 4) {
+      if (hasFewFields() || numPrimitiveFields < 4) {
         expressions.add(groupExpressions);
       } else {
         expressions.add(
@@ -588,7 +592,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
       if (group.isEmpty()) {
         continue;
       }
-      boolean inline = group.size() == 1 && numGroups < 10;
+      boolean inline = hasFewFields() || (group.size() == 1 && numGroups < 10);
       expressions.add(deserializeGroup(group, bean, buffer, inline));
     }
   }
@@ -665,6 +669,11 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
                     expr ->
                         setFieldValue(exprHolder.get("bean"), d, tryInlineCast(expr, castTypeRef)));
             walkPath.removeLast();
+            if (needsGeneratedReadFieldMethod(d)) {
+              action =
+                  objectCodecOptimizer.invokeGenerated(
+                      readCutPoints(bean, buffer), action, "readField");
+            }
             groupExpressions.add(action);
           }
           return groupExpressions;
@@ -675,6 +684,12 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
       return objectCodecOptimizer.invokeGenerated(
           readCutPoints(bean, buffer), exprSupplier.get(), "readFields");
     }
+  }
+
+  private boolean needsGeneratedReadFieldMethod(Descriptor descriptor) {
+    return !isMonomorphic(descriptor)
+        && !useCollectionSerialization(descriptor)
+        && !useMapSerialization(descriptor.getTypeRef());
   }
 
   protected Expression deserializeGroupForRecord(
@@ -813,7 +828,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
         // `bean` will be replaced by `Reference` to cut-off expr dependency.
         groupExpressions.add(setFieldValue(bean, descriptor, fieldValue));
       }
-      if (numPrimitiveFields < 4 || isRecord) {
+      if (hasFewFields() || numPrimitiveFields < 4 || isRecord) {
         expressions.add(groupExpressions);
       } else {
         expressions.add(
@@ -966,7 +981,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
       if (!compressStarted) {
         addIncReaderIndexExpr(groupExpressions, buffer, acc);
       }
-      if (numPrimitiveFields < 4 || isRecord) {
+      if (hasFewFields() || numPrimitiveFields < 4 || isRecord) {
         expressions.add(groupExpressions);
       } else {
         expressions.add(

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecOptimizer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecOptimizer.java
@@ -70,10 +70,8 @@ public class ObjectCodecOptimizer extends ExpressionOptimizer {
   final List<List<Descriptor>> primitiveGroups = new ArrayList<>();
   final List<List<Descriptor>> boxedWriteGroups = new ArrayList<>();
   final List<List<Descriptor>> boxedReadGroups = new ArrayList<>();
-  final List<List<Descriptor>> buildInWriteGroups = new ArrayList<>();
-  final List<List<Descriptor>> buildInReadGroups = new ArrayList<>();
-  final List<List<Descriptor>> otherWriteGroups = new ArrayList<>();
-  final List<List<Descriptor>> otherReadGroups = new ArrayList<>();
+  final List<List<Descriptor>> nonPrimitiveWriteGroups = new ArrayList<>();
+  final List<List<Descriptor>> nonPrimitiveReadGroups = new ArrayList<>();
 
   ObjectCodecOptimizer(
       Class<?> cls,
@@ -117,13 +115,13 @@ public class ObjectCodecOptimizer extends ExpressionOptimizer {
                 boxedReadWeight,
                 boxedReadGroups),
             MutableTuple3.of(
-                new ArrayList<>(descriptorGrouper.getBuildInDescriptors()), 8, buildInWriteGroups),
+                new ArrayList<>(descriptorGrouper.getNonPrimitiveDescriptors()),
+                6,
+                nonPrimitiveReadGroups),
             MutableTuple3.of(
-                new ArrayList<>(descriptorGrouper.getBuildInDescriptors()), 5, buildInReadGroups),
-            MutableTuple3.of(
-                new ArrayList<>(descriptorGrouper.getOtherDescriptors()), 4, otherReadGroups),
-            MutableTuple3.of(
-                new ArrayList<>(descriptorGrouper.getOtherDescriptors()), 9, otherWriteGroups));
+                new ArrayList<>(descriptorGrouper.getNonPrimitiveDescriptors()),
+                8,
+                nonPrimitiveWriteGroups));
     for (MutableTuple3<List<Descriptor>, Integer, List<List<Descriptor>>> decs : groups) {
       while (!decs.f0.isEmpty()) {
         int endIndex = Math.min(decs.f1, decs.f0.size());

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecOptimizer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecOptimizer.java
@@ -116,11 +116,11 @@ public class ObjectCodecOptimizer extends ExpressionOptimizer {
                 boxedReadGroups),
             MutableTuple3.of(
                 new ArrayList<>(descriptorGrouper.getNonPrimitiveDescriptors()),
-                6,
+                4,
                 nonPrimitiveReadGroups),
             MutableTuple3.of(
                 new ArrayList<>(descriptorGrouper.getNonPrimitiveDescriptors()),
-                8,
+                6,
                 nonPrimitiveWriteGroups));
     for (MutableTuple3<List<Descriptor>, Integer, List<List<Descriptor>>> decs : groups) {
       while (!decs.f0.isEmpty()) {

--- a/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
@@ -116,7 +116,7 @@ public class NativeTypeDefEncoder {
               new FieldInfo(
                   descriptor.getDeclaringClass(), descriptor.getName(), fieldType, (short) tagId);
         } else {
-          // tagId == -1 means opt-out, use field name
+          // Negative is the annotation default sentinel for no configured tag ID; use field name.
           fieldInfo =
               new FieldInfo(descriptor.getDeclaringClass(), descriptor.getName(), fieldType);
         }

--- a/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
@@ -76,15 +76,7 @@ public class NativeTypeDefEncoder {
       TypeResolver typeResolver, Class<?> cls, boolean resolveParent) {
     DescriptorGrouper descriptorGrouper =
         typeResolver.getFieldDescriptorGrouper(cls, resolveParent, false, IDENTITY_DESCRIPTOR);
-    List<Descriptor> descriptors = new ArrayList<>();
-    descriptorGrouper.getPrimitiveDescriptors().forEach(descriptors::add);
-    descriptorGrouper.getBoxedDescriptors().forEach(descriptors::add);
-    descriptorGrouper.getBuildInDescriptors().forEach(descriptors::add);
-    // Order must match ObjectSerializer serialization order: buildIn, container, other
-    descriptorGrouper.getCollectionDescriptors().forEach(descriptors::add);
-    descriptorGrouper.getMapDescriptors().forEach(descriptors::add);
-    descriptorGrouper.getOtherDescriptors().forEach(descriptors::add);
-    return descriptors;
+    return new ArrayList<>(descriptorGrouper.getSortedDescriptors());
   }
 
   public static List<FieldInfo> buildFieldsInfo(ClassResolver resolver, Class<?> cls) {

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
@@ -26,8 +26,10 @@ import static org.apache.fory.meta.NativeTypeDefEncoder.writeTypeName;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.fory.logging.Logger;
@@ -57,8 +59,10 @@ class TypeDefEncoder {
 
   /** Build class definition from fields of class. */
   static TypeDef buildTypeDef(XtypeResolver resolver, Class<?> type) {
+    List<Descriptor> fieldDescriptors =
+        dropShadowedXlangNameFields(type, resolver.getFieldDescriptors(type, true));
     DescriptorGrouper descriptorGrouper =
-        resolver.getFieldDescriptorGrouper(type, true, false, IDENTITY_DESCRIPTOR);
+        resolver.groupDescriptors(fieldDescriptors, false, IDENTITY_DESCRIPTOR);
     TypeInfo typeInfo = resolver.getTypeInfo(type);
     List<Descriptor> descriptors;
     int typeId = typeInfo.getTypeId();
@@ -69,6 +73,44 @@ class TypeDefEncoder {
     }
     return buildTypeDefWithFieldInfos(
         resolver, type, buildFieldsInfoFromDescriptors(resolver, type, descriptors));
+  }
+
+  private static List<Descriptor> dropShadowedXlangNameFields(
+      Class<?> type, List<Descriptor> descriptors) {
+    List<Descriptor> result = new ArrayList<>(descriptors.size());
+    Map<String, Integer> nameFieldIndex = new HashMap<>();
+    for (Descriptor descriptor : descriptors) {
+      if (descriptor.hasForyFieldId()) {
+        result.add(descriptor);
+        continue;
+      }
+      String fieldIdentifier = descriptor.getSnakeCaseName();
+      Integer previousIndex = nameFieldIndex.get(fieldIdentifier);
+      if (previousIndex == null) {
+        nameFieldIndex.put(fieldIdentifier, result.size());
+        result.add(descriptor);
+        continue;
+      }
+      Descriptor previous = result.get(previousIndex);
+      // Untagged xlang fields are addressed by snake_case identifier. When a subclass shadows an
+      // inherited field, only the nearest field can be represented without an explicit tag ID.
+      if (inheritanceDistance(type, descriptor) < inheritanceDistance(type, previous)) {
+        result.set(previousIndex, descriptor);
+      }
+    }
+    return result;
+  }
+
+  private static int inheritanceDistance(Class<?> type, Descriptor descriptor) {
+    String declaringClass = descriptor.getDeclaringClass();
+    int distance = 0;
+    for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+      if (current.getName().equals(declaringClass)) {
+        return distance;
+      }
+      distance++;
+    }
+    return Integer.MAX_VALUE;
   }
 
   static List<FieldInfo> buildFieldsInfo(TypeResolver resolver, Class<?> type, List<Field> fields) {

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
@@ -27,16 +27,13 @@ import static org.apache.fory.meta.NativeTypeDefEncoder.writeTypeName;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.meta.FieldTypes.FieldType;
-import org.apache.fory.reflect.ReflectionUtils;
 import org.apache.fory.resolver.TypeInfo;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.resolver.XtypeResolver;
@@ -104,7 +101,8 @@ class TypeDefEncoder {
                   return new FieldInfo(
                       type.getName(), descriptor.getName(), fieldType, (short) tagId);
                 }
-                // tagId == -1 means use field name, fall through to create regular FieldInfo
+                // Negative is the annotation default sentinel for no configured tag ID; fall
+                // through to create regular FieldInfo. User-facing tag IDs must be non-negative.
               }
               return new FieldInfo(type.getName(), descriptor.getName(), fieldType);
             })
@@ -113,7 +111,7 @@ class TypeDefEncoder {
 
   static TypeDef buildTypeDefWithFieldInfos(
       XtypeResolver resolver, Class<?> type, List<FieldInfo> fieldInfos) {
-    fieldInfos = new ArrayList<>(getClassFields(type, fieldInfos).values());
+    fieldInfos = new ArrayList<>(fieldInfos);
     TypeInfo typeInfo = resolver.getTypeInfo(type);
     MemoryBuffer encodeTypeDef = encodeTypeDef(resolver, type, fieldInfos);
     byte[] typeDefBytes = encodeTypeDef.getBytes(0, encodeTypeDef.writerIndex());
@@ -206,20 +204,6 @@ class TypeDefEncoder {
       default:
         throw new IllegalArgumentException("Unsupported TypeDef kind " + typeId);
     }
-  }
-
-  static Map<String, FieldInfo> getClassFields(Class<?> type, List<FieldInfo> fieldsInfo) {
-    Map<String, FieldInfo> sortedClassFields = new LinkedHashMap<>();
-    Map<String, List<FieldInfo>> classFields = NativeTypeDefEncoder.groupClassFields(fieldsInfo);
-    for (Class<?> clz : ReflectionUtils.getAllClasses(type, true)) {
-      List<FieldInfo> fieldInfos = classFields.get(clz.getName());
-      if (fieldInfos != null) {
-        for (FieldInfo fieldInfo : fieldInfos) {
-          sortedClassFields.put(fieldInfo.getFieldName(), fieldInfo);
-        }
-      }
-    }
-    return sortedClassFields;
   }
 
   /** Write field type and name info. Every field info format: `header + type info + field name` */

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
@@ -92,9 +92,23 @@ class TypeDefEncoder {
         continue;
       }
       Descriptor previous = result.get(previousIndex);
-      // Untagged xlang fields are addressed by snake_case identifier. When a subclass shadows an
-      // inherited field, only the nearest field can be represented without an explicit tag ID.
-      if (inheritanceDistance(type, descriptor) < inheritanceDistance(type, previous)) {
+      int distance = inheritanceDistance(type, descriptor);
+      int previousDistance = inheritanceDistance(type, previous);
+      if (!descriptor.getName().equals(previous.getName()) || distance == previousDistance) {
+        throw new IllegalArgumentException(
+            "Duplicate xlang field identifier "
+                + fieldIdentifier
+                + " for fields "
+                + previous.getName()
+                + " and "
+                + descriptor.getName()
+                + " in class "
+                + type.getName()
+                + ". Configure explicit non-negative field IDs to disambiguate them.");
+      }
+      // Untagged xlang fields are addressed by snake_case identifier. Only a true Java field hide
+      // across the inheritance chain can be represented by dropping the farther inherited field.
+      if (distance < previousDistance) {
         result.set(previousIndex, descriptor);
       }
     }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -1740,6 +1740,10 @@ public abstract class TypeResolver {
     int c;
     if (id1 != null && id2 != null) {
       c = Integer.compare(id1, id2);
+    } else if (id1 != null) {
+      c = -1;
+    } else if (id2 != null) {
+      c = 1;
     } else {
       c = getFieldSortKey(d1).compareTo(getFieldSortKey(d2));
     }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -1713,12 +1713,12 @@ public abstract class TypeResolver {
   /**
    * Gets the sort key for a field descriptor.
    *
-   * <p>If the field has a {@link ForyField} annotation with id &gt;= 0, returns the id as a string.
-   * Otherwise, returns the snake_case field name. This ensures fields are sorted by tag ID when
-   * configured, matching the fingerprint computation order.
+   * <p>If the field has a {@link ForyField} annotation with id &gt;= 0, returns the id as text.
+   * Otherwise, returns the snake_case field name. {@link #compareFieldSortKey} performs the
+   * protocol comparison so tagged fields sort numerically before name-based fields.
    *
    * @param descriptor the field descriptor
-   * @return the sort key (tag ID as string or snake_case name)
+   * @return the sort key text (tag ID as text or snake_case name)
    */
   protected static String getFieldSortKey(Descriptor descriptor) {
     if (descriptor.hasForyFieldId()) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleLayerSerializerBase.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleLayerSerializerBase.java
@@ -43,9 +43,7 @@ import org.apache.fory.util.Preconditions;
 public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSerializer<T> {
   protected TypeDef layerTypeDef;
   protected Class<?> layerMarkerClass;
-  protected SerializationFieldInfo[] buildInFields = new SerializationFieldInfo[0];
-  protected SerializationFieldInfo[] otherFields = new SerializationFieldInfo[0];
-  protected SerializationFieldInfo[] containerFields = new SerializationFieldInfo[0];
+  protected SerializationFieldInfo[] allFields = new SerializationFieldInfo[0];
 
   public CompatibleLayerSerializerBase(TypeResolver typeResolver, Class<T> type) {
     super(typeResolver, type);
@@ -64,9 +62,7 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
     this.layerMarkerClass = layerMarkerClass;
     DescriptorGrouper descriptorGrouper = typeResolver.createDescriptorGrouper(layerTypeDef, type);
     FieldGroups fieldGroups = FieldGroups.buildFieldInfos(typeResolver, descriptorGrouper);
-    buildInFields = fieldGroups.buildInFields;
-    otherFields = fieldGroups.userTypeFields;
-    containerFields = fieldGroups.containerFields;
+    allFields = fieldGroups.allFields;
   }
 
   protected final void checkLayerSerializerMeta() {
@@ -101,9 +97,12 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
 
   public void writeFieldsOnly(WriteContext writeContext, T value) {
     checkLayerSerializerMeta();
-    writeBuildInFields(writeContext, value);
-    writeContainerFields(writeContext, value);
-    writeOtherFields(writeContext, value);
+    MemoryBuffer buffer = writeContext.getBuffer();
+    RefWriter refWriter = writeContext.getRefWriter();
+    Generics generics = writeContext.getGenerics();
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      writeField(writeContext, value, buffer, refWriter, generics, fieldInfo);
+    }
   }
 
   public void writeFieldValues(WriteContext writeContext, Object[] vals) {
@@ -111,18 +110,9 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
     MemoryBuffer buffer = writeContext.getBuffer();
     RefWriter refWriter = writeContext.getRefWriter();
     int index = 0;
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      AbstractObjectSerializer.writeBuildInFieldValue(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, vals[index++]);
-    }
     Generics generics = writeContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      AbstractObjectSerializer.writeContainerFieldValue(
-          writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, vals[index++]);
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      AbstractObjectSerializer.writeField(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, vals[index++]);
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      writeFieldValue(writeContext, buffer, refWriter, generics, fieldInfo, vals[index++]);
     }
   }
 
@@ -132,21 +122,9 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
     RefReader refReader = readContext.getRefReader();
     Object[] vals = new Object[getNumFields()];
     int index = 0;
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      vals[index++] =
-          AbstractObjectSerializer.readBuildInFieldValue(
-              readContext, typeResolver, refReader, fieldInfo, buffer);
-    }
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      vals[index++] =
-          AbstractObjectSerializer.readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      vals[index++] =
-          AbstractObjectSerializer.readField(
-              readContext, typeResolver, refReader, fieldInfo, buffer);
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      vals[index++] = readFieldValue(readContext, buffer, refReader, generics, fieldInfo);
     }
     return vals;
   }
@@ -161,27 +139,24 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
 
   public T readAndSetFields(ReadContext readContext, T obj) {
     checkLayerSerializerMeta();
-    readBuildInFields(readContext, obj);
-    readContainerFields(readContext, obj);
-    readOtherFields(readContext, obj);
+    MemoryBuffer buffer = readContext.getBuffer();
+    RefReader refReader = readContext.getRefReader();
+    Generics generics = readContext.getGenerics();
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      readAndSetField(readContext, obj, buffer, refReader, generics, fieldInfo);
+    }
     return obj;
   }
 
   public int getNumFields() {
-    return buildInFields.length + containerFields.length + otherFields.length;
+    return allFields.length;
   }
 
   @SuppressWarnings("rawtypes")
   public void populateFieldInfo(ObjectIntMap fieldIndexMap, Class<?>[] fieldTypes) {
     checkLayerSerializerMeta();
     int index = 0;
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      populateSingleFieldInfo(fieldInfo, fieldIndexMap, fieldTypes, index++);
-    }
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      populateSingleFieldInfo(fieldInfo, fieldIndexMap, fieldTypes, index++);
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
+    for (SerializationFieldInfo fieldInfo : allFields) {
       populateSingleFieldInfo(fieldInfo, fieldIndexMap, fieldTypes, index++);
     }
   }
@@ -189,9 +164,7 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
   @SuppressWarnings("rawtypes")
   public void setFieldValuesFromPutFields(Object obj, ObjectIntMap fieldIndexMap, Object[] vals) {
     checkLayerSerializerMeta();
-    applyPutFieldValues(obj, fieldIndexMap, vals, buildInFields);
-    applyPutFieldValues(obj, fieldIndexMap, vals, containerFields);
-    applyPutFieldValues(obj, fieldIndexMap, vals, otherFields);
+    applyPutFieldValues(obj, fieldIndexMap, vals, allFields);
   }
 
   @SuppressWarnings("rawtypes")
@@ -199,91 +172,125 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
       Object obj, ObjectIntMap fieldIndexMap, int arraySize) {
     checkLayerSerializerMeta();
     Object[] vals = new Object[arraySize];
-    collectPutFieldValues(obj, fieldIndexMap, vals, buildInFields);
-    collectPutFieldValues(obj, fieldIndexMap, vals, containerFields);
-    collectPutFieldValues(obj, fieldIndexMap, vals, otherFields);
+    collectPutFieldValues(obj, fieldIndexMap, vals, allFields);
     return vals;
   }
 
   public void skipFields(ReadContext readContext) {
     checkLayerSerializerMeta();
-    skipBuildInFields(readContext);
-    skipContainerFields(readContext);
-    skipOtherFields(readContext);
-  }
-
-  private void writeBuildInFields(WriteContext writeContext, T value) {
-    MemoryBuffer buffer = writeContext.getBuffer();
-    RefWriter refWriter = writeContext.getRefWriter();
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      AbstractObjectSerializer.writeBuildInField(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, value);
-    }
-  }
-
-  private void writeContainerFields(WriteContext writeContext, T value) {
-    MemoryBuffer buffer = writeContext.getBuffer();
-    RefWriter refWriter = writeContext.getRefWriter();
-    Generics generics = writeContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      Object fieldValue = fieldAccessor.getObject(value);
-      AbstractObjectSerializer.writeContainerFieldValue(
-          writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, fieldValue);
-    }
-  }
-
-  private void writeOtherFields(WriteContext writeContext, T value) {
-    MemoryBuffer buffer = writeContext.getBuffer();
-    RefWriter refWriter = writeContext.getRefWriter();
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      Object fieldValue = fieldAccessor.getObject(value);
-      AbstractObjectSerializer.writeField(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
-    }
-  }
-
-  private void readBuildInFields(ReadContext readContext, T targetObject) {
-    MemoryBuffer buffer = readContext.getBuffer();
-    RefReader refReader = readContext.getRefReader();
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        AbstractObjectSerializer.readBuildInFieldValue(
-            readContext, typeResolver, refReader, fieldInfo, buffer, targetObject);
-      } else {
-        FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-      }
-    }
-  }
-
-  private void readContainerFields(ReadContext readContext, T obj) {
     MemoryBuffer buffer = readContext.getBuffer();
     RefReader refReader = readContext.getRefReader();
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      Object fieldValue =
-          AbstractObjectSerializer.readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        fieldAccessor.putObject(obj, fieldValue);
-      }
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      skipField(readContext, buffer, refReader, generics, fieldInfo);
     }
   }
 
-  private void readOtherFields(ReadContext readContext, T obj) {
-    MemoryBuffer buffer = readContext.getBuffer();
-    RefReader refReader = readContext.getRefReader();
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      Object fieldValue =
-          AbstractObjectSerializer.readField(
-              readContext, typeResolver, refReader, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
+  private void writeField(
+      WriteContext writeContext,
+      T value,
+      MemoryBuffer buffer,
+      RefWriter refWriter,
+      Generics generics,
+      SerializationFieldInfo fieldInfo) {
+    if (fieldInfo.codecCategory == FieldGroups.FieldCodecCategory.BUILD_IN) {
+      AbstractObjectSerializer.writeBuildInField(
+          writeContext, typeResolver, refWriter, fieldInfo, buffer, value);
+      return;
+    }
+    FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
+    Object fieldValue = fieldAccessor.getObject(value);
+    writeFieldValue(writeContext, buffer, refWriter, generics, fieldInfo, fieldValue);
+  }
+
+  private void writeFieldValue(
+      WriteContext writeContext,
+      MemoryBuffer buffer,
+      RefWriter refWriter,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      Object fieldValue) {
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        AbstractObjectSerializer.writeBuildInFieldValue(
+            writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+        return;
+      case CONTAINER:
+        AbstractObjectSerializer.writeContainerFieldValue(
+            writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, fieldValue);
+        return;
+      case OTHER:
+        AbstractObjectSerializer.writeField(
+            writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+        return;
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
+  }
+
+  private Object readFieldValue(
+      ReadContext readContext,
+      MemoryBuffer buffer,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo) {
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        return AbstractObjectSerializer.readBuildInFieldValue(
+            readContext, typeResolver, refReader, fieldInfo, buffer);
+      case CONTAINER:
+        return AbstractObjectSerializer.readContainerFieldValue(
+            readContext, typeResolver, refReader, generics, fieldInfo, buffer);
+      case OTHER:
+        return AbstractObjectSerializer.readField(
+            readContext, typeResolver, refReader, fieldInfo, buffer);
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
+  }
+
+  private void readAndSetField(
+      ReadContext readContext,
+      T obj,
+      MemoryBuffer buffer,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo) {
+    FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
+    if (fieldInfo.codecCategory == FieldGroups.FieldCodecCategory.BUILD_IN) {
       if (fieldAccessor != null) {
-        fieldAccessor.putObject(obj, fieldValue);
+        AbstractObjectSerializer.readBuildInFieldValue(
+            readContext, typeResolver, refReader, fieldInfo, buffer, obj);
+      } else {
+        FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
       }
+      return;
+    }
+    Object fieldValue = readFieldValue(readContext, buffer, refReader, generics, fieldInfo);
+    if (fieldAccessor != null) {
+      fieldAccessor.putObject(obj, fieldValue);
+    }
+  }
+
+  private void skipField(
+      ReadContext readContext,
+      MemoryBuffer buffer,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo) {
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
+        return;
+      case CONTAINER:
+        AbstractObjectSerializer.readContainerFieldValue(
+            readContext, typeResolver, refReader, generics, fieldInfo, buffer);
+        return;
+      case OTHER:
+        AbstractObjectSerializer.readField(readContext, typeResolver, refReader, fieldInfo, buffer);
+        return;
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
     }
   }
 
@@ -329,32 +336,6 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
           vals[index] = fieldAccessor.get(obj);
         }
       }
-    }
-  }
-
-  private void skipBuildInFields(ReadContext readContext) {
-    MemoryBuffer buffer = readContext.getBuffer();
-    RefReader refReader = readContext.getRefReader();
-    for (SerializationFieldInfo fieldInfo : buildInFields) {
-      FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-    }
-  }
-
-  private void skipContainerFields(ReadContext readContext) {
-    MemoryBuffer buffer = readContext.getBuffer();
-    RefReader refReader = readContext.getRefReader();
-    Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      AbstractObjectSerializer.readContainerFieldValue(
-          readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-    }
-  }
-
-  private void skipOtherFields(ReadContext readContext) {
-    MemoryBuffer buffer = readContext.getBuffer();
-    RefReader refReader = readContext.getRefReader();
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      AbstractObjectSerializer.readField(readContext, typeResolver, refReader, fieldInfo, buffer);
     }
   }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
@@ -66,12 +66,8 @@ import org.apache.fory.util.record.RecordUtils;
 public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   private static final Logger LOG = LoggerFactory.getLogger(CompatibleSerializer.class);
 
-  private final SerializationFieldInfo[] buildInFields;
-  private final SerializationFieldInfo[] containerFields;
-  private final SerializationFieldInfo[] otherFields;
-  private final CompatibleCollectionArrayReader.ReadAction[] buildInCompatibleReadActions;
-  private final CompatibleCollectionArrayReader.ReadAction[] containerCompatibleReadActions;
-  private final CompatibleCollectionArrayReader.ReadAction[] otherCompatibleReadActions;
+  private final SerializationFieldInfo[] allFields;
+  private final CompatibleCollectionArrayReader.ReadAction[] allCompatibleReadActions;
   private final boolean hasCompatibleCollectionArrayRead;
   private final RecordInfo recordInfo;
   private Serializer<T> serializer;
@@ -107,19 +103,9 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     }
     // d.getField() may be null if not exists in this class when meta share enabled.
     FieldGroups fieldGroups = FieldGroups.buildFieldInfos(typeResolver, descriptorGrouper);
-    buildInFields = fieldGroups.buildInFields;
-    containerFields = fieldGroups.containerFields;
-    otherFields = fieldGroups.userTypeFields;
-    buildInCompatibleReadActions =
-        buildCompatibleCollectionArrayReadActions(typeResolver, buildInFields);
-    containerCompatibleReadActions =
-        buildCompatibleCollectionArrayReadActions(typeResolver, containerFields);
-    otherCompatibleReadActions =
-        buildCompatibleCollectionArrayReadActions(typeResolver, otherFields);
-    hasCompatibleCollectionArrayRead =
-        buildInCompatibleReadActions != null
-            || containerCompatibleReadActions != null
-            || otherCompatibleReadActions != null;
+    allFields = fieldGroups.allFields;
+    allCompatibleReadActions = buildCompatibleCollectionArrayReadActions(typeResolver, allFields);
+    hasCompatibleCollectionArrayRead = allCompatibleReadActions != null;
     if (isRecord) {
       List<String> fieldNames =
           descriptorGrouper.getSortedDescriptors().stream()
@@ -256,8 +242,7 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   @Override
   public T read(ReadContext readContext) {
     if (isRecord) {
-      Object[] fieldValues =
-          new Object[buildInFields.length + otherFields.length + containerFields.length];
+      Object[] fieldValues = new Object[allFields.length];
       if (hasCompatibleCollectionArrayRead) {
         readFieldsWithCompatibleCollectionArray(readContext, fieldValues);
       } else {
@@ -283,48 +268,9 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   private void readFields(ReadContext readContext, T targetObject) {
     MemoryBuffer buffer = readContext.getBuffer();
     RefReader refReader = readContext.getRefReader();
-    // read order: primitive,boxed,final,other,collection,map
-    for (SerializationFieldInfo fieldInfo : this.buildInFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        AbstractObjectSerializer.readBuildInFieldValue(
-            readContext, typeResolver, refReader, fieldInfo, buffer, targetObject);
-      } else {
-        if (fieldInfo.fieldConverter == null) {
-          // Skip the field value from buffer since it doesn't exist in current class
-          FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-        } else {
-          compatibleRead(readContext, fieldInfo, targetObject);
-        }
-      }
-    }
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          AbstractObjectSerializer.readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        fieldAccessor.putObject(targetObject, fieldValue);
-      }
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          AbstractObjectSerializer.readField(
-              readContext, typeResolver, refReader, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        fieldAccessor.putObject(targetObject, fieldValue);
-      }
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      readField(readContext, targetObject, refReader, generics, fieldInfo, buffer, null);
     }
   }
 
@@ -332,42 +278,9 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     MemoryBuffer buffer = readContext.getBuffer();
     int counter = 0;
     RefReader refReader = readContext.getRefReader();
-    // read order: primitive,boxed,final,other,collection,map
-    for (SerializationFieldInfo fieldInfo : this.buildInFields) {
-      if (Utils.DEBUG_OUTPUT_ENABLED) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      if (fieldInfo.fieldAccessor != null) {
-        fields[counter++] =
-            AbstractObjectSerializer.readBuildInFieldValue(
-                readContext, typeResolver, refReader, fieldInfo, buffer);
-      } else {
-        // Skip the field value from buffer since it doesn't exist in current class.
-        // For records, fieldConverter can't be used since records are immutable and
-        // constructed all at once. We just read to advance buffer position.
-        FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-        // remapping will handle those extra fields from peers.
-        fields[counter++] = null;
-      }
-    }
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      if (Utils.DEBUG_OUTPUT_ENABLED) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          AbstractObjectSerializer.readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-      fields[counter++] = fieldValue;
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      if (Utils.DEBUG_OUTPUT_ENABLED) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          AbstractObjectSerializer.readField(
-              readContext, typeResolver, refReader, fieldInfo, buffer);
-      fields[counter++] = fieldValue;
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      fields[counter++] = readField(readContext, refReader, generics, fieldInfo, buffer, null);
     }
   }
 
@@ -383,66 +296,15 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   private void readFieldsWithCompatibleCollectionArray(ReadContext readContext, T targetObject) {
     MemoryBuffer buffer = readContext.getBuffer();
     RefReader refReader = readContext.getRefReader();
-    for (int i = 0; i < buildInFields.length; i++) {
-      SerializationFieldInfo fieldInfo = buildInFields[i];
-      CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(buildInCompatibleReadActions, i);
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        if (action != null) {
-          fieldAccessor.putObject(
-              targetObject,
-              CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action));
-        } else {
-          AbstractObjectSerializer.readBuildInFieldValue(
-              readContext, typeResolver, refReader, fieldInfo, buffer, targetObject);
-        }
-      } else {
-        if (fieldInfo.fieldConverter == null) {
-          // Skip the field value from buffer since it doesn't exist in current class
-          FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-        } else {
-          compatibleRead(readContext, fieldInfo, targetObject);
-        }
-      }
-    }
     Generics generics = readContext.getGenerics();
-    for (int i = 0; i < containerFields.length; i++) {
-      SerializationFieldInfo fieldInfo = containerFields[i];
+    for (int i = 0; i < allFields.length; i++) {
+      SerializationFieldInfo fieldInfo = allFields[i];
       CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(containerCompatibleReadActions, i);
+          compatibleCollectionArrayReadAction(allCompatibleReadActions, i);
       if (Utils.DEBUG_OUTPUT_VERBOSE) {
         printFieldDebugInfo(fieldInfo, buffer);
       }
-      Object fieldValue =
-          action == null
-              ? AbstractObjectSerializer.readContainerFieldValue(
-                  readContext, typeResolver, refReader, generics, fieldInfo, buffer)
-              : CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        fieldAccessor.putObject(targetObject, fieldValue);
-      }
-    }
-    for (int i = 0; i < otherFields.length; i++) {
-      SerializationFieldInfo fieldInfo = otherFields[i];
-      CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(otherCompatibleReadActions, i);
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          action == null
-              ? AbstractObjectSerializer.readField(
-                  readContext, typeResolver, refReader, fieldInfo, buffer)
-              : CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      if (fieldAccessor != null) {
-        fieldAccessor.putObject(targetObject, fieldValue);
-      }
+      readField(readContext, targetObject, refReader, generics, fieldInfo, buffer, action);
     }
   }
 
@@ -450,56 +312,74 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     MemoryBuffer buffer = readContext.getBuffer();
     int counter = 0;
     RefReader refReader = readContext.getRefReader();
-    for (int i = 0; i < buildInFields.length; i++) {
-      SerializationFieldInfo fieldInfo = buildInFields[i];
-      CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(buildInCompatibleReadActions, i);
-      if (Utils.DEBUG_OUTPUT_ENABLED) {
-        printFieldDebugInfo(fieldInfo, buffer);
-      }
-      if (fieldInfo.fieldAccessor != null) {
-        fields[counter++] =
-            action == null
-                ? AbstractObjectSerializer.readBuildInFieldValue(
-                    readContext, typeResolver, refReader, fieldInfo, buffer)
-                : CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
-      } else {
-        // Skip the field value from buffer since it doesn't exist in current class.
-        // For records, fieldConverter can't be used since records are immutable and
-        // constructed all at once. We just read to advance buffer position.
-        FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
-        // remapping will handle those extra fields from peers.
-        fields[counter++] = null;
-      }
-    }
     Generics generics = readContext.getGenerics();
-    for (int i = 0; i < containerFields.length; i++) {
-      SerializationFieldInfo fieldInfo = containerFields[i];
+    for (int i = 0; i < allFields.length; i++) {
+      SerializationFieldInfo fieldInfo = allFields[i];
       CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(containerCompatibleReadActions, i);
+          compatibleCollectionArrayReadAction(allCompatibleReadActions, i);
       if (Utils.DEBUG_OUTPUT_ENABLED) {
         printFieldDebugInfo(fieldInfo, buffer);
       }
-      Object fieldValue =
-          action == null
-              ? AbstractObjectSerializer.readContainerFieldValue(
-                  readContext, typeResolver, refReader, generics, fieldInfo, buffer)
-              : CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
-      fields[counter++] = fieldValue;
+      fields[counter++] = readField(readContext, refReader, generics, fieldInfo, buffer, action);
     }
-    for (int i = 0; i < otherFields.length; i++) {
-      SerializationFieldInfo fieldInfo = otherFields[i];
-      CompatibleCollectionArrayReader.ReadAction action =
-          compatibleCollectionArrayReadAction(otherCompatibleReadActions, i);
-      if (Utils.DEBUG_OUTPUT_ENABLED) {
-        printFieldDebugInfo(fieldInfo, buffer);
+  }
+
+  private void readField(
+      ReadContext readContext,
+      T targetObject,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      MemoryBuffer buffer,
+      CompatibleCollectionArrayReader.ReadAction action) {
+    FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
+    if (fieldAccessor == null) {
+      if (fieldInfo.codecCategory == FieldGroups.FieldCodecCategory.BUILD_IN) {
+        if (fieldInfo.fieldConverter == null) {
+          FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
+        } else {
+          compatibleRead(readContext, fieldInfo, targetObject);
+        }
+      } else {
+        readField(readContext, refReader, generics, fieldInfo, buffer, action);
       }
-      Object fieldValue =
-          action == null
-              ? AbstractObjectSerializer.readField(
-                  readContext, typeResolver, refReader, fieldInfo, buffer)
-              : CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
-      fields[counter++] = fieldValue;
+      return;
+    }
+    if (fieldInfo.codecCategory == FieldGroups.FieldCodecCategory.BUILD_IN && action == null) {
+      AbstractObjectSerializer.readBuildInFieldValue(
+          readContext, typeResolver, refReader, fieldInfo, buffer, targetObject);
+      return;
+    }
+    fieldAccessor.putObject(
+        targetObject, readField(readContext, refReader, generics, fieldInfo, buffer, action));
+  }
+
+  private Object readField(
+      ReadContext readContext,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      MemoryBuffer buffer,
+      CompatibleCollectionArrayReader.ReadAction action) {
+    if (action != null) {
+      return CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
+    }
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        if (fieldInfo.fieldAccessor == null) {
+          FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
+          return null;
+        }
+        return AbstractObjectSerializer.readBuildInFieldValue(
+            readContext, typeResolver, refReader, fieldInfo, buffer);
+      case CONTAINER:
+        return AbstractObjectSerializer.readContainerFieldValue(
+            readContext, typeResolver, refReader, generics, fieldInfo, buffer);
+      case OTHER:
+        return AbstractObjectSerializer.readField(
+            readContext, typeResolver, refReader, fieldInfo, buffer);
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
     }
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/FieldGroups.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/FieldGroups.java
@@ -24,7 +24,9 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.fory.meta.TypeExtMeta;
 import org.apache.fory.reflect.FieldAccessor;
@@ -52,21 +54,12 @@ public class FieldGroups {
   public FieldGroups(
       SerializationFieldInfo[] buildInFields,
       SerializationFieldInfo[] containerFields,
-      SerializationFieldInfo[] userTypeFields) {
+      SerializationFieldInfo[] userTypeFields,
+      SerializationFieldInfo[] allFields) {
     this.buildInFields = buildInFields;
     this.userTypeFields = userTypeFields;
     this.containerFields = containerFields;
-    int len = buildInFields.length + userTypeFields.length + containerFields.length;
-    SerializationFieldInfo[] fields = new SerializationFieldInfo[len];
-    System.arraycopy(buildInFields, 0, fields, 0, buildInFields.length);
-    System.arraycopy(containerFields, 0, fields, buildInFields.length, containerFields.length);
-    System.arraycopy(
-        userTypeFields,
-        0,
-        fields,
-        buildInFields.length + containerFields.length,
-        userTypeFields.length);
-    allFields = fields;
+    this.allFields = allFields;
   }
 
   public static FieldGroups buildFieldsInfo(TypeResolver typeResolver, List<Field> fields) {
@@ -109,24 +102,25 @@ public class FieldGroups {
         regularBuildIn.add(d);
       }
     }
+    Map<Descriptor, SerializationFieldInfo> fieldInfos = new IdentityHashMap<>();
     SerializationFieldInfo[] allBuildIn =
         new SerializationFieldInfo[primitives.size() + boxed.size() + regularBuildIn.size()];
     int cnt = 0;
     for (Descriptor d : primitives) {
-      allBuildIn[cnt++] = new SerializationFieldInfo(typeResolver, d);
+      allBuildIn[cnt++] = buildFieldInfo(typeResolver, d, FieldCodecCategory.BUILD_IN, fieldInfos);
     }
     for (Descriptor d : boxed) {
-      allBuildIn[cnt++] = new SerializationFieldInfo(typeResolver, d);
+      allBuildIn[cnt++] = buildFieldInfo(typeResolver, d, FieldCodecCategory.BUILD_IN, fieldInfos);
     }
     for (Descriptor d : regularBuildIn) {
-      allBuildIn[cnt++] = new SerializationFieldInfo(typeResolver, d);
+      allBuildIn[cnt++] = buildFieldInfo(typeResolver, d, FieldCodecCategory.BUILD_IN, fieldInfos);
     }
     cnt = 0;
     SerializationFieldInfo[] otherFields =
         new SerializationFieldInfo[grouper.getOtherDescriptors().size()];
     for (Descriptor descriptor : grouper.getOtherDescriptors()) {
       SerializationFieldInfo genericTypeField =
-          new SerializationFieldInfo(typeResolver, descriptor);
+          buildFieldInfo(typeResolver, descriptor, FieldCodecCategory.OTHER, fieldInfos);
       otherFields[cnt++] = genericTypeField;
     }
     cnt = 0;
@@ -135,12 +129,40 @@ public class FieldGroups {
     SerializationFieldInfo[] containerFields =
         new SerializationFieldInfo[collections.size() + maps.size()];
     for (Descriptor d : collections) {
-      containerFields[cnt++] = new SerializationFieldInfo(typeResolver, d);
+      containerFields[cnt++] =
+          buildFieldInfo(typeResolver, d, FieldCodecCategory.CONTAINER, fieldInfos);
     }
     for (Descriptor d : maps) {
-      containerFields[cnt++] = new SerializationFieldInfo(typeResolver, d);
+      containerFields[cnt++] =
+          buildFieldInfo(typeResolver, d, FieldCodecCategory.CONTAINER, fieldInfos);
     }
-    return new FieldGroups(allBuildIn, containerFields, otherFields);
+    SerializationFieldInfo[] allFields = new SerializationFieldInfo[grouper.getNumDescriptors()];
+    cnt = 0;
+    for (Descriptor descriptor : grouper.getSortedDescriptors()) {
+      SerializationFieldInfo fieldInfo = fieldInfos.get(descriptor);
+      if (fieldInfo == null) {
+        throw new IllegalStateException("Missing serialization field info for " + descriptor);
+      }
+      allFields[cnt++] = fieldInfo;
+    }
+    return new FieldGroups(allBuildIn, containerFields, otherFields, allFields);
+  }
+
+  private static SerializationFieldInfo buildFieldInfo(
+      TypeResolver typeResolver,
+      Descriptor descriptor,
+      FieldCodecCategory codecCategory,
+      Map<Descriptor, SerializationFieldInfo> fieldInfos) {
+    SerializationFieldInfo fieldInfo =
+        new SerializationFieldInfo(typeResolver, descriptor, codecCategory);
+    fieldInfos.put(descriptor, fieldInfo);
+    return fieldInfo;
+  }
+
+  public enum FieldCodecCategory {
+    BUILD_IN,
+    CONTAINER,
+    OTHER
   }
 
   public static final class SerializationFieldInfo {
@@ -165,9 +187,15 @@ public class FieldGroups {
     public final TypeInfoHolder classInfoHolder;
     public final TypeInfo containerTypeInfo;
     public final Serializer<?> containerSerializerOverride;
+    public final FieldCodecCategory codecCategory;
 
-    SerializationFieldInfo(TypeResolver resolver, Descriptor d) {
+    public SerializationFieldInfo(TypeResolver resolver, Descriptor d) {
+      this(resolver, d, FieldCodecCategory.OTHER);
+    }
+
+    SerializationFieldInfo(TypeResolver resolver, Descriptor d, FieldCodecCategory codecCategory) {
       this.descriptor = d;
+      this.codecCategory = codecCategory;
       this.type = descriptor.getRawType();
       this.typeRef = d.getTypeRef();
       this.dispatchId = DispatchId.getDispatchId(resolver, d);

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ObjectSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ObjectSerializer.java
@@ -33,7 +33,6 @@ import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.meta.TypeDef;
-import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.FieldGroups.SerializationFieldInfo;
 import org.apache.fory.serializer.struct.Fingerprint;
@@ -63,9 +62,7 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
   private static final Logger LOG = LoggerFactory.getLogger(ObjectSerializer.class);
 
   private final RecordInfo recordInfo;
-  private final SerializationFieldInfo[] buildInFields;
-  private final SerializationFieldInfo[] otherFields;
-  private final SerializationFieldInfo[] containerFields;
+  private final SerializationFieldInfo[] allFields;
   private final int classVersionHash;
 
   public ObjectSerializer(TypeResolver typeResolver, Class<T> cls) {
@@ -128,9 +125,7 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
       classVersionHash = 0;
     }
     FieldGroups fieldGroups = FieldGroups.buildFieldInfos(typeResolver, grouper);
-    buildInFields = fieldGroups.buildInFields;
-    otherFields = fieldGroups.userTypeFields;
-    containerFields = fieldGroups.containerFields;
+    allFields = fieldGroups.allFields;
   }
 
   @Override
@@ -139,11 +134,12 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
     if (typeResolver.checkClassVersion()) {
       buffer.writeInt32(classVersionHash);
     }
-    // write order: primitive,boxed,final,other,collection,map
+    // Protocol order: primitive, nullable primitive, then all non-primitives by field identifier.
     RefWriter refWriter = writeContext.getRefWriter();
-    writeBuildInFields(writeContext, value, refWriter);
-    writeContainerFields(writeContext, value, refWriter);
-    writeOtherFields(writeContext, value);
+    Generics generics = writeContext.getGenerics();
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      writeFieldByCodecCategory(writeContext, value, refWriter, generics, fieldInfo);
+    }
   }
 
   private void printWriteFieldDebugInfo(SerializationFieldInfo fieldInfo, MemoryBuffer buffer) {
@@ -162,42 +158,37 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
         buffer.readerIndex());
   }
 
-  private void writeOtherFields(WriteContext writeContext, T value) {
+  private void writeFieldByCodecCategory(
+      WriteContext writeContext,
+      T value,
+      RefWriter refWriter,
+      Generics generics,
+      SerializationFieldInfo fieldInfo) {
     MemoryBuffer buffer = writeContext.getBuffer();
-    RefWriter refWriter = writeContext.getRefWriter();
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printWriteFieldDebugInfo(fieldInfo, buffer);
-      }
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      Object fieldValue = fieldAccessor.getObject(value);
-      AbstractObjectSerializer.writeField(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+    if (Utils.DEBUG_OUTPUT_VERBOSE) {
+      printWriteFieldDebugInfo(fieldInfo, buffer);
     }
-  }
-
-  private void writeBuildInFields(WriteContext writeContext, T value, RefWriter refWriter) {
-    MemoryBuffer buffer = writeContext.getBuffer();
-    for (SerializationFieldInfo fieldInfo : this.buildInFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printWriteFieldDebugInfo(fieldInfo, buffer);
-      }
-      AbstractObjectSerializer.writeBuildInField(
-          writeContext, typeResolver, refWriter, fieldInfo, buffer, value);
-    }
-  }
-
-  private void writeContainerFields(WriteContext writeContext, T value, RefWriter refWriter) {
-    MemoryBuffer buffer = writeContext.getBuffer();
-    Generics generics = writeContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printWriteFieldDebugInfo(fieldInfo, buffer);
-      }
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      Object fieldValue = fieldAccessor.getObject(value);
-      writeContainerFieldValue(
-          writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, fieldValue);
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        AbstractObjectSerializer.writeBuildInField(
+            writeContext, typeResolver, refWriter, fieldInfo, buffer, value);
+        return;
+      case CONTAINER:
+        {
+          Object fieldValue = fieldInfo.fieldAccessor.getObject(value);
+          writeContainerFieldValue(
+              writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, fieldValue);
+          return;
+        }
+      case OTHER:
+        {
+          Object fieldValue = fieldInfo.fieldAccessor.getObject(value);
+          AbstractObjectSerializer.writeField(
+              writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+          return;
+        }
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
     }
   }
 
@@ -223,33 +214,12 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
       int hash = buffer.readInt32();
       checkClassVersion(type, hash, classVersionHash);
     }
-    Object[] fieldValues =
-        new Object[buildInFields.length + otherFields.length + containerFields.length];
+    Object[] fieldValues = new Object[allFields.length];
     int counter = 0;
-    // read order: primitive,boxed,final,other,collection,map
-    for (SerializationFieldInfo fieldInfo : this.buildInFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      fieldValues[counter++] =
-          readBuildInFieldValue(readContext, typeResolver, refReader, fieldInfo, buffer);
-    }
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-      fieldValues[counter++] = fieldValue;
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue = readField(readContext, typeResolver, refReader, fieldInfo, buffer);
-      fieldValues[counter++] = fieldValue;
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      fieldValues[counter++] =
+          readFieldByCodecCategory(readContext, refReader, generics, fieldInfo, buffer);
     }
     return fieldValues;
   }
@@ -261,38 +231,71 @@ public final class ObjectSerializer<T> extends AbstractObjectSerializer<T> {
       int hash = buffer.readInt32();
       checkClassVersion(type, hash, classVersionHash);
     }
-    // read order: primitive,boxed,final,other,collection,map
-    for (SerializationFieldInfo fieldInfo : this.buildInFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      // a numeric type can have only three kinds: primitive, not_null_boxed, nullable_boxed
-      readBuildInFieldValue(readContext, typeResolver, refReader, fieldInfo, buffer, obj);
-    }
     Generics generics = readContext.getGenerics();
-    for (SerializationFieldInfo fieldInfo : containerFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue =
-          readContainerFieldValue(
-              readContext, typeResolver, refReader, generics, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      fieldAccessor.putObject(obj, fieldValue);
-    }
-    for (SerializationFieldInfo fieldInfo : otherFields) {
-      if (Utils.DEBUG_OUTPUT_VERBOSE) {
-        printReadFieldDebugInfo(fieldInfo, buffer);
-      }
-      Object fieldValue = readField(readContext, typeResolver, refReader, fieldInfo, buffer);
-      FieldAccessor fieldAccessor = fieldInfo.fieldAccessor;
-      fieldAccessor.putObject(obj, fieldValue);
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      readAndSetFieldByCodecCategory(readContext, refReader, generics, fieldInfo, buffer, obj);
     }
     return obj;
   }
 
+  private Object readFieldByCodecCategory(
+      ReadContext readContext,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      MemoryBuffer buffer) {
+    if (Utils.DEBUG_OUTPUT_VERBOSE) {
+      printReadFieldDebugInfo(fieldInfo, buffer);
+    }
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        return readBuildInFieldValue(readContext, typeResolver, refReader, fieldInfo, buffer);
+      case CONTAINER:
+        return readContainerFieldValue(
+            readContext, typeResolver, refReader, generics, fieldInfo, buffer);
+      case OTHER:
+        return readField(readContext, typeResolver, refReader, fieldInfo, buffer);
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
+  }
+
+  private void readAndSetFieldByCodecCategory(
+      ReadContext readContext,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      MemoryBuffer buffer,
+      T obj) {
+    if (Utils.DEBUG_OUTPUT_VERBOSE) {
+      printReadFieldDebugInfo(fieldInfo, buffer);
+    }
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        // a numeric type can have only three kinds: primitive, not_null_boxed, nullable_boxed
+        readBuildInFieldValue(readContext, typeResolver, refReader, fieldInfo, buffer, obj);
+        return;
+      case CONTAINER:
+        {
+          Object fieldValue =
+              readContainerFieldValue(
+                  readContext, typeResolver, refReader, generics, fieldInfo, buffer);
+          fieldInfo.fieldAccessor.putObject(obj, fieldValue);
+          return;
+        }
+      case OTHER:
+        {
+          Object fieldValue = readField(readContext, typeResolver, refReader, fieldInfo, buffer);
+          fieldInfo.fieldAccessor.putObject(obj, fieldValue);
+          return;
+        }
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
+  }
+
   int getNumFields() {
-    return buildInFields.length + containerFields.length + otherFields.length;
+    return allFields.length;
   }
 
   public static int computeStructHash(TypeResolver typeResolver, DescriptorGrouper grouper) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ObjectStreamSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ObjectStreamSerializer.java
@@ -752,7 +752,7 @@ public class ObjectStreamSerializer extends AbstractObjectSerializer {
 
       // Build fieldIndexMap and putFieldTypes from serializer's field order.
       // This ensures putFields/writeFields API uses the same order as the serializer
-      // (buildIn, container, other groups), not ObjectStreamClass order.
+      // (primitive, nullable primitive, non-primitive), not ObjectStreamClass order.
       fieldIndexMap = new ObjectIntMap<>(4, 0.4f);
       if (streamTypeInfo != null
           && (streamTypeInfo.writeObjectMethod != null

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
@@ -412,16 +412,18 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
       fields.put(fieldKey(descriptor), i);
     }
     // Keep compatible-read descriptor ordering owned by TypeResolver, matching the sorted
-    // DescriptorGrouper order used by ObjectCodecBuilder and CompatibleCodecBuilder. FieldGroups
-    // may regroup descriptors for helper ownership, so it must not drive remote payload order.
-    List<Descriptor> remoteDescriptorsInWireOrder =
-        typeResolver
-            .createDescriptorGrouper(remoteTypeDef, remoteDescriptorClass)
-            .getSortedDescriptors();
+    // DescriptorGrouper order used by ObjectCodecBuilder and CompatibleCodecBuilder.
+    DescriptorGrouper remoteGrouper =
+        typeResolver.createDescriptorGrouper(remoteTypeDef, remoteDescriptorClass);
+    // Remote compatible reads must dispatch through the remote field's codec category. FieldGroups
+    // uses the grouper's sorted allFields order while retaining specialized
+    // build-in/container/other read paths.
+    SerializationFieldInfo[] remoteFieldInfosInWireOrder =
+        FieldGroups.buildFieldInfos(typeResolver, remoteGrouper).allFields;
     List<RemoteFieldInfo> remoteFields = new ArrayList<>(remoteFieldInfos.size());
     appendRemoteFields(
         remoteFields,
-        remoteDescriptorsInWireOrder,
+        remoteFieldInfosInWireOrder,
         remoteFieldInfosByKey,
         fieldIds,
         fields,
@@ -448,18 +450,17 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
 
   private void appendRemoteFields(
       List<RemoteFieldInfo> remoteFields,
-      List<Descriptor> remoteDescriptorsInWireOrder,
+      SerializationFieldInfo[] remoteFieldInfosInWireOrder,
       Map<String, FieldInfo> remoteFieldInfosByKey,
       Map<Short, Integer> fieldIds,
       Map<String, Integer> fields,
       List<Descriptor> localDescriptors) {
-    for (Descriptor descriptor : remoteDescriptorsInWireOrder) {
+    for (SerializationFieldInfo serializationFieldInfo : remoteFieldInfosInWireOrder) {
+      Descriptor descriptor = serializationFieldInfo.descriptor;
       FieldInfo fieldInfo = remoteFieldInfosByKey.get(remoteFieldKey(descriptor));
       if (fieldInfo == null) {
         throw new IllegalStateException("Missing remote field metadata for " + descriptor);
       }
-      SerializationFieldInfo serializationFieldInfo =
-          new SerializationFieldInfo(typeResolver, descriptor);
       int matchedId = matchField(fieldInfo, fieldIds, fields);
       Descriptor localDescriptor =
           matchedId == UNKNOWN_FIELD ? null : localDescriptors.get(matchedId);

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
@@ -176,6 +176,23 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
         fieldValue);
   }
 
+  protected final void writeFieldValue(
+      WriteContext writeContext, SerializationFieldInfo fieldInfo, Object fieldValue) {
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        writeBuildInFieldValue(writeContext, fieldInfo, fieldValue);
+        return;
+      case CONTAINER:
+        writeContainerFieldValue(writeContext, fieldInfo, fieldValue);
+        return;
+      case OTHER:
+        writeOtherFieldValue(writeContext, fieldInfo, fieldValue);
+        return;
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
+  }
+
   protected final Object readBuildInFieldValue(
       ReadContext readContext, SerializationFieldInfo fieldInfo) {
     // See writeBuildInFieldValue: built-in schema groups can still need container conversion.
@@ -201,6 +218,19 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
       ReadContext readContext, SerializationFieldInfo fieldInfo) {
     return AbstractObjectSerializer.readField(
         readContext, typeResolver, readContext.getRefReader(), fieldInfo, readContext.getBuffer());
+  }
+
+  protected final Object readFieldValue(ReadContext readContext, SerializationFieldInfo fieldInfo) {
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        return readBuildInFieldValue(readContext, fieldInfo);
+      case CONTAINER:
+        return readContainerFieldValue(readContext, fieldInfo);
+      case OTHER:
+        return readOtherFieldValue(readContext, fieldInfo);
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
   }
 
   protected final Object readRemoteField(ReadContext readContext, RemoteFieldInfo remoteField) {
@@ -357,15 +387,7 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
   }
 
   private Object readField(ReadContext readContext, SerializationFieldInfo fieldInfo) {
-    if (typeResolver.isCollectionDescriptor(fieldInfo.descriptor)
-        || typeResolver.isMap(fieldInfo.type)) {
-      return readContainerFieldValue(readContext, fieldInfo);
-    }
-    if (typeResolver.isBuildIn(fieldInfo.descriptor)
-        || typeResolver.usesPrimitiveFieldOrdering(fieldInfo.descriptor)) {
-      return readBuildInFieldValue(readContext, fieldInfo);
-    }
-    return readOtherFieldValue(readContext, fieldInfo);
+    return readFieldValue(readContext, fieldInfo);
   }
 
   private List<RemoteFieldInfo> buildRemoteFields(

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/UnknownClassSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/UnknownClassSerializers.java
@@ -47,15 +47,11 @@ public final class UnknownClassSerializers {
   private static final Logger LOG = LoggerFactory.getLogger(UnknownClassSerializers.class);
 
   private static final class ClassFieldsInfo {
-    private final SerializationFieldInfo[] buildInFields;
-    private final SerializationFieldInfo[] otherFields;
-    private final SerializationFieldInfo[] containerFields;
+    private final SerializationFieldInfo[] allFields;
     private final int classVersionHash;
 
     private ClassFieldsInfo(FieldGroups fieldGroups, int classVersionHash) {
-      this.buildInFields = fieldGroups.buildInFields;
-      this.otherFields = fieldGroups.userTypeFields;
-      this.containerFields = fieldGroups.containerFields;
+      this.allFields = fieldGroups.allFields;
       this.classVersionHash = classVersionHash;
     }
   }
@@ -180,28 +176,52 @@ public final class UnknownClassSerializers {
       if (config.checkClassVersion()) {
         buffer.writeInt32(fieldsInfo.classVersionHash);
       }
-      // write order: primitive,boxed,final,other,collection,map
-      for (SerializationFieldInfo fieldInfo : fieldsInfo.buildInFields) {
-        Object fieldValue = value.get(fieldInfo.qualifiedFieldName);
-        AbstractObjectSerializer.writeBuildInFieldValue(
-            writeContext, typeResolver, writeContext.getRefWriter(), fieldInfo, buffer, fieldValue);
-      }
+      // Protocol order: primitive, nullable primitive, then all non-primitives by field identifier.
       Generics generics = writeContext.getGenerics();
-      for (SerializationFieldInfo fieldInfo : fieldsInfo.containerFields) {
+      for (SerializationFieldInfo fieldInfo : fieldsInfo.allFields) {
         Object fieldValue = value.get(fieldInfo.qualifiedFieldName);
-        AbstractObjectSerializer.writeContainerFieldValue(
-            writeContext,
-            typeResolver,
-            writeContext.getRefWriter(),
-            generics,
-            fieldInfo,
-            buffer,
-            fieldValue);
+        writeFieldByCodecCategory(writeContext, generics, fieldInfo, buffer, fieldValue);
       }
-      for (SerializationFieldInfo fieldInfo : fieldsInfo.otherFields) {
-        Object fieldValue = value.get(fieldInfo.qualifiedFieldName);
-        AbstractObjectSerializer.writeField(
-            writeContext, typeResolver, writeContext.getRefWriter(), fieldInfo, buffer, fieldValue);
+    }
+
+    private void writeFieldByCodecCategory(
+        WriteContext writeContext,
+        Generics generics,
+        SerializationFieldInfo fieldInfo,
+        MemoryBuffer buffer,
+        Object fieldValue) {
+      switch (fieldInfo.codecCategory) {
+        case BUILD_IN:
+          AbstractObjectSerializer.writeBuildInFieldValue(
+              writeContext,
+              typeResolver,
+              writeContext.getRefWriter(),
+              fieldInfo,
+              buffer,
+              fieldValue);
+          return;
+        case CONTAINER:
+          AbstractObjectSerializer.writeContainerFieldValue(
+              writeContext,
+              typeResolver,
+              writeContext.getRefWriter(),
+              generics,
+              fieldInfo,
+              buffer,
+              fieldValue);
+          return;
+        case OTHER:
+          AbstractObjectSerializer.writeField(
+              writeContext,
+              typeResolver,
+              writeContext.getRefWriter(),
+              fieldInfo,
+              buffer,
+              fieldValue);
+          return;
+        default:
+          throw new IllegalStateException(
+              "Unknown field codec category " + fieldInfo.codecCategory);
       }
     }
 
@@ -228,29 +248,36 @@ public final class UnknownClassSerializers {
       UnknownClass.UnknownStruct obj = new UnknownClass.UnknownStruct(typeDef);
       readContext.reference(obj);
       List<MapEntry> entries = new ArrayList<>();
-      // read order: primitive,boxed,final,other,collection,map
+      // Protocol order: primitive, nullable primitive, then all non-primitives by field identifier.
       ClassFieldsInfo allFieldsInfo = getClassFieldsInfo(typeDef);
-      for (SerializationFieldInfo fieldInfo : allFieldsInfo.buildInFields) {
-        Object fieldValue =
-            AbstractObjectSerializer.readBuildInFieldValue(
-                readContext, typeResolver, readContext.getRefReader(), fieldInfo, buffer);
-        entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
-      }
       Generics generics = readContext.getGenerics();
-      for (SerializationFieldInfo fieldInfo : allFieldsInfo.containerFields) {
-        Object fieldValue =
-            AbstractObjectSerializer.readContainerFieldValue(
-                readContext, typeResolver, readContext.getRefReader(), generics, fieldInfo, buffer);
-        entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
-      }
-      for (SerializationFieldInfo fieldInfo : allFieldsInfo.otherFields) {
-        Object fieldValue =
-            AbstractObjectSerializer.readField(
-                readContext, typeResolver, readContext.getRefReader(), fieldInfo, buffer);
+      for (SerializationFieldInfo fieldInfo : allFieldsInfo.allFields) {
+        Object fieldValue = readFieldByCodecCategory(readContext, generics, fieldInfo, buffer);
         entries.add(new MapEntry(fieldInfo.qualifiedFieldName, fieldValue));
       }
       obj.setEntries(entries);
       return obj;
+    }
+
+    private Object readFieldByCodecCategory(
+        ReadContext readContext,
+        Generics generics,
+        SerializationFieldInfo fieldInfo,
+        MemoryBuffer buffer) {
+      switch (fieldInfo.codecCategory) {
+        case BUILD_IN:
+          return AbstractObjectSerializer.readBuildInFieldValue(
+              readContext, typeResolver, readContext.getRefReader(), fieldInfo, buffer);
+        case CONTAINER:
+          return AbstractObjectSerializer.readContainerFieldValue(
+              readContext, typeResolver, readContext.getRefReader(), generics, fieldInfo, buffer);
+        case OTHER:
+          return AbstractObjectSerializer.readField(
+              readContext, typeResolver, readContext.getRefReader(), fieldInfo, buffer);
+        default:
+          throw new IllegalStateException(
+              "Unknown field codec category " + fieldInfo.codecCategory);
+      }
     }
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
@@ -127,7 +127,7 @@ public class Descriptor {
     this.typeRef = typeRef;
     this.foryField = this.field.getAnnotation(ForyField.class);
     this.hasForyField = foryField != null;
-    this.foryFieldId = hasForyField ? foryField.id() : -1;
+    this.foryFieldId = resolveForyFieldId(foryField, name);
     this.dynamic = hasForyField ? foryField.dynamic() : ForyField.Dynamic.AUTO;
     typeAnnotation = getAnnotation(field);
     arrayType = field.isAnnotationPresent(ArrayType.class);
@@ -155,7 +155,7 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = null;
     this.hasForyField = false;
-    this.foryFieldId = -1;
+    this.foryFieldId = Integer.MIN_VALUE;
     this.dynamic = ForyField.Dynamic.AUTO;
     typeAnnotation = null;
     arrayType = false;
@@ -210,7 +210,10 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = null;
     this.hasForyField = hasForyField;
-    this.foryFieldId = hasForyField ? foryFieldId : -1;
+    if (hasForyField && foryFieldId < 0 && foryFieldId != Integer.MIN_VALUE) {
+      throw new IllegalArgumentException("@ForyField id must be non-negative for field " + name);
+    }
+    this.foryFieldId = hasForyField ? foryFieldId : Integer.MIN_VALUE;
     this.dynamic = hasForyField ? Objects.requireNonNull(dynamic) : ForyField.Dynamic.AUTO;
     typeAnnotation = null;
     this.arrayType = arrayType;
@@ -238,7 +241,7 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = this.field.getAnnotation(ForyField.class);
     this.hasForyField = foryField != null;
-    this.foryFieldId = hasForyField ? foryField.id() : -1;
+    this.foryFieldId = resolveForyFieldId(foryField, name);
     this.dynamic = hasForyField ? foryField.dynamic() : ForyField.Dynamic.AUTO;
     typeAnnotation = getAnnotation(field);
     arrayType = field.isAnnotationPresent(ArrayType.class);
@@ -261,7 +264,7 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = readMethod.getAnnotation(ForyField.class);
     this.hasForyField = foryField != null;
-    this.foryFieldId = hasForyField ? foryField.id() : -1;
+    this.foryFieldId = resolveForyFieldId(foryField, name);
     this.dynamic = hasForyField ? foryField.dynamic() : ForyField.Dynamic.AUTO;
     typeAnnotation =
         getTypeUseAnnotation(readMethod.getAnnotatedReturnType(), readMethod.getName());
@@ -287,12 +290,15 @@ public class Descriptor {
             ? builder.foryField
             : (this.field == null ? null : this.field.getAnnotation(ForyField.class));
     if (builder.hasForyField) {
+      if (builder.foryFieldId < 0 && builder.foryFieldId != Integer.MIN_VALUE) {
+        throw new IllegalArgumentException("@ForyField id must be non-negative for field " + name);
+      }
       this.hasForyField = true;
       this.foryFieldId = builder.foryFieldId;
       this.dynamic = Objects.requireNonNull(builder.dynamic);
     } else {
       this.hasForyField = foryField != null;
-      this.foryFieldId = hasForyField ? foryField.id() : -1;
+      this.foryFieldId = resolveForyFieldId(foryField, name);
       this.dynamic = hasForyField ? foryField.dynamic() : ForyField.Dynamic.AUTO;
     }
     typeAnnotation = field == null ? null : getAnnotation(field);
@@ -310,6 +316,18 @@ public class Descriptor {
 
   public DescriptorBuilder copyBuilder() {
     return new DescriptorBuilder(this);
+  }
+
+  private static int resolveForyFieldId(ForyField foryField, String fieldName) {
+    if (foryField == null) {
+      return Integer.MIN_VALUE;
+    }
+    int id = foryField.id();
+    if (id < 0 && id != Integer.MIN_VALUE) {
+      throw new IllegalArgumentException(
+          "@ForyField id must be non-negative for field " + fieldName);
+    }
+    return id;
   }
 
   public Descriptor copy(Method readMethod, Method writeMethod) {

--- a/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
@@ -155,7 +155,7 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = null;
     this.hasForyField = false;
-    this.foryFieldId = Integer.MIN_VALUE;
+    this.foryFieldId = -1;
     this.dynamic = ForyField.Dynamic.AUTO;
     typeAnnotation = null;
     arrayType = false;
@@ -210,10 +210,11 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = null;
     this.hasForyField = hasForyField;
-    if (hasForyField && foryFieldId < 0 && foryFieldId != Integer.MIN_VALUE) {
-      throw new IllegalArgumentException("@ForyField id must be non-negative for field " + name);
+    if (hasForyField && foryFieldId < -1) {
+      throw new IllegalArgumentException(
+          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + name);
     }
-    this.foryFieldId = hasForyField ? foryFieldId : Integer.MIN_VALUE;
+    this.foryFieldId = hasForyField ? foryFieldId : -1;
     this.dynamic = hasForyField ? Objects.requireNonNull(dynamic) : ForyField.Dynamic.AUTO;
     typeAnnotation = null;
     this.arrayType = arrayType;
@@ -290,8 +291,9 @@ public class Descriptor {
             ? builder.foryField
             : (this.field == null ? null : this.field.getAnnotation(ForyField.class));
     if (builder.hasForyField) {
-      if (builder.foryFieldId < 0 && builder.foryFieldId != Integer.MIN_VALUE) {
-        throw new IllegalArgumentException("@ForyField id must be non-negative for field " + name);
+      if (builder.foryFieldId < -1) {
+        throw new IllegalArgumentException(
+            "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + name);
       }
       this.hasForyField = true;
       this.foryFieldId = builder.foryFieldId;
@@ -320,12 +322,12 @@ public class Descriptor {
 
   private static int resolveForyFieldId(ForyField foryField, String fieldName) {
     if (foryField == null) {
-      return Integer.MIN_VALUE;
+      return -1;
     }
     int id = foryField.id();
-    if (id < 0 && id != Integer.MIN_VALUE) {
+    if (id < -1) {
       throw new IllegalArgumentException(
-          "@ForyField id must be non-negative for field " + fieldName);
+          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + fieldName);
     }
     return id;
   }

--- a/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
@@ -38,7 +38,7 @@ public class DescriptorBuilder {
   Method writeMethod;
   ForyField foryField;
   boolean hasForyField;
-  int foryFieldId = Integer.MIN_VALUE;
+  int foryFieldId = -1;
   ForyField.Dynamic dynamic = ForyField.Dynamic.AUTO;
   boolean arrayType;
   boolean nullable;
@@ -125,14 +125,15 @@ public class DescriptorBuilder {
     this.hasForyField = foryField != null;
     if (hasForyField) {
       this.foryFieldId = foryField.id();
-      if (foryFieldId < 0 && foryFieldId != Integer.MIN_VALUE) {
-        throw new IllegalArgumentException("@ForyField id must be non-negative");
+      if (foryFieldId < -1) {
+        throw new IllegalArgumentException(
+            "@ForyField id must be -1 (no tag ID) or a non-negative tag ID");
       }
       this.nullable = foryField.nullable();
       this.trackingRef = foryField.ref();
       this.dynamic = foryField.dynamic();
     } else {
-      this.foryFieldId = Integer.MIN_VALUE;
+      this.foryFieldId = -1;
       this.dynamic = ForyField.Dynamic.AUTO;
     }
     return this;

--- a/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
@@ -38,7 +38,7 @@ public class DescriptorBuilder {
   Method writeMethod;
   ForyField foryField;
   boolean hasForyField;
-  int foryFieldId = -1;
+  int foryFieldId = Integer.MIN_VALUE;
   ForyField.Dynamic dynamic = ForyField.Dynamic.AUTO;
   boolean arrayType;
   boolean nullable;
@@ -125,11 +125,14 @@ public class DescriptorBuilder {
     this.hasForyField = foryField != null;
     if (hasForyField) {
       this.foryFieldId = foryField.id();
+      if (foryFieldId < 0 && foryFieldId != Integer.MIN_VALUE) {
+        throw new IllegalArgumentException("@ForyField id must be non-negative");
+      }
       this.nullable = foryField.nullable();
       this.trackingRef = foryField.ref();
       this.dynamic = foryField.dynamic();
     } else {
-      this.foryFieldId = -1;
+      this.foryFieldId = Integer.MIN_VALUE;
       this.dynamic = ForyField.Dynamic.AUTO;
     }
     return this;

--- a/java/fory-core/src/main/java/org/apache/fory/type/DescriptorGrouper.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/DescriptorGrouper.java
@@ -31,7 +31,7 @@ import org.apache.fory.util.Preconditions;
 import org.apache.fory.util.record.RecordUtils;
 
 /**
- * A utility class to group class fields into groups.
+ * A utility class to group class fields into codec-owned groups.
  *
  * <ul>
  *   <li>primitive fields
@@ -49,9 +49,10 @@ import org.apache.fory.util.record.RecordUtils;
  * peer must independently sort fields using the same algorithm to ensure consistent
  * serialization/deserialization.
  *
- * <p>The sorting groups fields by type category (primitives, boxed, collections, maps, etc.) and
- * then sorts by field name within each category. Both reader and writer must apply this sorting to
- * produce identical field ordering.
+ * <p>The protocol field order is primitive non-nullable fields, primitive nullable fields, then all
+ * non-primitive fields sorted by field identifier. The codec-owned groups below are retained so
+ * serializers can keep specialized primitive, built-in, collection, map, and user-type operations;
+ * those implementation groups must not affect protocol order.
  */
 public class DescriptorGrouper {
 
@@ -72,6 +73,7 @@ public class DescriptorGrouper {
   private final Collection<Descriptor> mapDescriptors;
   private final Collection<Descriptor> buildInDescriptors;
   private Collection<Descriptor> otherDescriptors;
+  private Comparator<Descriptor> nonPrimitiveComparator;
 
   /**
    * Create a descriptor grouper.
@@ -109,12 +111,20 @@ public class DescriptorGrouper {
         descriptorsGroupedOrdered ? new ArrayList<>() : new TreeSet<>(comparator);
     this.otherDescriptors =
         descriptorsGroupedOrdered ? new ArrayList<>() : new TreeSet<>(comparator);
+    this.nonPrimitiveComparator = comparator;
   }
 
   public DescriptorGrouper setOtherDescriptorComparator(Comparator<Descriptor> comparator) {
     Preconditions.checkArgument(!sorted);
     this.otherDescriptors =
         descriptorsGroupedOrdered ? new ArrayList<>() : new TreeSet<>(comparator);
+    this.nonPrimitiveComparator = comparator;
+    return this;
+  }
+
+  public DescriptorGrouper setNonPrimitiveDescriptorComparator(Comparator<Descriptor> comparator) {
+    Preconditions.checkArgument(!sorted);
+    this.nonPrimitiveComparator = comparator;
     return this;
   }
 
@@ -173,10 +183,25 @@ public class DescriptorGrouper {
     List<Descriptor> descriptors = new ArrayList<>(getNumDescriptors());
     descriptors.addAll(getPrimitiveDescriptors());
     descriptors.addAll(getBoxedDescriptors());
+    descriptors.addAll(getNonPrimitiveDescriptors());
+    return descriptors;
+  }
+
+  public List<Descriptor> getNonPrimitiveDescriptors() {
+    Preconditions.checkArgument(sorted);
+    List<Descriptor> descriptors =
+        new ArrayList<>(
+            getBuildInDescriptors().size()
+                + getCollectionDescriptors().size()
+                + getMapDescriptors().size()
+                + getOtherDescriptors().size());
     descriptors.addAll(getBuildInDescriptors());
     descriptors.addAll(getCollectionDescriptors());
     descriptors.addAll(getMapDescriptors());
     descriptors.addAll(getOtherDescriptors());
+    if (!descriptorsGroupedOrdered) {
+      descriptors.sort(nonPrimitiveComparator);
+    }
     return descriptors;
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldSerializationTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldSerializationTest.java
@@ -62,13 +62,13 @@ public class ForyFieldSerializationTest extends ForyTestBase {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class PersonWithOptOutTagId {
-    @ForyField(id = -1, nullable = false)
+    @ForyField(nullable = false)
     public String veryLongFieldNameForFirstName;
 
-    @ForyField(id = -1, nullable = false)
+    @ForyField(nullable = false)
     public String anotherVeryLongFieldNameForLastName;
 
-    @ForyField(id = -1, nullable = false)
+    @ForyField(nullable = false)
     public int age;
   }
 
@@ -79,8 +79,8 @@ public class ForyFieldSerializationTest extends ForyTestBase {
     @ForyField(id = 0, nullable = false)
     public String firstName;
 
-    // This field uses field name (id = -1)
-    @ForyField(id = -1, nullable = false)
+    // This field uses field name metadata.
+    @ForyField(nullable = false)
     public String veryLongFieldNameForLastName;
 
     public int age; // No annotation, uses field name
@@ -197,7 +197,7 @@ public class ForyFieldSerializationTest extends ForyTestBase {
     assertEquals(deserializedWithOptOut.age, 30);
 
     System.out.printf(
-        "Mode: %s/%s/codegen=%s - With tag: %d bytes, Without tag: %d bytes, Opt-out (id=-1): %d bytes%n",
+        "Mode: %s/%s/codegen=%s - With tag: %d bytes, Without tag: %d bytes, Annotated without IDs: %d bytes%n",
         xlang,
         compatible,
         codegen,
@@ -213,20 +213,20 @@ public class ForyFieldSerializationTest extends ForyTestBase {
             "Expected tag ID version (%d bytes) to be <= field name version (%d bytes) in mode %s/%s/codegen=%s",
             bytesWithTag.length, bytesWithoutTag.length, xlang, compatible, codegen));
 
-    // Tag ID version should also be smaller than or equal to opt-out version (id=-1)
+    // Tag ID version should also be smaller than or equal to annotated-without-ID version.
     assertTrue(
         bytesWithTag.length <= bytesWithOptOut.length,
         String.format(
-            "Expected tag ID version (%d bytes) to be <= opt-out id=-1 version (%d bytes) in mode %s/%s/codegen=%s",
+            "Expected tag ID version (%d bytes) to be <= annotated-without-ID version (%d bytes) in mode %s/%s/codegen=%s",
             bytesWithTag.length, bytesWithOptOut.length, xlang, compatible, codegen));
 
-    // Opt-out (id=-1) should have similar size to no annotation (both use field names)
+    // Annotated fields without IDs should have similar size to no annotation.
     // They should be equal or very close in size
     int sizeDifference = Math.abs(bytesWithOptOut.length - bytesWithoutTag.length);
     assertTrue(
         sizeDifference <= 5,
         String.format(
-            "Expected opt-out id=-1 (%d bytes) to have similar size to no annotation (%d bytes), but difference is %d bytes",
+            "Expected annotated-without-ID (%d bytes) to have similar size to no annotation (%d bytes), but difference is %d bytes",
             bytesWithOptOut.length, bytesWithoutTag.length, sizeDifference));
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
@@ -44,10 +44,16 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     @ForyField(id = 5, nullable = false)
     public String fieldWithTag5;
 
-    @ForyField(id = -1, nullable = false)
+    @ForyField(nullable = false)
     public String fieldOptingOutOfTag;
 
     public String fieldWithoutAnnotation;
+  }
+
+  @Data
+  public static class NegativeTagIdClass {
+    @ForyField(id = -1)
+    public String invalidField;
   }
 
   @Test(dataProvider = "languageAndCodegen")
@@ -89,14 +95,14 @@ public class ForyFieldTagIdTest extends ForyTestBase {
         (short) 5,
         "Field with id=5 should have tag value 5 in xlang=" + xlang);
 
-    // Verify field with id=-1 does NOT have tag (opts out)
+    // Verify field with annotation but no ID does NOT have tag
     assertFalse(
         fieldOptOut.hasFieldId(),
-        "Field with id=-1 should NOT have tag (opt-out) in xlang=" + xlang);
+        "Field without configured ID should NOT have tag in xlang=" + xlang);
     assertEquals(
         fieldOptOut.getFieldName(),
         "fieldOptingOutOfTag",
-        "Field with id=-1 should use field name in xlang=" + xlang);
+        "Field without configured ID should use field name in xlang=" + xlang);
 
     // Verify field without annotation does NOT have tag
     assertFalse(
@@ -136,14 +142,14 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     // Verify annotation values
     assertEquals(annotation0.id(), 0, "Field 0 should have id=0");
     assertEquals(annotation5.id(), 5, "Field 5 should have id=5");
-    assertEquals(annotationOptOut.id(), -1, "Opt-out field should have id=-1");
+    assertEquals(annotationOptOut.id(), Integer.MIN_VALUE, "Field without ID should use sentinel");
     assertNull(
         annotationNoAnnotation, "Field without annotation should have no ForyField annotation");
   }
 
   @Test
-  public void testIdMinusOneOptOutBehavior() {
-    // Test that id=-1 explicitly opts out of tag ID usage
+  public void testMissingIdUsesFieldNameBehavior() {
+    // Test that omitting id uses field-name metadata.
     Fory fory =
         Fory.builder()
             .withXlang(true)
@@ -167,6 +173,19 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     assertEquals(deserialized.getFieldWithTag5(), "value5");
     assertEquals(deserialized.getFieldOptingOutOfTag(), "optOutValue");
     assertEquals(deserialized.getFieldWithoutAnnotation(), "noAnnotationValue");
+  }
+
+  @Test
+  public void testNegativeTagIdRejected() {
+    Fory fory =
+        Fory.builder()
+            .withXlang(true)
+            .withCompatible(false)
+            .requireClassRegistration(false)
+            .build();
+    org.testng.Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDef.buildTypeDef(fory.getTypeResolver(), NegativeTagIdClass.class));
   }
 
   /** Helper method to find a FieldInfo by field name */

--- a/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
@@ -52,7 +52,7 @@ public class ForyFieldTagIdTest extends ForyTestBase {
 
   @Data
   public static class NegativeTagIdClass {
-    @ForyField(id = -1)
+    @ForyField(id = -2)
     public String invalidField;
   }
 
@@ -142,7 +142,7 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     // Verify annotation values
     assertEquals(annotation0.id(), 0, "Field 0 should have id=0");
     assertEquals(annotation5.id(), 5, "Field 5 should have id=5");
-    assertEquals(annotationOptOut.id(), Integer.MIN_VALUE, "Field without ID should use sentinel");
+    assertEquals(annotationOptOut.id(), -1, "Field without ID should use sentinel");
     assertNull(
         annotationNoAnnotation, "Field without annotation should have no ForyField annotation");
   }

--- a/java/fory-core/src/test/java/org/apache/fory/builder/ObjectCodecBuilderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/builder/ObjectCodecBuilderTest.java
@@ -154,7 +154,7 @@ public class ObjectCodecBuilderTest extends ForyTestBase {
     public long f2;
     public String f3;
     public List<String> f4;
-    public Map<String, Integer> f5;
+    public Object f5;
   }
 
   @Test(dataProvider = "compressNumber")
@@ -175,7 +175,7 @@ public class ObjectCodecBuilderTest extends ForyTestBase {
     JaninoUtils.CodeStats classStats = JaninoUtils.getClassStats(bytecode);
     Assert.assertFalse(
         classStats.methodsSize.keySet().stream()
-            .anyMatch(name -> name.startsWith("writeFields") || name.startsWith("readFields")));
+            .anyMatch(name -> name.startsWith("writeFields") || name.startsWith("readField")));
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/builder/ObjectCodecBuilderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/builder/ObjectCodecBuilderTest.java
@@ -148,6 +148,36 @@ public class ObjectCodecBuilderTest extends ForyTestBase {
                         e.getKey(), compileUnit.getQualifiedClassName(), e.getValue())));
   }
 
+  @Data
+  public static class SmallInlineFields {
+    public int f1;
+    public long f2;
+    public String f3;
+    public List<String> f4;
+    public Map<String, Integer> f5;
+  }
+
+  @Test(dataProvider = "compressNumber")
+  public void testSmallStructInlinesFieldGroups(boolean compressNumber) {
+    Fory fory =
+        Fory.builder().withNumberCompressed(compressNumber).requireClassRegistration(false).build();
+    ObjectCodecBuilder codecBuilder = new ObjectCodecBuilder(SmallInlineFields.class, fory);
+    CompileUnit compileUnit =
+        new CompileUnit(
+            CodeGenerator.getPackage(SmallInlineFields.class),
+            codecBuilder.codecClassName(SmallInlineFields.class),
+            codecBuilder::genCode);
+    byte[] bytecode =
+        JaninoUtils.toBytecode(SmallInlineFields.class.getClassLoader(), compileUnit)
+            .values()
+            .iterator()
+            .next();
+    JaninoUtils.CodeStats classStats = JaninoUtils.getClassStats(bytecode);
+    Assert.assertFalse(
+        classStats.methodsSize.keySet().stream()
+            .anyMatch(name -> name.startsWith("writeFields") || name.startsWith("readFields")));
+  }
+
   @Test
   public void testContainer() {
     Fory fory = Fory.builder().withXlang(false).requireClassRegistration(false).build();

--- a/java/fory-core/src/test/java/org/apache/fory/builder/StaticCompatibleCodecBuilderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/builder/StaticCompatibleCodecBuilderTest.java
@@ -34,7 +34,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
@@ -49,7 +51,10 @@ import org.apache.fory.meta.TypeDef;
 import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.reflect.TypeRef;
 import org.apache.fory.resolver.TypeResolver;
+import org.apache.fory.serializer.FieldGroups.FieldCodecCategory;
 import org.apache.fory.serializer.Serializer;
+import org.apache.fory.serializer.StaticGeneratedStructSerializer;
+import org.apache.fory.serializer.StaticGeneratedStructSerializer.RemoteFieldInfo;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -147,6 +152,60 @@ public class StaticCompatibleCodecBuilderTest {
       Assert.assertEquals(getField(readerType, result, "id"), 42);
       Assert.assertEquals(getField(readerType, result, "added"), "default");
       Assert.assertEquals(getField(readerType, result, "name"), xlang ? "xlang" : "native");
+    }
+  }
+
+  @Test
+  public void testStaticCompatibleSerializerPreservesRemoteCodecCategories() throws Exception {
+    CompilationResult writerResult =
+        compile(
+            "test.StaticCompatibleCategoryPayload",
+            "package test;\n"
+                + "import java.util.List;\n"
+                + "import java.util.Map;\n"
+                + "public class StaticCompatibleCategoryPayload {\n"
+                + "  public int id;\n"
+                + "  public String name;\n"
+                + "  public List<String> labels;\n"
+                + "  public Map<String, Integer> scores;\n"
+                + "  public StaticCompatibleCategoryPayload() {}\n"
+                + "}\n");
+    CompilationResult readerResult =
+        compile(
+            "test.StaticCompatibleCategoryPayload",
+            "package test;\n"
+                + "import java.util.List;\n"
+                + "import java.util.Map;\n"
+                + "public class StaticCompatibleCategoryPayload {\n"
+                + "  public int id;\n"
+                + "  public String name;\n"
+                + "  public List<String> labels;\n"
+                + "  public Map<String, Integer> scores;\n"
+                + "  public StaticCompatibleCategoryPayload() {}\n"
+                + "}\n");
+    Assert.assertTrue(writerResult.success, writerResult.diagnostics());
+    Assert.assertTrue(readerResult.success, readerResult.diagnostics());
+    try (URLClassLoader writerLoader = writerResult.classLoader();
+        URLClassLoader readerLoader = readerResult.classLoader()) {
+      Class<?> writerType = writerLoader.loadClass("test.StaticCompatibleCategoryPayload");
+      Class<?> readerType = readerLoader.loadClass("test.StaticCompatibleCategoryPayload");
+      Fory writer = compatibleFory(writerLoader, writerType, false, "category-writer");
+      Fory reader = compatibleFory(readerLoader, readerType, false, "category-reader");
+      TypeDef remoteTypeDef = TypeDef.buildTypeDef(writer.getTypeResolver(), writerType);
+      Class<Object> readerClass = cast(readerType);
+      Class<? extends Serializer> compatibleSerializerClass =
+          CodecUtils.loadOrGenStaticCompatibleCodecClass(
+              reader.getTypeResolver(), readerClass, remoteTypeDef);
+      Serializer<Object> compatibleSerializer =
+          compatibleSerializerClass
+              .getConstructor(TypeResolver.class, Class.class, TypeDef.class)
+              .newInstance(reader.getTypeResolver(), readerClass, remoteTypeDef);
+
+      Map<String, FieldCodecCategory> categories = remoteCodecCategories(compatibleSerializer);
+      Assert.assertEquals(categories.get("id"), FieldCodecCategory.BUILD_IN);
+      Assert.assertEquals(categories.get("name"), FieldCodecCategory.BUILD_IN);
+      Assert.assertEquals(categories.get("labels"), FieldCodecCategory.CONTAINER);
+      Assert.assertEquals(categories.get("scores"), FieldCodecCategory.CONTAINER);
     }
   }
 
@@ -415,6 +474,21 @@ public class StaticCompatibleCodecBuilderTest {
           atLeastOnce());
       return result;
     }
+  }
+
+  private static Map<String, FieldCodecCategory> remoteCodecCategories(
+      Serializer<Object> compatibleSerializer) throws Exception {
+    Field remoteFieldsField =
+        StaticGeneratedStructSerializer.class.getDeclaredField("remoteFields");
+    remoteFieldsField.setAccessible(true);
+    List<?> remoteFields = (List<?>) remoteFieldsField.get(compatibleSerializer);
+    Map<String, FieldCodecCategory> categories = new HashMap<>();
+    for (Object field : remoteFields) {
+      RemoteFieldInfo remoteField = (RemoteFieldInfo) field;
+      categories.put(
+          remoteField.descriptor.getName(), remoteField.serializationFieldInfo.codecCategory);
+    }
+    return categories;
   }
 
   private static Fory compatibleFory(

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
@@ -82,7 +82,6 @@ public class TypeDefEncoderTest {
 
     private String noAnnotation;
 
-    @ForyField(id = -1) // -1 means use field name
     private String optOutField;
 
     @ForyField(id = 60)
@@ -97,11 +96,17 @@ public class TypeDefEncoderTest {
 
     private String noAnnotation;
 
-    @ForyField(id = -1) // -1 means use field name
     private String optOutField;
 
     @ForyField(id = 50) // Duplicate with annotatedField1
     private int annotatedField2;
+  }
+
+  // Test data: Class with invalid negative tag ID
+  @Data
+  public static class ClassWithNegativeTagId {
+    @ForyField(id = -1)
+    private String field;
   }
 
   // Test data: Class with single field
@@ -120,6 +125,15 @@ public class TypeDefEncoderTest {
   }
 
   public static class EmptyStruct {}
+
+  public static class ParentNameOrderedNonPrimitives {
+    private String zString;
+  }
+
+  public static class ChildNameOrderedNonPrimitives extends ParentNameOrderedNonPrimitives {
+    private Map<String, Integer> aMap;
+    private int count;
+  }
 
   @Data
   public static class ClassWithNameOrderedNonPrimitives {
@@ -178,16 +192,13 @@ public class TypeDefEncoderTest {
     int f31;
   }
 
-  // Test data: Class with all fields using field names (tagId = -1)
+  // Test data: Class with all fields using field names
   @Data
   public static class ClassWithAllFieldNames {
-    @ForyField(id = -1)
     private String field1;
 
-    @ForyField(id = -1)
     private int field2;
 
-    @ForyField(id = -1)
     private double field3;
   }
 
@@ -292,7 +303,7 @@ public class TypeDefEncoderTest {
     Assert.assertFalse(fieldInfos.get(1).hasFieldId());
     Assert.assertEquals(fieldInfos.get(1).getFieldName(), "noAnnotation");
 
-    // optOutField with id=-1 should not have a tag (uses field name)
+    // optOutField should not have a tag (uses field name)
     Assert.assertFalse(fieldInfos.get(2).hasFieldId());
     Assert.assertEquals(fieldInfos.get(2).getFieldName(), "optOutField");
 
@@ -319,6 +330,16 @@ public class TypeDefEncoderTest {
         IllegalArgumentException.class,
         () ->
             TypeDefEncoder.buildFieldsInfo(resolver, ClassWithMixedDuplicateTagIds.class, fields));
+  }
+
+  @Test
+  public void testBuildFieldsInfoRejectsNegativeTagId() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    TypeResolver resolver = fory.getTypeResolver();
+    List<Field> fields = Collections.singletonList(getField(ClassWithNegativeTagId.class, "field"));
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDefEncoder.buildFieldsInfo(resolver, ClassWithNegativeTagId.class, fields));
   }
 
   @Test
@@ -378,7 +399,7 @@ public class TypeDefEncoderTest {
 
     Assert.assertEquals(fieldInfos.size(), 3);
 
-    // All fields with id=-1 should not have tags (use field names)
+    // All fields without configured IDs should not have tags (use field names)
     for (FieldInfo fieldInfo : fieldInfos) {
       Assert.assertFalse(fieldInfo.hasFieldId());
     }
@@ -439,6 +460,17 @@ public class TypeDefEncoderTest {
         TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithNameOrderedNonPrimitives.class);
 
     Assert.assertEquals(fieldNames(typeDef), Arrays.asList("count", "aMap", "mList", "zString"));
+  }
+
+  @Test
+  public void testTypeDefOrdersInheritedNonPrimitivesByProtocolOrder() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ChildNameOrderedNonPrimitives.class);
+
+    TypeDef typeDef =
+        TypeDef.buildTypeDef(fory.getTypeResolver(), ChildNameOrderedNonPrimitives.class);
+
+    Assert.assertEquals(fieldNames(typeDef), Arrays.asList("count", "aMap", "zString"));
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
@@ -105,7 +105,7 @@ public class TypeDefEncoderTest {
   // Test data: Class with invalid negative tag ID
   @Data
   public static class ClassWithNegativeTagId {
-    @ForyField(id = -1)
+    @ForyField(id = -2)
     private String field;
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
@@ -135,6 +135,27 @@ public class TypeDefEncoderTest {
     private int count;
   }
 
+  public static class ParentShadowedField {
+    private String duplicateName;
+  }
+
+  public static class ChildShadowedField extends ParentShadowedField {
+    private String duplicateName;
+    private int count;
+  }
+
+  public static class ClassWithSnakeCaseCollision {
+    private String fooBar;
+    private String foo_bar;
+  }
+
+  public static class ClassWithTaggedSnakeCaseCollision {
+    @ForyField(id = 7)
+    private String fooBar;
+
+    private String foo_bar;
+  }
+
   @Data
   public static class ClassWithNameOrderedNonPrimitives {
     private String zString;
@@ -471,6 +492,37 @@ public class TypeDefEncoderTest {
         TypeDef.buildTypeDef(fory.getTypeResolver(), ChildNameOrderedNonPrimitives.class);
 
     Assert.assertEquals(fieldNames(typeDef), Arrays.asList("count", "aMap", "zString"));
+  }
+
+  @Test
+  public void testTypeDefDropsOnlyInheritedShadowedXlangName() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ChildShadowedField.class);
+
+    TypeDef typeDef = TypeDef.buildTypeDef(fory.getTypeResolver(), ChildShadowedField.class);
+
+    Assert.assertEquals(fieldNames(typeDef), Arrays.asList("count", "duplicateName"));
+  }
+
+  @Test
+  public void testTypeDefRejectsUntaggedSnakeCaseCollision() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ClassWithSnakeCaseCollision.class);
+
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithSnakeCaseCollision.class));
+  }
+
+  @Test
+  public void testTypeDefAllowsTaggedSnakeCaseCollision() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ClassWithTaggedSnakeCaseCollision.class);
+
+    TypeDef typeDef =
+        TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithTaggedSnakeCaseCollision.class);
+
+    Assert.assertEquals(fieldNames(typeDef), Arrays.asList("fooBar", "foo_bar"));
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Data;
 import org.apache.fory.Fory;
 import org.apache.fory.annotation.ForyField;
@@ -118,6 +120,28 @@ public class TypeDefEncoderTest {
   }
 
   public static class EmptyStruct {}
+
+  @Data
+  public static class ClassWithNameOrderedNonPrimitives {
+    private String zString;
+    private Map<String, Integer> aMap;
+    private List<String> mList;
+    private int count;
+  }
+
+  @Data
+  public static class ClassWithTaggedNonPrimitives {
+    @ForyField(id = 3)
+    private String stringField;
+
+    @ForyField(id = 1)
+    private Map<String, Integer> mapField;
+
+    @ForyField(id = 2)
+    private List<String> listField;
+
+    private int count;
+  }
 
   public static class ManyFields {
     int f00;
@@ -407,6 +431,29 @@ public class TypeDefEncoderTest {
   }
 
   @Test
+  public void testTypeDefOrdersNonPrimitivesByNameIdentifier() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ClassWithNameOrderedNonPrimitives.class);
+
+    TypeDef typeDef =
+        TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithNameOrderedNonPrimitives.class);
+
+    Assert.assertEquals(fieldNames(typeDef), Arrays.asList("count", "aMap", "mList", "zString"));
+  }
+
+  @Test
+  public void testTypeDefOrdersNonPrimitivesByNumericTagIdentifier() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
+    fory.register(ClassWithTaggedNonPrimitives.class);
+
+    TypeDef typeDef =
+        TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithTaggedNonPrimitives.class);
+
+    Assert.assertEquals(
+        fieldNames(typeDef), Arrays.asList("count", "mapField", "listField", "stringField"));
+  }
+
+  @Test
   public void testExtendedFieldCountHeaderDoesNotSetRegisterByName() {
     Fory fory = Fory.builder().withXlang(true).withCompatible(false).withMetaShare(true).build();
     fory.register(ManyFields.class, 6002);
@@ -548,6 +595,12 @@ public class TypeDefEncoderTest {
     Assert.assertTrue(index >= Long.BYTES);
     malformed[index + needleBytes.length - 1] ^= 1;
     return malformed;
+  }
+
+  private static List<String> fieldNames(TypeDef typeDef) {
+    return typeDef.getFieldsInfo().stream()
+        .map(FieldInfo::getFieldName)
+        .collect(Collectors.toList());
   }
 
   private static byte[] rewriteHeaderWithBodyOnlyHash(TypeDef typeDef) {

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefTest.java
@@ -530,7 +530,7 @@ public class TypeDefTest extends ForyTestBase {
     fory.register(TestFieldsOrderClass2.class, "demo.Class2");
     TypeDef typeDef = TypeDef.buildTypeDef(fory.getTypeResolver(), TestFieldsOrderClass2.class);
     assertEquals(typeDef.getClassName(), TestFieldsOrderClass2.class.getName());
-    // xtype ignore duplicate fields from parent class.
+    // Xlang TypeDef keeps the nearest field when a child hides an inherited field by name.
     assertEquals(
         typeDef.getFieldsInfo().size(),
         ReflectionUtils.getFields(TestFieldsOrderClass2.class, true).size() - 1);

--- a/java/fory-core/src/test/java/org/apache/fory/type/DescriptorGrouperTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/type/DescriptorGrouperTest.java
@@ -379,4 +379,28 @@ public class DescriptorGrouperTest extends ForyTestBase {
         createDescriptor(TypeRef.of(Instant.class), "a_instant", -1, "TestClass", false);
     assertTrue(comparator.compare(date, instant) > 0);
   }
+
+  @Test
+  public void testXlangSortedDescriptorsCollapseNonPrimitiveGroups() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(false).build();
+    List<Descriptor> descriptors = new ArrayList<>();
+    descriptors.add(createDescriptor(TypeRef.of(int.class), "m_int", -1, "TestClass", false));
+    descriptors.add(createDescriptor(TypeRef.of(Integer.class), "n_int", -1, "TestClass", false));
+    descriptors.add(createDescriptor(TypeRef.of(String.class), "z_string", -1, "TestClass", false));
+    descriptors.add(
+        createDescriptor(new TypeRef<Map<String, Integer>>() {}, "a_map", -1, "TestClass", false));
+    descriptors.add(
+        createDescriptor(new TypeRef<List<String>>() {}, "b_list", -1, "TestClass", false));
+    descriptors.add(createDescriptor(TypeRef.of(Object.class), "c_object", -1, "TestClass", false));
+
+    DescriptorGrouper grouper =
+        fory.getTypeResolver().groupDescriptors(descriptors, false, descriptor -> descriptor);
+
+    List<String> sortedNames =
+        grouper.getSortedDescriptors().stream()
+            .map(Descriptor::getName)
+            .collect(Collectors.toList());
+    assertEquals(
+        sortedNames, Arrays.asList("m_int", "n_int", "a_map", "b_list", "c_object", "z_string"));
+  }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/xlang/XlangTestBase.java
+++ b/java/fory-core/src/test/java/org/apache/fory/xlang/XlangTestBase.java
@@ -1444,7 +1444,7 @@ public abstract class XlangTestBase extends ForyTestBase {
   static class VersionCheckStruct {
     int f1;
 
-    @ForyField(id = -1, nullable = true)
+    @ForyField(nullable = true)
     String f2;
 
     double f3;
@@ -1494,7 +1494,7 @@ public abstract class XlangTestBase extends ForyTestBase {
   public static class Dog implements Animal {
     int age;
 
-    @ForyField(id = -1, nullable = true)
+    @ForyField(nullable = true)
     String name;
 
     @Override

--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -74,8 +74,8 @@ export const isPrimitiveTypeId = (typeId: number): boolean => {
 
 export const refTrackingUnableTypeId = (typeId: number): boolean => {
   return (
-    PRIMITIVE_TYPE_IDS.includes(typeId as any) ||
-    [TypeId.DURATION, TypeId.DATE, TypeId.TIMESTAMP, TypeId.STRING].includes(
+    PRIMITIVE_TYPE_IDS.includes(typeId as any)
+    || [TypeId.DURATION, TypeId.DATE, TypeId.TIMESTAMP, TypeId.STRING].includes(
       typeId as any,
     )
   );
@@ -355,10 +355,10 @@ export class TypeMeta {
 
   private fingerprintTypeId(typeId: number) {
     if (
-      TypeId.userDefinedType(typeId) ||
-      typeId === TypeId.UNION ||
-      typeId === TypeId.TYPED_UNION ||
-      typeId === TypeId.NAMED_UNION
+      TypeId.userDefinedType(typeId)
+      || typeId === TypeId.UNION
+      || typeId === TypeId.TYPED_UNION
+      || typeId === TypeId.NAMED_UNION
     ) {
       return TypeId.UNKNOWN;
     }
@@ -387,8 +387,8 @@ export class TypeMeta {
           if (fieldTypeId === TypeId.NAMED_ENUM) {
             fieldTypeId = TypeId.ENUM;
           } else if (
-            fieldTypeId === TypeId.NAMED_UNION ||
-            fieldTypeId === TypeId.TYPED_UNION
+            fieldTypeId === TypeId.NAMED_UNION
+            || fieldTypeId === TypeId.TYPED_UNION
           ) {
             fieldTypeId = TypeId.UNION;
           }
@@ -633,8 +633,8 @@ export class TypeMeta {
       if (typeId === TypeId.NAMED_ENUM) {
         typeId = TypeId.ENUM;
       } else if (
-        typeId === TypeId.NAMED_UNION ||
-        typeId === TypeId.TYPED_UNION
+        typeId === TypeId.NAMED_UNION
+        || typeId === TypeId.TYPED_UNION
       ) {
         typeId = TypeId.UNION;
       }
@@ -786,12 +786,12 @@ export class TypeMeta {
 
     let currentClassHeader: number;
     if (isStruct) {
-      currentClassHeader =
-        STRUCT_TYPEDEF_FLAG |
-        Math.min(this.fields.length, SMALL_NUM_FIELDS_THRESHOLD);
+      currentClassHeader
+        = STRUCT_TYPEDEF_FLAG
+        | Math.min(this.fields.length, SMALL_NUM_FIELDS_THRESHOLD);
       if (
-        this.type.typeId === TypeId.COMPATIBLE_STRUCT ||
-        this.type.typeId === TypeId.NAMED_COMPATIBLE_STRUCT
+        this.type.typeId === TypeId.COMPATIBLE_STRUCT
+        || this.type.typeId === TypeId.NAMED_COMPATIBLE_STRUCT
       ) {
         currentClassHeader |= COMPATIBLE_TYPEDEF_FLAG;
       }
@@ -978,8 +978,8 @@ export class TypeMeta {
     if (isCompressed) {
       headerLowBits |= COMPRESS_META_FLAG;
     }
-    const header =
-      TypeMeta.headerHashBits(buffer, headerLowBits) | headerLowBits;
+    const header
+      = TypeMeta.headerHashBits(buffer, headerLowBits) | headerLowBits;
     return {
       header: BigInt.asUintN(64, header),
       headerHash: Number(header >> HASH_SHIFT_BITS),
@@ -1036,9 +1036,9 @@ export class TypeMeta {
       if (c >= "A" && c <= "Z") {
         if (i > 0) {
           const prevUpper = chars[i - 1] >= "A" && chars[i - 1] <= "Z";
-          const nextUpperOrEnd =
-            i + 1 >= chars.length ||
-            (chars[i + 1] >= "A" && chars[i + 1] <= "Z");
+          const nextUpperOrEnd
+            = i + 1 >= chars.length
+            || (chars[i + 1] >= "A" && chars[i + 1] <= "Z");
 
           if (!prevUpper || !nextUpperOrEnd) {
             result.push("_");
@@ -1071,12 +1071,12 @@ export class TypeMeta {
     b: { fieldName: string; fieldId?: number },
   ) {
     if (
-      a.fieldId !== undefined &&
-      a.fieldId !== null &&
-      a.fieldId >= 0 &&
-      b.fieldId !== undefined &&
-      b.fieldId !== null &&
-      b.fieldId >= 0
+      a.fieldId !== undefined
+      && a.fieldId !== null
+      && a.fieldId >= 0
+      && b.fieldId !== undefined
+      && b.fieldId !== null
+      && b.fieldId >= 0
     ) {
       return a.fieldId - b.fieldId;
     }

--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -74,8 +74,8 @@ export const isPrimitiveTypeId = (typeId: number): boolean => {
 
 export const refTrackingUnableTypeId = (typeId: number): boolean => {
   return (
-    PRIMITIVE_TYPE_IDS.includes(typeId as any)
-    || [TypeId.DURATION, TypeId.DATE, TypeId.TIMESTAMP, TypeId.STRING].includes(
+    PRIMITIVE_TYPE_IDS.includes(typeId as any) ||
+    [TypeId.DURATION, TypeId.DATE, TypeId.TIMESTAMP, TypeId.STRING].includes(
       typeId as any,
     )
   );
@@ -165,7 +165,7 @@ export class FieldInfo {
   }
 
   hasFieldId() {
-    return typeof this.fieldId === "number";
+    return typeof this.fieldId === "number" && this.fieldId >= 0;
   }
 
   getFieldId() {
@@ -355,10 +355,10 @@ export class TypeMeta {
 
   private fingerprintTypeId(typeId: number) {
     if (
-      TypeId.userDefinedType(typeId)
-      || typeId === TypeId.UNION
-      || typeId === TypeId.TYPED_UNION
-      || typeId === TypeId.NAMED_UNION
+      TypeId.userDefinedType(typeId) ||
+      typeId === TypeId.UNION ||
+      typeId === TypeId.TYPED_UNION ||
+      typeId === TypeId.NAMED_UNION
     ) {
       return TypeId.UNKNOWN;
     }
@@ -378,6 +378,7 @@ export class TypeMeta {
     let fieldInfo: FieldInfo[] = [];
     if (TypeId.structType(typeInfo.typeId)) {
       const structTypeInfo = typeInfo;
+      const usedFieldIds = new Set<number>();
       fieldInfo = Object.entries(structTypeInfo.options!.props!).map(
         ([fieldName, typeInfo]) => {
           let fieldTypeId = typeResolver
@@ -386,12 +387,22 @@ export class TypeMeta {
           if (fieldTypeId === TypeId.NAMED_ENUM) {
             fieldTypeId = TypeId.ENUM;
           } else if (
-            fieldTypeId === TypeId.NAMED_UNION
-            || fieldTypeId === TypeId.TYPED_UNION
+            fieldTypeId === TypeId.NAMED_UNION ||
+            fieldTypeId === TypeId.TYPED_UNION
           ) {
             fieldTypeId = TypeId.UNION;
           }
           const { trackingRef, nullable, id, userTypeId, options } = typeInfo;
+          if (typeof id === "number" && id < 0) {
+            throw new Error(`Field id for ${fieldName} must be non-negative`);
+          }
+          const fieldId = typeof id === "number" ? id : undefined;
+          if (fieldId !== undefined) {
+            if (usedFieldIds.has(fieldId)) {
+              throw new Error(`Duplicate field id ${fieldId}`);
+            }
+            usedFieldIds.add(fieldId);
+          }
           return new FieldInfo(
             fieldName,
             fieldTypeId,
@@ -399,7 +410,7 @@ export class TypeMeta {
             trackingRef,
             nullable,
             options!,
-            id,
+            fieldId,
           );
         },
       );
@@ -543,7 +554,10 @@ export class TypeMeta {
     );
   }
 
-  private static readMetaSizeFromLow(reader: BinaryReader, headerLow: number): number {
+  private static readMetaSizeFromLow(
+    reader: BinaryReader,
+    headerLow: number,
+  ): number {
     let metaSize = headerLow & META_SIZE_MASKS;
     if (metaSize === META_SIZE_MASKS) {
       metaSize += reader.readVarUInt32();
@@ -619,8 +633,8 @@ export class TypeMeta {
       if (typeId === TypeId.NAMED_ENUM) {
         typeId = TypeId.ENUM;
       } else if (
-        typeId === TypeId.NAMED_UNION
-        || typeId === TypeId.TYPED_UNION
+        typeId === TypeId.NAMED_UNION ||
+        typeId === TypeId.TYPED_UNION
       ) {
         typeId = TypeId.UNION;
       }
@@ -714,6 +728,9 @@ export class TypeMeta {
     const localNameByNormalized = new Map<string, string>();
     for (const [fieldName, typeInfo] of Object.entries(localProps)) {
       if (typeof typeInfo.id === "number") {
+        if (typeInfo.id < 0) {
+          throw new Error(`Field id for ${fieldName} must be non-negative`);
+        }
         localNameById.set(typeInfo.id, fieldName);
       }
       const normalized = TypeMeta.toSnakeCase(fieldName);
@@ -769,12 +786,12 @@ export class TypeMeta {
 
     let currentClassHeader: number;
     if (isStruct) {
-      currentClassHeader
-        = STRUCT_TYPEDEF_FLAG
-        | Math.min(this.fields.length, SMALL_NUM_FIELDS_THRESHOLD);
+      currentClassHeader =
+        STRUCT_TYPEDEF_FLAG |
+        Math.min(this.fields.length, SMALL_NUM_FIELDS_THRESHOLD);
       if (
-        this.type.typeId === TypeId.COMPATIBLE_STRUCT
-        || this.type.typeId === TypeId.NAMED_COMPATIBLE_STRUCT
+        this.type.typeId === TypeId.COMPATIBLE_STRUCT ||
+        this.type.typeId === TypeId.NAMED_COMPATIBLE_STRUCT
       ) {
         currentClassHeader |= COMPATIBLE_TYPEDEF_FLAG;
       }
@@ -961,8 +978,8 @@ export class TypeMeta {
     if (isCompressed) {
       headerLowBits |= COMPRESS_META_FLAG;
     }
-    const header = TypeMeta.headerHashBits(buffer, headerLowBits)
-      | headerLowBits;
+    const header =
+      TypeMeta.headerHashBits(buffer, headerLowBits) | headerLowBits;
     return {
       header: BigInt.asUintN(64, header),
       headerHash: Number(header >> HASH_SHIFT_BITS),
@@ -1019,9 +1036,9 @@ export class TypeMeta {
       if (c >= "A" && c <= "Z") {
         if (i > 0) {
           const prevUpper = chars[i - 1] >= "A" && chars[i - 1] <= "Z";
-          const nextUpperOrEnd
-            = i + 1 >= chars.length
-            || (chars[i + 1] >= "A" && chars[i + 1] <= "Z");
+          const nextUpperOrEnd =
+            i + 1 >= chars.length ||
+            (chars[i + 1] >= "A" && chars[i + 1] <= "Z");
 
           if (!prevUpper || !nextUpperOrEnd) {
             result.push("_");
@@ -1036,10 +1053,17 @@ export class TypeMeta {
   }
 
   static getFieldSortKey(i: { fieldName: string; fieldId?: number }) {
-    if (i.fieldId !== undefined && i.fieldId !== null) {
+    if (i.fieldId !== undefined && i.fieldId !== null && i.fieldId >= 0) {
       return `${i.fieldId}`;
     }
     return TypeMeta.toSnakeCase(i.fieldName);
+  }
+
+  static compareOrdinal(a: string, b: string) {
+    if (a === b) {
+      return 0;
+    }
+    return a < b ? -1 : 1;
   }
 
   static compareFieldSortKey(
@@ -1047,20 +1071,23 @@ export class TypeMeta {
     b: { fieldName: string; fieldId?: number },
   ) {
     if (
-      a.fieldId !== undefined
-      && a.fieldId !== null
-      && b.fieldId !== undefined
-      && b.fieldId !== null
+      a.fieldId !== undefined &&
+      a.fieldId !== null &&
+      a.fieldId >= 0 &&
+      b.fieldId !== undefined &&
+      b.fieldId !== null &&
+      b.fieldId >= 0
     ) {
       return a.fieldId - b.fieldId;
     }
-    if (a.fieldId !== undefined && a.fieldId !== null) {
+    if (a.fieldId !== undefined && a.fieldId !== null && a.fieldId >= 0) {
       return -1;
     }
-    if (b.fieldId !== undefined && b.fieldId !== null) {
+    if (b.fieldId !== undefined && b.fieldId !== null && b.fieldId >= 0) {
       return 1;
     }
-    return TypeMeta.getFieldSortKey(a).localeCompare(
+    return TypeMeta.compareOrdinal(
+      TypeMeta.getFieldSortKey(a),
       TypeMeta.getFieldSortKey(b),
     );
   }

--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -1054,6 +1054,12 @@ export class TypeMeta {
     ) {
       return a.fieldId - b.fieldId;
     }
+    if (a.fieldId !== undefined && a.fieldId !== null) {
+      return -1;
+    }
+    if (b.fieldId !== undefined && b.fieldId !== null) {
+      return 1;
+    }
     return TypeMeta.getFieldSortKey(a).localeCompare(
       TypeMeta.getFieldSortKey(b),
     );
@@ -1069,11 +1075,7 @@ export class TypeMeta {
   >(typeInfos: Array<T>): Array<T> {
     const primitiveFields: Array<T> = [];
     const nullablePrimitiveFields: Array<T> = [];
-    const internalTypeFields: Array<T> = [];
-    const listFields: Array<T> = [];
-    const setFields: Array<T> = [];
-    const mapFields: Array<T> = [];
-    const otherFields: Array<T> = [];
+    const nonPrimitiveFields: Array<T> = [];
 
     for (const typeInfo of typeInfos) {
       const typeId = typeInfo.typeId;
@@ -1089,18 +1091,7 @@ export class TypeMeta {
         continue;
       }
 
-      // Categorize based on type_id
-      if (typeId === TypeId.LIST) {
-        listFields.push(typeInfo);
-      } else if (typeId === TypeId.SET) {
-        setFields.push(typeInfo);
-      } else if (typeId === TypeId.MAP) {
-        mapFields.push(typeInfo);
-      } else if (TypeId.isBuiltin(typeId)) {
-        internalTypeFields.push(typeInfo);
-      } else {
-        otherFields.push(typeInfo);
-      }
+      nonPrimitiveFields.push(typeInfo);
     }
 
     // Sort functions
@@ -1132,33 +1123,16 @@ export class TypeMeta {
       return -1;
     };
 
-    const typeIdThenNameSorter = (a: T, b: T) => {
-      if (a.typeId !== b.typeId) {
-        return a.typeId - b.typeId;
-      }
-      return nameSorter(a, b);
-    };
-
     const nameSorter = (a: T, b: T) => TypeMeta.compareFieldSortKey(a, b);
 
-    // Field IDs identify fields for fingerprints and compatible matching. They are only tie
-    // breakers inside the language-neutral direct payload groups, even when every field is tagged.
     primitiveFields.sort(primitiveComparator);
     nullablePrimitiveFields.sort(primitiveComparator);
-    internalTypeFields.sort(typeIdThenNameSorter);
-    listFields.sort(typeIdThenNameSorter);
-    setFields.sort(typeIdThenNameSorter);
-    mapFields.sort(typeIdThenNameSorter);
-    otherFields.sort(nameSorter);
+    nonPrimitiveFields.sort(nameSorter);
 
     return [
       primitiveFields,
       nullablePrimitiveFields,
-      internalTypeFields,
-      listFields,
-      setFields,
-      mapFields,
-      otherFields,
+      nonPrimitiveFields,
     ].flat();
   }
 }

--- a/javascript/packages/core/lib/typeInfo.ts
+++ b/javascript/packages/core/lib/typeInfo.ts
@@ -79,6 +79,9 @@ export class TypeInfo<T = unknown> extends ExtensibleFunction {
   }
   id?: number;
   setId(v: number | undefined) {
+    if (typeof v === "number" && v < 0) {
+      throw new Error("field id must be non-negative");
+    }
     this.id = v;
     return this;
   }

--- a/javascript/test/typemeta.test.ts
+++ b/javascript/test/typemeta.test.ts
@@ -59,19 +59,19 @@ describe("typemeta", () => {
     expect((bytes[8] & 0x80) !== 0).toBe(true);
   });
 
-  test("keeps tagged direct payload order grouped instead of field-id ordered", () => {
+  test("orders tagged non-primitive fields directly by field id", () => {
     const typeMeta = TypeMeta.fromTypeInfo(
       Type.struct(7005, {
-        stringValue: Type.string().setId(1),
-        mapValue: Type.map(Type.string(), Type.int32()).setId(2),
+        stringValue: Type.string().setId(2),
+        mapValue: Type.map(Type.string(), Type.int32()).setId(1),
         intValue: Type.int32().setId(10),
       }),
     );
 
     expect(typeMeta.getFieldInfo().map((field) => field.fieldName)).toEqual([
       "intValue",
-      "stringValue",
       "mapValue",
+      "stringValue",
     ]);
   });
 

--- a/javascript/test/typemeta.test.ts
+++ b/javascript/test/typemeta.test.ts
@@ -75,6 +75,37 @@ describe("typemeta", () => {
     ]);
   });
 
+  test("rejects negative field ids", () => {
+    expect(() => Type.string().setId(-1)).toThrow(
+      "field id must be non-negative",
+    );
+  });
+
+  test("orders name-based identifiers with ordinal comparison", () => {
+    const typeMeta = TypeMeta.fromTypeInfo(
+      Type.struct(7011, {
+        a_: Type.string(),
+        a1: Type.string(),
+      }),
+    );
+
+    expect(typeMeta.getFieldInfo().map((field) => field.fieldName)).toEqual([
+      "a1",
+      "a_",
+    ]);
+  });
+
+  test("rejects duplicate explicit field ids", () => {
+    expect(() =>
+      TypeMeta.fromTypeInfo(
+        Type.struct(7008, {
+          first: Type.string().setId(1),
+          second: Type.map(Type.string(), Type.int32()).setId(1),
+        }),
+      ),
+    ).toThrow("Duplicate field id 1");
+  });
+
   test("writes the zero size extension when the TypeMeta body is exactly 0xFF bytes", () => {
     const typeMeta = TypeMeta.fromTypeInfo(Type.struct(7003, {})) as any;
     const body = new Uint8Array(0xff);
@@ -129,11 +160,7 @@ describe("typemeta", () => {
     const bodyOnlyHash = bodyOnlyHeaderHashBits(bytes.subarray(bodyOffset));
     expect(header & HEADER_HASH_MASK).not.toBe(bodyOnlyHash);
 
-    view.setBigUint64(
-      0,
-      bodyOnlyHash | (header & LOW_HEADER_BITS_MASK),
-      true,
-    );
+    view.setBigUint64(0, bodyOnlyHash | (header & LOW_HEADER_BITS_MASK), true);
     const reader = new BinaryReader({});
     reader.reset(malformed);
 
@@ -171,9 +198,10 @@ describe("typemeta", () => {
       } as any,
       config,
     );
-    (context as any).typeMetaCache.set(Number(header >> 32n), new Map([
-      [Number(header & 0xffffffffn), typeMeta],
-    ]));
+    (context as any).typeMetaCache.set(
+      Number(header >> 32n),
+      new Map([[Number(header & 0xffffffffn), typeMeta]]),
+    );
     context.reset(writer.dump());
 
     expect(context.readTypeMeta()).toBe(typeMeta);
@@ -229,9 +257,11 @@ describe("typemeta", () => {
       value: Type.int32().setId(1),
     });
 
-    const changedBytes = changedWriterFory.register(changedWriterType).serialize({
-      value: "hello",
-    });
+    const changedBytes = changedWriterFory
+      .register(changedWriterType)
+      .serialize({
+        value: "hello",
+      });
     const localBytes = localWriterFory.register(localWriterType).serialize({
       value: 123,
     });
@@ -244,9 +274,12 @@ describe("typemeta", () => {
   test("regenerated read serializers keep getTypeInfo", () => {
     const fory = new Fory({ compatible: true });
     const serializer = (fory as any).typeResolver.regenerateReadSerializer(
-      Type.struct({ namespace: "example", typeName: "repro_struct" }, {
-        value: Type.int32(),
-      }),
+      Type.struct(
+        { namespace: "example", typeName: "repro_struct" },
+        {
+          value: Type.int32(),
+        },
+      ),
     );
 
     expect(typeof serializer.getTypeInfo).toBe("function");
@@ -268,9 +301,10 @@ describe("typemeta", () => {
     const localChildType = Type.struct(7311, {
       value: Type.int32().setId(1),
     });
-    const createParentType = () => Type.struct(7312, {
-      child: Type.struct(7311).setId(1),
-    });
+    const createParentType = () =>
+      Type.struct(7312, {
+        child: Type.struct(7311).setId(1),
+      });
 
     stringWriterFory.register(stringChildType);
     boolWriterFory.register(boolChildType);
@@ -283,8 +317,8 @@ describe("typemeta", () => {
     const reader = readerFory.register(createParentType());
 
     const typeResolver = (readerFory as any).typeResolver;
-    const generateReadSerializer
-      = typeResolver.generateReadSerializer.bind(typeResolver);
+    const generateReadSerializer =
+      typeResolver.generateReadSerializer.bind(typeResolver);
     let generatedReaders = 0;
     typeResolver.generateReadSerializer = (typeInfo: any) => {
       generatedReaders++;
@@ -386,8 +420,14 @@ describe("typemeta", () => {
     expect(result.bools).toBeInstanceOf(BoolArray);
     expect(Array.from(result.bools)).toEqual([true, false]);
     expect(result.float16s).toBeInstanceOf(Float16Array as any);
-    expect(Array.from(result.float16s as Iterable<number>)[0]).toBeCloseTo(1.5, 1);
-    expect(Array.from(result.float16s as Iterable<number>)[1]).toBeCloseTo(-2, 1);
+    expect(Array.from(result.float16s as Iterable<number>)[0]).toBeCloseTo(
+      1.5,
+      1,
+    );
+    expect(Array.from(result.float16s as Iterable<number>)[1]).toBeCloseTo(
+      -2,
+      1,
+    );
     expect(result.bfloat16s).toBeInstanceOf(BFloat16Array);
     expect(Array.from(result.bfloat16s as Iterable<number>)).toEqual([1.5, -2]);
   });
@@ -435,7 +475,9 @@ describe("typemeta", () => {
     const nullableBytes = serializer.serialize({
       values: [1, null, 3],
     });
-    expect(() => readerFory.register(readerType).deserialize(nullableBytes)).toThrow();
+    expect(() =>
+      readerFory.register(readerType).deserialize(nullableBytes),
+    ).toThrow();
   });
 
   test("rejects incompatible immediate list and dense array element fields", () => {
@@ -453,7 +495,9 @@ describe("typemeta", () => {
       values: ["1", "2"],
     });
 
-    expect(() => readerFory.register(readerType).deserialize(bytes)).toThrow(/list\/array/);
+    expect(() => readerFory.register(readerType).deserialize(bytes)).toThrow(
+      /list\/array/,
+    );
   });
 
   test("rejects nested compatible list and dense array positions", () => {
@@ -471,7 +515,9 @@ describe("typemeta", () => {
       values: [new Int32Array([1, 2])],
     });
 
-    expect(() => readerFory.register(readerType).deserialize(bytes)).toThrow(/list\/array/);
+    expect(() => readerFory.register(readerType).deserialize(bytes)).toThrow(
+      /list\/array/,
+    );
   });
 
   test("keeps compatible named schema evolution working when field count differs", () => {
@@ -692,10 +738,7 @@ function typeMetaBodyOffset(bytes: Uint8Array) {
 
 function bodyOnlyHeaderHashBits(buffer: Uint8Array) {
   const hash = x64hash128(buffer, 47);
-  let header = BigInt.asIntN(
-    64,
-    hash.getBigInt64(0, false) << HASH_SHIFT_BITS,
-  );
+  let header = BigInt.asIntN(64, hash.getBigInt64(0, false) << HASH_SHIFT_BITS);
   if (header < 0n) {
     header = -header;
   }

--- a/python/pyfory/field.py
+++ b/python/pyfory/field.py
@@ -41,6 +41,7 @@ from typing import Any, Callable, Dict, Mapping, Optional
 # Key used to store Fory metadata in field.metadata
 FORY_FIELD_METADATA_KEY = "__fory__"
 FORY_OBJECT_METADATA_KEY = "__fory_object__"
+_FIELD_ID_UNSET = object()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -49,7 +50,7 @@ class ForyFieldMeta:
     Fory field metadata extracted from field.metadata.
 
     Attributes:
-        id: Field tag ID. -1 means use field name encoding, >=0 means use tag ID.
+        id: Field tag ID. -1 is the internal sentinel for no configured ID; >=0 means use tag ID.
         nullable: Whether null flag is written. Default False.
         ref: Whether reference tracking is enabled for this field. Default False.
         ignore: Whether to ignore this field during serialization. Default False.
@@ -103,7 +104,7 @@ def dataclass(_cls=None, *, evolving: bool = True, slots: bool = False, **kwargs
 
 
 def field(
-    id: int = -1,
+    id: int = _FIELD_ID_UNSET,
     *,
     nullable: bool = False,
     ref: bool = False,
@@ -125,10 +126,10 @@ def field(
     This wraps dataclasses.field() and stores Fory configuration in field.metadata.
 
     Args:
-        id: Field tag ID (optional, default -1).
-            - -1 (default): Use field name with meta string encoding
+        id: Field tag ID (optional).
+            - omitted: Use field name with meta string encoding
             - >=0: Use numeric tag ID (more compact, stable across renames)
-            Must be unique within the class (except -1).
+            Must be unique within the class. Negative configured IDs are invalid.
 
         nullable: Whether to write null flag for this field.
             - False (default): Skip null flag, field cannot be None
@@ -173,10 +174,12 @@ def field(
             shape: Shape = pyfory.field(3, dynamic=True)                   # Force type info
     """
     # Validate id
-    if not isinstance(id, int):
+    if id is _FIELD_ID_UNSET:
+        id = -1
+    elif not isinstance(id, int):
         raise TypeError(f"id must be an int, got {type(id).__name__}")
-    if id < -1:
-        raise ValueError(f"id must be >= -1, got {id}")
+    elif id < 0:
+        raise ValueError(f"id must be non-negative, got {id}")
 
     # Build Fory metadata
     fory_meta = ForyFieldMeta(

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -327,7 +327,7 @@ class FieldInfo:
         self.name = name
         self.field_type = field_type
         self.defined_class = defined_class
-        self.tag_id = tag_id  # -1 = use field name encoding, >=0 = use tag ID encoding
+        self.tag_id = tag_id  # -1 is the internal no-ID sentinel, >=0 = use tag ID encoding
 
     def uses_tag_id(self) -> bool:
         """Returns True if this field uses TAG_ID encoding."""

--- a/python/pyfory/struct.py
+++ b/python/pyfory/struct.py
@@ -54,8 +54,6 @@ from pyfory.policy import DEFAULT_POLICY
 from pyfory.types import (
     TypeId,
     is_primitive_array_type,
-    is_list_type,
-    is_map_type,
     get_primitive_type_size,
     is_polymorphic_type,
     is_primitive_type,
@@ -934,9 +932,7 @@ def _to_snake_case(name: str) -> str:
             next_is_lower = index + 1 < len(name) and name[index + 1].islower()
             previous_lower_or_digit = previous.islower() or previous.isdigit()
             previous_upper = previous.isupper()
-            if result and result[-1] != "_" and (
-                previous_lower_or_digit or (previous_upper and next_is_lower)
-            ):
+            if result and result[-1] != "_" and (previous_lower_or_digit or (previous_upper and next_is_lower)):
                 result.append("_")
             result.append(char.lower())
         else:

--- a/python/pyfory/struct.py
+++ b/python/pyfory/struct.py
@@ -133,7 +133,7 @@ class FieldInfo:
     type_hint: type  # Type annotation
 
     # Fory metadata (from pyfory.field()) - used for hash computation
-    tag_id: int  # -1 = use field name, >=0 = use tag ID
+    tag_id: int  # -1 is the internal no-ID sentinel, >=0 = use tag ID
     nullable: bool  # Effective nullable flag (considers Optional[T])
     ref: bool  # Field-level ref setting (for hash computation)
     dynamic: bool  # Whether type info is written for this field
@@ -922,6 +922,29 @@ class StructFieldSerializerVisitor(TypeVisitor):
 _UNKNOWN_TYPE_ID = -1
 
 
+def _to_snake_case(name: str) -> str:
+    result = []
+    previous = ""
+    for index, char in enumerate(name):
+        if char == "_":
+            result.append(char)
+            previous = char
+            continue
+        if char.isupper():
+            next_is_lower = index + 1 < len(name) and name[index + 1].islower()
+            previous_lower_or_digit = previous.islower() or previous.isdigit()
+            previous_upper = previous.isupper()
+            if result and result[-1] != "_" and (
+                previous_lower_or_digit or (previous_upper and next_is_lower)
+            ):
+                result.append("_")
+            result.append(char.lower())
+        else:
+            result.append(char)
+        previous = char
+    return "".join(result).rstrip("_")
+
+
 def _sort_fields(type_resolver, field_names, serializers, nullable_map=None, field_infos_list=None):
     (boxed_types, nullable_boxed_types, internal_types, collection_types, set_types, map_types, other_types) = group_fields(
         type_resolver, field_names, serializers, nullable_map, field_infos_list
@@ -949,7 +972,7 @@ def group_fields(type_resolver, field_names, serializers, nullable_map=None, fie
         if tag_id >= 0:
             sort_key = (0, tag_id, "")
         else:
-            sort_key = (1, field_name, "")
+            sort_key = (1, _to_snake_case(field_name), field_name)
         if serializer is None:
             non_primitive_types.append((_UNKNOWN_TYPE_ID, serializer, field_name, sort_key))
         else:
@@ -999,10 +1022,10 @@ def compute_struct_fingerprint(type_resolver, field_names, serializers, nullable
 
     Fingerprint Format:
         Each field contributes: <field_id_or_name>,<type_id>,<ref>,<nullable>[<child...>];
-        Fields are sorted by tag ID (if >=0) or field name (if id=-1).
+        Fields are sorted by tag ID (if >=0) or snake_case field name when no ID is configured.
 
     Field Components:
-        - field_id_or_name: Tag ID as string if id >= 0, otherwise field name
+        - field_id_or_name: Tag ID as string if id >= 0, otherwise snake_case field name
         - type_id: Fory TypeId as decimal string (e.g., "4" for INT32)
         - ref: "1" if field has ref=True in pyfory.field(), "0" otherwise
               (based on field annotation, NOT runtime config)
@@ -1047,9 +1070,9 @@ def compute_struct_fingerprint(type_resolver, field_names, serializers, nullable
             field_id_or_name = str(tag_id)
             sort_key = (0, tag_id, "")  # 0 = tag ID fields come first
         else:
-            field_id_or_name = field_name
-            # Sort by field name (lexicographic) for name-based fields
-            sort_key = (1, field_name, "")  # 1 = name fields come after
+            field_id_or_name = _to_snake_case(field_name)
+            # Sort by snake_case field name for name-based fields.
+            sort_key = (1, field_id_or_name, field_name)  # 1 = name fields come after
 
         fp_fields.append((sort_key, field_id_or_name, type_fingerprint))
 

--- a/python/pyfory/struct.py
+++ b/python/pyfory/struct.py
@@ -937,10 +937,10 @@ def group_fields(type_resolver, field_names, serializers, nullable_map=None, fie
         field_info_map = {fi.name: fi for fi in field_infos_list}
     boxed_types = []
     nullable_boxed_types = []
+    non_primitive_types = []
     collection_types = []
     set_types = []
     map_types = []
-    internal_types = []
     other_types = []
     type_ids = []
     for field_name, serializer in zip(field_names, serializers):
@@ -951,7 +951,7 @@ def group_fields(type_resolver, field_names, serializers, nullable_map=None, fie
         else:
             sort_key = (1, field_name, "")
         if serializer is None:
-            other_types.append((_UNKNOWN_TYPE_ID, serializer, field_name, sort_key))
+            non_primitive_types.append((_UNKNOWN_TYPE_ID, serializer, field_name, sort_key))
         else:
             type_ids.append(
                 (
@@ -967,24 +967,9 @@ def group_fields(type_resolver, field_names, serializers, nullable_map=None, fie
         is_nullable = nullable_map.get(field_name, False)
         if is_primitive_type(type_id):
             container = nullable_boxed_types if is_nullable else boxed_types
-        elif type_id == TypeId.SET:
-            container = set_types
-        elif type_id == TypeId.LIST or is_list_type(serializer.type_):
-            container = collection_types
-        elif is_map_type(serializer.type_):
-            container = map_types
-        elif is_polymorphic_type(type_id) or type_id in {TypeId.ENUM, TypeId.NAMED_ENUM} or is_union_type(type_id):
-            container = other_types
-        elif type_id >= TypeId.BOUND:
-            # Native mode user-registered types have type_id >= BOUND
-            container = other_types
         else:
-            assert TypeId.UNKNOWN < type_id < TypeId.BOUND, (type_id,)
-            container = internal_types
+            container = non_primitive_types
         container.append((type_id, serializer, field_name, sort_key))
-
-    def sorter(item):
-        return item[0], item[3]
 
     def numeric_sorter(item):
         id_ = item[0]
@@ -1003,12 +988,9 @@ def group_fields(type_resolver, field_names, serializers, nullable_map=None, fie
 
     boxed_types = sorted(boxed_types, key=numeric_sorter)
     nullable_boxed_types = sorted(nullable_boxed_types, key=numeric_sorter)
-    collection_types = sorted(collection_types, key=lambda item: item[3])
-    set_types = sorted(set_types, key=lambda item: item[3])
-    internal_types = sorted(internal_types, key=sorter)
-    map_types = sorted(map_types, key=lambda item: item[3])
+    non_primitive_types = sorted(non_primitive_types, key=lambda item: item[3])
     other_types = sorted(other_types, key=lambda item: item[3])
-    return (boxed_types, nullable_boxed_types, internal_types, collection_types, set_types, map_types, other_types)
+    return (boxed_types, nullable_boxed_types, non_primitive_types, collection_types, set_types, map_types, other_types)
 
 
 def compute_struct_fingerprint(type_resolver, field_names, serializers, nullable_map=None, field_infos_list=None):

--- a/python/pyfory/tests/test_field_meta.py
+++ b/python/pyfory/tests/test_field_meta.py
@@ -73,11 +73,11 @@ class TestFieldFunction:
         assert obj.data == {}
 
     def test_field_name_encoding(self):
-        """Test field with id=-1 uses field name encoding."""
+        """Test field without an ID uses field name encoding."""
 
         @dataclass
         class TestClass:
-            name: str = pyfory.field(-1)
+            name: str = pyfory.field()
 
         meta = extract_field_meta(fields(TestClass)[0])
         assert meta.id == -1
@@ -122,7 +122,7 @@ class TestFieldFunction:
         @dataclass
         class TestClass:
             name: str = pyfory.field(0)
-            _cache: dict = pyfory.field(-1, ignore=True, default_factory=dict)
+            _cache: dict = pyfory.field(ignore=True, default_factory=dict)
 
         cache_field = [f for f in fields(TestClass) if f.name == "_cache"][0]
         meta = extract_field_meta(cache_field)
@@ -181,10 +181,10 @@ class TestValidation:
         with pytest.raises(ValueError, match="Optional"):
             fory.serialize(obj)
 
-    def test_negative_id_below_minus_one(self):
-        """Test that id < -1 raises ValueError."""
-        with pytest.raises(ValueError, match="id must be >= -1"):
-            pyfory.field(-2)
+    def test_negative_id(self):
+        """Test that negative configured IDs raise ValueError."""
+        with pytest.raises(ValueError, match="id must be non-negative"):
+            pyfory.field(-1)
 
     def test_non_int_id(self):
         """Test that non-integer id raises TypeError."""
@@ -242,7 +242,7 @@ class TestSerialization:
         @dataclass
         class CachedData:
             value: Int32 = pyfory.field(0)
-            _cache: dict = pyfory.field(-1, ignore=True, default_factory=dict)
+            _cache: dict = pyfory.field(ignore=True, default_factory=dict)
 
         fory = Fory(xlang=True, compatible=False, ref=True)
         fory.register_type(CachedData, typename="test.CachedData")
@@ -288,7 +288,7 @@ class TestSerialization:
             # Explicit tag ID
             id: Int32 = pyfory.field(0)
             # Field name encoding
-            description: str = pyfory.field(-1)
+            description: str = pyfory.field()
             # No pyfory.field() - uses defaults
             count: int = 0
 

--- a/python/pyfory/tests/test_struct.py
+++ b/python/pyfory/tests/test_struct.py
@@ -328,6 +328,17 @@ def test_tagged_non_primitive_fields_sort_by_identifier():
     ]
 
 
+def test_name_based_fields_sort_by_snake_case_identifier():
+    @dataclass
+    class CamelCaseClass:
+        alphaString: str = ""
+        alpha_list: List[str] = dataclasses.field(default_factory=list)
+
+    fory = Fory(xlang=True, compatible=False, ref=True)
+    serializer = DataClassSerializer(fory.type_resolver, CamelCaseClass)
+    assert serializer._field_names == ["alpha_list", "alphaString"]
+
+
 def test_duration_and_decimal_fields_use_declared_serializers():
     @dataclass
     class TemporalNumberClass:

--- a/python/pyfory/tests/test_struct.py
+++ b/python/pyfory/tests/test_struct.py
@@ -290,20 +290,32 @@ def test_sort_fields():
     #    Float64(8), Float32(4), bool(1), Int8(1) => f13, f5, f7, f11
     # 2. Compressed primitives (compress=1) by -size, then name:
     #    Int64(8), Int32(4) => f12, f1
-    # 3. Internal types by type_id, then name: str, datetime, bytes => f4, f15, f6
-    # 4. Collection types by type_id, then name: list => f10, f2
-    # 5. Set types by type_id, then name: set => f14
-    # 6. Map types by type_id, then name: dict => f3, f9
-    # 7. Other types (polymorphic/any) by name: any => f8
-    assert serializer._field_names == ["f13", "f5", "f7", "f11", "f12", "f1", "f4", "f15", "f6", "f10", "f2", "f14", "f3", "f9", "f8"]
+    # 3. All non-primitives directly by field identifier.
+    assert serializer._field_names == [
+        "f13",
+        "f5",
+        "f7",
+        "f11",
+        "f12",
+        "f1",
+        "f10",
+        "f14",
+        "f15",
+        "f2",
+        "f3",
+        "f4",
+        "f6",
+        "f8",
+        "f9",
+    ]
 
 
-def test_tagged_fields_keep_grouped_payload_order():
+def test_tagged_non_primitive_fields_sort_by_identifier():
     @dataclass
     class TaggedClass:
         later_int: pyfory.Int32 = pyfory.field(id=20, default=0)
         early_string: str = pyfory.field(id=10, default="")
-        middle_map: Dict[str, pyfory.Int64] = pyfory.field(id=15, default_factory=dict)
+        middle_map: Dict[str, pyfory.Int64] = pyfory.field(id=5, default_factory=dict)
         first_bool: bool = pyfory.field(id=1, default=False)
 
     fory = Fory(xlang=True, compatible=False, ref=True)
@@ -311,8 +323,8 @@ def test_tagged_fields_keep_grouped_payload_order():
     assert serializer._field_names == [
         "first_bool",
         "later_int",
-        "early_string",
         "middle_map",
+        "early_string",
     ]
 
 

--- a/rust/fory-derive/src/object/field_meta.rs
+++ b/rust/fory-derive/src/object/field_meta.rs
@@ -18,7 +18,7 @@
 //! Field-level metadata parsing for `#[fory(...)]` attributes.
 //!
 //! This module provides support for field-level optimization attributes:
-//! - `id = N`: Field tag ID for compact encoding (>=0) or field name encoding (-1)
+//! - `id = N`: Non-negative field tag ID for compact encoding
 //! - `nullable`: Whether the field can be null (default: false, except Option/RcWeak/ArcWeak)
 //! - `ref`: Whether to enable reference tracking (default: false, except Rc/Arc/RcWeak/ArcWeak)
 //! - `skip`: Skip this field during serialization
@@ -36,7 +36,7 @@ use syn::{Field, GenericArgument, PathArguments, Type};
 /// Represents parsed `#[fory(...)]` field attributes
 #[derive(Debug, Clone, Default)]
 pub struct ForyFieldMeta {
-    /// Field tag ID: None = use field name, Some(-1) = explicit opt-out, Some(>=0) = use tag ID
+    /// Field tag ID: None = use field name, Some(>=0) = use tag ID
     pub id: Option<i32>,
     /// Whether the field can be null (None = use type-based default)
     pub nullable: Option<bool>,

--- a/rust/fory-derive/src/object/field_meta.rs
+++ b/rust/fory-derive/src/object/field_meta.rs
@@ -188,8 +188,8 @@ fn parse_meta_item(
         }
         let lit: syn::LitInt = nested.value()?.parse()?;
         let id: i32 = lit.base10_parse()?;
-        if id < -1 {
-            return Err(syn::Error::new(lit.span(), "id must be >= -1"));
+        if id < 0 {
+            return Err(syn::Error::new(lit.span(), "id must be non-negative"));
         }
         if meta.id.is_some() {
             return Err(syn::Error::new(nested.path.span(), "duplicate id config"));
@@ -544,6 +544,16 @@ mod tests {
         assert_eq!(meta.nullable, None);
         assert_eq!(meta.r#ref, None);
         assert!(!meta.skip);
+    }
+
+    #[test]
+    fn test_parse_rejects_negative_id() {
+        let field: Field = parse_quote! {
+            #[fory(id = -1)]
+            name: String
+        };
+        let err = parse_field_meta(&field).unwrap_err();
+        assert!(err.to_string().contains("id must be non-negative"));
     }
 
     #[test]

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -196,20 +196,14 @@ impl FieldSortKey {
 fn compare_field_sort_key(a: &FieldSortKey, b: &FieldSortKey) -> std::cmp::Ordering {
     match (a.id, b.id) {
         (Some(id_a), Some(id_b)) => id_a.cmp(&id_b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
         _ => a.text.cmp(&b.text),
     }
 }
 
 type FieldGroup = Vec<(String, FieldSortKey, u32)>;
-type FieldGroups = (
-    FieldGroup,
-    FieldGroup,
-    FieldGroup,
-    FieldGroup,
-    FieldGroup,
-    FieldGroup,
-    FieldGroup,
-);
+type FieldGroups = (FieldGroup, FieldGroup, FieldGroup);
 
 /// Extract the inner generic arguments from a type name while ignoring path qualifiers.
 ///
@@ -416,34 +410,6 @@ fn is_compress(type_id: u32) -> bool {
     .contains(&type_id)
 }
 
-fn is_internal_type_id(type_id: u32) -> bool {
-    [
-        TypeId::STRING as u32,
-        TypeId::DATE as u32,
-        TypeId::TIMESTAMP as u32,
-        TypeId::DURATION as u32,
-        TypeId::DECIMAL as u32,
-        TypeId::BINARY as u32,
-        TypeId::BOOL_ARRAY as u32,
-        TypeId::INT8_ARRAY as u32,
-        TypeId::INT16_ARRAY as u32,
-        TypeId::INT32_ARRAY as u32,
-        TypeId::INT64_ARRAY as u32,
-        TypeId::INT128_ARRAY as u32,
-        TypeId::FLOAT8_ARRAY as u32,
-        TypeId::FLOAT16_ARRAY as u32,
-        TypeId::BFLOAT16_ARRAY as u32,
-        TypeId::FLOAT32_ARRAY as u32,
-        TypeId::FLOAT64_ARRAY as u32,
-        TypeId::UINT8_ARRAY as u32,
-        TypeId::UINT16_ARRAY as u32,
-        TypeId::UINT32_ARRAY as u32,
-        TypeId::UINT64_ARRAY as u32,
-        TypeId::U128_ARRAY as u32,
-    ]
-    .contains(&type_id)
-}
-
 /// Group fields into serialization categories while normalizing field names to snake_case.
 /// The returned groups preserve the ordering rules required by the serialization layout.
 fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
@@ -451,11 +417,7 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
 
     let mut primitive_fields = Vec::new();
     let mut nullable_primitive_fields = Vec::new();
-    let mut internal_type_fields = Vec::new();
-    let mut list_fields = Vec::new();
-    let mut set_fields = Vec::new();
-    let mut map_fields = Vec::new();
-    let mut other_fields = Vec::new();
+    let mut non_primitive_fields = Vec::new();
 
     // First handle Forward fields separately to avoid borrow checker issues
     for (idx, field) in fields.iter().enumerate() {
@@ -463,7 +425,7 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
             let raw_ident = get_field_name(field, idx);
             let ident = to_snake_case(&raw_ident);
             // Forward fields don't have explicit IDs; sort by name.
-            other_fields.push((
+            non_primitive_fields.push((
                 ident.clone(),
                 FieldSortKey::name(ident),
                 TypeId::UNKNOWN as u32,
@@ -508,20 +470,10 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
                     adjust_type_id_for_encoding(get_type_id_by_name(ty_str), &meta)
                 };
 
-                // Categorize based on type_id
                 if is_primitive {
                     primitive_fields.push((ident, sort_key, type_id));
-                } else if is_internal_type_id(type_id) {
-                    internal_type_fields.push((ident, sort_key, type_id));
-                } else if type_id == TypeId::LIST as u32 {
-                    list_fields.push((ident, sort_key, type_id));
-                } else if type_id == TypeId::SET as u32 {
-                    set_fields.push((ident, sort_key, type_id));
-                } else if type_id == TypeId::MAP as u32 {
-                    map_fields.push((ident, sort_key, type_id));
                 } else {
-                    // User-defined type
-                    other_fields.push((ident, sort_key, type_id));
+                    non_primitive_fields.push((ident, sort_key, type_id));
                 }
             };
 
@@ -560,15 +512,6 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
             .then_with(|| a.0.cmp(&b.0))
     }
 
-    fn type_id_then_name_sorter(
-        a: &(String, FieldSortKey, u32),
-        b: &(String, FieldSortKey, u32),
-    ) -> std::cmp::Ordering {
-        a.2.cmp(&b.2)
-            .then_with(|| compare_field_sort_key(&a.1, &b.1))
-            .then_with(|| a.0.cmp(&b.0))
-    }
-
     fn name_sorter(
         a: &(String, FieldSortKey, u32),
         b: &(String, FieldSortKey, u32),
@@ -578,20 +521,12 @@ fn group_fields_by_type(fields: &[&Field]) -> FieldGroups {
 
     primitive_fields.sort_by(numeric_sorter);
     nullable_primitive_fields.sort_by(numeric_sorter);
-    internal_type_fields.sort_by(type_id_then_name_sorter);
-    list_fields.sort_by(name_sorter);
-    set_fields.sort_by(name_sorter);
-    map_fields.sort_by(name_sorter);
-    other_fields.sort_by(name_sorter);
+    non_primitive_fields.sort_by(name_sorter);
 
     (
         primitive_fields,
         nullable_primitive_fields,
-        internal_type_fields,
-        list_fields,
-        set_fields,
-        map_fields,
-        other_fields,
+        non_primitive_fields,
     )
 }
 
@@ -610,23 +545,12 @@ pub(crate) fn get_sorted_field_names(fields: &[&Field]) -> Vec<String> {
 
     // For named structs, sort by Fory field order. Tag IDs are the field identifier inside each
     // group, but they do not bypass the language-neutral grouping rules.
-    let (
-        primitive_fields,
-        nullable_primitive_fields,
-        internal_type_fields,
-        list_fields,
-        set_fields,
-        map_fields,
-        other_fields,
-    ) = group_fields_by_type(fields);
+    let (primitive_fields, nullable_primitive_fields, non_primitive_fields) =
+        group_fields_by_type(fields);
 
     let mut all_fields = primitive_fields;
     all_fields.extend(nullable_primitive_fields);
-    all_fields.extend(internal_type_fields);
-    all_fields.extend(list_fields);
-    all_fields.extend(set_fields);
-    all_fields.extend(map_fields);
-    all_fields.extend(other_fields);
+    all_fields.extend(non_primitive_fields);
 
     all_fields.into_iter().map(|(name, _, _)| name).collect()
 }
@@ -989,15 +913,8 @@ mod tests {
         ];
         let field_refs: Vec<&syn::Field> = fields.iter().collect();
 
-        let (
-            primitive_fields,
-            nullable_primitive_fields,
-            internal_type_fields,
-            list_fields,
-            set_fields,
-            map_fields,
-            other_fields,
-        ) = group_fields_by_type(&field_refs);
+        let (primitive_fields, nullable_primitive_fields, non_primitive_fields) =
+            group_fields_by_type(&field_refs);
 
         let primitive_names: Vec<&str> = primitive_fields
             .iter()
@@ -1011,35 +928,20 @@ mod tests {
             .collect();
         assert_eq!(nullable_names, vec!["optional_value"]);
 
-        let internal_names: Vec<&str> = internal_type_fields
+        let non_primitive_names: Vec<&str> = non_primitive_fields
             .iter()
             .map(|(name, _, _)| name.as_str())
             .collect();
-        assert_eq!(internal_names, vec!["simple_string"]);
-
-        let list_names: Vec<&str> = list_fields
-            .iter()
-            .map(|(name, _, _)| name.as_str())
-            .collect();
-        assert_eq!(list_names, vec!["list_items"]);
-
-        let set_names: Vec<&str> = set_fields
-            .iter()
-            .map(|(name, _, _)| name.as_str())
-            .collect();
-        assert_eq!(set_names, vec!["set_items"]);
-
-        let map_names: Vec<&str> = map_fields
-            .iter()
-            .map(|(name, _, _)| name.as_str())
-            .collect();
-        assert_eq!(map_names, vec!["map_values"]);
-
-        let other_names: Vec<&str> = other_fields
-            .iter()
-            .map(|(name, _, _)| name.as_str())
-            .collect();
-        assert_eq!(other_names, vec!["custom_type"]);
+        assert_eq!(
+            non_primitive_names,
+            vec![
+                "custom_type",
+                "list_items",
+                "map_values",
+                "set_items",
+                "simple_string"
+            ]
+        );
 
         let sorted_names = get_sorted_field_names(&field_refs);
         assert_eq!(
@@ -1047,11 +949,11 @@ mod tests {
             vec![
                 "camel_case".to_string(),
                 "optional_value".to_string(),
-                "simple_string".to_string(),
-                "list_items".to_string(),
-                "set_items".to_string(),
-                "map_values".to_string(),
                 "custom_type".to_string(),
+                "list_items".to_string(),
+                "map_values".to_string(),
+                "set_items".to_string(),
+                "simple_string".to_string(),
             ]
         );
     }
@@ -1067,30 +969,23 @@ mod tests {
         ];
         let field_refs: Vec<&syn::Field> = fields.iter().collect();
 
-        let (
-            _primitive_fields,
-            _nullable_primitive_fields,
-            internal_type_fields,
-            _list_fields,
-            _set_fields,
-            _map_fields,
-            other_fields,
-        ) = group_fields_by_type(&field_refs);
+        let (_primitive_fields, _nullable_primitive_fields, non_primitive_fields) =
+            group_fields_by_type(&field_refs);
 
-        let internal_names: Vec<&str> = internal_type_fields
+        let non_primitive_names: Vec<&str> = non_primitive_fields
             .iter()
             .map(|(name, _, _)| name.as_str())
             .collect();
         assert_eq!(
-            internal_names,
-            vec!["bytes_value", "int8_array", "uint8_array", "uint16_array"]
+            non_primitive_names,
+            vec![
+                "bytes_value",
+                "int8_array",
+                "uint8_array",
+                "uint16_array",
+                "custom_type"
+            ]
         );
-
-        let other_names: Vec<&str> = other_fields
-            .iter()
-            .map(|(name, _, _)| name.as_str())
-            .collect();
-        assert_eq!(other_names, vec!["custom_type"]);
 
         let sorted_names = get_sorted_field_names(&field_refs);
         assert_eq!(

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -882,7 +882,7 @@ struct NestedAnnotatedContainerCompatible {
 #[derive(ForyStruct, Debug, PartialEq)]
 struct EmptyStructEvolution {}
 
-// Java f1 has @ForyField(id = -1, nullable = true), so it's nullable
+// Java f1 has @ForyField(nullable = true), so it's nullable
 #[derive(ForyStruct, Debug, PartialEq)]
 struct OneStringFieldStruct {
     #[fory(nullable = true)]

--- a/swift/Sources/ForyMacro/ForyObjectMacro.swift
+++ b/swift/Sources/ForyMacro/ForyObjectMacro.swift
@@ -734,14 +734,8 @@ private func parseFields(_ declaration: some DeclGroupSyntax) throws -> ParsedDe
             let group: Int
             if classification.isPrimitive {
                 group = isOptional ? 2 : 1
-            } else if classification.isMap {
-                group = 5
-            } else if classification.isCollection {
-                group = 4
-            } else if classification.isBuiltIn {
-                group = 3
             } else {
-                group = 6
+                group = 3
             }
 
             fields.append(
@@ -1986,6 +1980,12 @@ private func compareFieldIdentifier(_ lhs: ParsedField, _ rhs: ParsedField) -> B
     if let lhsID = lhs.fieldID, let rhsID = rhs.fieldID, lhsID != rhsID {
         return lhsID < rhsID
     }
+    if lhs.fieldID != nil && rhs.fieldID == nil {
+        return true
+    }
+    if lhs.fieldID == nil && rhs.fieldID != nil {
+        return false
+    }
     if lhs.fieldIdentifier != rhs.fieldIdentifier {
         return lhs.fieldIdentifier < rhs.fieldIdentifier
     }
@@ -2027,13 +2027,6 @@ private func sortFields(_ fields: [ParsedField]) -> [ParsedField] {
             if lhs.primitiveSize != rhs.primitiveSize {
                 return lhs.primitiveSize > rhs.primitiveSize
             }
-            if lhs.typeID != rhs.typeID {
-                return lhs.typeID < rhs.typeID
-            }
-            if let identifierOrder = compareFieldIdentifier(lhs, rhs) {
-                return identifierOrder
-            }
-        case 3, 4, 5:
             if lhs.typeID != rhs.typeID {
                 return lhs.typeID < rhs.typeID
             }

--- a/swift/Tests/ForyTests/ForySwiftTests.swift
+++ b/swift/Tests/ForyTests/ForySwiftTests.swift
@@ -55,6 +55,19 @@ struct TaggedFieldOrder: Equatable {
 }
 
 @ForyStruct
+struct NonPrimitiveFieldOrder: Equatable {
+  @ForyField(id: 20)
+  var stringValue: String
+
+  @ForyField(id: 10)
+  var mapValue: [String: Int32]
+
+  var binaryValue: Data
+  var addressValue: Address
+  var intValue: Int32
+}
+
+@ForyStruct
 struct EncodedNumberFields: Equatable {
   @ForyField(encoding: .fixed)
   var u32Fixed: UInt32
@@ -910,6 +923,14 @@ func macroTaggedFieldsKeepGroupedPayloadOrder() throws {
   #expect(try buffer.readVarInt32() == value.intValue)
   let tailContext = ReadContext(buffer: buffer, typeResolver: fory.typeResolver, trackRef: false)
   #expect(try String.foryReadData(tailContext) == value.textTail)
+}
+
+@Test
+func macroNonPrimitiveFieldsSortByFieldIdentifier() throws {
+  let fields = NonPrimitiveFieldOrder.foryFieldsInfo(trackRef: false)
+
+  #expect(fields.map(\.fieldName) == ["intValue", "mapValue", "stringValue", "addressValue", "binaryValue"])
+  #expect(fields.map(\.fieldID) == [nil, 10, 20, nil, nil])
 }
 
 @Test

--- a/swift/Tests/ForyTests/ForySwiftTests.swift
+++ b/swift/Tests/ForyTests/ForySwiftTests.swift
@@ -989,13 +989,13 @@ func macroReducedPrecisionFieldsUseXlangTypeIDs() {
   let fields = ReducedPrecisionMacroFields.foryFieldsInfo(trackRef: false)
   #expect(fields.count == 4)
   #expect(
-    fields.map(\.fieldName) == ["float16Value", "bfloat16Value", "float16Array", "bfloat16Array"])
+    fields.map(\.fieldName) == ["float16Value", "bfloat16Value", "bfloat16Array", "float16Array"])
   #expect(
     fields.map(\.fieldType.typeID) == [
       TypeId.float16.rawValue,
       TypeId.bfloat16.rawValue,
-      TypeId.float16Array.rawValue,
-      TypeId.bfloat16Array.rawValue
+      TypeId.bfloat16Array.rawValue,
+      TypeId.float16Array.rawValue
     ])
 }
 


### PR DESCRIPTION


## Why?

The xlang field-ordering spec and several runtimes still treated non-primitive fields as separate type-specific groups. This PR simplifies the rule so non-primitive fields use one language-neutral identifier order, and makes invalid negative field ids fail early instead of being interpreted as name-based fields.

## What does this PR do?

- Updates the xlang serialization spec so fields are ordered as non-null primitives, nullable primitives, then all non-primitives sorted by field identifier.
- Applies the simplified ordering across C++, C#, Dart, Go, Java, JavaScript, Python, Rust, and Swift runtimes or generators.
- Allows mixed explicit field ids and name-based identifiers, with explicit ids sorted before name identifiers inside a field group.
- Rejects negative configured field ids in supported generators, parsers, and macros; name-based fields now omit an explicit id instead of using `-1`.
- Updates language guides and cross-language fixtures to match the new field-id and ordering behavior.
- Adds focused tests for non-primitive field ordering, mixed identifier ordering, and negative field-id diagnostics.

## Related issues

#1017 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?

Yes. Xlang non-primitive struct field ordering now follows field identifiers directly, and configured negative field ids are rejected. Fields without explicit ids continue to use name-based identifiers.

- [ ] Does this PR introduce any public API change?
- [x] Does this PR introduce any binary protocol compatibility change?

## Benchmark

N/A
