### PR TITLE
chore: bump versions after 1.1.0 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "fory",
-    version = "1.1.0",
+    version = "1.2.0",
 )
 
 # Platforms (needed for platform-specific build configurations)

--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation "org.apache.fory:fory-core:1.0.0"
+implementation "org.apache.fory:fory-core:1.1.0"
 ```
 
 **Scala**
@@ -147,7 +147,7 @@ implementation "org.apache.fory:fory-core:1.0.0"
 sbt:
 
 ```scala
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.0.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.1.0"
 ```
 
 **Kotlin**
@@ -155,7 +155,7 @@ libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.0.0"
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.0.0")
+implementation("org.apache.fory:fory-kotlin:1.1.0")
 ```
 
 Maven:
@@ -164,7 +164,7 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -186,7 +186,7 @@ pip install "pyfory[format]"
 
 ```toml
 [dependencies]
-fory = "1.0.0"
+fory = "1.1.0"
 ```
 
 **C++**
@@ -198,7 +198,7 @@ include(FetchContent)
 FetchContent_Declare(
   fory
   GIT_REPOSITORY https://github.com/apache/fory.git
-  GIT_TAG v1.0.0
+  GIT_TAG v1.1.0
   SOURCE_SUBDIR cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -209,8 +209,8 @@ Bazel:
 
 ```bazel
 # MODULE.bazel
-bazel_dep(name = "fory", version = "1.0.0")
-git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
+git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.1.0")
 
 # BUILD
 deps = ["@fory//cpp/fory/serialization:fory_serialization"]
@@ -243,13 +243,13 @@ npm install @apache-fory/core @apache-fory/hps
 **C#**
 
 ```bash
-dotnet add package Apache.Fory --version 1.0.0
+dotnet add package Apache.Fory --version 1.1.0
 ```
 
 **Dart**
 
 ```bash
-dart pub add fory:^1.0.0
+dart pub add fory:^1.1.0
 dart pub add dev:build_runner
 ```
 
@@ -259,7 +259,7 @@ Add Fory to `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apache/fory.git", exact: "1.0.0")
+  .package(url: "https://github.com/apache/fory.git", exact: "1.1.0")
 ],
 targets: [
   .target(

--- a/benchmarks/cpp/CMakeLists.txt
+++ b/benchmarks/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ if(POLICY CMP0169)
 endif()
 
 project(fory_cpp_benchmark
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "C++ Benchmark comparing Fory, Protobuf, and Msgpack serialization"
     LANGUAGES CXX
 )

--- a/benchmarks/go/go.mod
+++ b/benchmarks/go/go.mod
@@ -20,7 +20,7 @@ module github.com/apache/fory/benchmarks/go
 go 1.24.0
 
 require (
-	github.com/apache/fory/go/fory v1.1.0-alpha.0
+	github.com/apache/fory/go/fory v1.2.0-alpha.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	google.golang.org/protobuf v1.36.0
 )

--- a/benchmarks/java/pom.xml
+++ b/benchmarks/java/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmark</artifactId>

--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "fory-benchmarks"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 edition = "2021"
 
 [[bin]]

--- a/ci/release.py
+++ b/ci/release.py
@@ -183,6 +183,12 @@ def bump_version(**kwargs):
                 _normalize_js_version(new_version),
                 _update_js_version,
             )
+            _bump_version(
+                "integration_tests/idl_tests/javascript",
+                "package.json",
+                _normalize_js_version(new_version),
+                _update_js_version,
+            )
         elif lang == "cpp":
             bump_cpp_version(new_version)
         elif lang == "go":
@@ -213,13 +219,13 @@ def bump_java_version(new_version):
     new_version = _normalize_java_version(new_version)
     for p in [
         "integration_tests/graalvm_tests",
+        "integration_tests/grpc_tests/java",
         "integration_tests/jdk_compatibility_tests",
         "integration_tests/jpms_tests",
         "integration_tests/idl_tests/java",
         "benchmarks/java",
         "java/fory-core",
         "java/fory-format",
-        "java/fory-simd",
         "java/fory-extensions",
         "java/fory-graalvm-feature",
         "java/fory-test-core",
@@ -253,6 +259,12 @@ def bump_python_version(new_version):
         new_version,
         _update_pyproject_version,
     )
+    _bump_version(
+        "integration_tests/grpc_tests/python",
+        "pyproject.toml",
+        new_version,
+        _update_pyproject_version,
+    )
 
 
 def bump_rust_version(new_version):
@@ -278,6 +290,7 @@ def bump_kotlin_version(new_version):
         "kotlin/fory-kotlin",
         "kotlin/fory-kotlin-ksp",
         "kotlin/fory-kotlin-tests",
+        "integration_tests/idl_tests/kotlin",
     ]:
         _bump_version(p, "pom.xml", new_version, _update_pom_parent_version)
 
@@ -289,6 +302,7 @@ def bump_cpp_version(new_version):
         "integration_tests/idl_tests/cpp",
     ]:
         _bump_version(p, "CMakeLists.txt", new_version, _update_cmake_project_version)
+    _bump_version("", "MODULE.bazel", new_version, _update_bazel_module_version)
 
 
 def bump_go_version(new_version):
@@ -297,6 +311,7 @@ def bump_go_version(new_version):
         "integration_tests/idl_tests/go",
     ]:
         _bump_version(p, "go.mod", new_version, _update_go_mod_version)
+    _bump_version("go/fory/cmd/fory", "main.go", new_version, _update_go_cli_version)
 
 
 def bump_dart_version(new_version):
@@ -304,6 +319,7 @@ def bump_dart_version(new_version):
         "dart",
         "dart/packages/fory",
         "dart/packages/fory-test",
+        "integration_tests/idl_tests/dart",
     ]:
         _bump_version(p, "pubspec.yaml", new_version, _update_pubspec_version)
     _bump_version(
@@ -503,6 +519,24 @@ def _update_cmake_project_version(lines, v: str):
     return lines
 
 
+def _update_bazel_module_version(lines, v: str):
+    bazel_version = _normalize_cmake_version(v)
+    in_module = False
+    for index, line in enumerate(lines):
+        if re.search(r"^\s*module\(", line):
+            in_module = True
+        if in_module and re.search(r"^\s*version\s*=", line):
+            lines[index] = re.sub(
+                r'(version\s*=\s*")[^"]+(")',
+                r"\g<1>" + bazel_version + r"\2",
+                line,
+            )
+            return lines
+        if in_module and ")" in line:
+            in_module = False
+    raise ValueError("No MODULE.bazel module version found")
+
+
 def _update_go_mod_version(lines, v: str):
     go_version = _normalize_go_version(v)
     for index, line in enumerate(lines):
@@ -516,12 +550,23 @@ def _update_go_mod_version(lines, v: str):
     return lines
 
 
+def _update_go_cli_version(lines, v: str):
+    v = v.strip()
+    if v.startswith("v"):
+        v = v[1:]
+    for index, line in enumerate(lines):
+        if line.startswith("const version = "):
+            lines[index] = f'const version = "{v}"\n'
+            return lines
+    raise ValueError("No Go CLI version constant found")
+
+
 def _update_pubspec_version(lines, v: str):
     for index, line in enumerate(lines):
         if re.match(r"^version\s*:", line):
             lines[index] = f"version: {v}\n"
             continue
-        if re.match(r"^\s*fory\s*:", line):
+        if re.match(r"^\s*fory\s*:\s+\S+", line):
             prefix = re.match(r"^(\s*fory\s*:)\s*.*", line)
             if prefix:
                 lines[index] = f"{prefix.group(1)} {v}\n"

--- a/compiler/fory_compiler/__init__.py
+++ b/compiler/fory_compiler/__init__.py
@@ -17,7 +17,7 @@
 
 """Fory IDL compiler for Apache Fory."""
 
-__version__ = "1.1.0.dev0"
+__version__ = "1.2.0.dev0"
 
 from fory_compiler.ir.ast import Schema, Message, Enum, Field, EnumValue, Import
 from fory_compiler.frontend.fdl import FDLFrontend

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-compiler"
-version = "1.1.0.dev0"
+version = "1.2.0.dev0"
 description = "FDL (Fory Definition Language) compiler for Apache Fory cross-language serialization"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(fory
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Apache Fory - A blazingly fast multi-language serialization framework"
     LANGUAGES CXX
 )

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-dev</Version>
+    <Version>1.2.0-dev</Version>
     <Authors>Apache Software Foundation</Authors>
     <Company>Apache Software Foundation</Company>
     <Description>Apache Fory for .NET provides high-performance cross-language serialization with source-generated serializers and schema evolution support.</Description>

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -31,7 +31,7 @@ From NuGet, reference the single `Apache.Fory` package. It includes the runtime 
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.0.0" />
+  <PackageReference Include="Apache.Fory" Version="1.1.0" />
 </ItemGroup>
 ```
 

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0-dev
+
+- Start the next Dart workspace development cycle after the 1.1.0 release.
+
+## 1.1.0
+
+- Align the Dart workspace version with the Apache Fory 1.1.0 release.
+
 ## 1.0.0
 
 - Initial version.

--- a/dart/packages/fory-test/pubspec.yaml
+++ b/dart/packages/fory-test/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory_test
 description: Apache Fory Dart consumer and integration tests
-version: 1.1.0-dev
+version: 1.2.0-dev
 
 resolution: workspace
 
@@ -25,7 +25,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  fory: 1.1.0-dev
+  fory: 1.2.0-dev
 
 dev_dependencies:
   build_runner: '>=2.7.0 <3.0.0'

--- a/dart/packages/fory/CHANGELOG.md
+++ b/dart/packages/fory/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.1.0-dev
+## 1.2.0-dev
+
+- Start the next development cycle after the 1.1.0 release.
+
+## 1.1.0
 
 - Refresh pub.dev package metadata and documentation links.
 - Update code generation dependencies for current stable Dart tooling.

--- a/dart/packages/fory/README.md
+++ b/dart/packages/fory/README.md
@@ -23,7 +23,7 @@ Add `fory` to your package dependencies.
 
 ```yaml
 dependencies:
-  fory: ^1.0.0
+  fory: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/dart/packages/fory/pubspec.yaml
+++ b/dart/packages/fory/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory
 description: Cross-language Apache Fory runtime for Dart with generated serializers, schema evolution, and custom type support.
-version: 1.1.0-dev
+version: 1.2.0-dev
 homepage: https://github.com/apache/fory
 repository: https://github.com/apache/fory/tree/main/dart/packages/fory
 issue_tracker: https://github.com/apache/fory/issues

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory_dart
 description: Apache Fory Dart workspace for the runtime package, generated serializers, and integration tests.
-version: 1.1.0-dev
+version: 1.2.0-dev
 # repository: https://github.com/my_org/my_repo
 
 environment:
@@ -25,7 +25,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  fory: 1.1.0-dev
+  fory: 1.2.0-dev
   build_runner: '>=2.7.0 <3.0.0'
 dev_dependencies:
   lints: ^6.1.0

--- a/docs/compiler/compiler-guide.md
+++ b/docs/compiler/compiler-guide.md
@@ -674,7 +674,7 @@ Add the Fory dependency to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.0.0
+  fory: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.4.0
@@ -866,5 +866,5 @@ fory = "x.y.z"
 
 ```yaml
 dependencies:
-  fory: ^1.0.0
+  fory: ^1.1.0
 ```

--- a/docs/guide/cpp/index.md
+++ b/docs/guide/cpp/index.md
@@ -63,7 +63,7 @@ include(FetchContent)
 FetchContent_Declare(
     fory
     GIT_REPOSITORY https://github.com/apache/fory.git
-    GIT_TAG        v1.0.0
+    GIT_TAG        v1.1.0
     SOURCE_SUBDIR  cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -93,11 +93,11 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.1.1")
 
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
-    commit = "v1.0.0",  # Or use a specific commit hash for reproducibility
+    commit = "v1.1.0",  # Or use a specific commit hash for reproducibility
 )
 ```
 
@@ -129,7 +129,7 @@ bazel run //:my_app
 For local development, you can use `local_path_override` instead:
 
 ```bazel
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 local_path_override(
     module_name = "fory",
     path = "/path/to/fory",

--- a/docs/guide/csharp/index.md
+++ b/docs/guide/csharp/index.md
@@ -44,7 +44,7 @@ Reference the single `Apache.Fory` package. It includes the runtime and the sour
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.0.0" />
+  <PackageReference Include="Apache.Fory" Version="1.1.0" />
 </ItemGroup>
 ```
 

--- a/docs/guide/dart/index.md
+++ b/docs/guide/dart/index.md
@@ -46,7 +46,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.0.0
+  fory: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/docs/guide/java/compression.md
+++ b/docs/guide/java/compression.md
@@ -84,7 +84,7 @@ CompressedArraySerializers.registerSerializers(fory);
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-simd</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 

--- a/docs/guide/kotlin/index.md
+++ b/docs/guide/kotlin/index.md
@@ -52,14 +52,14 @@ See [Java Features](../java/index.md#features) for complete feature list.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.0.0")
+implementation("org.apache.fory:fory-kotlin:1.1.0")
 ```
 
 ## Quick Start

--- a/docs/guide/rust/basic-serialization.md
+++ b/docs/guide/rust/basic-serialization.md
@@ -147,7 +147,7 @@ let later = timestamp.checked_add_duration(duration)?;
 
 ```toml
 [dependencies]
-fory = { version = "1.0.0", features = ["chrono"] }
+fory = { version = "1.1.0", features = ["chrono"] }
 ```
 
 ### Custom Types

--- a/docs/guide/rust/index.md
+++ b/docs/guide/rust/index.md
@@ -48,7 +48,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.0.0"
+fory = "1.1.0"
 ```
 
 ### Basic Example

--- a/docs/guide/scala/index.md
+++ b/docs/guide/scala/index.md
@@ -49,7 +49,7 @@ See [Java Features](../java/index.md#features) for complete feature list.
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.0.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.1.0"
 ```
 
 ## Quick Start

--- a/docs/guide/xlang/getting-started.md
+++ b/docs/guide/xlang/getting-started.md
@@ -31,14 +31,14 @@ This guide covers installation and basic setup for cross-language serialization 
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```gradle
-implementation 'org.apache.fory:fory-core:1.0.0'
+implementation 'org.apache.fory:fory-core:1.1.0'
 ```
 
 ### Python
@@ -57,7 +57,7 @@ go get github.com/apache/fory/go/fory
 
 ```toml
 [dependencies]
-fory = "1.0.0"
+fory = "1.1.0"
 ```
 
 ### JavaScript/TypeScript
@@ -75,13 +75,13 @@ npm install @apache-fory/core @apache-fory/hps
 ### C\#
 
 ```bash
-dotnet add package Apache.Fory --version 1.0.0
+dotnet add package Apache.Fory --version 1.1.0
 ```
 
 ### Dart
 
 ```bash
-dart pub add fory:^1.0.0
+dart pub add fory:^1.1.0
 dart pub add dev:build_runner
 ```
 
@@ -91,20 +91,20 @@ Add Fory to `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apache/fory.git", exact: "1.0.0")
+  .package(url: "https://github.com/apache/fory.git", exact: "1.1.0")
 ]
 ```
 
 ### Scala
 
 ```scala
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.0.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.1.0"
 ```
 
 ### Kotlin
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.0.0")
+implementation("org.apache.fory:fory-kotlin:1.1.0")
 ```
 
 ### C++

--- a/examples/cpp/hello_row/MODULE.bazel.example
+++ b/examples/cpp/hello_row/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.0.0")
+# bazel_dep(name = "fory", version = "1.1.0")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_row/README.md
+++ b/examples/cpp/hello_row/README.md
@@ -77,7 +77,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/examples/cpp/hello_world/MODULE.bazel.example
+++ b/examples/cpp/hello_world/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.0.0")
+# bazel_dep(name = "fory", version = "1.1.0")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_world/README.md
+++ b/examples/cpp/hello_world/README.md
@@ -70,7 +70,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.0.0")
+bazel_dep(name = "fory", version = "1.1.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/go/fory/cmd/fory/main.go
+++ b/go/fory/cmd/fory/main.go
@@ -36,7 +36,7 @@ var (
 	versionFlag = flag.Bool("version", false, "show version information")
 )
 
-const version = "1.0.0"
+const version = "1.2.0-dev"
 
 func main() {
 	flag.Parse()

--- a/integration_tests/android_tests/README.md
+++ b/integration_tests/android_tests/README.md
@@ -4,8 +4,8 @@ This project runs Android API 26+ instrumented tests for Java `fory-core`. The
 instrumented tests run against the release build type so R8/minification covers
 the static generated serializer path.
 
-The tests consume `org.apache.fory:fory-core:1.1.0-SNAPSHOT` and
-`org.apache.fory:fory-annotation-processor:1.1.0-SNAPSHOT` from the local Maven
+The tests consume `org.apache.fory:fory-core:1.2.0-SNAPSHOT` and
+`org.apache.fory:fory-annotation-processor:1.2.0-SNAPSHOT` from the local Maven
 repository, so install the Java artifacts before running Gradle:
 
 ```bash

--- a/integration_tests/android_tests/build.gradle
+++ b/integration_tests/android_tests/build.gradle
@@ -58,11 +58,11 @@ android {
 }
 
 dependencies {
-    implementation('org.apache.fory:fory-core:1.1.0-SNAPSHOT') {
+    implementation('org.apache.fory:fory-core:1.2.0-SNAPSHOT') {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'org.codehaus.janino', module: 'janino'
     }
-    annotationProcessor 'org.apache.fory:fory-annotation-processor:1.1.0-SNAPSHOT'
+    annotationProcessor 'org.apache.fory:fory-annotation-processor:1.2.0-SNAPSHOT'
     implementation 'com.google.guava:guava:32.1.2-android'
     implementation 'org.slf4j:slf4j-api:2.0.12'
 

--- a/integration_tests/graalvm_tests/pom.xml
+++ b/integration_tests/graalvm_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/grpc_tests/java/pom.xml
+++ b/integration_tests/grpc_tests/java/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/grpc_tests/python/pyproject.toml
+++ b/integration_tests/grpc_tests/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-grpc-tests"
-version = "0.18.0.dev0"
+version = "1.2.0.dev0"
 description = "gRPC compiler integration tests for Apache Fory"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/integration_tests/idl_tests/cpp/CMakeLists.txt
+++ b/integration_tests/idl_tests/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(fory_idl_tests
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Fory IDL compiler integration tests"
     LANGUAGES CXX
 )

--- a/integration_tests/idl_tests/dart/pubspec.yaml
+++ b/integration_tests/idl_tests/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: idl_dart_tests
-version: 1.1.0-dev
+version: 1.2.0-dev
 publish_to: none
 
 environment:

--- a/integration_tests/idl_tests/go/go.mod
+++ b/integration_tests/idl_tests/go/go.mod
@@ -19,7 +19,7 @@ module github.com/apache/fory/integration_tests/idl_tests/go
 
 go 1.24.0
 
-require github.com/apache/fory/go/fory v1.1.0-alpha.0
+require github.com/apache/fory/go/fory v1.2.0-alpha.0
 
 require github.com/spaolacci/murmur3 v1.1.0 // indirect
 

--- a/integration_tests/idl_tests/java/pom.xml
+++ b/integration_tests/idl_tests/java/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/idl_tests/javascript/package.json
+++ b/integration_tests/idl_tests/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fory-idl-tests",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "Fory IDL integration tests for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/integration_tests/idl_tests/kotlin/pom.xml
+++ b/integration_tests/idl_tests/kotlin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../../../kotlin/pom.xml</relativePath>
     </parent>
 

--- a/integration_tests/idl_tests/python/pyproject.toml
+++ b/integration_tests/idl_tests/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-idl-tests"
-version = "1.1.0.dev0"
+version = "1.2.0.dev0"
 description = "IDL compiler integration tests for Apache Fory"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/integration_tests/idl_tests/rust/Cargo.lock
+++ b/integration_tests/idl_tests/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fory"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 dependencies = [
  "fory-core",
  "fory-derive",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "fory-core"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 dependencies = [
  "byteorder",
  "chrono",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "fory-derive"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 dependencies = [
  "fory-core",
  "proc-macro2",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "idl_tests"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 dependencies = [
  "chrono",
  "fory",

--- a/integration_tests/idl_tests/rust/Cargo.toml
+++ b/integration_tests/idl_tests/rust/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "idl_tests"
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/integration_tests/jdk_compatibility_tests/pom.xml
+++ b/integration_tests/jdk_compatibility_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/jpms_tests/pom.xml
+++ b/integration_tests/jpms_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java/README.md
+++ b/java/README.md
@@ -61,28 +61,28 @@ Apache Fory™ Java provides blazingly-fast serialization for the Java ecosystem
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 
 <!-- Optional: Row format support -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 
 <!-- Optional: Serializers for Protobuf data -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-extensions</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 
 <!-- Optional: SIMD acceleration (Java 16+) -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-simd</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -90,11 +90,11 @@ Apache Fory™ Java provides blazingly-fast serialization for the Java ecosystem
 
 ```gradle
 dependencies {
-    implementation 'org.apache.fory:fory-core:1.0.0'
+    implementation 'org.apache.fory:fory-core:1.1.0'
     // Optional modules
-    implementation 'org.apache.fory:fory-format:1.0.0'
-    implementation 'org.apache.fory:fory-simd:1.0.0'
-    implementation 'org.apache.fory:fory-extensions:1.0.0'
+    implementation 'org.apache.fory:fory-format:1.1.0'
+    implementation 'org.apache.fory:fory-simd:1.1.0'
+    implementation 'org.apache.fory:fory-extensions:1.1.0'
 }
 ```
 

--- a/java/fory-annotation-processor/pom.xml
+++ b/java/fory-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-core/pom.xml
+++ b/java/fory-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-extensions/pom.xml
+++ b/java/fory-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-format/pom.xml
+++ b/java/fory-format/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-graalvm-feature/pom.xml
+++ b/java/fory-graalvm-feature/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java/fory-latest-jdk-tests/pom.xml
+++ b/java/fory-latest-jdk-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>fory-latest-jdk-tests</artifactId>

--- a/java/fory-test-core/pom.xml
+++ b/java/fory-test-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-testsuite/pom.xml
+++ b/java/fory-testsuite/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Fory Project Parent POM</name>
   <description>
     Apache Fory™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy.

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -6066,7 +6066,7 @@
     },
     "packages/core": {
       "name": "@apache-fory/core",
-      "version": "1.1.0-alpha.0",
+      "version": "1.2.0-alpha.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hps"
@@ -6099,7 +6099,7 @@
     },
     "packages/hps": {
       "name": "@apache-fory/hps",
-      "version": "1.1.0-alpha.0",
+      "version": "1.2.0-alpha.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apache-fory/core",
-  "version": "1.1.0-alpha.0",
+  "version": "1.2.0-alpha.0",
   "description": "Apache Fory™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy",
   "homepage": "https://fory.apache.org/docs/guide/javascript",
   "main": "dist/index.js",

--- a/javascript/packages/hps/package.json
+++ b/javascript/packages/hps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apache-fory/hps",
-  "version": "1.1.0-alpha.0",
+  "version": "1.2.0-alpha.0",
   "description": "Apache Fory™ nodejs high-performance suite",
   "homepage": "https://fory.apache.org/docs/guide/javascript",
   "main": "dist/index.js",

--- a/kotlin/fory-kotlin-ksp/pom.xml
+++ b/kotlin/fory-kotlin-ksp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/fory-kotlin-tests/pom.xml
+++ b/kotlin/fory-kotlin-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/fory-kotlin/pom.xml
+++ b/kotlin/fory-kotlin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-kotlin-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/python/pyfory/__init__.py
+++ b/python/pyfory/__init__.py
@@ -135,7 +135,7 @@ from pyfory.type_util import (  # noqa: F401 # pylint: disable=unused-import
 )
 from pyfory.policy import DeserializationPolicy  # noqa: F401 # pylint: disable=unused-import
 
-__version__ = "1.1.0.dev0"
+__version__ = "1.2.0.dev0"
 
 __all__ = [
     # Core classes

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0-alpha.0"
+version = "1.2.0-alpha.0"
 rust-version = "1.70"
 description = "Apache Fory: Blazingly fast multi-language serialization framework with trait objects and reference support."
 license = "Apache-2.0"
@@ -42,5 +42,5 @@ keywords = ["serialization", "serde", "trait-object", "zero-copy", "schema-evolu
 categories = ["encoding"]
 
 [workspace.dependencies]
-fory-core = { path = "fory-core", version = "1.1.0-alpha.0" }
-fory-derive = { path = "fory-derive", version = "1.1.0-alpha.0" }
+fory-core = { path = "fory-core", version = "1.2.0-alpha.0" }
+fory-derive = { path = "fory-derive", version = "1.2.0-alpha.0" }

--- a/rust/README.md
+++ b/rust/README.md
@@ -33,7 +33,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.0.0"
+fory = "1.1.0"
 ```
 
 ### Basic Example

--- a/scala/README.md
+++ b/scala/README.md
@@ -165,7 +165,7 @@ val fory = ForyScala.builder().withXlang(false)
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.0.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.1.0"
 ```
 
 ## Building

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-val foryVersion = "1.1.0-SNAPSHOT"
+val foryVersion = "1.2.0-SNAPSHOT"
 val scala213Version = "2.13.15"
 ThisBuild / apacheSonatypeProjectProfile := "fory"
 version := foryVersion

--- a/swift/README.md
+++ b/swift/README.md
@@ -33,7 +33,7 @@ The Swift implementation provides high-performance object graph serialization wi
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apache/fory.git", from: "1.0.0")
+    .package(url: "https://github.com/apache/fory.git", from: "1.1.0")
 ],
 targets: [
     .target(


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

