### PR TITLE
feat(java): make DefaultJdkClassAllowList public

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
@@ -103,8 +103,8 @@ public class AllowListChecker implements TypeChecker {
     if (checkLevel == CheckLevel.DISABLE) {
       return true;
     }
-    boolean disallowed = containsPrefix(disallowList, disallowListPrefix, className);
-    boolean allowed = containsPrefix(allowList, allowListPrefix, className);
+    boolean disallowed = containsPrefix(disallowList, disallowListPrefix, className) || DisallowedList.contains(className);
+    boolean allowed = containsPrefix(allowList, allowListPrefix, className) || DefaultJdkClassAllowList.contains(className);
     if (className.startsWith("[")) {
       Tuple2<String, Integer> componentInfo = TypeUtils.getArrayComponentInfo(className);
       String componentName = componentInfo.f0;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/AllowListChecker.java
@@ -103,8 +103,12 @@ public class AllowListChecker implements TypeChecker {
     if (checkLevel == CheckLevel.DISABLE) {
       return true;
     }
-    boolean disallowed = containsPrefix(disallowList, disallowListPrefix, className) || DisallowedList.contains(className);
-    boolean allowed = containsPrefix(allowList, allowListPrefix, className) || DefaultJdkClassAllowList.contains(className);
+    boolean disallowed =
+        containsPrefix(disallowList, disallowListPrefix, className)
+            || DisallowedList.contains(className);
+    boolean allowed =
+        containsPrefix(allowList, allowListPrefix, className)
+            || DefaultJdkClassAllowList.contains(className);
     if (className.startsWith("[")) {
       Tuple2<String, Integer> componentInfo = TypeUtils.getArrayComponentInfo(className);
       String componentName = componentInfo.f0;

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/DefaultJdkClassAllowList.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/DefaultJdkClassAllowList.java
@@ -90,12 +90,12 @@ public final class DefaultJdkClassAllowList {
     return CLASS_NAMES.contains(className) || className.startsWith("java.util.function.");
   }
 
-    /**
-     * Get the allowed class names as an immutable set.
-     *
-     * @return Set of allowed class names
-     */
-    public static Set<String> getAllowClasses() {
-        return CLASS_NAMES;
-    }
+  /**
+   * Get the allowed class names as an immutable set.
+   *
+   * @return Set of allowed class names
+   */
+  public static Set<String> getAllowClasses() {
+    return CLASS_NAMES;
+  }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/DefaultJdkClassAllowList.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/DefaultJdkClassAllowList.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** JDK interface names which can be loaded without explicit class registration. */
-final class DefaultJdkClassAllowList {
+public final class DefaultJdkClassAllowList {
   private static final Set<String> CLASS_NAMES = new HashSet<>();
 
   static {
@@ -89,4 +89,13 @@ final class DefaultJdkClassAllowList {
   static boolean contains(String className) {
     return CLASS_NAMES.contains(className) || className.startsWith("java.util.function.");
   }
+
+    /**
+     * Get the allowed class names as an immutable set.
+     *
+     * @return Set of allowed class names
+     */
+    public static Set<String> getAllowClasses() {
+        return CLASS_NAMES;
+    }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/DisallowedList.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/DisallowedList.java
@@ -317,4 +317,8 @@ public final class DisallowedList {
       throw new InsecureException(String.format("%s hit disallowed list", clsName));
     }
   }
+
+  public static boolean contains(String className) {
+      return DEFAULT_DISALLOWED_LIST_SET.contains(className);
+  }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/DisallowedList.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/DisallowedList.java
@@ -319,6 +319,6 @@ public final class DisallowedList {
   }
 
   public static boolean contains(String className) {
-      return DEFAULT_DISALLOWED_LIST_SET.contains(className);
+    return DEFAULT_DISALLOWED_LIST_SET.contains(className);
   }
 }


### PR DESCRIPTION
…trieve allowed class names



## Why?

 Cause: org.apache.fory.exception.InsecureException: Class java.io.Serializable isn't in the allow list for serialization or deserialization. If this class is allowed, add it with AllowListChecker#allowClass

     AllowListChecker checker = new AllowListChecker(AllowListChecker.CheckLevel.STRICT);
     checker.allowClasses(DefaultJdkClassAllowList.getAllowClasses());




## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

