### PR TITLE
feat(compiler): reject non-thread-safe payload types in Rust compiler

### DIFF
--- a/compiler/fory_compiler/generators/rust.py
+++ b/compiler/fory_compiler/generators/rust.py
@@ -93,11 +93,127 @@ class RustGenerator(BaseGenerator):
     def generate(self) -> List[GeneratedFile]:
         """Generate Rust files for the schema."""
         files = []
+        self._grpc_reachable_type_ids = (
+            self.validate_grpc_payload_safe() if self.options.grpc else set()
+        )
 
         # Generate a single module file with all types
         files.append(self.generate_module())
 
         return files
+
+    def is_grpc_reachable_type(self, type_def: object) -> bool:
+        if not hasattr(self, "_grpc_reachable_type_ids"):
+            raise AttributeError(
+                "RustGenerator gRPC reachability is initialized by generate()"
+            )
+        return id(type_def) in self._grpc_reachable_type_ids
+
+    def grpc_payload_root_names(self) -> Set[str]:
+        names: Set[str] = set()
+        for service in self.schema.services:
+            if self.is_imported_type(service):
+                continue
+            for method in service.methods:
+                names.add(method.request_type.name)
+                names.add(method.response_type.name)
+        return names
+
+    def validate_grpc_payload_safe(self) -> Set[int]:
+        reachable: Set[int] = set()
+
+        def require_thread_safe_ref(
+            path: List[str], description: str, ref_options: dict
+        ) -> None:
+            if ref_options.get("thread_safe_pointer") is not True:
+                raise ValueError(
+                    f"Rust gRPC payload type {'.'.join(path)} uses non-thread-safe {description}; "
+                    "consider using ref(thread_safe=true)"
+                )
+
+        def visit_named(
+            type_name: str,
+            path: List[str],
+            parent_stack: Optional[List[Message]] = None,
+        ) -> None:
+            resolved = self.resolve_named_type(type_name, parent_stack)
+            if resolved is None:
+                return
+            key = id(resolved)
+            if key in reachable:
+                return
+            reachable.add(key)
+            owner_stack = self._parent_stack_for_type(resolved)
+            if isinstance(resolved, Message):
+                if self.is_imported_type(resolved):
+                    raise ValueError(
+                        f"Rust gRPC payload type {'.'.join(path)} is an imported message. "
+                        "Consider moving the message definition into the "
+                        "current schema or remove it from the gRPC service payload."
+                    )
+                lineage = owner_stack + [resolved]
+                for field in resolved.fields:
+                    visit_field(field, path + [field.name], lineage)
+            elif isinstance(resolved, Union):
+                if self.is_imported_type(resolved):
+                    raise ValueError(
+                        f"Rust gRPC payload type {'.'.join(path)} is an imported union. "
+                        "Consider moving the union definition into the "
+                        "current schema or remove it from the gRPC service payload."
+                    )
+                for field in resolved.fields:
+                    visit_field(
+                        field,
+                        path + [self.to_pascal_case(field.name)],
+                        owner_stack,
+                    )
+
+        def visit_field(
+            field: Field,
+            path: List[str],
+            parent_stack: Optional[List[Message]],
+        ) -> None:
+            if field.ref:
+                require_thread_safe_ref(path, "ref", field.ref_options)
+            if isinstance(field.field_type, ListType) and field.element_ref:
+                require_thread_safe_ref(
+                    path, "list element ref", field.element_ref_options
+                )
+            visit_field_type(field.field_type, path, parent_stack)
+
+        def visit_field_type(
+            field_type: FieldType,
+            path: List[str],
+            parent_stack: Optional[List[Message]],
+        ) -> None:
+            if isinstance(field_type, PrimitiveType):
+                # All primitive types but `any` is safe (`Send` + `Sync`).
+                if field_type.kind == PrimitiveKind.ANY:
+                    raise ValueError(
+                        f"Rust gRPC payload type {'.'.join(path)} uses non-thread-safe any"
+                    )
+            elif isinstance(field_type, NamedType):
+                visit_named(field_type.name, path + [field_type.name], parent_stack)
+            elif isinstance(field_type, ListType):
+                if field_type.element_ref:
+                    require_thread_safe_ref(
+                        path, "list element ref", field_type.element_ref_options
+                    )
+                visit_field_type(field_type.element_type, path, parent_stack)
+            elif isinstance(field_type, ArrayType):
+                visit_field_type(field_type.element_type, path, parent_stack)
+            elif isinstance(field_type, MapType):
+                if field_type.value_ref:
+                    require_thread_safe_ref(
+                        path, "map value ref", field_type.value_ref_options
+                    )
+                visit_field_type(field_type.key_type, path, parent_stack)
+                visit_field_type(field_type.value_type, path, parent_stack)
+
+        for root in self.grpc_payload_root_names():
+            visit_named(root, [root])
+
+        return reachable
 
     def get_module_name(self) -> str:
         """Get the Rust module name."""
@@ -374,10 +490,14 @@ class RustGenerator(BaseGenerator):
         for trait in ("Clone", "Debug", "PartialEq", "Eq", "Hash"):
             if self.union_supports_trait(union, trait, parent_stack):
                 derives.append(trait)
+        if self.is_grpc_reachable_type(union):
+            # Tell the derive macro that this union intentionally omits UnknownCase.
+            lines.append("#[fory(no_unknown_case)]")
         lines.append(f"#[derive({', '.join(derives)})]")
         lines.append(f"pub enum {union.name} {{")
-        lines.append("    #[fory(unknown)]")
-        lines.append("    Unknown(::fory::UnknownCase),")
+        if not self.is_grpc_reachable_type(union):
+            lines.append("    #[fory(unknown)]")
+            lines.append("    Unknown(::fory::UnknownCase),")
 
         for index, field in enumerate(union.fields):
             variant_name = self.to_pascal_case(field.name)
@@ -543,21 +663,32 @@ class RustGenerator(BaseGenerator):
         )
 
     def _lineage_for_message(self, message: Message) -> List[Message]:
-        lineage: List[Message] = []
+        return self._parent_stack_for_type(message) + [message]
 
-        def visit(current: Message, parents: List[Message]) -> bool:
-            if current is message:
-                lineage.extend(parents + [current])
+    def _parent_stack_for_type(self, type_def: object) -> List[Message]:
+        found: List[Message] = []
+
+        def visit(current: Message, stack: List[Message]) -> bool:
+            if current is type_def:
+                found.extend(stack)
                 return True
+            for nested_union in current.nested_unions:
+                if nested_union is type_def:
+                    found.extend(stack + [current])
+                    return True
+            for nested_enum in current.nested_enums:
+                if nested_enum is type_def:
+                    found.extend(stack + [current])
+                    return True
             for nested in current.nested_messages:
-                if visit(nested, parents + [current]):
+                if visit(nested, stack + [current]):
                     return True
             return False
 
         for top in self.schema.messages:
             if visit(top, []):
                 break
-        return lineage
+        return found
 
     def union_supports_trait(
         self,

--- a/compiler/fory_compiler/tests/test_generated_code.py
+++ b/compiler/fory_compiler/tests/test_generated_code.py
@@ -68,9 +68,9 @@ def parse_fbs(source: str) -> Schema:
 
 
 def generate_files(
-    schema: Schema, generator_cls: Type[BaseGenerator]
+    schema: Schema, generator_cls: Type[BaseGenerator], grpc: bool = False
 ) -> Dict[str, str]:
-    options = GeneratorOptions(output_dir=Path("/tmp"))
+    options = GeneratorOptions(output_dir=Path("/tmp"), grpc=grpc)
     generator = generator_cls(schema, options)
     return {item.path: item.content for item in generator.generate()}
 
@@ -224,6 +224,184 @@ def test_rust_nested_container_ref_uses_correct_pointer_type():
     )
 
     rust_output = render_files(generate_files(schema, RustGenerator))
+
+    assert (
+        "pub groups: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<Node>>>,"
+        in rust_output
+    )
+    assert "::std::vec::Vec<::std::vec::Vec<::std::rc::Rc<Node>>>" not in rust_output
+    assert (
+        "pub nodes: ::std::collections::HashMap<::std::string::String, "
+        "::std::collections::HashMap<::std::string::String, ::std::sync::Arc<Node>>>,"
+        in rust_output
+    )
+    assert (
+        "::std::collections::HashMap<::std::string::String, "
+        "::std::collections::HashMap<::std::string::String, ::std::rc::Rc<Node>>>"
+        not in rust_output
+    )
+
+
+def test_rust_grpc_reachable_union_has_no_unknown_case():
+    schema = parse_fdl(
+        dedent(
+            """
+            package gen;
+
+            message Dog {
+                string name = 1;
+            }
+
+            union Animal {
+                Dog dog = 1;
+            }
+
+            message Request {
+                Animal animal = 1;
+            }
+
+            message Response {
+                Animal animal = 1;
+            }
+
+            service Zoo {
+                rpc Echo(Request) returns (Response);
+            }
+            """
+        )
+    )
+
+    rust_output = render_files(generate_files(schema, RustGenerator, grpc=True))
+    assert "#[fory(no_unknown_case)]" in rust_output
+    assert "#[fory(unknown)]" not in rust_output
+    assert "Unknown(" not in rust_output
+
+
+def test_rust_grpc_rejects_non_thread_safe_payload():
+    with pytest.raises(
+        ValueError,
+        match="Rust gRPC payload type Request.groups uses non-thread-safe list element ref",
+    ):
+        generate_files(
+            parse_fdl(
+                dedent(
+                    """
+                    package gen;
+
+                    message Node {
+                        string value = 1;
+                    }
+
+                    message Request {
+                        list<list<ref Node>> groups = 1;
+                    }
+
+                    message Response {
+                        string ok = 1;
+                    }
+
+                    service S {
+                        rpc Call(Request) returns (Response);
+                    }
+                    """
+                )
+            ),
+            RustGenerator,
+            grpc=True,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Rust gRPC payload type Request.nodes uses non-thread-safe map value ref",
+    ):
+        generate_files(
+            parse_fdl(
+                dedent(
+                    """
+                    package gen;
+
+                    message Node {
+                        string value = 1;
+                    }
+
+                    message Request {
+                        map<string, map<string, ref Node>> nodes = 1;
+                    }
+
+                    message Response {
+                        string ok = 1;
+                    }
+
+                    service S {
+                        rpc Call(Request) returns (Response);
+                    }
+                    """
+                )
+            ),
+            RustGenerator,
+            grpc=True,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Rust gRPC payload type Request.payload uses non-thread-safe any",
+    ):
+        generate_files(
+            parse_fdl(
+                dedent(
+                    """
+                    package gen;
+
+                    message Request {
+                        any payload = 1;
+                    }
+
+                    message Response {
+                        string ok = 1;
+                    }
+
+                    service S {
+                        rpc Call(Request) returns (Response);
+                    }
+                    """
+                )
+            ),
+            RustGenerator,
+            grpc=True,
+        )
+
+
+def test_rust_grpc_allows_thread_safe_payload():
+    rust_output = render_files(
+        generate_files(
+            parse_fdl(
+                dedent(
+                    """
+                    package gen;
+
+                    message Node {
+                        string value = 1;
+                    }
+
+                    message Request {
+                        list<list<ref(thread_safe=true) Node>> groups = 1;
+                        map<string, map<string, ref(thread_safe=true) Node>> nodes = 2;
+                    }
+
+                    message Response {
+                        string ok = 1;
+                    }
+
+                    service S {
+                        rpc Call(Request) returns (Response);
+                    }
+                    """
+                )
+            ),
+            RustGenerator,
+            grpc=True,
+        )
+    )
 
     assert (
         "pub groups: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<Node>>>,"

--- a/rust/fory-derive/src/object/derive_enum.rs
+++ b/rust/fory-derive/src/object/derive_enum.rs
@@ -979,7 +979,7 @@ fn rust_compatible_variant_read_branches(
         .collect()
 }
 
-pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
+pub fn gen_read_data(data_enum: &DataEnum, no_unknown_case: bool) -> TokenStream {
     let is_union_compatible = is_union_compatible_enum(data_enum);
     let has_data_variants = data_enum
         .variants
@@ -1037,16 +1037,29 @@ pub fn gen_read_data(data_enum: &DataEnum) -> TokenStream {
         // ForyUnion validation guarantees xlang-compatible ADTs have the
         // runtime Unknown carrier. A skip/default fallback here would drop
         // forward-compatible payload metadata instead of preserving it.
-        let variant = data_enum
+        match data_enum
             .variants
             .iter()
             .find(|variant| is_runtime_unknown_variant(variant))
-            .expect("xlang-compatible ForyUnion requires Unknown(UnknownCase)");
-        let ident = &variant.ident;
-        quote! {
-            _ => {
-                let value = ::fory_core::serializer::unknown_case::read_payload(context, ordinal)?;
-                Ok(Self::#ident(value))
+        {
+            Some(variant) => {
+                let ident = &variant.ident;
+                quote! {
+                    _ => {
+                        let value = ::fory_core::serializer::unknown_case::read_payload(context, ordinal)?;
+                        Ok(Self::#ident(value))
+                    }
+                }
+            }
+            None if no_unknown_case => {
+                quote! {
+                    _ => return Err(::fory_core::error::Error::unknown_enum(
+                        "unknown union variant: union has no UnknownCase carrier"
+                    ))
+                }
+            }
+            None => {
+                panic!("xlang-compatible ForyUnion requires Unknown(UnknownCase)");
             }
         }
     } else {

--- a/rust/fory-derive/src/object/derive_union.rs
+++ b/rust/fory-derive/src/object/derive_union.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::util::{enum_variant_id, has_fory_unknown_attr, is_runtime_unknown_variant};
+use super::util::{
+    enum_variant_id, has_fory_no_unknown_case_attr, has_fory_unknown_attr,
+    is_runtime_unknown_variant,
+};
 use syn::{Attribute, Data, DataEnum, DeriveInput, Fields};
 
 pub(crate) fn validate_input(input: &DeriveInput) -> syn::Result<()> {
@@ -44,10 +47,18 @@ pub(crate) fn validate_input(input: &DeriveInput) -> syn::Result<()> {
             "ForyUnion unknown case must be #[fory(unknown)] Unknown(UnknownCase) without an id",
         ));
     }
-    if is_typed_adt_union(data_enum) && !data_enum.variants.iter().any(is_runtime_unknown_variant) {
+    let has_runtime_unknown_case = data_enum.variants.iter().any(is_runtime_unknown_variant);
+    let no_unknown_case = has_fory_no_unknown_case_attr(&input.attrs);
+    if no_unknown_case && has_runtime_unknown_case {
         return Err(syn::Error::new(
             input.ident.span(),
-            "ForyUnion typed ADT unions require #[fory(unknown)] Unknown(UnknownCase)",
+            "ForyUnion #[fory(no_unknown_case)] cannot be combined with #[fory(unknown)] Unknown(UnknownCase)",
+        ));
+    }
+    if is_typed_adt_union(data_enum) && !no_unknown_case && !has_runtime_unknown_case {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "ForyUnion typed ADT unions require #[fory(unknown)] Unknown(UnknownCase) unless #[fory(no_unknown_case)] is set",
         ));
     }
     let non_unknown_count = data_enum
@@ -278,5 +289,18 @@ mod tests {
 
         let error = validate_input(&input).unwrap_err();
         assert!(error.to_string().contains("duplicate ForyUnion case id 0"));
+    }
+
+    #[test]
+    fn no_unknown_case_allows_closed_union() {
+        let input: DeriveInput = parse_quote!(
+            #[fory(no_unknown_case)]
+            enum ClosedUnion {
+                #[fory(default)]
+                Dog(String),
+            }
+        );
+
+        validate_input(&input).unwrap();
     }
 }

--- a/rust/fory-derive/src/object/serializer.rs
+++ b/rust/fory-derive/src/object/serializer.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::object::util::is_default_value_variant;
+use crate::object::util::{has_fory_no_unknown_case_attr, is_default_value_variant};
 use crate::object::{derive_enum, misc, read, write};
 use crate::util::{extract_fields, source_fields};
 use crate::ForyAttrs;
@@ -125,17 +125,20 @@ pub fn derive_serializer(ast: &syn::DeriveInput, attrs: ForyAttrs) -> TokenStrea
                 quote! { ::fory_core::TypeId::STRUCT },
             )
         }
-        syn::Data::Enum(e) => (
-            derive_enum::gen_write(e),
-            derive_enum::gen_write_data(e),
-            derive_enum::gen_write_type_info(e),
-            derive_enum::gen_read(e),
-            derive_enum::gen_read_with_type_info(e),
-            derive_enum::gen_read_data(e),
-            derive_enum::gen_read_type_info(e),
-            derive_enum::gen_reserved_space(),
-            derive_enum::gen_static_type_id(e),
-        ),
+        syn::Data::Enum(e) => {
+            let no_unknown_case = has_fory_no_unknown_case_attr(&ast.attrs);
+            (
+                derive_enum::gen_write(e),
+                derive_enum::gen_write_data(e),
+                derive_enum::gen_write_type_info(e),
+                derive_enum::gen_read(e),
+                derive_enum::gen_read_with_type_info(e),
+                derive_enum::gen_read_data(e, no_unknown_case),
+                derive_enum::gen_read_type_info(e),
+                derive_enum::gen_reserved_space(),
+                derive_enum::gen_static_type_id(e),
+            )
+        }
         syn::Data::Union(_) => {
             panic!("Union is not supported")
         }

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -909,6 +909,25 @@ pub(crate) fn has_fory_unknown_attr(variant: &syn::Variant) -> bool {
     })
 }
 
+pub(crate) fn has_fory_no_unknown_case_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("fory") {
+            return false;
+        }
+        let mut no_unknown_case = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("no_unknown_case") {
+                no_unknown_case = true;
+            } else if !meta.input.is_empty() {
+                let value = meta.value()?;
+                let _ = value.parse::<syn::Expr>()?;
+            }
+            Ok(())
+        });
+        no_unknown_case
+    })
+}
+
 pub(crate) fn is_unknown_case_type(ty: &Type) -> bool {
     let Type::Path(type_path) = ty else {
         return false;


### PR DESCRIPTION
## Why?

This is a prerequisite PR for Rust gRPC code generation. 

In the Rust gRPC code generation requirement, we chose tonic as the network transport layer for gRPC, so the generated Rust code needs to be compatible with tonic.

In tonic, a gRPC payload (a request or a response) type must be both `Send` and `Sync`, e.g. 

https://docs.rs/tonic/latest/tonic/client/struct.Grpc.html#method.unary

However, in Fory, users can define the following types, which cause the generated Rust types to be neither `Send` nor `Sync`:

- Non-thread-safe refs
- `any`

In addition, Fory currently generates an `UnknownCase` by default for a union type.

https://github.com/apache/fory/blob/33b0d6e8b73d1769d98824195b9155043266f3fe/compiler/fory_compiler/generators/rust.py#L379-L380

However, the type of its `value` field is `Arc<dyn Any>`, rather than something like `Arc<dyn Any + Send + Sync>`.

https://github.com/apache/fory/blob/33b0d6e8b73d1769d98824195b9155043266f3fe/rust/fory-core/src/types/unknown_case.rs#L24-L32

## What does this PR do?

In this PR, I made the following changes:

1. Before generating Rust gRPC stub code, all types used by gRPC payloads are checked via graph traversal. If their fields contain non-thread-safe refs or `any`, an error will be raised directly with a corresponding diagnostic message for the user.
2. `UnknownCase` is not generated for unions used by gRPC payloads. Currently, I use a special macro attribute `#[fory(no_unknown_case)]` to make the derive macro logic handle this case specially, rather than directly panicking when encountering a union without an `UnknownCase`.
3. Add testcases accordingly.

It is worth noting that, for simplicity, if a gRPC payload type contains imported types, the current implementation will directly raise an error and exit.

## Related issues

https://github.com/apache/fory/issues/3266

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?

All unions in gRPC payload types will not generate `UnknownCase`.

## Benchmark

N/A.