### PR TITLE
fix(java): fix deflater memory leak

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/meta/DeflaterMetaCompressor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/DeflaterMetaCompressor.java
@@ -34,9 +34,13 @@ public class DeflaterMetaCompressor implements MetaCompressor {
     deflater.finish();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     byte[] buffer = new byte[128];
-    while (!deflater.finished()) {
-      int compressedSize = deflater.deflate(buffer);
-      outputStream.write(buffer, 0, compressedSize);
+    try {
+      while (!deflater.finished()) {
+        int compressedSize = deflater.deflate(buffer);
+        outputStream.write(buffer, 0, compressedSize);
+      }
+    } finally {
+      deflater.end();
     }
     return outputStream.toByteArray();
   }


### PR DESCRIPTION


## Why?

A large number of `Fory` instances on `COMPATIBLE` mode or large amount and size object meta result in native memory leak.

Native memory allocated by `libzip.so` won't be cleaned unitl next GC, making many `64M` memory chunks staying in memory space.



## What does this PR do?

Explicitly close native memory allocated by libzip.so.

Decompress method is fixed in #3472. Only compress method should be fixed.



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR:  `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

