### PR TITLE
fix(java): support copy of non-serializable JDK classes such as java.lang.Package

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/platform/GraalvmSupport.java
+++ b/java/fory-core/src/main/java/org/apache/fory/platform/GraalvmSupport.java
@@ -39,6 +39,7 @@ import org.apache.fory.serializer.ExternalizableSerializer;
 import org.apache.fory.serializer.JavaSerializer;
 import org.apache.fory.serializer.JdkProxySerializer;
 import org.apache.fory.serializer.LambdaSerializer;
+import org.apache.fory.serializer.NonSerializableSerializer;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.ObjectStreamSerializer;
 import org.apache.fory.serializer.PrimitiveArraySerializers;
@@ -140,6 +141,7 @@ public class GraalvmSupport {
     registerDefaultSerializerClass(ObjectStreamSerializer.class);
     registerDefaultSerializerClass(JavaSerializer.class);
     registerDefaultSerializerClass(ObjectSerializer.class);
+    registerDefaultSerializerClass(NonSerializableSerializer.class);
   }
 
   /** Returns true if current process is running in graalvm native image build stage. */

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -1500,9 +1500,7 @@ public class ClassResolver extends TypeResolver {
       }
       if (config.checkJdkClassSerializable()) {
         if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)){
-            // Issue #2941: previously threw UnsupportedOperationException here, which also broke
-            // Fory.copy() for non-serializable JDK classes (e.g. java.lang.Package). Route to a
-            // serializer that still refuses binary serialization (write/read throw) but
+            // Route to a serializer that still refuses binary serialization (write/read throw) but
             // supports field copy via AbstractObjectSerializer
             return NonSerializableSerializer.class;
         }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -1500,7 +1500,7 @@ public class ClassResolver extends TypeResolver {
       }
       if (config.checkJdkClassSerializable()) {
         if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)) {
-            return NonSerializableSerializer.class;
+          return NonSerializableSerializer.class;
         }
       }
       if (ScalaTypes.SCALA_AVAILABLE && ReflectionUtils.isScalaSingletonObject(cls)) {
@@ -1513,8 +1513,6 @@ public class ClassResolver extends TypeResolver {
         }
       }
       if (isCollection(cls)) {
-        // Serializer of common collection such as ArrayList/LinkedList should be registered
-        // already.
         serializerClass = ChildContainerSerializers.getCollectionSerializerClass(cls);
         if (serializerClass != null) {
           return serializerClass;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -114,10 +114,37 @@ import org.apache.fory.meta.TypeExtMeta;
 import org.apache.fory.platform.AndroidSupport;
 import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.reflect.ReflectionUtils;
-import org.apache.fory.serializer.*;
+import org.apache.fory.serializer.ArraySerializers;
+import org.apache.fory.serializer.BufferSerializers;
+import org.apache.fory.serializer.CompatibleSerializer;
+import org.apache.fory.serializer.CopyOnlyObjectSerializer;
+import org.apache.fory.serializer.EnumSerializer;
+import org.apache.fory.serializer.ExceptionSerializers;
+import org.apache.fory.serializer.ExternalizableSerializer;
+import org.apache.fory.serializer.ForyCopyableSerializer;
+import org.apache.fory.serializer.JavaSerializer;
+import org.apache.fory.serializer.JdkProxySerializer;
+import org.apache.fory.serializer.LambdaSerializer;
+import org.apache.fory.serializer.LocaleSerializer;
+import org.apache.fory.serializer.NonSerializableSerializer;
 import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
+import org.apache.fory.serializer.NoneSerializer;
+import org.apache.fory.serializer.ObjectSerializer;
+import org.apache.fory.serializer.OptionalSerializers;
+import org.apache.fory.serializer.PrimitiveArraySerializers;
+import org.apache.fory.serializer.PrimitiveSerializers;
+import org.apache.fory.serializer.ReplaceResolveSerializer;
+import org.apache.fory.serializer.SerializedLambdaSerializer;
+import org.apache.fory.serializer.Serializer;
+import org.apache.fory.serializer.Serializers;
+import org.apache.fory.serializer.Shareable;
+import org.apache.fory.serializer.SqlTimeSerializers;
+import org.apache.fory.serializer.TimeSerializers;
+import org.apache.fory.serializer.UnknownClass;
 import org.apache.fory.serializer.UnknownClass.UnknownEmptyStruct;
 import org.apache.fory.serializer.UnknownClass.UnknownStruct;
+import org.apache.fory.serializer.UnknownClassSerializers;
+import org.apache.fory.serializer.UnsignedSerializers;
 import org.apache.fory.serializer.collection.ChildContainerSerializers;
 import org.apache.fory.serializer.collection.CollectionLikeSerializer;
 import org.apache.fory.serializer.collection.CollectionSerializer;
@@ -1472,7 +1499,7 @@ public class ClassResolver extends TypeResolver {
         }
       }
       if (config.checkJdkClassSerializable()) {
-        if (cls.getName().startsWith("java") && !(Serializable.class.isAssignableFrom(cls))){
+        if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)){
             // Issue #2941: previously threw UnsupportedOperationException here, which also broke
             // Fory.copy() for non-serializable JDK classes (e.g. java.lang.Package). Route to a
             // serializer that still refuses binary serialization (write/read throw) but

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -181,7 +181,7 @@ import org.apache.fory.util.record.RecordUtils;
  */
 @NotThreadSafe
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class    ClassResolver extends TypeResolver {
+public class ClassResolver extends TypeResolver {
   private static final Logger LOG = LoggerFactory.getLogger(ClassResolver.class);
 
   public static final int NATIVE_START_ID = Types.BOUND;
@@ -1474,9 +1474,9 @@ public class    ClassResolver extends TypeResolver {
       if (config.checkJdkClassSerializable()) {
         if (cls.getName().startsWith("java") && !(Serializable.class.isAssignableFrom(cls))){
             // Issue #2941: previously threw UnsupportedOperationException here, which also broke
-            // Fory.copy() for non-serlializble JDK classes (e.g. java.lang.Package). Route to a
+            // Fory.copy() for non-serializable JDK classes (e.g. java.lang.Package). Route to a
             // serializer that still refuses binary serialization (write/read throw) but
-            // supports copy() via reflective field copy
+            // supports field copy via AbstractObjectSerializer
             return NonSerializableSerializer.class;
         }
       }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -1500,8 +1500,6 @@ public class ClassResolver extends TypeResolver {
       }
       if (config.checkJdkClassSerializable()) {
         if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)) {
-            // Route to a serializer that still refuses binary serialization (write/read throw) but
-            // supports field copy via AbstractObjectSerializer
             return NonSerializableSerializer.class;
         }
       }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -116,6 +116,7 @@ import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.reflect.ReflectionUtils;
 import org.apache.fory.serializer.ArraySerializers;
 import org.apache.fory.serializer.BufferSerializers;
+import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.CopyOnlyObjectSerializer;
 import org.apache.fory.serializer.EnumSerializer;
@@ -127,7 +128,6 @@ import org.apache.fory.serializer.JdkProxySerializer;
 import org.apache.fory.serializer.LambdaSerializer;
 import org.apache.fory.serializer.LocaleSerializer;
 import org.apache.fory.serializer.NonSerializableSerializer;
-import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import org.apache.fory.serializer.NoneSerializer;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.OptionalSerializers;
@@ -1499,7 +1499,7 @@ public class ClassResolver extends TypeResolver {
         }
       }
       if (config.checkJdkClassSerializable()) {
-        if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)){
+        if (cls.getName().startsWith("java") && !Serializable.class.isAssignableFrom(cls)) {
             // Route to a serializer that still refuses binary serialization (write/read throw) but
             // supports field copy via AbstractObjectSerializer
             return NonSerializableSerializer.class;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -207,7 +207,7 @@ import org.apache.fory.util.record.RecordUtils;
  */
 @NotThreadSafe
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class ClassResolver extends TypeResolver {
+public class    ClassResolver extends TypeResolver {
   private static final Logger LOG = LoggerFactory.getLogger(ClassResolver.class);
 
   public static final int NATIVE_START_ID = Types.BOUND;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/ClassResolver.java
@@ -114,36 +114,10 @@ import org.apache.fory.meta.TypeExtMeta;
 import org.apache.fory.platform.AndroidSupport;
 import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.reflect.ReflectionUtils;
-import org.apache.fory.serializer.ArraySerializers;
-import org.apache.fory.serializer.BufferSerializers;
+import org.apache.fory.serializer.*;
 import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
-import org.apache.fory.serializer.CompatibleSerializer;
-import org.apache.fory.serializer.CopyOnlyObjectSerializer;
-import org.apache.fory.serializer.EnumSerializer;
-import org.apache.fory.serializer.ExceptionSerializers;
-import org.apache.fory.serializer.ExternalizableSerializer;
-import org.apache.fory.serializer.ForyCopyableSerializer;
-import org.apache.fory.serializer.JavaSerializer;
-import org.apache.fory.serializer.JdkProxySerializer;
-import org.apache.fory.serializer.LambdaSerializer;
-import org.apache.fory.serializer.LocaleSerializer;
-import org.apache.fory.serializer.NoneSerializer;
-import org.apache.fory.serializer.ObjectSerializer;
-import org.apache.fory.serializer.OptionalSerializers;
-import org.apache.fory.serializer.PrimitiveArraySerializers;
-import org.apache.fory.serializer.PrimitiveSerializers;
-import org.apache.fory.serializer.ReplaceResolveSerializer;
-import org.apache.fory.serializer.SerializedLambdaSerializer;
-import org.apache.fory.serializer.Serializer;
-import org.apache.fory.serializer.Serializers;
-import org.apache.fory.serializer.Shareable;
-import org.apache.fory.serializer.SqlTimeSerializers;
-import org.apache.fory.serializer.TimeSerializers;
-import org.apache.fory.serializer.UnknownClass;
 import org.apache.fory.serializer.UnknownClass.UnknownEmptyStruct;
 import org.apache.fory.serializer.UnknownClass.UnknownStruct;
-import org.apache.fory.serializer.UnknownClassSerializers;
-import org.apache.fory.serializer.UnsignedSerializers;
 import org.apache.fory.serializer.collection.ChildContainerSerializers;
 import org.apache.fory.serializer.collection.CollectionLikeSerializer;
 import org.apache.fory.serializer.collection.CollectionSerializer;
@@ -1498,9 +1472,12 @@ public class    ClassResolver extends TypeResolver {
         }
       }
       if (config.checkJdkClassSerializable()) {
-        if (cls.getName().startsWith("java") && !(Serializable.class.isAssignableFrom(cls))) {
-          throw new UnsupportedOperationException(
-              String.format("Class %s doesn't support serialization.", cls));
+        if (cls.getName().startsWith("java") && !(Serializable.class.isAssignableFrom(cls))){
+            // Issue #2941: previously threw UnsupportedOperationException here, which also broke
+            // Fory.copy() for non-serlializble JDK classes (e.g. java.lang.Package). Route to a
+            // serializer that still refuses binary serialization (write/read throw) but
+            // supports copy() via reflective field copy
+            return NonSerializableSerializer.class;
         }
       }
       if (ScalaTypes.SCALA_AVAILABLE && ReflectionUtils.isScalaSingletonObject(cls)) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -34,21 +34,18 @@ import org.apache.fory.resolver.TypeResolver;
  * differ deliberately.
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
-  public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
-
-      super(typeResolver, type);
-  }
+  public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) { super(typeResolver, type); }
 
 
   @Override
   public void write(WriteContext writeContext, T value) {
-      throw new UnsupportedOperationException(
-              String.format("Class %s doesn't support serialization.", type.getName()));
+    throw new UnsupportedOperationException(
+      String.format("Class %s doesn't support serialization.", type.getName()));
   }
 
   @Override
   public T read(ReadContext readContext) {
-      throw new UnsupportedOperationException(
-              String.format("Class %s doesn't support serialization.", type.getName()));
+    throw new UnsupportedOperationException(
+      String.format("Class %s doesn't support serialization.", type.getName()));
   }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -33,20 +33,19 @@ import org.apache.fory.resolver.TypeResolver;
  * that transitively contain such classes (issue #2941).
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
+  public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
+      super(typeResolver, type);
+  }
 
-    public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
-        super(typeResolver, type);
-    }
+  @Override
+  public void write(WriteContext writeContext, T value) {
+      throw new UnsupportedOperationException(
+              String.format("Class %s doesn't support serialization.", type.getName()));
+  }
 
-    @Override
-    public void write(WriteContext writeContext, T value) {
-        throw new UnsupportedOperationException(
-                String.format("Class %s doesn't support serialization.", type));
-    }
-
-    @Override
-    public T read(ReadContext readContext) {
-        throw new UnsupportedOperationException(
-                String.format("Class %s doesn't support serialization.", type));
-    }
+  @Override
+  public T read(ReadContext readContext) {
+      throw new UnsupportedOperationException(
+              String.format("Class %s doesn't support serialization.", type.getName()));
+  }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -24,13 +24,14 @@ import org.apache.fory.context.WriteContext;
 import org.apache.fory.resolver.TypeResolver;
 
 /**
- * Serializer for non-Serializable JDK classes (e.g. {@code java.lang.Package}).
+ * Serializer for non-Serializable JDK classes. Binary serialization is unsupported —
+ * {@link #write}/{@link #read} throw {@link UnsupportedOperationException} — while copy
+ * reuses {@link AbstractObjectSerializer}'s field-copy implementation.
  *
- * <p>Binary serialization remains unsupported — {@link #write} and {@link #read} throw
- * {@link UnsupportedOperationException}, preserving the prior behavior of {@code ClassResolver}'s
- * JDK-serializable guard. However {@code copy} is supported via the field copy via
- * {@link AbstractObjectSerializer}, so {@code Fory.copy()} can handle object graphs
- * that transitively contain such classes (issue #2941).
+ * <p>Distinct from {@link CopyOnlyObjectSerializer}, which blocks serialization for
+ * registration-security reasons (remediable by registering the class). Here serialization
+ * is intrinsically unsupported and not remediable by registration, so the failure semantics
+ * differ deliberately.
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
   public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -35,8 +35,10 @@ import org.apache.fory.resolver.TypeResolver;
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
   public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
+
       super(typeResolver, type);
   }
+
 
   @Override
   public void write(WriteContext writeContext, T value) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -28,8 +28,8 @@ import org.apache.fory.resolver.TypeResolver;
  *
  * <p>Binary serialization remains unsupported — {@link #write} and {@link #read} throw
  * {@link UnsupportedOperationException}, preserving the prior behavior of {@code ClassResolver}'s
- * JDK-serializable guard. However {@code copy} is supported via the reflection-based field copy
- * inherited from {@link AbstractObjectSerializer}, so {@code Fory.copy()} can handle object graphs
+ * JDK-serializable guard. However {@code copy} is supported via the field copy via
+ * {@link AbstractObjectSerializer}, so {@code Fory.copy()} can handle object graphs
  * that transitively contain such classes (issue #2941).
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer;
+
+import org.apache.fory.context.ReadContext;
+import org.apache.fory.context.WriteContext;
+import org.apache.fory.resolver.TypeResolver;
+
+/**
+ * Serializer for non-Serializable JDK classes (e.g. {@code java.lang.Package}).
+ *
+ * <p>Binary serialization remains unsupported — {@link #write} and {@link #read} throw
+ * {@link UnsupportedOperationException}, preserving the prior behavior of {@code ClassResolver}'s
+ * JDK-serializable guard. However {@code copy} is supported via the reflection-based field copy
+ * inherited from {@link AbstractObjectSerializer}, so {@code Fory.copy()} can handle object graphs
+ * that transitively contain such classes (issue #2941).
+ */
+public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
+
+    public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
+        super(typeResolver, type);
+    }
+
+    @Override
+    public void write(WriteContext writeContext, T value) {
+        throw new UnsupportedOperationException(
+                String.format("Class %s doesn't support serialization.", type));
+    }
+
+    @Override
+    public T read(ReadContext readContext) {
+        throw new UnsupportedOperationException(
+                String.format("Class %s doesn't support serialization.", type));
+    }
+}

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/NonSerializableSerializer.java
@@ -24,28 +24,29 @@ import org.apache.fory.context.WriteContext;
 import org.apache.fory.resolver.TypeResolver;
 
 /**
- * Serializer for non-Serializable JDK classes. Binary serialization is unsupported —
- * {@link #write}/{@link #read} throw {@link UnsupportedOperationException} — while copy
- * reuses {@link AbstractObjectSerializer}'s field-copy implementation.
+ * Serializer for non-Serializable JDK classes. Binary serialization is unsupported — {@link
+ * #write}/{@link #read} throw {@link UnsupportedOperationException} — while copy reuses {@link
+ * AbstractObjectSerializer}'s field-copy implementation.
  *
  * <p>Distinct from {@link CopyOnlyObjectSerializer}, which blocks serialization for
- * registration-security reasons (remediable by registering the class). Here serialization
- * is intrinsically unsupported and not remediable by registration, so the failure semantics
- * differ deliberately.
+ * registration-security reasons (remediable by registering the class). Here serialization is
+ * intrinsically unsupported and not remediable by registration, so the failure semantics differ
+ * deliberately.
  */
 public final class NonSerializableSerializer<T> extends AbstractObjectSerializer<T> {
-  public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) { super(typeResolver, type); }
-
+  public NonSerializableSerializer(TypeResolver typeResolver, Class<T> type) {
+    super(typeResolver, type);
+  }
 
   @Override
   public void write(WriteContext writeContext, T value) {
     throw new UnsupportedOperationException(
-      String.format("Class %s doesn't support serialization.", type.getName()));
+        String.format("Class %s doesn't support serialization.", type.getName()));
   }
 
   @Override
   public T read(ReadContext readContext) {
     throw new UnsupportedOperationException(
-      String.format("Class %s doesn't support serialization.", type.getName()));
+        String.format("Class %s doesn't support serialization.", type.getName()));
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -469,28 +469,14 @@ public class ForyCopyTest extends ForyTestBase {
       Package pkg = String.class.getPackage();
       Package copy = fory.copy(pkg);
       Assert.assertNotNull(copy);
+      Assert.assertEquals(copy.getName(), pkg.getName());
   }
 
-  @Test
-  public void testCopyHashMapStillWorks(){
-      // Regression for chaokunyang's concern (comments on issue #2941): HashMap keeps
-      //essential state (size, table) in transient field. The copy path copies all fields
-      // including transient, so this must still produce an equal map.
-      Fory fory = Fory.builder()
-              .withLanguage(Language.JAVA)
-              .requireClassRegistration(false)
-              .build();
-      Map<String, Integer> map = new HashMap<>();
-      map.put("a", 1);
-      map.put("b", 2);
-      Map<String, Integer> copy = fory.copy(map);
-      Assert.assertEquals(map, copy);
-  }
 
   @Test
   public void testSerializeNonSerializableJdkClassStillThrows(){
-      // Regression guard: we must not have weakened serialization. Serliazing a
-      // non-serliazable JDK class must still throw, jsut defered to write time.
+      // Regression guard: we must not have weakened serialization. Serializing a
+      // non-serializable JDK class must still throw, just deferred to write time.
 
       Fory fory = Fory.builder()
               .withLanguage(Language.JAVA)

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -460,8 +460,7 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testCopyNonSerializableJdkClass() {
-    Fory fory =
-        Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
+    Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
     Class<? extends Serializer> serializerClass =
         fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
     Assert.assertSame(serializerClass, NonSerializableSerializer.class);

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -477,6 +477,7 @@ public class ForyCopyTest extends ForyTestBase {
 
       Fory fory = Fory.builder()
               .withLanguage(Language.JAVA)
+              .withRefCopy(true)
               .requireClassRegistration(false)
               .build();
       try {

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -462,6 +462,7 @@ public class ForyCopyTest extends ForyTestBase {
 
     Fory fory = Fory.builder()
             .withLanguage(Language.JAVA)
+            .withRefCopy(true)
             .requireClassRegistration(false)
             .build();
     Package pkg = String.class.getPackage();

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -460,15 +460,21 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testCopyNonSerializableJdkClass() {
-    Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
-      Class<? extends Serializer> serializerClass = fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
-      Assert.assertSame(serializerClass, NonSerializableSerializer.class);
+    Fory fory =
+        Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
+    Class<? extends Serializer> serializerClass =
+        fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
+    Assert.assertSame(serializerClass, NonSerializableSerializer.class);
   }
-
 
   @Test
   public void testSerializeNonSerializableJdkClassStillThrows() {
-    Fory fory = Fory.builder().withLanguage(Language.JAVA).withRefCopy(true).requireClassRegistration(false).build();
+    Fory fory =
+        Fory.builder()
+            .withLanguage(Language.JAVA)
+            .withRefCopy(true)
+            .requireClassRegistration(false)
+            .build();
     try {
       fory.serialize(String.class.getPackage());
       Assert.fail("Expected serialization of java.lang.Package to fail");
@@ -477,5 +483,4 @@ public class ForyCopyTest extends ForyTestBase {
       Assert.assertTrue(e.getMessage().contains("doesn't support serialization"));
     }
   }
-
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -79,6 +79,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import org.apache.fory.collection.LazyMap;
+import org.apache.fory.config.Language;
 import org.apache.fory.context.CopyContext;
 import org.apache.fory.context.ReadContext;
 import org.apache.fory.context.WriteContext;
@@ -454,4 +455,15 @@ public class ForyCopyTest extends ForyTestBase {
       assertEquals(fory.copy(collectionFields).toCanEqual(), collectionFields.toCanEqual());
     }
   }
+
+    @Test
+    public void testCopyNonSerializablePackage() {
+        Fory fory = Fory.builder()
+                .withLanguage(Language.JAVA)
+                .withRefCopy(true)
+                .requireClassRegistration(false)   // get past the registration gate
+                .build();
+        Package pkg = String.class.getPackage(); // java.lang
+        Package copy = fory.copy(pkg);           // now expect the real bug
+    }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -460,33 +460,23 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testCopyNonSerializableJdkClass() {
-      Fory fory =
-              Fory.builder()
-                      .withLanguage(Language.JAVA)
-                      .requireClassRegistration(false)
-                      .build();
+    Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
       Class<? extends Serializer> serializerClass =
-              fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
+        fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
       Assert.assertSame(serializerClass, NonSerializableSerializer.class);
   }
 
 
   @Test
   public void testSerializeNonSerializableJdkClassStillThrows() {
-      // Serializing anon-serializable JDK class must still throw, just deferred to write time.
-
-      Fory fory = Fory.builder()
-              .withLanguage(Language.JAVA)
-              .withRefCopy(true)
-              .requireClassRegistration(false)
-              .build();
-      try {
-          fory.serialize(String.class.getPackage());
-          Assert.fail("Expected serialization of java.lang.Package to fail");
-      } catch (SerializationException e) {
-          Assert.assertTrue(e.getCause() instanceof UnsupportedOperationException);
-          Assert.assertTrue(e.getMessage().contains("doesn't support serialization"));
-      }
+    Fory fory = Fory.builder().withLanguage(Language.JAVA).withRefCopy(true).requireClassRegistration(false).build();
+    try {
+      fory.serialize(String.class.getPackage());
+      Assert.fail("Expected serialization of java.lang.Package to fail");
+    } catch (SerializationException e) {
+      Assert.assertTrue(e.getCause() instanceof UnsupportedOperationException);
+      Assert.assertTrue(e.getMessage().contains("doesn't support serialization"));
+    }
   }
 
 }

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -88,6 +88,7 @@ import org.apache.fory.exception.SerializationException;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.EnumSerializerTest;
 import org.apache.fory.serializer.EnumSerializerTest.EnumFoo;
+import org.apache.fory.serializer.NonSerializableSerializer;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.collection.ChildContainerSerializersTest.ChildArrayDeque;
 import org.apache.fory.serializer.collection.SynchronizedSerializersTest;
@@ -458,17 +459,15 @@ public class ForyCopyTest extends ForyTestBase {
   }
 
   @Test
-  public void testCopyNonSerializableJdkClass(){
-
-    Fory fory = Fory.builder()
-            .withLanguage(Language.JAVA)
-            .withRefCopy(true)
-            .requireClassRegistration(false)
-            .build();
-    Package pkg = String.class.getPackage();
-    Package copy = fory.copy(pkg);
-    Assert.assertNotNull(copy);
-    Assert.assertEquals(copy.getName(), pkg.getName());
+  public void testCopyNonSerializableJdkClass() {
+      Fory fory =
+              Fory.builder()
+                      .withLanguage(Language.JAVA)
+                      .requireClassRegistration(false)
+                      .build();
+      Class<? extends Serializer> serializerClass =
+              fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
+      Assert.assertSame(serializerClass, NonSerializableSerializer.class);
   }
 
 

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -459,8 +459,6 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testCopyNonSerializableJdkClass(){
-    // Issue #2941: copying an object that is (or contains) a non-serializable JDK class
-    // like java.lang.Package used to throw. It should now succeed.
 
     Fory fory = Fory.builder()
             .withLanguage(Language.JAVA)
@@ -475,8 +473,7 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testSerializeNonSerializableJdkClassStillThrows() {
-      // Regression guard: we must not have weakened serialization. Serializing a
-      // non-serializable JDK class must still throw, just deferred to write time.
+      // Serializing anon-serializable JDK class must still throw, just deferred to write time.
 
       Fory fory = Fory.builder()
               .withLanguage(Language.JAVA)

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -461,8 +461,7 @@ public class ForyCopyTest extends ForyTestBase {
   @Test
   public void testCopyNonSerializableJdkClass() {
     Fory fory = Fory.builder().withLanguage(Language.JAVA).requireClassRegistration(false).build();
-      Class<? extends Serializer> serializerClass =
-        fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
+      Class<? extends Serializer> serializerClass = fory.getTypeResolver().getSerializerClass(java.lang.Package.class);
       Assert.assertSame(serializerClass, NonSerializableSerializer.class);
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -459,22 +459,22 @@ public class ForyCopyTest extends ForyTestBase {
 
   @Test
   public void testCopyNonSerializableJdkClass(){
-      // Issue #2941: copying an object that is (or contains) a non-serializable JDK class
-      // like java.lang.Package used to throw. It should now succeed.
+    // Issue #2941: copying an object that is (or contains) a non-serializable JDK class
+    // like java.lang.Package used to throw. It should now succeed.
 
-      Fory fory = Fory.builder()
-              .withLanguage(Language.JAVA)
-              .requireClassRegistration(false)
-              .build();
-      Package pkg = String.class.getPackage();
-      Package copy = fory.copy(pkg);
-      Assert.assertNotNull(copy);
-      Assert.assertEquals(copy.getName(), pkg.getName());
+    Fory fory = Fory.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .build();
+    Package pkg = String.class.getPackage();
+    Package copy = fory.copy(pkg);
+    Assert.assertNotNull(copy);
+    Assert.assertEquals(copy.getName(), pkg.getName());
   }
 
 
   @Test
-  public void testSerializeNonSerializableJdkClassStillThrows(){
+  public void testSerializeNonSerializableJdkClassStillThrows() {
       // Regression guard: we must not have weakened serialization. Serializing a
       // non-serializable JDK class must still throw, just deferred to write time.
 

--- a/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/ForyCopyTest.java
@@ -84,6 +84,7 @@ import org.apache.fory.context.CopyContext;
 import org.apache.fory.context.ReadContext;
 import org.apache.fory.context.WriteContext;
 import org.apache.fory.exception.ForyException;
+import org.apache.fory.exception.SerializationException;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.EnumSerializerTest;
 import org.apache.fory.serializer.EnumSerializerTest.EnumFoo;
@@ -456,14 +457,52 @@ public class ForyCopyTest extends ForyTestBase {
     }
   }
 
-    @Test
-    public void testCopyNonSerializablePackage() {
-        Fory fory = Fory.builder()
-                .withLanguage(Language.JAVA)
-                .withRefCopy(true)
-                .requireClassRegistration(false)   // get past the registration gate
-                .build();
-        Package pkg = String.class.getPackage(); // java.lang
-        Package copy = fory.copy(pkg);           // now expect the real bug
-    }
+  @Test
+  public void testCopyNonSerializableJdkClass(){
+      // Issue #2941: copying an object that is (or contains) a non-serializable JDK class
+      // like java.lang.Package used to throw. It should now succeed.
+
+      Fory fory = Fory.builder()
+              .withLanguage(Language.JAVA)
+              .requireClassRegistration(false)
+              .build();
+      Package pkg = String.class.getPackage();
+      Package copy = fory.copy(pkg);
+      Assert.assertNotNull(copy);
+  }
+
+  @Test
+  public void testCopyHashMapStillWorks(){
+      // Regression for chaokunyang's concern (comments on issue #2941): HashMap keeps
+      //essential state (size, table) in transient field. The copy path copies all fields
+      // including transient, so this must still produce an equal map.
+      Fory fory = Fory.builder()
+              .withLanguage(Language.JAVA)
+              .requireClassRegistration(false)
+              .build();
+      Map<String, Integer> map = new HashMap<>();
+      map.put("a", 1);
+      map.put("b", 2);
+      Map<String, Integer> copy = fory.copy(map);
+      Assert.assertEquals(map, copy);
+  }
+
+  @Test
+  public void testSerializeNonSerializableJdkClassStillThrows(){
+      // Regression guard: we must not have weakened serialization. Serliazing a
+      // non-serliazable JDK class must still throw, jsut defered to write time.
+
+      Fory fory = Fory.builder()
+              .withLanguage(Language.JAVA)
+              .requireClassRegistration(false)
+              .build();
+      try {
+          fory.serialize(String.class.getPackage());
+          Assert.fail("Expected serialization of java.lang.Package to fail");
+      } catch (SerializationException e) {
+          Assert.assertTrue(e.getCause() instanceof UnsupportedOperationException);
+          Assert.assertTrue(e.getMessage().contains("doesn't support serialization"));
+      }
+  }
+
 }


### PR DESCRIPTION


## Why?

`Fory.copy(obj)` throws `UnsupportedOperationException: Class java.lang.Package
doesn't support serialization` (wrapped in `CopyException`) when the object graph
contains a non-`Serializable` JDK class, even though the same object round-trips
fine through `serialize` + `deserialize`. This makes deep-copying common
real-world object graphs (e.g. Hibernate objects) fail.

## What does this PR do?

Root cause: `ClassResolver.getSerializerClass` rejects non-`Serializable` JDK
classes via the `checkJdkClassSerializable` guard. The check is correct for
serialization, but because copy and serialize share the same per-class serializer
created in `createSerializer`, the guard fired at serializer-creation time and
broke `copy()` as collateral damage.

Fix: route these classes to a new `NonSerializableSerializer`. Its `write`/`read`
still throw `UnsupportedOperationException` (binary serialization behavior is
unchanged — the failure is simply deferred to write time), but it inherits the
field-copy implementation from `AbstractObjectSerializer`, so `Fory.copy()` now
works. Transient fields are still copied (e.g. `HashMap`'s `size`/`table`), since
the inherited copy path copies all non-static fields.

`NonSerializableSerializer` is kept deliberately distinct from
`CopyOnlyObjectSerializer`: the latter blocks serialization for
registration-security reasons (remediable by registering the class), whereas a
non-`Serializable` JDK class is intrinsically non-serializable and not remediable
by registration, so the failure semantics differ. The new serializer is also
registered in `GraalvmSupport`'s default serializer set, consistent with every
other class returned by `getSerializerClass`.

Files changed:
- `resolver/ClassResolver.java` — route non-`Serializable` JDK classes to the new serializer instead of throwing.
- `serializer/NonSerializableSerializer.java` — new serializer (copy supported, serialize unsupported).
- `platform/GraalvmSupport.java` — register the new serializer for native-image builds.
- `test/ForyCopyTest.java` — tests.

Behavior note: serialization of these classes now surfaces as
`SerializationException` wrapping `UnsupportedOperationException`, rather than the
raw `UnsupportedOperationException` thrown eagerly at serializer creation.


## Related issues

Fixes issue #2941.

## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: `yes`
- [x] If `yes`, I included a completed AI Contribution Checklist in this PR description and the required `AI Usage Disclosure`.
- [x] If `yes`, my PR description includes the `ai_review` summary and screenshot evidence/links from both fresh reviewers on the current diff.

- [x] Substantial AI assistance was used: `yes`
- [x] I can explain and defend all important changes without AI help.
- [x] I reviewed AI-assisted code changes line by line before submission.
- [x] I completed line-by-line self-review first and fixed issues before requesting AI review.
- [x] I ran two fresh AI review agents on the current diff: one using `.claude/skills/fory-code-review/SKILL.md` and one without.
- [x] I addressed all AI review comments and repeated the loop until both reviewers reported no further actionable comments.
- [x] I attached evidence of the final clean AI review from both reviewers below.
- [x] I ran human verification and recorded evidence below.
- [x] I added/updated tests where required.
- [x] N/A — no protocol/wire-format change; no separate performance evidence required (see below).
- [x] I verified licensing and provenance compliance.


\```
AI Usage Disclosure
- substantial_ai_assistance: yes
- scope: design drafting, code drafting, tests, PR rationale
- affected_files_or_subsystems: java/fory-core — resolver/ClassResolver.java, serializer/NonSerializableSerializer.java (new), platform/GraalvmSupport.java, test/ForyCopyTest.java
- ai_review: Completed line-by-line self-review and fixed issues first. Ran two fresh reviewers on the final diff — one using .claude/skills/fory-code-review/SKILL.md, one without. Addressed all actionable comments (duplicate-serializer justification, removal of issue/history references in comments, GraalVM registration, test assertion strength, typos) and reran both until neither reported further actionable comments.
- ai_review_artifacts:  Attached are the result of AI Agents. The claude command for independent agent is: 
Do a thorough, independent code review of the changes on my current branch
versus main: `git diff main...fix-issue-2941`. Review every changed line for
correctness, edge cases, performance, maintainability, test quality, and style.
Do NOT use any project-specific review skill — I want a fresh general review.
List concrete actionable issues.
The claude command for SKILL based agent is: 
Review the changes on my current branch versus main using the guidance in
.claude/skills/fory-code-review/SKILL.md. Diff: `git diff main...fix-issue-2941`.
Go line by line and list any actionable issues.

<img width="1859" height="304" alt="Screenshot from 2026-06-28 02-06-37" src="https://github.com/user-attachments/assets/65d5b72d-ccce-4690-98fa-16da2173e08c" />
<img width="1877" height="148" alt="Screenshot from 2026-06-28 01-58-47" src="https://github.com/user-attachments/assets/b5703716-eb0b-4ed1-856e-d1cab00f1d87" />

- human_verification: cd java && mvn -pl fory-core test -Dtest=org.apache.fory.ForyCopyTest — pass. cd java && mvn -pl fory-core test — pass. Local spotless:check could not run due to a google-java-format/JDK incompatibility (JCAnyPattern NoClassDefFoundError) affecting files unrelated to this change; relying on project CI for the format gate. Reviewed all results.
- performance_verification: N/A — change only redirects serializer resolution for non-Serializable JDK classes that previously threw; existing hot paths unchanged.
- provenance_license_confirmation: Apache-2.0-compatible provenance confirmed; no incompatible third-party code introduced. New file carries the standard ASF license header.
\```

## Does this PR introduce any user-facing change?



- [x] No public API change. `Fory.copy()` now succeeds where it previously threw; no signature or contract change.
- [x] No binary protocol compatibility change. Serialization of these classes is still refused (now at write time).


## Benchmark

N/A — see performance_verification above.