### PR TITLE
FIX(java): prevent StackOverflow in normalizeIterableTypeArguments fo…

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/reflect/TypeRef.java
+++ b/java/fory-core/src/main/java/org/apache/fory/reflect/TypeRef.java
@@ -175,10 +175,13 @@ public class TypeRef<T> {
     if (!hasFullExplicitRawArgs(type, rawType, typeArguments)) {
       return typeArguments;
     }
+    TypeRef<?> elementType = rawIterableElementType(rawType);
+    // Avoid infinite recursion for self-referential collections.
+    if (elementType.getRawType() == rawType) {
+      return typeArguments;
+    }
     return Collections.singletonList(
-        resolveTypeVariables(
-            rawIterableElementType(rawType).getType(),
-            explicitTypeVarRefs(rawType, typeArguments)));
+        resolveTypeVariables(elementType.getType(), explicitTypeVarRefs(rawType, typeArguments)));
   }
 
   private static List<TypeRef<?>> normalizeMapTypeArguments(


### PR DESCRIPTION
…r self-referential collections

Add a check to detect when the element type's raw type matches the container type, which would cause infinite recursion in normalizeIterableTypeArguments.

This fixes issues with self-referential collections like Box<T> implements List<Box<?>> where the element type is the same as the container type.



## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

