### PR TITLE
fix(ci): checkstyle CI error output

### DIFF
--- a/.github/maven-style-matcher.json
+++ b/.github/maven-style-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "maven-checkstyle",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^\\[WARN\\]\\s+(\\S.*\\.java):(\\d+):(?:(\\d+):)?\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1882,6 +1882,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: Register Checkstyle problem matcher
+        run: echo "::add-matcher::.github/maven-style-matcher.json"
       - name: Check code style
         run: python ./ci/run_ci.py format
 


### PR DESCRIPTION
## Why?

CI currently can fail with an `Error:` with no further message, which is unhelpful

## What does this PR do?

Attempt to improve CI reporting by matching checkstyle warning lines to CI build output.
Small GitHub runner configuration changes.

## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: `yes` / `no`

I verified this by hand - introduce Checkstyle failure, shows up in "Annotations" on runner results page.

## Does this PR introduce any user-facing change?
No
