### PR TITLE
ci: reuse cached Swift build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,15 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Compute Swift package cache key
+        id: swift-package-cache
+        run: |
+          {
+            swift --version
+            xcodebuild -version
+          } > "$RUNNER_TEMP/swift-toolchain.txt"
+          cat "$RUNNER_TEMP/swift-toolchain.txt"
+          echo "toolchain=$(shasum -a 256 "$RUNNER_TEMP/swift-toolchain.txt" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
       - name: Cache Swift package dependencies and build artifacts
         uses: actions/cache@v4
         with:
@@ -460,9 +469,9 @@ jobs:
             ~/.swiftpm
             ~/Library/Caches/org.swift.swiftpm
             swift/.build
-          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-${{ hashFiles('swift/Package.resolved', 'swift/Package.swift', 'swift/Sources/**') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-xlang-release-${{ steps.swift-package-cache.outputs.toolchain }}-${{ hashFiles('swift/Package.resolved', 'swift/Package.swift', 'swift/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-swiftpm-
+            ${{ runner.os }}-${{ runner.arch }}-swiftpm-xlang-release-${{ steps.swift-package-cache.outputs.toolchain }}-
       - name: Prebuild Swift xlang peer for cache reuse
         run: |
           cd swift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,19 +516,36 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Generate Swift IDL test code
         run: python ./integration_tests/idl_tests/generate_idl.py --lang swift
+      - name: Compute Swift IDL package cache key
+        id: swift-idl-package-cache
+        run: |
+          {
+            swift --version
+            xcodebuild -version
+          } > "$RUNNER_TEMP/swift-toolchain.txt"
+          cat "$RUNNER_TEMP/swift-toolchain.txt"
+          echo "toolchain=$(shasum -a 256 "$RUNNER_TEMP/swift-toolchain.txt" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
       - name: Cache Swift IDL package build artifacts
+        id: swift-idl-build-cache
         uses: actions/cache@v4
         with:
           path: |
             integration_tests/idl_tests/swift/idl_package/.build
             integration_tests/idl_tests/swift/idl_package/.swiftpm
-          key: ${{ runner.os }}-${{ runner.arch }}-swift-idl-package-${{ hashFiles('integration_tests/idl_tests/swift/idl_package/Package.swift', 'integration_tests/idl_tests/swift/idl_package/Package.resolved', 'swift/Package.swift', 'swift/Package.resolved', 'swift/Sources/ForyMacro/**') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-idl-debug-${{ steps.swift-idl-package-cache.outputs.toolchain }}-${{ hashFiles('integration_tests/idl_tests/swift/idl_package/Package.swift', 'integration_tests/idl_tests/swift/idl_package/Package.resolved', 'integration_tests/idl_tests/swift/idl_package/Sources/**', 'integration_tests/idl_tests/swift/idl_package/Tests/**', 'swift/Package.swift', 'swift/Package.resolved', 'swift/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-swift-idl-package-
+            ${{ runner.os }}-${{ runner.arch }}-swiftpm-idl-debug-${{ steps.swift-idl-package-cache.outputs.toolchain }}-
       - name: Prebuild Swift IDL package
         run: |
           cd integration_tests/idl_tests/swift/idl_package
+          if [[ "${{ steps.swift-idl-build-cache.outputs.cache-hit }}" == "true" && -f .build/fory-swift-idl-prebuilt ]]; then
+            echo "Using cached Swift IDL package build artifacts"
+            echo "FORY_SWIFT_IDL_PREBUILT=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
           swift build --disable-automatic-resolution --build-tests
+          touch .build/fory-swift-idl-prebuilt
+          echo "FORY_SWIFT_IDL_PREBUILT=1" >> "$GITHUB_ENV"
       - name: Run Swift IDL package tests
         env:
           ENABLE_FORY_DEBUG_OUTPUT: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,7 @@ jobs:
           cat "$RUNNER_TEMP/swift-toolchain.txt"
           echo "toolchain=$(shasum -a 256 "$RUNNER_TEMP/swift-toolchain.txt" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
       - name: Cache Swift package dependencies and build artifacts
+        id: swift-build-cache
         uses: actions/cache@v4
         with:
           path: |
@@ -475,7 +476,13 @@ jobs:
       - name: Prebuild Swift xlang peer for cache reuse
         run: |
           cd swift
+          if [[ "${{ steps.swift-build-cache.outputs.cache-hit }}" == "true" && -x .build/release/ForyXlangTests ]]; then
+            echo "Using cached Swift xlang peer at swift/.build/release/ForyXlangTests"
+            echo "FORY_SWIFT_PEER_PREBUILT=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
           swift build -c release --disable-automatic-resolution --product ForyXlangTests
+          echo "FORY_SWIFT_PEER_PREBUILT=1" >> "$GITHUB_ENV"
       - name: Run Swift Xlang Test
         env:
           ENABLE_FORY_DEBUG_OUTPUT: "1"

--- a/integration_tests/idl_tests/java/src/test/java/org/apache/fory/idl_tests/IdlRoundTripTest.java
+++ b/integration_tests/idl_tests/java/src/test/java/org/apache/fory/idl_tests/IdlRoundTripTest.java
@@ -117,6 +117,7 @@ import tree.TreeForyModule;
 import tree.TreeNode;
 
 public class IdlRoundTripTest {
+  private static final String SWIFT_IDL_PREBUILT_ENV = "FORY_SWIFT_IDL_PREBUILT";
 
   @Test
   public void testAddressBookRoundTripCompatible() throws Exception {
@@ -813,7 +814,13 @@ public class IdlRoundTripTest {
             compatible
                 ? "IdlRoundTripTests/testAddressBookRoundTripCompatible"
                 : "IdlRoundTripTests/testAddressBookRoundTripSchemaConsistent";
-        command = Arrays.asList("swift", "test", "--filter", swiftTest);
+        command = new ArrayList<>(Arrays.asList("swift", "test"));
+        if ("1".equals(System.getenv(SWIFT_IDL_PREBUILT_ENV))) {
+          // CI cache keys include generated Swift IDL sources, package inputs, and toolchain
+          // identity. Trust that explicit signal instead of letting SwiftPM rebuild after checkout.
+          command.add("--skip-build");
+        }
+        command.addAll(Arrays.asList("--filter", swiftTest));
         peerCommand.environment.put("ENABLE_FORY_DEBUG_OUTPUT", "1");
         break;
       case "javascript":

--- a/java/fory-core/src/test/java/org/apache/fory/xlang/SwiftXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/xlang/SwiftXlangTest.java
@@ -42,6 +42,7 @@ public class SwiftXlangTest extends XlangTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(SwiftXlangTest.class);
   private static final String SWIFT_EXECUTABLE = "swift";
   private static final String SWIFT_PEER_TARGET = "ForyXlangTests";
+  private static final String SWIFT_PEER_PREBUILT_ENV = "FORY_SWIFT_PEER_PREBUILT";
   private static final File SWIFT_WORK_DIR = new File("../../swift");
   private static final Path SWIFT_WORK_DIR_PATH = SWIFT_WORK_DIR.toPath();
   private static final Path SWIFT_PEER_BINARY_PATH =
@@ -70,8 +71,16 @@ public class SwiftXlangTest extends XlangTestBase {
     }
     Assert.assertTrue(swiftInstalled, "swift is required for SwiftXlangTest");
 
+    if ("1".equals(System.getenv(SWIFT_PEER_PREBUILT_ENV))) {
+      // CI cache keys include Swift package inputs and toolchain identity. Trust that explicit
+      // signal instead of file mtimes because restored cache entries can predate checkout files.
+      usePeerBinary();
+      LOG.info("Completed ensurePeerReady for Swift xlang tests");
+      return;
+    }
+
     if (isPeerBinaryUpToDate()) {
-      swiftPeerBinaryPath = SWIFT_PEER_BINARY_PATH.toAbsolutePath().toString();
+      usePeerBinary();
       LOG.info("Completed ensurePeerReady for Swift xlang tests");
       return;
     }
@@ -103,6 +112,11 @@ public class SwiftXlangTest extends XlangTestBase {
     }
     Assert.assertTrue(built, "failed to build Swift xlang peer target " + SWIFT_PEER_TARGET);
 
+    usePeerBinary();
+    LOG.info("Completed ensurePeerReady for Swift xlang tests");
+  }
+
+  private void usePeerBinary() {
     Path peerBinary = SWIFT_PEER_BINARY_PATH;
     Assert.assertTrue(
         Files.isRegularFile(peerBinary),
@@ -111,7 +125,6 @@ public class SwiftXlangTest extends XlangTestBase {
         Files.isExecutable(peerBinary),
         "Swift xlang peer binary is not executable: " + peerBinary.toAbsolutePath());
     swiftPeerBinaryPath = peerBinary.toAbsolutePath().toString();
-    LOG.info("Completed ensurePeerReady for Swift xlang tests");
   }
 
   @Override


### PR DESCRIPTION
## Why?

Swift xlang and Swift IDL CI can restore SwiftPM build artifacts but still spend minutes rerunning SwiftPM builds. The cache key also needs to include the Swift/Xcode toolchain because `macos-latest` can move between toolchains while the source hash stays unchanged.

For xlang, the Java test has its own peer readiness check and can rebuild the Swift peer unless CI passes an explicit prebuilt signal. For IDL, both the workflow prebuild step and the Java IDL peer invocation can trigger SwiftPM work unless they consume the restored build explicitly.

## What does this PR do?

- Adds Swift/Xcode toolchain fingerprints to Swift xlang and Swift IDL cache keys.
- Keeps source/package hashes so real Swift input changes still get their own cache key.
- Skips Swift xlang prebuild on an exact cache hit when `.build/release/ForyXlangTests` exists.
- Teaches `SwiftXlangTest` to trust the explicit CI prebuilt signal instead of mtime checks.
- Skips Swift IDL prebuild on an exact cache hit with a marker written by the seeded build.
- Teaches Java IDL Swift peer runs to add `--skip-build` when CI sets `FORY_SWIFT_IDL_PREBUILT=1`.

## Verification

- Did not run local tests per request.
- Ran static whitespace check: `git diff --check`.
- Remote CI for head `63852940`: https://github.com/apache/fory/actions/runs/28598203127
  - Full PR checks settled green: 57 passed, 10 skipped, 0 failed.
  - Swift Xlang cache-hit attempt: primary cache hit, prebuild 0s, Swift Xlang job 1m17s.
  - Swift IDL first seed attempt after new key: prebuild 6m08s, job 9m35s.
  - Swift IDL cache-hit rerun: primary cache hit, prebuild 0s, direct Swift IDL tests 18s, Java IDL peer 1m46s, job 3m19s.
  - Logs show `Using cached Swift xlang peer at swift/.build/release/ForyXlangTests` and `Using cached Swift IDL package build artifacts`.
  - Targeted log search found no SwiftPM compile output such as `[n/m] Compiling`, `SwiftCompile`, or `swift-frontend` in the cache-hit Swift paths.