### PR TITLE
ci: declare workflow-level `contents: read` on ci and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ on:
       - "NOTICE"
     types: ["opened", "reopened", "synchronize"]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect Changed Paths

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ on:
       - "**.yml"
       - "**.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: 🍇 Markdown


### PR DESCRIPTION
Both workflows run pure CI / lint checks; no GitHub API writes from the workflows. Workflow-level `contents: read` is sufficient as the cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.