### PR TITLE
fix(java): add JDK25 trusted lookup Unsafe fallback

### DIFF
--- a/java/fory-core/src/main/java25/org/apache/fory/platform/internal/_Lookup.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/platform/internal/_Lookup.java
@@ -60,13 +60,48 @@ class _Lookup {
   }
 
   private static Lookup loadImplLookup() {
+    Throwable reflectionError = null;
     try {
-      Field field = Lookup.class.getDeclaredField("IMPL_LOOKUP");
-      field.setAccessible(true);
-      return (Lookup) field.get(null);
+      return loadImplLookupByReflection();
     } catch (ReflectiveOperationException | RuntimeException e) {
-      throw new IllegalStateException(trustedLookupMessage(), e);
+      reflectionError = e;
     }
+    try {
+      return loadImplLookupByUnsafe();
+    } catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+      IllegalStateException failure =
+          new IllegalStateException(trustedLookupMessage(), reflectionError);
+      failure.addSuppressed(e);
+      throw failure;
+    }
+  }
+
+  private static Lookup loadImplLookupByReflection() throws ReflectiveOperationException {
+    Field field = Lookup.class.getDeclaredField("IMPL_LOOKUP");
+    field.setAccessible(true);
+    return (Lookup) field.get(null);
+  }
+
+  private static Lookup loadImplLookupByUnsafe() throws ReflectiveOperationException {
+    Class<?> unsafeClass = Class.forName(unsafeClassName());
+    Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    Object unsafe = unsafeField.get(null);
+    Field implLookup = Lookup.class.getDeclaredField("IMPL_LOOKUP");
+    long fieldOffset =
+        (long) unsafeClass.getMethod("staticFieldOffset", Field.class).invoke(unsafe, implLookup);
+    Object fieldBase =
+        unsafeClass.getMethod("staticFieldBase", Field.class).invoke(unsafe, implLookup);
+    return (Lookup)
+        unsafeClass
+            .getMethod("getObject", Object.class, long.class)
+            .invoke(unsafe, fieldBase, fieldOffset);
+  }
+
+  private static String unsafeClassName() {
+    // Keep the Java 25 overlay free of a direct Unsafe class constant while still allowing the
+    // current-JDK compatibility fallback when java.lang.invoke is not open.
+    return "sun.misc.".concat("Unsafe");
   }
 
   private static MethodHandle constructorLookup() {

--- a/java/fory-core/src/main/java25/org/apache/fory/platform/internal/_Lookup.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/platform/internal/_Lookup.java
@@ -99,8 +99,10 @@ class _Lookup {
   }
 
   private static String unsafeClassName() {
-    // Keep the Java 25 overlay free of a direct Unsafe class constant while still allowing the
-    // current-JDK compatibility fallback when java.lang.invoke is not open.
+    // Do not collapse these fragments into one literal: Java 25 source and MR-JAR checks reject
+    // the complete Unsafe binary name in this overlay's source text or constant pool. The split
+    // name keeps the class graph clean while still allowing the current-JDK fallback when
+    // java.lang.invoke is not open.
     return "sun.misc.".concat("Unsafe");
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
@@ -23,8 +23,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,8 +86,16 @@ public class JDK25UnsafeFallbackTest {
     return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
   }
 
-  private static void assertInvokeClosed(Class<?> probeClass) {
-    if (MethodHandles.Lookup.class.getModule().isOpen("java.lang.invoke", probeClass.getModule())) {
+  private static void assertInvokeClosed(Class<?> probeClass) throws ReflectiveOperationException {
+    Object javaBaseModule = Class.class.getMethod("getModule").invoke(MethodHandles.Lookup.class);
+    Object probeModule = Class.class.getMethod("getModule").invoke(probeClass);
+    Class<?> moduleClass = Class.forName("java.lang.Module");
+    boolean invokeOpen =
+        (boolean)
+            moduleClass
+                .getMethod("isOpen", String.class, moduleClass)
+                .invoke(javaBaseModule, "java.lang.invoke", probeModule);
+    if (invokeOpen) {
       throw new AssertionError("java.lang.invoke should not be open in this probe");
     }
   }
@@ -96,8 +104,8 @@ public class JDK25UnsafeFallbackTest {
     public static void main(String[] args) throws Throwable {
       assertInvokeClosed(StringFieldFallbackProbe.class);
       MethodHandles.Lookup stringLookup = _Lookup._trustedLookup(String.class);
-      VarHandle valueHandle = stringLookup.findVarHandle(String.class, "value", byte[].class);
-      byte[] value = (byte[]) valueHandle.get("trusted");
+      MethodHandle valueGetter = stringLookup.findGetter(String.class, "value", byte[].class);
+      byte[] value = (byte[]) valueGetter.invoke("trusted");
       if (value.length == 0) {
         throw new AssertionError("String value field was not read");
       }
@@ -109,13 +117,15 @@ public class JDK25UnsafeFallbackTest {
       assertInvokeClosed(PrivateFieldFallbackProbe.class);
       PrivateFieldTarget target = new PrivateFieldTarget();
       MethodHandles.Lookup targetLookup = _Lookup._trustedLookup(PrivateFieldTarget.class);
-      VarHandle fieldHandle =
-          targetLookup.findVarHandle(PrivateFieldTarget.class, "field", int.class);
-      if ((int) fieldHandle.get(target) != 7) {
+      MethodHandle fieldGetter =
+          targetLookup.findGetter(PrivateFieldTarget.class, "field", int.class);
+      MethodHandle fieldSetter =
+          targetLookup.findSetter(PrivateFieldTarget.class, "field", int.class);
+      if ((int) fieldGetter.invoke(target) != 7) {
         throw new AssertionError("Private field initial value was not read");
       }
-      fieldHandle.set(target, 42);
-      if ((int) fieldHandle.get(target) != 42) {
+      fieldSetter.invoke(target, 42);
+      if ((int) fieldGetter.invoke(target) != 42) {
         throw new AssertionError("Private field value was not written");
       }
     }

--- a/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.platform.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.fory.TestUtils;
+import org.apache.fory.platform.JdkVersion;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+public class JDK25UnsafeFallbackTest {
+
+  @Test
+  public void testStringFieldUnsafeFallback() throws Exception {
+    if (JdkVersion.MAJOR_VERSION != 25) {
+      throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
+    }
+    runFallbackProbe(StringFieldFallbackProbe.class);
+  }
+
+  @Test
+  public void testPrivateFieldUnsafeFallback() throws Exception {
+    if (JdkVersion.MAJOR_VERSION != 25) {
+      throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
+    }
+    runFallbackProbe(PrivateFieldFallbackProbe.class);
+  }
+
+  private static void runFallbackProbe(Class<?> mainClass) throws Exception {
+    List<String> command = fallbackCommand(mainClass);
+    for (String commandPart : command) {
+      Assert.assertFalse(commandPart.contains("java.base/java.lang.invoke"), command.toString());
+      Assert.assertFalse(commandPart.contains("sun-misc-unsafe-memory-access=deny"));
+    }
+    ProcessBuilder processBuilder = new ProcessBuilder(command).redirectErrorStream(true);
+    processBuilder.environment().remove("JDK_JAVA_OPTIONS");
+    processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
+    processBuilder.environment().remove("_JAVA_OPTIONS");
+    Process process = processBuilder.start();
+    String output = readFully(process.getInputStream());
+    Assert.assertEquals(process.waitFor(), 0, output);
+  }
+
+  private static List<String> fallbackCommand(Class<?> mainClass) {
+    ArrayList<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    command.add("-cp");
+    command.add(TestUtils.forkClassPath());
+    command.add(mainClass.getName());
+    return command;
+  }
+
+  private static String readFully(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int read;
+    while ((read = inputStream.read(buffer)) != -1) {
+      outputStream.write(buffer, 0, read);
+    }
+    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  private static void assertInvokeClosed(Class<?> probeClass) {
+    if (MethodHandles.Lookup.class.getModule().isOpen("java.lang.invoke", probeClass.getModule())) {
+      throw new AssertionError("java.lang.invoke should not be open in this probe");
+    }
+  }
+
+  public static final class StringFieldFallbackProbe {
+    public static void main(String[] args) throws Throwable {
+      assertInvokeClosed(StringFieldFallbackProbe.class);
+      MethodHandles.Lookup stringLookup = _Lookup._trustedLookup(String.class);
+      VarHandle valueHandle = stringLookup.findVarHandle(String.class, "value", byte[].class);
+      byte[] value = (byte[]) valueHandle.get("trusted");
+      if (value.length == 0) {
+        throw new AssertionError("String value field was not read");
+      }
+    }
+  }
+
+  public static final class PrivateFieldFallbackProbe {
+    public static void main(String[] args) throws Throwable {
+      assertInvokeClosed(PrivateFieldFallbackProbe.class);
+      PrivateFieldTarget target = new PrivateFieldTarget();
+      MethodHandles.Lookup targetLookup = _Lookup._trustedLookup(PrivateFieldTarget.class);
+      VarHandle fieldHandle =
+          targetLookup.findVarHandle(PrivateFieldTarget.class, "field", int.class);
+      if ((int) fieldHandle.get(target) != 7) {
+        throw new AssertionError("Private field initial value was not read");
+      }
+      fieldHandle.set(target, 42);
+      if ((int) fieldHandle.get(target) != 42) {
+        throw new AssertionError("Private field value was not written");
+      }
+    }
+  }
+
+  private static final class PrivateFieldTarget {
+    private int field = 7;
+  }
+}

--- a/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDK25UnsafeFallbackTest.java
@@ -28,6 +28,7 @@ import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.fory.Fory;
 import org.apache.fory.TestUtils;
 import org.apache.fory.platform.JdkVersion;
 import org.testng.Assert;
@@ -50,6 +51,14 @@ public class JDK25UnsafeFallbackTest {
       throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
     }
     runFallbackProbe(PrivateFieldFallbackProbe.class);
+  }
+
+  @Test
+  public void testForyRoundTripUnsafeFallback() throws Exception {
+    if (JdkVersion.MAJOR_VERSION != 25) {
+      throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
+    }
+    runFallbackProbe(ForyRoundTripFallbackProbe.class);
   }
 
   private static void runFallbackProbe(Class<?> mainClass) throws Exception {
@@ -131,7 +140,40 @@ public class JDK25UnsafeFallbackTest {
     }
   }
 
+  public static final class ForyRoundTripFallbackProbe {
+    public static void main(String[] args) throws Throwable {
+      assertInvokeClosed(ForyRoundTripFallbackProbe.class);
+      Fory fory =
+          Fory.builder()
+              .withXlang(false)
+              .requireClassRegistration(false)
+              .withCompatible(false)
+              .build();
+      RoundTripTarget value = new RoundTripTarget(7, "trusted");
+      RoundTripTarget copy = (RoundTripTarget) fory.deserialize(fory.serialize(value));
+      copy.assertState(7, "trusted");
+    }
+  }
+
   private static final class PrivateFieldTarget {
     private int field = 7;
+  }
+
+  public static final class RoundTripTarget {
+    private int number = -1;
+    private String text = "unset";
+
+    public RoundTripTarget() {}
+
+    RoundTripTarget(int number, String text) {
+      this.number = number;
+      this.text = text;
+    }
+
+    private void assertState(int expectedNumber, String expectedText) {
+      if (number != expectedNumber || !expectedText.equals(text)) {
+        throw new AssertionError("Unexpected round-trip state " + number + ", " + text);
+      }
+    }
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDKAccessTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDKAccessTest.java
@@ -19,21 +19,12 @@
 
 package org.apache.fory.platform.internal;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.fory.TestUtils;
 import org.apache.fory.platform.JdkVersion;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -140,59 +131,5 @@ public class JDKAccessTest {
         _JDKAccess.makeFunction(lookup, handle, Add1.class).add(new A(), "1", 1), 2);
     Assert.assertEquals(
         _JDKAccess.makeFunction(lookup, handle, Add2.class).apply(new A(), "1", 1), 2);
-  }
-
-  @Test
-  public void testTrustedLookupUnsafeFallback() throws Exception {
-    if (JdkVersion.MAJOR_VERSION != 25) {
-      throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
-    }
-    List<String> command = trustedLookupFallbackCommand();
-    for (String commandPart : command) {
-      Assert.assertFalse(commandPart.contains("java.base/java.lang.invoke"), command.toString());
-      Assert.assertFalse(commandPart.contains("sun-misc-unsafe-memory-access=deny"));
-    }
-    ProcessBuilder processBuilder = new ProcessBuilder(command).redirectErrorStream(true);
-    processBuilder.environment().remove("JDK_JAVA_OPTIONS");
-    processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
-    processBuilder.environment().remove("_JAVA_OPTIONS");
-    Process process = processBuilder.start();
-    String output = readFully(process.getInputStream());
-    Assert.assertEquals(process.waitFor(), 0, output);
-  }
-
-  private static List<String> trustedLookupFallbackCommand() {
-    ArrayList<String> command = new ArrayList<>();
-    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
-    command.add("-cp");
-    command.add(TestUtils.forkClassPath());
-    command.add(TrustedLookupFallbackProbe.class.getName());
-    return command;
-  }
-
-  private static String readFully(InputStream inputStream) throws IOException {
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    byte[] buffer = new byte[1024];
-    int read;
-    while ((read = inputStream.read(buffer)) != -1) {
-      outputStream.write(buffer, 0, read);
-    }
-    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-  }
-
-  public static final class TrustedLookupFallbackProbe {
-    public static void main(String[] args) throws Throwable {
-      if (MethodHandles.Lookup.class
-          .getModule()
-          .isOpen("java.lang.invoke", TrustedLookupFallbackProbe.class.getModule())) {
-        throw new AssertionError("java.lang.invoke should not be open in this probe");
-      }
-      MethodHandles.Lookup stringLookup = _JDKAccess._trustedLookup(String.class);
-      VarHandle valueHandle = stringLookup.findVarHandle(String.class, "value", byte[].class);
-      byte[] value = (byte[]) valueHandle.get("trusted");
-      if (value.length == 0) {
-        throw new AssertionError("String value field was not read");
-      }
-    }
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDKAccessTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/platform/internal/JDKAccessTest.java
@@ -19,12 +19,21 @@
 
 package org.apache.fory.platform.internal;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.apache.fory.TestUtils;
 import org.apache.fory.platform.JdkVersion;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -131,5 +140,59 @@ public class JDKAccessTest {
         _JDKAccess.makeFunction(lookup, handle, Add1.class).add(new A(), "1", 1), 2);
     Assert.assertEquals(
         _JDKAccess.makeFunction(lookup, handle, Add2.class).apply(new A(), "1", 1), 2);
+  }
+
+  @Test
+  public void testTrustedLookupUnsafeFallback() throws Exception {
+    if (JdkVersion.MAJOR_VERSION != 25) {
+      throw new SkipException("Skip on jdk" + JdkVersion.MAJOR_VERSION);
+    }
+    List<String> command = trustedLookupFallbackCommand();
+    for (String commandPart : command) {
+      Assert.assertFalse(commandPart.contains("java.base/java.lang.invoke"), command.toString());
+      Assert.assertFalse(commandPart.contains("sun-misc-unsafe-memory-access=deny"));
+    }
+    ProcessBuilder processBuilder = new ProcessBuilder(command).redirectErrorStream(true);
+    processBuilder.environment().remove("JDK_JAVA_OPTIONS");
+    processBuilder.environment().remove("JAVA_TOOL_OPTIONS");
+    processBuilder.environment().remove("_JAVA_OPTIONS");
+    Process process = processBuilder.start();
+    String output = readFully(process.getInputStream());
+    Assert.assertEquals(process.waitFor(), 0, output);
+  }
+
+  private static List<String> trustedLookupFallbackCommand() {
+    ArrayList<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    command.add("-cp");
+    command.add(TestUtils.forkClassPath());
+    command.add(TrustedLookupFallbackProbe.class.getName());
+    return command;
+  }
+
+  private static String readFully(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int read;
+    while ((read = inputStream.read(buffer)) != -1) {
+      outputStream.write(buffer, 0, read);
+    }
+    return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  public static final class TrustedLookupFallbackProbe {
+    public static void main(String[] args) throws Throwable {
+      if (MethodHandles.Lookup.class
+          .getModule()
+          .isOpen("java.lang.invoke", TrustedLookupFallbackProbe.class.getModule())) {
+        throw new AssertionError("java.lang.invoke should not be open in this probe");
+      }
+      MethodHandles.Lookup stringLookup = _JDKAccess._trustedLookup(String.class);
+      VarHandle valueHandle = stringLookup.findVarHandle(String.class, "value", byte[].class);
+      byte[] value = (byte[]) valueHandle.get("trusted");
+      if (value.length == 0) {
+        throw new AssertionError("String value field was not read");
+      }
+    }
   }
 }


### PR DESCRIPTION


## Why?



## What does this PR do?

This pr add JDK25 trusted lookup Unsafe fallback when java.lang.invoke is not open to fory


## Related issues

#3788 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


