### PR TITLE
fix(c++): replace deprecated std::aligned_storage

### DIFF
--- a/cpp/fory/util/result.h
+++ b/cpp/fory/util/result.h
@@ -321,8 +321,9 @@ public:
 /// ```
 template <typename E> class Result<void, E> {
 private:
-  using ErrorStorage =
-      typename std::aligned_storage<sizeof(E), alignof(E)>::type;
+  using ErrorStorage = struct alignas(E) {
+    std::byte data[sizeof(E)];
+  };
 
   ErrorStorage error_storage_;
   bool has_value_;

--- a/cpp/fory/util/result.h
+++ b/cpp/fory/util/result.h
@@ -22,6 +22,7 @@
 #include "fory/util/error.h"
 #include "fory/util/logging.h"
 #include "fory/util/macros.h"
+#include <cstddef>
 #include <new>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
## Why?

`std::aligned_storage` is marked as deprecated in C++23, as can be seen in the following compilation warning:
```
<project>/build/_deps/fory-src/cpp/fory/util/result.h:325:21: warning: ‘template<long unsigned int _Len, long unsigned int _Align> struct std::aligned_storage’ is deprecated [-Wdeprecated-declarations]
   325 |       typename std::aligned_storage<sizeof(E), alignof(E)>::type;
       |                     ^~~~~~~~~~~~~~~
 In file included from /usr/include/c++/13/bits/move.h:37,
                  from /usr/include/c++/13/bits/atomic_base.h:39,
                  from /usr/include/c++/13/atomic:41,
                  from <project source file>:
 /usr/include/c++/13/type_traits:2099:5: note: declared here
  2099 |     aligned_storage
```

## What does this PR do?

Replaces `std::aligned_storage` with a `std::byte` array enclosed in an aligned struct.

* `std::byte` is available since C++17 - the minimum supported version by fory.
* `alignas` is available since C++11

This change shouldn't break anything.

## AI Contribution Checklist

- [ ] Substantial AI assistance was used in this PR: no

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

