### PR TITLE
fix(java): fix unbounded LinkedBlockingQueue deserialization

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/collection/CollectionSerializers.java
@@ -994,7 +994,6 @@ public class CollectionSerializers {
       setNumElements(numElements);
       int capacity = buffer.readVarUInt32Small7();
       checkBoundedQueueCapacity(numElements, capacity);
-      buffer.checkReadableBytes(capacity);
       LinkedBlockingQueue queue = new LinkedBlockingQueue<>(capacity);
       readContext.reference(queue);
       return queue;

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
@@ -1159,6 +1159,7 @@ public class CollectionSerializersTest extends ForyTestBase {
       queue.add(2);
       LinkedBlockingQueue<Integer> deserialized = serDe(fory, queue);
       assertEquals(new ArrayList<>(deserialized), new ArrayList<>(queue));
+      assertEquals(deserialized.remainingCapacity() + deserialized.size(), Integer.MAX_VALUE);
     }
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/collection/CollectionSerializersTest.java
@@ -1153,6 +1153,13 @@ public class CollectionSerializersTest extends ForyTestBase {
       assertEquals(new ArrayList<>(deserialized), new ArrayList<>(queue));
       assertEquals(deserialized.remainingCapacity() + deserialized.size(), 3);
     }
+    {
+      LinkedBlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
+      queue.add(1);
+      queue.add(2);
+      LinkedBlockingQueue<Integer> deserialized = serDe(fory, queue);
+      assertEquals(new ArrayList<>(deserialized), new ArrayList<>(queue));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Why?

`LinkedBlockingQueueSerializer` fails to deserialize default unbounded `new LinkedBlockingQueue<>()`. Serialize works, deserialize throws `IndexOutOfBoundsException` because capacity on the wire is `Integer.MAX_VALUE` and `checkReadableBytes(capacity)` tries to read ~2GB. Bounded queues like `new LinkedBlockingQueue<>(16)` work fine.

## What does this PR do?

- Drop `checkReadableBytes(capacity)` in `LinkedBlockingQueueSerializer.newCollection`
- Add regression test for unbounded queue round-trip

## Related issues

- Fixes #3783

## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: `no`