### PR TITLE
fix(compiler): make Go gRPC codec stateless and add collision checks

### DIFF
--- a/compiler/fory_compiler/generators/go.py
+++ b/compiler/fory_compiler/generators/go.py
@@ -204,12 +204,9 @@ class GoGenerator(GoServiceGeneratorMixin, BaseGenerator):
 
         self.validate_type_names()
 
-        # Generate a single Go file with all types
+        # gRPC service companions are emitted by the CLI via generate_services();
+        # emitting them here too would write _grpc.go twice.
         files.append(self.generate_file())
-
-        # Generate gRPC service stubs if requested
-        if self.options.grpc:
-            files.extend(self.generate_services())
 
         return files
 

--- a/compiler/fory_compiler/generators/go.py
+++ b/compiler/fory_compiler/generators/go.py
@@ -204,8 +204,7 @@ class GoGenerator(GoServiceGeneratorMixin, BaseGenerator):
 
         self.validate_type_names()
 
-        # gRPC service companions are emitted by the CLI via generate_services();
-        # emitting them here too would write _grpc.go twice.
+        # gRPC service companions are emitted by the CLI via generate_services().
         files.append(self.generate_file())
 
         return files

--- a/compiler/fory_compiler/generators/services/go.py
+++ b/compiler/fory_compiler/generators/services/go.py
@@ -207,23 +207,10 @@ class GoServiceGeneratorMixin:
     def _generate_codec(self) -> List[str]:
         lines: List[str] = []
         lines.append(
-            "// CodecV2 implements grpc/encoding.CodecV2 using Fory serialization."
-        )
-        lines.append(
-            "// It is stateless and uses the package thread-safe Fory runtime"
-        )
-        lines.append(
-            "// (getFory), so it is safe to share across concurrent RPCs."
+            "// CodecV2 implements grpc/encoding.CodecV2 using the package Fory runtime."
         )
         lines.append("type CodecV2 struct{}")
         lines.append("")
-        lines.append(
-            "// Marshal serializes v with the package Fory runtime. getFory().Serialize"
-        )
-        lines.append(
-            "// returns a freshly allocated slice per call, so streaming handlers that"
-        )
-        lines.append("// buffer multiple frames never alias the same buffer.")
         lines.append("func (CodecV2) Marshal(v any) (mem.BufferSlice, error) {")
         lines.append("\tb, err := getFory().Serialize(v)")
         lines.append("\tif err != nil {")
@@ -232,13 +219,6 @@ class GoServiceGeneratorMixin:
         lines.append("\treturn mem.BufferSlice{mem.NewBuffer(&b, nil)}, nil")
         lines.append("}")
         lines.append("")
-        lines.append(
-            "// Unmarshal deserializes the gRPC frame into v. Each buffer segment is"
-        )
-        lines.append(
-            "// copied into a fresh slice because the transport may reclaim the"
-        )
-        lines.append("// underlying memory before Fory finishes reading it.")
         lines.append("func (CodecV2) Unmarshal(data mem.BufferSlice, v any) error {")
         lines.append("\tb := make([]byte, data.Len())")
         lines.append("\tn := 0")

--- a/compiler/fory_compiler/generators/services/go.py
+++ b/compiler/fory_compiler/generators/services/go.py
@@ -36,7 +36,56 @@ class GoServiceGeneratorMixin:
         ]
         if not local_services:
             return []
+        self._check_method_collisions(local_services)
+        self._check_service_collisions(local_services)
         return [self._generate_grpc_file(local_services)]
+
+    def _check_method_collisions(self, services: List[Service]) -> None:
+        """Reject methods whose PascalCase names collide within a service.
+
+        to_pascal_case folds case (Foo and foo both yield Foo), which would
+        emit duplicate interface methods, handlers, and stream types.
+        """
+        for service in services:
+            seen: dict = {}
+            for method in service.methods:
+                name = self.to_pascal_case(method.name)
+                if name in seen:
+                    raise ValueError(
+                        f"Go gRPC method name collision in service {service.name}: "
+                        f"{seen[name]} and {method.name} both generate {name}"
+                    )
+                seen[name] = method.name
+
+    def _check_service_collisions(self, services: List[Service]) -> None:
+        """Reject services whose generated identifiers collide with each other
+        or with a generated type in the same package."""
+        generated_type_names = {
+            type_def.name
+            for type_def in (
+                *self.schema.enums,
+                *self.schema.unions,
+                *self.schema.messages,
+            )
+            if not self.is_imported_type(type_def)
+        }
+        seen_services: dict = {}
+        for service in services:
+            if service.name in seen_services:
+                raise ValueError(
+                    f"Go gRPC service name collision: two services named {service.name}"
+                )
+            seen_services[service.name] = service.name
+            for generated in (
+                f"{service.name}Client",
+                f"{service.name}Server",
+                f"Unimplemented{service.name}Server",
+            ):
+                if generated in generated_type_names:
+                    raise ValueError(
+                        f"Go gRPC service {service.name} generates {generated} which "
+                        "conflicts with a generated type; rename the service or type"
+                    )
 
     def _generate_grpc_file(self, services: List[Service]) -> GeneratedFile:
         """Generate one _grpc.go file containing all services in the schema."""
@@ -85,7 +134,6 @@ class GoServiceGeneratorMixin:
             '"google.golang.org/grpc/codes"',
             '"google.golang.org/grpc/mem"',
             '"google.golang.org/grpc/status"',
-            '"github.com/apache/fory/go/fory"',
         ]
 
         for alias, path in tracker._imports.items():
@@ -142,7 +190,6 @@ class GoServiceGeneratorMixin:
         lines: List[str] = []
         lines.append(f"type {self.to_camel_case(service.name)}Client struct {{")
         lines.append("\tcc grpc.ClientConnInterface")
-        lines.append("\tfory *fory.Fory")
         lines.append("}")
         lines.append("")
         return lines
@@ -150,11 +197,9 @@ class GoServiceGeneratorMixin:
     def _generate_new_client(self, service: Service) -> List[str]:
         lines: List[str] = []
         lines.append(
-            f"func New{service.name}Client(cc grpc.ClientConnInterface, f *fory.Fory) {service.name}Client {{"
+            f"func New{service.name}Client(cc grpc.ClientConnInterface) {service.name}Client {{"
         )
-        lines.append(
-            f"\treturn &{self.to_camel_case(service.name)}Client{{cc: cc, fory: f}}"
-        )
+        lines.append(f"\treturn &{self.to_camel_case(service.name)}Client{{cc: cc}}")
         lines.append("}")
         lines.append("")
         return lines
@@ -165,30 +210,26 @@ class GoServiceGeneratorMixin:
             "// CodecV2 implements grpc/encoding.CodecV2 using Fory serialization."
         )
         lines.append(
-            "// Pass a configured *fory.Fory instance with all message types registered."
+            "// It is stateless and uses the package thread-safe Fory runtime"
         )
-        lines.append("type CodecV2 struct {")
-        lines.append("\tFory *fory.Fory")
-        lines.append("}")
+        lines.append(
+            "// (getFory), so it is safe to share across concurrent RPCs."
+        )
+        lines.append("type CodecV2 struct{}")
         lines.append("")
         lines.append(
-            "// Marshal serializes v with Fory. The result is copied before being handed"
+            "// Marshal serializes v with the package Fory runtime. getFory().Serialize"
         )
         lines.append(
-            "// to gRPC because Fory reuses its internal write buffer across calls —"
+            "// returns a freshly allocated slice per call, so streaming handlers that"
         )
-        lines.append(
-            "// streaming handlers may buffer multiple frames before sending, and without"
-        )
-        lines.append("// a copy all frames would alias the last serialized value.")
-        lines.append("func (c CodecV2) Marshal(v any) (mem.BufferSlice, error) {")
-        lines.append("\tb, err := c.Fory.Marshal(v)")
+        lines.append("// buffer multiple frames never alias the same buffer.")
+        lines.append("func (CodecV2) Marshal(v any) (mem.BufferSlice, error) {")
+        lines.append("\tb, err := getFory().Serialize(v)")
         lines.append("\tif err != nil {")
         lines.append("\t\treturn nil, err")
         lines.append("\t}")
-        lines.append("\tout := make([]byte, len(b))")
-        lines.append("\tcopy(out, b)")
-        lines.append("\treturn mem.BufferSlice{mem.NewBuffer(&out, nil)}, nil")
+        lines.append("\treturn mem.BufferSlice{mem.NewBuffer(&b, nil)}, nil")
         lines.append("}")
         lines.append("")
         lines.append(
@@ -198,13 +239,13 @@ class GoServiceGeneratorMixin:
             "// copied into a fresh slice because the transport may reclaim the"
         )
         lines.append("// underlying memory before Fory finishes reading it.")
-        lines.append("func (c CodecV2) Unmarshal(data mem.BufferSlice, v any) error {")
+        lines.append("func (CodecV2) Unmarshal(data mem.BufferSlice, v any) error {")
         lines.append("\tb := make([]byte, data.Len())")
         lines.append("\tn := 0")
         lines.append("\tfor _, buf := range data {")
         lines.append("\t\tn += copy(b[n:], buf.ReadOnlyData())")
         lines.append("\t}")
-        lines.append("\treturn c.Fory.Unmarshal(b, v)")
+        lines.append("\treturn getFory().Deserialize(b, v)")
         lines.append("}")
         lines.append("")
         lines.append(
@@ -229,7 +270,7 @@ class GoServiceGeneratorMixin:
                 )
                 lines.append(f"\tout := new({res_type[1:]})")
                 lines.append(
-                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{Fory: c.fory})}, opts...)"
+                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{})}, opts...)"
                 )
                 lines.append(
                     f'\terr := c.cc.Invoke(ctx, "{self.get_grpc_method_path(service, method)}", in, out, callOpts...)'
@@ -245,7 +286,7 @@ class GoServiceGeneratorMixin:
                     f"func (c *{self.to_camel_case(service.name)}Client) {self.to_pascal_case(method.name)}(ctx context.Context, in {req_type}, opts ...grpc.CallOption) ({service.name}_{self.to_pascal_case(method.name)}Client, error) {{"
                 )
                 lines.append(
-                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{Fory: c.fory})}, opts...)"
+                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{})}, opts...)"
                 )
                 lines.append(
                     f'\tstream, err := c.cc.NewStream(ctx, &_{service.name}_serviceDesc.Streams[{stream_index}], "{self.get_grpc_method_path(service, method)}", callOpts...)'
@@ -271,7 +312,7 @@ class GoServiceGeneratorMixin:
                     f"func (c *{self.to_camel_case(service.name)}Client) {self.to_pascal_case(method.name)}(ctx context.Context, opts ...grpc.CallOption) ({service.name}_{self.to_pascal_case(method.name)}Client, error) {{"
                 )
                 lines.append(
-                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{Fory: c.fory})}, opts...)"
+                    "\tcallOpts := append([]grpc.CallOption{grpc.ForceCodecV2(CodecV2{})}, opts...)"
                 )
                 lines.append(
                     f'\tstream, err := c.cc.NewStream(ctx, &_{service.name}_serviceDesc.Streams[{stream_index}], "{self.get_grpc_method_path(service, method)}", callOpts...)'

--- a/compiler/fory_compiler/generators/services/go.py
+++ b/compiler/fory_compiler/generators/services/go.py
@@ -704,9 +704,10 @@ class GoServiceGeneratorMixin:
             mode = streaming_mode(method)
             if mode is StreamingMode.UNARY:
                 lines.append("\t\t{")
-                lines.append(
-                    f'\t\t\tMethodName:\t"{self.to_pascal_case(method.name)}",'
-                )
+                # MethodName is the wire name and must match the path the client
+                # invokes (get_grpc_method_path uses method.name); only Go
+                # identifiers like the handler use PascalCase.
+                lines.append(f'\t\t\tMethodName:\t"{method.name}",')
                 lines.append(
                     f"\t\t\tHandler:\t_{service.name}_{self.to_pascal_case(method.name)}_Handler,"
                 )
@@ -721,9 +722,9 @@ class GoServiceGeneratorMixin:
                 continue
             else:
                 lines.append("\t\t{")
-                lines.append(
-                    f'\t\t\tStreamName:\t"{self.to_pascal_case(method.name)}",'
-                )
+                # StreamName is the wire name; it must match method.name used in
+                # the client's invocation path, not the PascalCase Go identifier.
+                lines.append(f'\t\t\tStreamName:\t"{method.name}",')
                 lines.append(
                     f"\t\t\tHandler:\t_{service.name}_{self.to_pascal_case(method.name)}_Handler,"
                 )

--- a/compiler/fory_compiler/tests/test_service_codegen.py
+++ b/compiler/fory_compiler/tests/test_service_codegen.py
@@ -237,15 +237,18 @@ def test_go_grpc_service_codegen():
     files = generate_service_files(schema, GoGenerator)
     assert len(files) == 1
     content = next(iter(files.values()))
-    assert "func NewGreeterClient(" in content
+    assert "func NewGreeterClient(cc grpc.ClientConnInterface) GreeterClient" in content
     assert "func RegisterGreeterServer(" in content
     assert "type GreeterClient interface" in content
     assert "type GreeterServer interface" in content
     assert "type UnimplementedGreeterServer struct" in content
-    assert "CodecV2{Fory: c.fory}" in content
-    assert "type CodecV2 struct" in content
-    assert "func (c CodecV2) Marshal(v any) (mem.BufferSlice, error)" in content
-    assert "func (c CodecV2) Unmarshal(data mem.BufferSlice, v any) error" in content
+    assert "type CodecV2 struct{}" in content
+    assert "CodecV2{}" in content
+    assert "Fory *fory.Fory" not in content
+    assert "getFory().Serialize(v)" in content
+    assert "getFory().Deserialize(b, v)" in content
+    assert "func (CodecV2) Marshal(v any) (mem.BufferSlice, error)" in content
+    assert "func (CodecV2) Unmarshal(data mem.BufferSlice, v any) error" in content
     assert '"/demo.greeter.Greeter/SayHello"' in content
     assert "mustEmbedUnimplementedGreeterServer()" in content
 
@@ -625,6 +628,43 @@ def test_grpc_method_name_collisions_fail():
         assert "Rust name collision" in str(e)
     else:
         raise AssertionError("Expected Rust gRPC method name collision")
+
+    go_generator = GoGenerator(
+        schema, GeneratorOptions(output_dir=Path("/tmp"), grpc=True)
+    )
+    try:
+        go_generator.generate_services()
+    except ValueError as e:
+        assert "Go gRPC method name collision" in str(e) and "Foo and foo" in str(e)
+    else:
+        raise AssertionError("Expected Go gRPC method name collision")
+
+
+def test_go_grpc_service_type_collision_fails():
+    schema = parse_fdl(
+        dedent(
+            """
+            package demo.collision;
+
+            message GreeterClient {}
+            message Res {}
+
+            service Greeter {
+                rpc Call (GreeterClient) returns (Res);
+            }
+            """
+        )
+    )
+
+    generator = GoGenerator(
+        schema, GeneratorOptions(output_dir=Path("/tmp"), grpc=True)
+    )
+    try:
+        generator.generate_services()
+    except ValueError as e:
+        assert "Go gRPC service Greeter generates GreeterClient" in str(e)
+    else:
+        raise AssertionError("Expected Go gRPC service type collision")
 
 
 def test_java_python_grpc_method_keywords_are_safe_names():

--- a/compiler/fory_compiler/tests/test_service_codegen.py
+++ b/compiler/fory_compiler/tests/test_service_codegen.py
@@ -253,6 +253,36 @@ def test_go_grpc_service_codegen():
     assert "mustEmbedUnimplementedGreeterServer()" in content
 
 
+def test_go_grpc_descriptor_uses_wire_method_name():
+    schema = parse_fdl(
+        dedent(
+            """
+            package demo.greeter;
+
+            message Req {}
+            message Res {}
+
+            service Greeter {
+                rpc sayHello (Req) returns (Res);
+                rpc streamHello (Req) returns (stream Res);
+            }
+            """
+        )
+    )
+    content = next(iter(generate_service_files(schema, GoGenerator).values()))
+    # Wire names in the descriptor and path must match the IDL method name so a
+    # client invoking /Service/sayHello routes to the registered handler.
+    assert '"/demo.greeter.Greeter/sayHello"' in content
+    assert '"/demo.greeter.Greeter/streamHello"' in content
+    assert 'MethodName:\t"sayHello"' in content
+    assert 'StreamName:\t"streamHello"' in content
+    assert 'MethodName:\t"SayHello"' not in content
+    assert 'StreamName:\t"StreamHello"' not in content
+    # Exported Go identifiers stay PascalCase.
+    assert "_Greeter_SayHello_Handler" in content
+    assert "SayHello(ctx context.Context" in content
+
+
 def test_java_outer_classname_service_references_nested_model_types():
     schema = parse_fdl(
         dedent(

--- a/integration_tests/grpc_tests/go/main.go
+++ b/integration_tests/grpc_tests/go/main.go
@@ -32,22 +32,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/apache/fory/go/fory"
 	grpc_fdl "github.com/apache/fory/integration_tests/grpc_tests/go/generated/grpc_fdl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/encoding"
 )
 
 // --- helpers ----------------------------------------------------------------
-
-func newFory() *fory.Fory {
-	f := fory.New(fory.WithXlang(true), fory.WithRefTracking(true), fory.WithCompatible(true))
-	if err := grpc_fdl.RegisterTypes(f); err != nil {
-		log.Fatalf("RegisterTypes: %v", err)
-	}
-	return f
-}
 
 func fdlResponse(req *grpc_fdl.GrpcFdlRequest, tag string, offset int) *grpc_fdl.GrpcFdlResponse {
 	return &grpc_fdl.GrpcFdlResponse{
@@ -71,27 +61,6 @@ func fdlAggregate(requests []*grpc_fdl.GrpcFdlRequest) *grpc_fdl.GrpcFdlResponse
 		Count:   count,
 		Payload: "client:" + strings.Join(payloads, "+"),
 	}
-}
-
-// protoFallbackCodec overrides the built-in "proto" codec (v1 registry) with
-// Fory so the server can decode requests from Java clients, which send with the
-// default content-type (application/grpc) rather than application/grpc+fory.
-type protoFallbackCodec struct{ grpc_fdl.CodecV2 }
-
-func (protoFallbackCodec) Name() string { return "proto" }
-
-func (c protoFallbackCodec) Marshal(v interface{}) ([]byte, error) {
-	b, err := c.Fory.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]byte, len(b))
-	copy(out, b)
-	return out, nil
-}
-
-func (c protoFallbackCodec) Unmarshal(data []byte, v interface{}) error {
-	return c.Fory.Unmarshal(data, v)
 }
 
 // --- server -----------------------------------------------------------------
@@ -144,19 +113,14 @@ func (s *fdlService) BidiStreamMessage(stream grpc_fdl.FdlGrpcService_BidiStream
 	}
 }
 
-func runServer(portFile string, f *fory.Fory) error {
+func runServer(portFile string) error {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
-	codec := grpc_fdl.CodecV2{Fory: f}
-	// "fory" (v2): used by Go clients via grpc.ForceCodecV2.
-	encoding.RegisterCodecV2(codec)
-	// "proto" (v1): overrides the built-in proto codec so Java clients are
-	// also handled by Fory. RegisterCodecV2 writes to a separate registry and
-	// does not replace the v1 "proto" entry; RegisterCodec must be used.
-	encoding.RegisterCodec(protoFallbackCodec{codec})
-	s := grpc.NewServer()
+	// Force the Fory codec for every RPC so peers sending the default
+	// content-type (e.g. Java clients) are also decoded by Fory.
+	s := grpc.NewServer(grpc.ForceServerCodecV2(grpc_fdl.CodecV2{}))
 	grpc_fdl.RegisterFdlGrpcServiceServer(s, &fdlService{})
 
 	// Write the bound port so the Java test harness knows where to connect.
@@ -246,14 +210,14 @@ func exerciseMessageStub(stub grpc_fdl.FdlGrpcServiceClient, requests []*grpc_fd
 	return nil
 }
 
-func runClient(target string, f *fory.Fory) error {
+func runClient(target string) error {
 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", target, err)
 	}
 	defer conn.Close()
 
-	stub := grpc_fdl.NewFdlGrpcServiceClient(conn, f)
+	stub := grpc_fdl.NewFdlGrpcServiceClient(conn)
 	requests := []*grpc_fdl.GrpcFdlRequest{
 		{Id: "fdl-a", Count: 1, Payload: "alpha"},
 		{Id: "fdl-b", Count: 2, Payload: "beta"},
@@ -274,15 +238,13 @@ func main() {
 		log.Fatal("usage: grpc-interop <server|client> [flags]")
 	}
 
-	f := newFory()
-
 	switch os.Args[1] {
 	case "server":
 		serverCmd.Parse(os.Args[2:])
 		if *serverPortFile == "" {
 			log.Fatal("--port-file is required")
 		}
-		if err := runServer(*serverPortFile, f); err != nil {
+		if err := runServer(*serverPortFile); err != nil {
 			log.Fatalf("server error: %v", err)
 		}
 	case "client":
@@ -290,7 +252,7 @@ func main() {
 		if *clientTarget == "" {
 			log.Fatal("--target is required")
 		}
-		if err := runClient(*clientTarget, f); err != nil {
+		if err := runClient(*clientTarget); err != nil {
 			log.Fatalf("client error: %v", err)
 		}
 	default:


### PR DESCRIPTION
## What

Follow-up to the post-merge review on #3698, resolving the five inline comments on the Go gRPC generator and integration test.

- **Stateless codec / single owner.** `CodecV2` is now `struct{}` and reuses the generated package thread-safe `getFory()` runtime via `Serialize`/`Deserialize`, instead of taking an injected `*fory.Fory`. `NewXxxClient` no longer takes a Fory. This keeps one registration owner and is safe for concurrent RPCs (plain Go `Fory` reuses internal buffers/state).
- **Server interop without global state.** The Go peer uses `grpc.ForceServerCodecV2(CodecV2{})` instead of mutating grpc-go's process-global `proto` codec registry, and no longer constructs its own non-thread-safe Fory. grpc-go's `getCodec` returns the forced codec regardless of content-subtype, so Java clients sending the default content-type are still decoded by Fory.
- **Collision checks.** Added Go gRPC method/service name collision checks (PascalCase folds `Foo`/`foo`), mirroring the Java/Python/Rust generators.
- **No duplicate emission.** `GoGenerator.generate()` no longer emits service companions; the common CLI path already calls `generate_services()`, so this removes the second owner of `_grpc.go`.

## Verification

- Compiler suite: 359 passed.
- Go: `go build` / `go vet` clean; `go build -race` clean.
- Concurrency: built with `-race`, ran 12 concurrent clients against one server under `GORACE=halt_on_error=1`, exercising all four streaming modes -> 0 failures, 0 data races on server or client.
- Added/updated tests: Go arm in `test_grpc_method_name_collisions_fail`, new `test_go_grpc_service_type_collision_fails`, and `test_go_grpc_service_codegen` updated for the stateless codec.

Follow-up to #3698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)