### PR TITLE
fix(C++): add unordered_map type info hooks

### DIFF
--- a/cpp/fory/serialization/map_serializer.h
+++ b/cpp/fory/serialization/map_serializer.h
@@ -1105,6 +1105,21 @@ struct Serializer<std::unordered_map<K, V, Args...>> {
   static constexpr TypeId type_id = TypeId::MAP;
   using MapType = std::unordered_map<K, V, Args...>;
 
+  static inline void write_type_info(WriteContext &ctx) {
+    ctx.write_uint8(static_cast<uint8_t>(type_id));
+  }
+
+  static inline void read_type_info(ReadContext &ctx) {
+    const TypeInfo *type_info = ctx.read_any_type_info(ctx.error());
+    if (FORY_PREDICT_FALSE(ctx.has_error())) {
+      return;
+    }
+    if (!type_id_matches(type_info->type_id, static_cast<uint32_t>(type_id))) {
+      ctx.set_error(Error::type_mismatch(type_info->type_id,
+                                         static_cast<uint32_t>(type_id)));
+    }
+  }
+
   static inline void write(const MapType &map, WriteContext &ctx,
                            RefMode ref_mode, bool write_type,
                            bool has_generics = false) {

--- a/cpp/fory/serialization/map_serializer_test.cc
+++ b/cpp/fory/serialization/map_serializer_test.cc
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 using namespace fory::serialization;
 
@@ -95,6 +96,15 @@ TEST(MapSerializerTest, NestedMapRoundtrip) {
   std::map<std::string, std::map<std::string, int32_t>> nested{
       {"group1", {{"a", 1}, {"b", 2}}}, {"group2", {{"c", 3}, {"d", 4}}}};
   test_map_roundtrip(nested);
+}
+
+TEST(MapSerializerTest, NestedMapElementRoundtrip) {
+  std::vector<std::map<std::string, int32_t>> ordered{{{"a", 1}, {"b", 2}},
+                                                      {{"c", 3}, {"d", 4}}};
+  test_map_roundtrip(ordered);
+  std::vector<std::unordered_map<std::string, int32_t>> unordered{
+      {{"a", 1}, {"b", 2}}, {{"c", 3}, {"d", 4}}};
+  test_map_roundtrip(unordered);
 }
 
 struct MapsInStruct {


### PR DESCRIPTION
## Why?

Nested collection IDL like `list<map<...>>` requires the element serializer to expose `write_type_info` and `read_type_info`.

In C++, `std::map` already did this, but `std::unordered_map` did not, causing generated C++ for nested map collections to fail during template instantiation.

## What does this PR do?

- Add missing type-info hooks for the C++ `std::unordered_map` serializer.
- Add testcase.

## Related issues

N/A.

## AI Contribution Checklist

- [X] Substantial AI assistance was used in this PR: `no`

## Does this PR introduce any user-facing change?

N/A.

## Benchmark

N/A.
