### PR TITLE
fix(compiler): handle nested container ref pointer options in Rust compiler correctly

### DIFF
--- a/compiler/fory_compiler/generators/rust.py
+++ b/compiler/fory_compiler/generators/rust.py
@@ -1039,12 +1039,18 @@ class RustGenerator(BaseGenerator):
         elif isinstance(field_type, ListType):
             effective_element_optional = element_optional or field_type.element_optional
             effective_element_ref = element_ref or field_type.element_ref
+            element_pointer_type = pointer_type
+            if field_type.element_ref:
+                element_pointer_type = self.get_pointer_type(
+                    field_type.element_ref_options,
+                    field_type.element_ref_options.get("weak_ref") is True,
+                )
             element_type = self.generate_type(
                 field_type.element_type,
                 nullable=effective_element_optional,
                 ref=effective_element_ref,
                 parent_stack=parent_stack,
-                pointer_type=pointer_type,
+                pointer_type=element_pointer_type,
             )
             list_type = f"::std::vec::Vec<{element_type}>"
             if ref:
@@ -1076,12 +1082,18 @@ class RustGenerator(BaseGenerator):
                 parent_stack=parent_stack,
                 pointer_type=pointer_type,
             )
+            value_pointer_type = pointer_type
+            if field_type.value_ref:
+                value_pointer_type = self.get_pointer_type(
+                    field_type.value_ref_options,
+                    field_type.value_ref_options.get("weak_ref") is True,
+                )
             value_type = self.generate_type(
                 field_type.value_type,
                 nullable=False,
                 ref=field_type.value_ref,
                 parent_stack=parent_stack,
-                pointer_type=pointer_type,
+                pointer_type=value_pointer_type,
             )
             map_type = f"::std::collections::HashMap<{key_type}, {value_type}>"
             if ref:

--- a/compiler/fory_compiler/tests/test_generated_code.py
+++ b/compiler/fory_compiler/tests/test_generated_code.py
@@ -205,6 +205,43 @@ def test_rust_generated_code_can_use_chrono_temporal_types():
     assert "::fory::Duration" not in rust_output
 
 
+def test_rust_nested_container_ref_uses_correct_pointer_type():
+    schema = parse_fdl(
+        dedent(
+            """
+            package gen;
+
+            message Node {
+                string value = 1;
+            }
+
+            message Request {
+                list<list<ref(thread_safe=true) Node>> groups = 1;
+                map<string, map<string, ref(thread_safe=true) Node>> nodes = 2;
+            }
+            """
+        )
+    )
+
+    rust_output = render_files(generate_files(schema, RustGenerator))
+
+    assert (
+        "pub groups: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<Node>>>,"
+        in rust_output
+    )
+    assert "::std::vec::Vec<::std::vec::Vec<::std::rc::Rc<Node>>>" not in rust_output
+    assert (
+        "pub nodes: ::std::collections::HashMap<::std::string::String, "
+        "::std::collections::HashMap<::std::string::String, ::std::sync::Arc<Node>>>,"
+        in rust_output
+    )
+    assert (
+        "::std::collections::HashMap<::std::string::String, "
+        "::std::collections::HashMap<::std::string::String, ::std::rc::Rc<Node>>>"
+        not in rust_output
+    )
+
+
 def test_generated_code_integer_encoding_variants_equivalent():
     fdl = dedent(
         """


### PR DESCRIPTION
## Why?

The Rust compiler should correctly apply ref pointer options for **nested** container element/value references.

## What does this PR do?

- Handle nested container ref pointer options correctly.
- Add corresponding testcase.

## Related issues

Fixes https://github.com/apache/fory/issues/3730.

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: no
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?

N/A.

## Benchmark

N/A.