### PR TITLE
feat(java): capture and forward extra fields in compatible mode

### DIFF
--- a/docs/guide/java/extra-fields.md
+++ b/docs/guide/java/extra-fields.md
@@ -67,9 +67,32 @@ its nested children can each declare one and capture independently — see
   compatible mode (the default).
   [same-schema mode](schema-evolution.md#same-schema-optimization).
 - **A sink field** of type `ForyExtraFields` per class.
+- **A mutable owner — not a record.** The sink is populated field-by-field while the object is being
+  read, so the owner must exist before its fields are set. A `record` is built from its constructor
+  arguments and is immutable, so there is no instance to capture into mid-read. See
+  [Records Are Not Supported](#records-are-not-supported).
 - Supported across the runtime interpreter, and the runtime JIT
   (`withCodegen(true)`).
   Cross-language (xlang) mode is not supported. Using `ForyExtraFields` under xlang mode will cause errors.
+
+### Records Are Not Supported
+
+Declaring a `ForyExtraFields` component on a `record` is **rejected** — Fory throws an
+`UnsupportedOperationException` when it builds the serializer for that type (for both serialization
+and deserialization, under the interpreter and the JIT), rather than silently dropping the extra
+fields:
+
+```java
+// Rejected: ForyExtraFields on a record.
+public record PersonView(int age, ForyExtraFields extraFields) {}
+// -> UnsupportedOperationException: ForyExtraFields is not supported on records: ...
+//    Extra-field capture requires a mutable owner; declare the ForyExtraFields sink
+//    on a regular class instead.
+```
+
+Capture requires a mutable owner: the framework fills the sink as it reads each unmatched field, but
+a record's fields can only be supplied all at once to its canonical constructor, and the instance
+does not exist until then. Use a regular class instead.
 
 ## Constraints
 
@@ -182,7 +205,94 @@ replays every level correctly. This is exercised directly in `ForyExtraFieldsTes
 `roundTripTripleNestedObjectWithInnerSink` (three levels deep), and
 `roundTripMultipleNestedObjectsWithOwnSinks` (two sibling children capturing independently).
 
+### Converted (Type-Mismatched) Fields
+
+[Compatible mode](schema-evolution.md#compatible-mode) can bridge some scalar type mismatches
+between the writer and reader — for example a remote `int score` deserializing into a local `long
+score`. Such a field is **matched** (the reader does declare `score`), but reached through a scalar
+converter rather than a direct field write, because the reader's field type differs from the wire
+type.
+
+When a converter field is combined with a sink, Fory captures the field **twice**, for two
+different purposes:
+
+- The local field (`score`) holds the converted value (`95` as a `long`), for application code to
+  read normally.
+- The sink **also** preserves the untouched, remote-typed value (`95` as the wire's original
+  `int`), keyed by the field's identity like any other captured field.
+
+The sink copy exists purely for replay. Re-deriving the remote value from the local one at
+re-serialization time is not always exact — a remote `BigDecimal("1.0")` converted to a local `int`
+loses the original scale, and reconverting `1` back to `BigDecimal` would produce `"1"`, not
+`"1.0"`. Capturing the pre-conversion value sidesteps that: replay always emits the exact original
+bytes, never a value re-derived from a lossy local conversion.
+
+```java
+// Remote: age, score (int), bonus (int, unknown to the reader)
+Fory foryA = Fory.builder().withXlang(false).withCompatible(true).build();
+byte[] aToB = foryA.serialize(new UpstreamConverted(30, 95, 7));
+
+// Local: age matches, score converts int -> long, bonus is captured
+public class DownstreamConvertedSink {
+  public int age;
+  public long score;              // converter field: reads the remote int, converts to long
+  public ForyExtraFields extraFields;
+}
+
+Fory foryB = Fory.builder().withXlang(false).withCompatible(true).build();
+DownstreamConvertedSink b = foryB.deserialize(aToB, DownstreamConvertedSink.class);
+b.score;   // 95L -- the converted value, for application code
+
+// The sink holds the untouched remote value alongside it:
+ForyExtraFields.FieldIdentity scoreId =
+    ForyExtraFields.FieldIdentity.of(UpstreamConverted.class.getName(), "score");
+b.extraFields.get(scoreId);   // 95 (an Integer) -- the original remote-typed value
+
+byte[] bToC = foryB.serialize(b);   // replays the exact original int, plus bonus
+```
+
+Replaying a converter field this way needs the target object at read time to capture the
+pre-conversion value into the sink. Both the interpreter and the JIT-compiled (codegen) reader
+provide it, for every converter field remote type — non-nullable primitives, nullable/boxed
+scalars, `BigDecimal`, `String`, the unsigned wrapper types, and `Float16`/`BFloat16` alike.
+
+One narrower constraint remains, independent of codegen vs. the interpreter: a converter field
+combined with a sink is schema-incompatible when the remote type is reference-tracked (e.g.
+`BigDecimal` under `withRefTracking(true)`) but the local converted type is a primitive-family type
+(`int`, `long`, `String`, etc.) that can never carry ref-tracking itself. That combination fails.
+
 ## Future Work
 
 Adiding Extra-field capture for
 the annotation processor, Scala macros, and KSP is planned for a follow-up change.
+
+AI Usage Disclosure
+
+- substantial_ai_assistance: yes
+- scope: docs, code drafting, tests, design drafting
+- affected_files_or_subsystems:
+  - docs/guide/java/extra-fields.md
+  - builder/BaseObjectCodecBuilder
+  - builder/CompatibleCodecBuilder
+  - builder/ObjectCodecBuilder
+  - builder/StaticCompatibleCodecBuilder
+  - context/MetaWriteContext
+  - context/WriteContext
+  - resolver/TypeInfo
+  - resolver/TypeResolver
+  - serializer/CompatibleLayerSerializerBase
+  - serializer/CompatibleSerializer
+  - serializer/ForyExtraFields
+  - serializer/ForyExtraFieldsSupport
+  - serializer/UnknownClassSerializers
+  - serializer/converter/FieldConverters
+  - serializer/CompatibleFieldConvertTest
+  - serializer/ForyExtraFieldsTest
+  - serializer/GraphMemoryBudgetTest
+  - builder/StaticCompatibleCodecBuilderTest
+  - native-image.properties
+- ai_review: Line-by-line review of serializer logic and field capture/replay mechanics completed. Architecture validated against compatible-mode constraints and reference-tracking edge cases. Documentation reviewed for clarity and completeness across nested structures, converter fields, and round-trip scenarios.
+- ai_review_artifacts:https://claude.ai/code/session_01JAyGgABzsVxarBkJ6zq9Tk , https://claude.ai/code/session_01VA4BrfmpXTVmGKiyu3Sv1t
+- human_verification: mvn -T10 clean test
+- performance_verification: N/A (feature addition with no performance regression expected; benchmarks validated in test suite)
+- provenance_license_confirmation: Apache-2.0-compatible provenance confirmed; no incompatible third-party code introduced

--- a/docs/guide/java/extra-fields.md
+++ b/docs/guide/java/extra-fields.md
@@ -1,0 +1,188 @@
+---
+title: Extra Fields
+sidebar_position: 7
+id: extra_fields
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+This page describes `ForyExtraFields` [Java], an opt-in mechanism for capturing and preserving fields
+that exist in a writer's schema but are unknown to the reader's class.
+
+## The Problem
+
+In [compatible mode](schema-evolution.md#compatible-mode), a reader can deserialize a payload whose
+writer schema differs from its own. When the writer includes a field that the reader's class does
+not declare, that field is **silently dropped**.
+
+## The Solution
+
+A class opts in by declaring **a field** of type `ForyExtraFields`:
+
+```java
+import org.apache.fory.serializer.ForyExtraFields;
+
+public class PersonView {
+  public int age;                      // known field
+  public ForyExtraFields extraFields;  // sink for everything else
+}
+```
+
+When Fory deserializes a payload into `PersonView`:
+
+- Fields that match the local class (`age`) are read normally.
+- Every unmatched remote field is **captured** into `extraFields` instead of being discarded.
+- If no fields are unmatched, `extraFields` stays `null` — the sink is only allocated on demand.
+
+On re-serialization, Fory emits the **original (remote) schema** and replays every field — matched
+fields from the object, unmatched fields from the sink — so a downstream peer with the full schema
+recovers them exactly.
+
+The field can be named anything; detection is by type, not name, and Fory walks the class hierarchy,
+so the sink may also be inherited from a superclass.
+
+A class uses a **single** sink. All of an object's unmatched fields are captured into one
+name-keyed map, so a second `ForyExtraFields` field would have no distinct role to play — Fory uses
+the first one it finds. This is a limit **per class, not per object
+graph**: every object in a nested structure resolves its own sink from its own class, so a parent and
+its nested children can each declare one and capture independently — see
+[Nested and Collection Fields](#nested-and-collection-fields).
+
+## Requirements
+
+- **Compatible mode.** Extra-field capture depends on schema metadata, so it works only when
+  compatible mode (the default).
+  [same-schema mode](schema-evolution.md#same-schema-optimization).
+- **A sink field** of type `ForyExtraFields` per class.
+- Supported across the runtime interpreter, and the runtime JIT
+  (`withCodegen(true)`).
+  Cross-language (xlang) mode is not supported. Using `ForyExtraFields` under xlang mode will cause errors.
+
+## Constraints
+
+Replay needs a Fory that has deserialized a payload carrying that schema and still
+has it cached, ie the instance that produced this object.
+
+## Reading Captured Fields
+
+`ForyExtraFields` exposes read-only, name-keyed lookup of the captured values. The sink is populated by
+Fory during deserialization; application code reads from it by field name:
+
+```java
+byte[] bytes = /* payload written by a full-schema peer */;
+PersonView view = fory.deserialize(bytes, PersonView.class);
+
+if (view.extraFields != null) {
+  // Field values are keyed by their original field name.
+  String name = (String) view.extraFields.get("name");
+
+  // getOrDefault avoids a null value for absent keys.
+  int score = (Integer) view.extraFields.getOrDefault("score", 0);
+
+  // Presence check — distinguishes "captured as null" from "not captured".
+  boolean hasName = view.extraFields.containsKey("name");
+
+  // Print the captured values.
+  System.out.println(name);
+  System.out.println(score);
+}
+```
+
+| Method                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `get(name)`               | Captured value for `name`, or `null` if absent (or captured null) |
+| `getOrDefault(name, def)` | Captured value, or `def` if the key is absent                     |
+| `containsKey(name)`       | Whether a value was captured for `name` (true even if it is null) |
+| `isEmpty()`               | Whether no fields were captured                                   |
+| `getTypeDef()`            | The remote schema (`TypeDef`) the fields were captured from       |
+
+Notes:
+
+- **Primitives are boxed.** A captured `int` reads back as an `Integer`, a `long` as a `Long`, and
+  so on, because the map holds `Object` values.
+- **`null` values are preserved.** A field that was written as `null` is captured as a `null` entry
+  (not omitted), so `containsKey` returns `true` while `get` returns `null`. On re-serialization it
+  is replayed as `null`.
+- The map is **read-only** to application code; there is no public way to add or mutate captured
+  entries.
+
+## Forwarding: Round-Trip Recovery
+
+When a partial-schema peer re-serializes an object
+whose sink is populated, Fory writes the object under the **original remote schema** so the next peer
+sees byte layout identical to what the original writer would have produced:
+
+```java
+// --- A: full-schema writer ---
+Fory foryA = Fory.builder().withXlang(false).withCompatible(true).build();
+Upstream original = new Upstream(/* f0..f9 */);
+byte[] aToB = foryA.serialize(original);
+
+// --- B: partial-schema intermediary with a sink ---
+Fory foryB = Fory.builder().withXlang(false).withCompatible(true).build();
+DownstreamWithSink b = foryB.deserialize(aToB, DownstreamWithSink.class);
+// b knows f0..f8; f9 was captured into b.extraFields.
+
+byte[] bToC = foryB.serialize(b);   // replays the full A-schema, including f9
+
+// --- C: full-schema receiver recovers everything ---
+Fory foryC = Fory.builder().withXlang(false).withCompatible(true).build();
+Upstream recovered = foryC.deserialize(bToC, Upstream.class);
+// recovered.f9 equals original.f9
+```
+
+This works across **multi-hop chains**. Each hop matches the fields it knows and
+captures the rest, and every hop re-stamps the original schema, so a peer several hops downstream
+still recovers the full object.
+
+### Reference Sharing
+
+If the original writer had two fields aliasing the same object, that identity is preserved through
+capture and replay
+
+```java
+DownstreamRefSink result = fory.deserialize(bytes, DownstreamRefSink.class);
+Object shared = result.extraFields.get("shared");
+Object alias  = result.extraFields.get("alias");
+assert shared == alias;   // same instance, identity preserved
+```
+
+### Nested and Collection Fields
+
+Capture works with Fory's existing type system. Unknown fields may themselves be objects, collections, arrays, or nested structures; they are captured and replayed using Fory's normal serialization mechanisms.
+
+The "one sink per class" limit is per class rather than per object graph, **each object in a
+nested structure captures into its own sink**, resolved from its own class. A parent with no sink can
+hold a child that has one, siblings can each capture independently, and this works to any depth:
+
+```java
+// Full graph:  Outer → Middle → Inner{f0, f1}
+// Partial graph the reader knows:  Outer → Middle → Inner{f0, ForyExtraFields}
+OuterPartial b = fory.deserialize(bytes, OuterPartial.class);
+
+// The unknown Inner.f1 lands in the innermost object's own sink:
+Object f1 = b.middle.inner.extraFields.get("f1");
+```
+
+Each sink preserves the remote schema of the object it belongs to, so re-serializing the whole graph
+replays every level correctly. This is exercised directly in `ForyExtraFieldsTest` — see
+`roundTripTripleNestedObjectWithInnerSink` (three levels deep), and
+`roundTripMultipleNestedObjectsWithOwnSinks` (two sibling children capturing independently).
+
+## Future Work
+
+Adiding Extra-field capture for
+the annotation processor, Scala macros, and KSP is planned for a follow-up change.

--- a/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
@@ -129,11 +129,12 @@ import org.apache.fory.resolver.RefMode;
 import org.apache.fory.resolver.TypeInfo;
 import org.apache.fory.resolver.TypeInfoHolder;
 import org.apache.fory.resolver.TypeResolver;
+import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.DeferedLazySerializer.DeferredLazyObjectSerializer;
 import org.apache.fory.serializer.EnumSerializer;
 import org.apache.fory.serializer.FinalFieldReplaceResolveSerializer;
-import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.PrimitiveSerializers.LongSerializer;
 import org.apache.fory.serializer.ReplaceResolveSerializer;
@@ -923,17 +924,6 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
                   classInfo,
                   inlineInvoke(typeResolverRef, "getTypeInfo", classInfoTypeRef, clsExpr))));
     }
-    // Mirror WriteContext.writeRef
-    Expression extraFieldsReplay =
-        new Expression.LogicalAnd(
-            inlineInvoke(classInfo, "hasExtraFieldsSink", PRIMITIVE_BOOLEAN_TYPE),
-            new Invoke(
-                writeContextRef(),
-                "tryWriteExtraFieldsSchema",
-                PRIMITIVE_BOOLEAN_TYPE,
-                typeResolverRef,
-                classInfo,
-                inputObject));
     ListExpression normalWrite = new ListExpression();
     normalWrite.add(
         typeResolver(r -> r.writeClassExpr(typeResolverRef, writeContextRef(), classInfo)));
@@ -944,7 +934,21 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
             PRIMITIVE_VOID_TYPE,
             writeContextRef(),
             inputObject));
-    writeClassAndObject.add(new If(not(extraFieldsReplay), normalWrite));
+    if (ForyExtraFieldsSupport.isEnabled(config)) {
+      Expression extraFieldsReplay =
+          new Expression.LogicalAnd(
+              inlineInvoke(classInfo, "hasExtraFieldsSink", PRIMITIVE_BOOLEAN_TYPE),
+              new Invoke(
+                  writeContextRef(),
+                  "tryWriteExtraFieldsSchema",
+                  PRIMITIVE_BOOLEAN_TYPE,
+                  typeResolverRef,
+                  classInfo,
+                  inputObject));
+      writeClassAndObject.add(new If(not(extraFieldsReplay), normalWrite));
+    } else {
+      writeClassAndObject.add(normalWrite);
+    }
     Expression write =
         exactClassWrite == null
             ? writeClassAndObject
@@ -967,7 +971,8 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
                         typeResolverRef, writeContextRef(), buffer, typeInfo, clz)),
             new Invoke(
                 serializer, writeMethodName, PRIMITIVE_VOID_TYPE, writeContextRef(), inputObject));
-    if (ForyExtraFields.findSinkField(clz) == null) {
+    if (!ForyExtraFieldsSupport.isEnabled(config)
+        || ForyExtraFieldsSupport.findSinkField(clz) == null) {
       return normalWrite;
     }
     Expression extraFieldsReplay =
@@ -2350,7 +2355,10 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
   }
 
   protected Expression deserializeField(
-      Expression buffer, Descriptor descriptor, Function<Expression, Expression> callback) {
+      Expression bean,
+      Expression buffer,
+      Descriptor descriptor,
+      Function<Expression, Expression> callback) {
     if (hasCompatibleCollectionArrayRead(descriptor)) {
       Expression value = deserializeCompatibleListArrayField(descriptor);
       return new ListExpression(value, callback.apply(value));

--- a/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/BaseObjectCodecBuilder.java
@@ -133,6 +133,7 @@ import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.DeferedLazySerializer.DeferredLazyObjectSerializer;
 import org.apache.fory.serializer.EnumSerializer;
 import org.apache.fory.serializer.FinalFieldReplaceResolveSerializer;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.PrimitiveSerializers.LongSerializer;
 import org.apache.fory.serializer.ReplaceResolveSerializer;
@@ -922,15 +923,28 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
                   classInfo,
                   inlineInvoke(typeResolverRef, "getTypeInfo", classInfoTypeRef, clsExpr))));
     }
-    writeClassAndObject.add(
+    // Mirror WriteContext.writeRef
+    Expression extraFieldsReplay =
+        new Expression.LogicalAnd(
+            inlineInvoke(classInfo, "hasExtraFieldsSink", PRIMITIVE_BOOLEAN_TYPE),
+            new Invoke(
+                writeContextRef(),
+                "tryWriteExtraFieldsSchema",
+                PRIMITIVE_BOOLEAN_TYPE,
+                typeResolverRef,
+                classInfo,
+                inputObject));
+    ListExpression normalWrite = new ListExpression();
+    normalWrite.add(
         typeResolver(r -> r.writeClassExpr(typeResolverRef, writeContextRef(), classInfo)));
-    writeClassAndObject.add(
+    normalWrite.add(
         new Invoke(
             invokeInline(classInfo, "getSerializer", getSerializerType(clz)),
             writeMethodName,
             PRIMITIVE_VOID_TYPE,
             writeContextRef(),
             inputObject));
+    writeClassAndObject.add(new If(not(extraFieldsReplay), normalWrite));
     Expression write =
         exactClassWrite == null
             ? writeClassAndObject
@@ -945,11 +959,26 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     }
     Reference typeInfo = addExactTypeInfoField(clz);
     Expression serializer = getOrCreateSerializer(clz);
-    return new ListExpression(
-        typeResolver(
-            r -> r.writeExactClassExpr(typeResolverRef, writeContextRef(), buffer, typeInfo, clz)),
+    ListExpression normalWrite =
+        new ListExpression(
+            typeResolver(
+                r ->
+                    r.writeExactClassExpr(
+                        typeResolverRef, writeContextRef(), buffer, typeInfo, clz)),
+            new Invoke(
+                serializer, writeMethodName, PRIMITIVE_VOID_TYPE, writeContextRef(), inputObject));
+    if (ForyExtraFields.findSinkField(clz) == null) {
+      return normalWrite;
+    }
+    Expression extraFieldsReplay =
         new Invoke(
-            serializer, writeMethodName, PRIMITIVE_VOID_TYPE, writeContextRef(), inputObject));
+            writeContextRef(),
+            "tryWriteExtraFieldsSchema",
+            PRIMITIVE_BOOLEAN_TYPE,
+            typeResolverRef,
+            typeInfo,
+            inputObject);
+    return new If(not(extraFieldsReplay), normalWrite);
   }
 
   protected Expression writeTypeInfo(

--- a/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleCodecBuilder.java
@@ -39,20 +39,25 @@ import org.apache.fory.Fory;
 import org.apache.fory.builder.Generated.GeneratedCompatibleSerializer;
 import org.apache.fory.codegen.CodeGenerator;
 import org.apache.fory.codegen.Expression;
+import org.apache.fory.codegen.Expression.Invoke;
 import org.apache.fory.codegen.Expression.Literal;
 import org.apache.fory.codegen.Expression.StaticInvoke;
 import org.apache.fory.config.ForyBuilder;
 import org.apache.fory.context.ReadContext;
+import org.apache.fory.context.WriteContext;
 import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.meta.TypeDef;
 import org.apache.fory.platform.GraalvmSupport;
+import org.apache.fory.reflect.FieldAccessor;
+import org.apache.fory.reflect.ReflectionUtils;
 import org.apache.fory.reflect.TypeRef;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.CodegenSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.FieldGroups.SerializationFieldInfo;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.Serializers;
@@ -93,13 +98,20 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
   private static final String REMOTE_FIELD_INFOS_NAME = "_f_remoteFieldInfos";
   private static final String LOCAL_FIELD_INFOS_NAME = "_f_localFieldInfosByRemoteOrder";
   private static final String CONSTRUCTOR_TYPE_DEF_NAME = "_f_typeDef";
+  private static final String EXTRA_FIELDS_SINK_ACCESSOR_NAME = "_f_extraFieldsSinkAccessor";
+  private static final String EXTRA_FIELDS_LOCAL_NAME = "_f_extra";
 
   private final TypeDef typeDef;
   private final String defaultValueLanguage;
   private final DefaultValueUtils.DefaultValueField[] defaultValueFields;
   private final Map<Descriptor, Integer> fieldInfoIds = new IdentityHashMap<>();
+  private final Field extraFieldsSinkField;
   private String remoteFieldInfosName;
   private String localFieldInfosName;
+  private String extraFieldsSinkAccessorName;
+  private String storedTypeDefFieldName;
+  private Expression extraFieldsSinkExprBean;
+  private Expression extraFieldsSinkExpr;
 
   public CompatibleCodecBuilder(TypeRef<?> beanType, Fory fory, TypeDef typeDef) {
     super(beanType, fory, GeneratedCompatibleSerializer.class);
@@ -153,6 +165,7 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
     }
     this.defaultValueLanguage = defaultValueLanguage;
     this.defaultValueFields = defaultValueFields;
+    this.extraFieldsSinkField = ForyExtraFields.findSinkField(beanClass);
   }
 
   // Must be static to be shared across the whole process life.
@@ -225,6 +238,16 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
             decodeCode);
     ctx.overrideMethod(
         readMethodName, decodeCode, Object.class, ReadContext.class, READ_CONTEXT_NAME);
+    if (extraFieldsSinkField != null) {
+      ctx.overrideMethod(
+          writeMethodName,
+          buildExtraFieldsWriteCode(),
+          void.class,
+          WriteContext.class,
+          WRITE_CONTEXT_NAME,
+          Object.class,
+          ROOT_OBJECT_NAME);
+    }
     registerJITNotifyCallback();
     ctx.addConstructor(
         constructorCode,
@@ -263,9 +286,62 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
     return Serializers.newSerializer(typeResolver, cls, serializerClass);
   }
 
-  @Override
-  public Expression buildEncodeExpression() {
-    throw new IllegalStateException("unreachable");
+  /**
+   * Generates the body of the {@code write} method for classes that declare a {@link
+   * ForyExtraFields} sink. Mirrors {@link CompatibleSerializer#write}.
+   */
+  private String buildExtraFieldsWriteCode() {
+    extraFieldsSinkAccessorExpr();
+    ctx.clearExprState();
+    String encodeCode = buildEncodeExpression().genCode(ctx).code();
+    encodeCode = ctx.optimizeMethodCode(encodeCode);
+    encodeCode = encodeCode == null ? "" : encodeCode;
+    StringBuilder body = new StringBuilder();
+    appendBufferAndRefWriterDeclarations(body, encodeCode);
+    body.append(
+        StringUtils.format(
+            "${extraType} ${extra} = (${extraType}) ${accessor}.getObject(${obj});\n"
+                + "if (${extra} == null || ${extra}.isEmpty()) {\n"
+                + "  this.${serializer}.write(${writeContext}, ${obj});\n"
+                + "  return;\n"
+                + "}\n",
+            "extraType",
+            ctx.type(ForyExtraFields.class),
+            "extra",
+            EXTRA_FIELDS_LOCAL_NAME,
+            "accessor",
+            extraFieldsSinkAccessorName,
+            "obj",
+            ROOT_OBJECT_NAME,
+            "serializer",
+            SERIALIZER_FIELD_NAME,
+            "writeContext",
+            WRITE_CONTEXT_NAME));
+    body.append(encodeCode);
+    return body.toString();
+  }
+
+  private void appendBufferAndRefWriterDeclarations(StringBuilder body, String encodeCode) {
+    body.append(
+        StringUtils.format(
+            "${bufferType} ${buffer} = ${writeContext}.getBuffer();\n",
+            "bufferType",
+            ctx.type(MemoryBuffer.class),
+            "buffer",
+            BUFFER_NAME,
+            "writeContext",
+            WRITE_CONTEXT_NAME));
+    if (encodeCode.contains(REF_WRITER_NAME)) {
+      body.append(
+          StringUtils.format(
+              "${refWriterType} ${refWriter} = (${refWriterType}) ${writeContext}.getRefWriter();\n",
+              "refWriterType",
+              ctx.type(concreteRefWriterType),
+              "refWriter",
+              REF_WRITER_NAME,
+              "writeContext",
+              WRITE_CONTEXT_NAME));
+    }
   }
 
   @Override
@@ -373,7 +449,8 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
   }
 
   private boolean shouldSkipField(Descriptor descriptor) {
-    return descriptor.getField() == null
+    return extraFieldsSinkField == null
+        && descriptor.getField() == null
         && descriptor.getFieldConverter() == null
         && !descriptor.getRawType().isPrimitive();
   }
@@ -387,19 +464,90 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
   }
 
   @Override
+  protected Expression getFieldValue(Expression bean, Descriptor descriptor) {
+    if (extraFieldsSinkField != null && descriptor.getField() == null) {
+      if (extraFieldsSinkExpr == null || extraFieldsSinkExprBean != bean) {
+        extraFieldsSinkExprBean = bean;
+        extraFieldsSinkExpr =
+            tryInlineCast(
+                new Invoke(extraFieldsSinkAccessorExpr(), "getObject", OBJECT_TYPE, bean),
+                TypeRef.of(ForyExtraFields.class));
+      }
+      Invoke raw =
+          new Invoke(
+              extraFieldsSinkExpr, "get", OBJECT_TYPE, Literal.ofString(descriptor.getName()));
+      return tryInlineCast(raw, descriptor.getTypeRef());
+    }
+    return super.getFieldValue(bean, descriptor);
+  }
+
+  @Override
   protected Expression setFieldValue(Expression bean, Descriptor descriptor, Expression value) {
     if (descriptor.getField() == null) {
       FieldConverter<?> converter = descriptor.getFieldConverter();
       if (converter != null) {
         return setFieldConverterTargetValue(bean, descriptor, converter, value);
       }
-      // Field doesn't exist in current class, skip set this field value.
+      // If Field doesn't exist in current class,
+      if (extraFieldsSinkField != null) {
+        return new StaticInvoke(
+            ForyExtraFields.class,
+            "capture",
+            TypeRef.of(void.class),
+            bean,
+            extraFieldsSinkAccessorExpr(),
+            typeDefFieldExpr(),
+            Literal.ofString(descriptor.getName()),
+            value);
+      }
       // Note that the field value shouldn't be an inlined value, otherwise field value read may
-      // be ignored.
-      // Add an ignored call here to make expression type to void.
+      // be ignored. Add an ignored call here to make expression type to void.
       return new StaticInvoke(ExceptionUtils.class, "ignore", value);
     }
     return super.setFieldValue(bean, descriptor, value);
+  }
+
+  private String ensureLazyFieldGenerated(
+      String cachedFieldName, String nameConstant, TypeRef<?> fieldType, Expression initializer) {
+    if (cachedFieldName == null) {
+      cachedFieldName = ctx.newName(nameConstant);
+      ctx.addField(false, true, ctx.type(fieldType), cachedFieldName, initializer);
+    }
+    return cachedFieldName;
+  }
+
+  private Expression extraFieldsSinkAccessorExpr() {
+    extraFieldsSinkAccessorName =
+        ensureLazyFieldGenerated(
+            extraFieldsSinkAccessorName,
+            EXTRA_FIELDS_SINK_ACCESSOR_NAME,
+            TypeRef.of(FieldAccessor.class),
+            new StaticInvoke(
+                FieldAccessor.class,
+                "createAccessor",
+                TypeRef.of(FieldAccessor.class),
+                getOrCreateField(
+                    true,
+                    Field.class,
+                    extraFieldsSinkField.getName() + "SinkField",
+                    () ->
+                        new StaticInvoke(
+                            ReflectionUtils.class,
+                            "getField",
+                            TypeRef.of(Field.class),
+                            staticBeanClassExpr(),
+                            Literal.ofString(extraFieldsSinkField.getName())))));
+    return new Expression.Reference(extraFieldsSinkAccessorName, TypeRef.of(FieldAccessor.class));
+  }
+
+  private Expression typeDefFieldExpr() {
+    storedTypeDefFieldName =
+        ensureLazyFieldGenerated(
+            storedTypeDefFieldName,
+            "_f_storedTypeDef",
+            TypeRef.of(TypeDef.class),
+            new Expression.Reference(CONSTRUCTOR_TYPE_DEF_NAME, TypeRef.of(TypeDef.class)));
+    return new Expression.Reference(storedTypeDefFieldName, TypeRef.of(TypeDef.class));
   }
 
   private Expression setFieldConverterTargetValue(

--- a/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/CompatibleCodecBuilder.java
@@ -58,6 +58,7 @@ import org.apache.fory.serializer.CodegenSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.FieldGroups.SerializationFieldInfo;
 import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.Serializers;
@@ -100,11 +101,13 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
   private static final String CONSTRUCTOR_TYPE_DEF_NAME = "_f_typeDef";
   private static final String EXTRA_FIELDS_SINK_ACCESSOR_NAME = "_f_extraFieldsSinkAccessor";
   private static final String EXTRA_FIELDS_LOCAL_NAME = "_f_extra";
+  private static final String EXTRA_FIELDS_FIELD_ID_NAME = "_f_extraFieldId";
 
   private final TypeDef typeDef;
   private final String defaultValueLanguage;
   private final DefaultValueUtils.DefaultValueField[] defaultValueFields;
   private final Map<Descriptor, Integer> fieldInfoIds = new IdentityHashMap<>();
+  private final Map<Descriptor, String> extraFieldsFieldIdNames = new IdentityHashMap<>();
   private final Field extraFieldsSinkField;
   private String remoteFieldInfosName;
   private String localFieldInfosName;
@@ -165,7 +168,10 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
     }
     this.defaultValueLanguage = defaultValueLanguage;
     this.defaultValueFields = defaultValueFields;
-    this.extraFieldsSinkField = ForyExtraFields.findSinkField(beanClass);
+    this.extraFieldsSinkField =
+        ForyExtraFieldsSupport.isEnabled(config)
+            ? ForyExtraFieldsSupport.findSinkField(beanClass)
+            : null;
   }
 
   // Must be static to be shared across the whole process life.
@@ -394,7 +400,7 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
       for (Descriptor descriptor : group) {
         FieldConverter<?> converter = descriptor.getFieldConverter();
         Expression targetValue =
-            converter == null ? null : fieldConverterTargetRead(descriptor, converter);
+            converter == null ? null : fieldConverterTargetRead(bean, descriptor, converter);
         if (targetValue != null) {
           expressions.add(
               new Expression.ListExpression(
@@ -403,6 +409,7 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
         } else {
           expressions.add(
               deserializeField(
+                  bean,
                   buffer,
                   descriptor,
                   value ->
@@ -417,15 +424,18 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
 
   @Override
   protected Expression deserializeField(
-      Expression buffer, Descriptor descriptor, Function<Expression, Expression> callback) {
+      Expression bean,
+      Expression buffer,
+      Descriptor descriptor,
+      Function<Expression, Expression> callback) {
     FieldConverter<?> converter = descriptor.getFieldConverter();
     if (shouldSkipField(descriptor)) {
       return skipField(descriptor);
     }
     if (converter == null) {
-      return super.deserializeField(buffer, descriptor, callback);
+      return super.deserializeField(bean, buffer, descriptor, callback);
     }
-    Expression targetValue = fieldConverterTargetRead(descriptor, converter);
+    Expression targetValue = fieldConverterTargetRead(bean, descriptor, converter);
     Preconditions.checkState(
         targetValue != null,
         "Unsupported compatible scalar converter target " + FieldConverters.toType(converter));
@@ -442,7 +452,7 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
         continue;
       }
       TypeRef<?> castTypeRef = readValueTypeRef(descriptor);
-      Expression value = deserializeField(buffer, descriptor, expression -> expression);
+      Expression value = deserializeField(bean, buffer, descriptor, expression -> expression);
       expressions.add(setFieldValue(bean, descriptor, tryInlineCast(value, castTypeRef)));
     }
     return expressions;
@@ -474,8 +484,7 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
                 TypeRef.of(ForyExtraFields.class));
       }
       Invoke raw =
-          new Invoke(
-              extraFieldsSinkExpr, "get", OBJECT_TYPE, Literal.ofString(descriptor.getName()));
+          new Invoke(extraFieldsSinkExpr, "get", OBJECT_TYPE, extraFieldsFieldIdExpr(descriptor));
       return tryInlineCast(raw, descriptor.getTypeRef());
     }
     return super.getFieldValue(bean, descriptor);
@@ -491,13 +500,14 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
       // If Field doesn't exist in current class,
       if (extraFieldsSinkField != null) {
         return new StaticInvoke(
-            ForyExtraFields.class,
+            ForyExtraFieldsSupport.class,
             "capture",
             TypeRef.of(void.class),
+            readContextRef(),
             bean,
             extraFieldsSinkAccessorExpr(),
             typeDefFieldExpr(),
-            Literal.ofString(descriptor.getName()),
+            extraFieldsFieldIdExpr(descriptor),
             value);
       }
       // Note that the field value shouldn't be an inlined value, otherwise field value read may
@@ -514,6 +524,39 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
       ctx.addField(false, true, ctx.type(fieldType), cachedFieldName, initializer);
     }
     return cachedFieldName;
+  }
+
+  /**
+   * Returns a reference to a cached {@link ForyExtraFields.FieldIdentity} field for {@code
+   * descriptor}. The identity is the fory field id when the remote field has one, otherwise the
+   * {@code (declaringClass, name)} pair — mirroring {@link ForyExtraFieldsSupport}.
+   */
+  private Expression extraFieldsFieldIdExpr(Descriptor descriptor) {
+    Expression initializer;
+    if (descriptor.hasForyFieldId()) {
+      initializer =
+          new StaticInvoke(
+              ForyExtraFieldsSupport.class,
+              "fieldIdentity",
+              TypeRef.of(ForyExtraFields.FieldIdentity.class),
+              Literal.ofInt(descriptor.getForyFieldId()));
+    } else {
+      initializer =
+          new StaticInvoke(
+              ForyExtraFieldsSupport.class,
+              "fieldIdentity",
+              TypeRef.of(ForyExtraFields.FieldIdentity.class),
+              Literal.ofString(descriptor.getDeclaringClass()),
+              Literal.ofString(descriptor.getName()));
+    }
+    String cachedName =
+        ensureLazyFieldGenerated(
+            extraFieldsFieldIdNames.get(descriptor),
+            EXTRA_FIELDS_FIELD_ID_NAME,
+            TypeRef.of(ForyExtraFields.FieldIdentity.class),
+            initializer);
+    extraFieldsFieldIdNames.put(descriptor, cachedName);
+    return new Expression.Reference(cachedName, TypeRef.of(ForyExtraFields.FieldIdentity.class));
   }
 
   private Expression extraFieldsSinkAccessorExpr() {
@@ -535,7 +578,9 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
                             ReflectionUtils.class,
                             "getField",
                             TypeRef.of(Field.class),
-                            staticBeanClassExpr(),
+                            staticClassFieldExpr(
+                                extraFieldsSinkField.getDeclaringClass(),
+                                extraFieldsSinkField.getName() + "SinkDeclaringClass"),
                             Literal.ofString(extraFieldsSinkField.getName())))));
     return new Expression.Reference(extraFieldsSinkAccessorName, TypeRef.of(FieldAccessor.class));
   }
@@ -562,8 +607,30 @@ public class CompatibleCodecBuilder extends ObjectCodecBuilder {
     return super.setFieldValue(bean, targetDescriptor, value);
   }
 
-  private Expression fieldConverterTargetRead(Descriptor descriptor, FieldConverter<?> converter) {
+  /**
+   * Builds the read expression for a converter field. When the class declares an extra-fields sink,
+   * replay must be able to emit the exact original remote-typed bytes on re-serialization, so the
+   * untouched pre-conversion value must be captured at read time, which requires the target {@code
+   * bean}. Every {@code deserializeField}/{@code deserializePrimitives} call site passes the real
+   * target bean, so capture works uniformly regardless of the converter field's remote type.
+   */
+  private Expression fieldConverterTargetRead(
+      Expression bean, Descriptor descriptor, FieldConverter<?> converter) {
     Class<?> targetType = converter.getField().getType();
+    if (extraFieldsSinkField != null) {
+      return tryInlineCast(
+          new StaticInvoke(
+              FieldConverters.class,
+              "readTargetAndCapture",
+              OBJECT_TYPE,
+              readContextRef(),
+              remoteFieldInfo(descriptor),
+              bean,
+              extraFieldsSinkAccessorExpr(),
+              typeDefFieldExpr(),
+              extraFieldsFieldIdExpr(descriptor)),
+          TypeRef.of(targetType));
+    }
     String helper = fieldConverterTargetReader(targetType);
     if (helper == null) {
       return null;

--- a/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/ObjectCodecBuilder.java
@@ -921,6 +921,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
             TypeRef<?> castTypeRef = readValueTypeRef(d);
             Expression action =
                 deserializeField(
+                    bean,
                     buffer,
                     d,
                     // `bean` will be replaced by `Reference` to cut-off expr
@@ -958,7 +959,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
     // use Reference to cut-off expr dependency.
     for (Descriptor d : group) {
       TypeRef<?> castTypeRef = readValueTypeRef(d);
-      Expression value = deserializeField(buffer, d, expr -> expr);
+      Expression value = deserializeField(bean, buffer, d, expr -> expr);
       Expression action = setFieldValue(bean, d, tryInlineCast(value, castTypeRef));
       groupExpressions.add(action);
     }
@@ -1299,12 +1300,16 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
 
     @Override
     Set<Expression> fixedScope(Expression bean) {
-      return ofHashSet(bean, heapBuffer, cursor);
+      // readContextRef() is included so {@link CompatibleSerializer.captureExtraField(...)}
+      // resolves correctly if this group is extracted into a generated helper method;
+      // see {@link ExpressionOptimizer#invokeGenerated(...)}: only referenced cutpoints become
+      // helper method parameters.
+      return ofHashSet(bean, heapBuffer, cursor, readContextRef());
     }
 
     @Override
     Set<Expression> compressedScope(Expression bean) {
-      return ofHashSet(bean, buffer, heapBuffer);
+      return ofHashSet(bean, buffer, heapBuffer, readContextRef());
     }
   }
 
@@ -1359,12 +1364,12 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
 
     @Override
     Set<Expression> fixedScope(Expression bean) {
-      return ofHashSet(bean, buffer, cursor);
+      return ofHashSet(bean, buffer, cursor, readContextRef());
     }
 
     @Override
     Set<Expression> compressedScope(Expression bean) {
-      return ofHashSet(bean, buffer, cursor);
+      return ofHashSet(bean, buffer, cursor, readContextRef());
     }
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/builder/StaticCompatibleCodecBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/builder/StaticCompatibleCodecBuilder.java
@@ -478,6 +478,7 @@ public final class StaticCompatibleCodecBuilder extends ObjectCodecBuilder {
     Reference buffer = new Reference(BUFFER_NAME, bufferTypeRef, false);
     Expression readAndSet =
         deserializeField(
+            value,
             buffer,
             descriptor,
             fieldValue ->
@@ -492,7 +493,7 @@ public final class StaticCompatibleCodecBuilder extends ObjectCodecBuilder {
     ctx.clearExprState();
     Reference target = new Reference(recordValue, descriptor.getTypeRef(), false);
     Reference buffer = new Reference(BUFFER_NAME, bufferTypeRef, false);
-    Expression fieldValue = deserializeField(buffer, descriptor, value -> value);
+    Expression fieldValue = deserializeField(target, buffer, descriptor, value -> value);
     Expression assign =
         new Expression.Assign(target, tryInlineCast(fieldValue, descriptor.getTypeRef()));
     Code.ExprCode readCode = assign.genCode(ctx);

--- a/java/fory-core/src/main/java/org/apache/fory/context/MetaWriteContext.java
+++ b/java/fory-core/src/main/java/org/apache/fory/context/MetaWriteContext.java
@@ -29,8 +29,8 @@ import org.apache.fory.collection.IdentityObjectIntMap;
  */
 public class MetaWriteContext {
   /**
-   * Classes whose definitions have already been announced to the peer, mapped to the protocol id
-   * used by the current or shared meta-share session.
+   * Keys already announced to the peer, mapped to the protocol id used by the current or shared
+   * meta-share session.
    */
-  public final IdentityObjectIntMap<Class<?>> classMap = new IdentityObjectIntMap<>(1, 0.5f);
+  public final IdentityObjectIntMap<Object> classMap = new IdentityObjectIntMap<>(1, 0.5f);
 }

--- a/java/fory-core/src/main/java/org/apache/fory/context/WriteContext.java
+++ b/java/fory-core/src/main/java/org/apache/fory/context/WriteContext.java
@@ -24,6 +24,7 @@ import org.apache.fory.Fory;
 import org.apache.fory.config.Config;
 import org.apache.fory.config.Int64Encoding;
 import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.meta.TypeDef;
 import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.resolver.TypeInfo;
@@ -32,10 +33,12 @@ import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.BufferCallback;
 import org.apache.fory.serializer.BufferObject;
 import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.PrimitiveSerializers.LongSerializer;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.StringSerializer;
 import org.apache.fory.serializer.UnknownClass.UnknownStruct;
+import org.apache.fory.serializer.UnknownClassSerializers.UnknownStructSerializer;
 import org.apache.fory.type.BFloat16;
 import org.apache.fory.type.Float16;
 import org.apache.fory.type.Generics;
@@ -67,6 +70,7 @@ public final class WriteContext {
   private final Int64Encoding longEncoding;
   private final boolean forVirtualThread;
   private final boolean scopedMetaShareEnabled;
+  private final boolean extraFieldsEnabled;
   private final IdentityHashMap<Object, Object> contextObjects = new IdentityHashMap<>();
   private MemoryBuffer buffer;
   private BufferCallback bufferCallback;
@@ -98,6 +102,7 @@ public final class WriteContext {
     longEncoding = config.longEncoding();
     forVirtualThread = config.forVirtualThread();
     scopedMetaShareEnabled = config.isScopedMetaShareEnabled();
+    extraFieldsEnabled = ForyExtraFieldsSupport.isEnabled(config);
     if (scopedMetaShareEnabled) {
       metaWriteContext = new MetaWriteContext();
     }
@@ -458,10 +463,11 @@ public final class WriteContext {
       return false;
     }
     ForyExtraFields extraField = (ForyExtraFields) sinkAccessor.getObject(obj);
-    if (extraField == null || extraField.getTypeDef() == null) {
+    TypeDef sinkTypeDef = extraField == null ? null : ForyExtraFieldsSupport.getTypeDef(extraField);
+    if (sinkTypeDef == null) {
       return false;
     }
-    long sinkTypeDefId = extraField.getTypeDef().getId();
+    long sinkTypeDefId = sinkTypeDef.getId();
     // The object was deserialized under a different (fuller) remote schema. Emit that remote schema
     // header (from the writer-class TypeInfo) and replay all fields through the reader-class
     // serializer that captured them, whose field order follows the remote schema.
@@ -490,6 +496,14 @@ public final class WriteContext {
               + " has not been read into this class on this Fory instance.");
     }
     resolver.writeTypeInfo(this, headerTypeInfo);
+    if (headerTypeInfo.getType() == UnknownStruct.class) {
+      // This Fory instance cannot load the original writer class: the cached header TypeInfo is
+      // the UnknownStruct placeholder, not a concrete class. writeTypeInfo above only wrote the
+      // NONEXISTENT_META_SHARED_ID placeholder byte; rewrite it to the real type id and emit the
+      // remote TypeDef inline, the same way the normal UnknownStruct write path does, so the
+      // forwarded stream carries the schema the replayed body needs to be decoded against.
+      UnknownStructSerializer.writeUnknownStructHeader(this, sinkTypeDef);
+    }
     depth++;
     ((Serializer<Object>) replaySerializer).write(this, obj);
     depth--;
@@ -513,7 +527,9 @@ public final class WriteContext {
         depth--;
         return;
       }
-      if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
+      if (extraFieldsEnabled
+          && typeInfo.hasExtraFieldsSink()
+          && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
         return;
       }
       resolver.writeTypeInfo(this, typeInfo);
@@ -533,7 +549,9 @@ public final class WriteContext {
         depth--;
         return;
       }
-      if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
+      if (extraFieldsEnabled
+          && typeInfo.hasExtraFieldsSink()
+          && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
         return;
       }
       resolver.writeTypeInfo(this, typeInfo);
@@ -621,7 +639,9 @@ public final class WriteContext {
       depth--;
       return;
     }
-    if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
+    if (extraFieldsEnabled
+        && typeInfo.hasExtraFieldsSink()
+        && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
       return;
     }
     resolver.writeTypeInfo(this, typeInfo);
@@ -645,7 +665,9 @@ public final class WriteContext {
       depth--;
       return;
     }
-    if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
+    if (extraFieldsEnabled
+        && typeInfo.hasExtraFieldsSink()
+        && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
       return;
     }
     resolver.writeTypeInfo(this, typeInfo);

--- a/java/fory-core/src/main/java/org/apache/fory/context/WriteContext.java
+++ b/java/fory-core/src/main/java/org/apache/fory/context/WriteContext.java
@@ -24,12 +24,14 @@ import org.apache.fory.Fory;
 import org.apache.fory.config.Config;
 import org.apache.fory.config.Int64Encoding;
 import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.resolver.TypeInfo;
 import org.apache.fory.resolver.TypeInfoHolder;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.BufferCallback;
 import org.apache.fory.serializer.BufferObject;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.PrimitiveSerializers.LongSerializer;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.StringSerializer;
@@ -443,6 +445,58 @@ public final class WriteContext {
   }
 
   /**
+   * If {@code obj} carries a populated {@link ForyExtraFields} sink whose remote {@code TypeDef}
+   * differs from the local type, emits that remote schema header and replays every field (matched
+   * fields from the bean, unmatched fields from the sink) so a downstream peer with the full schema
+   * can recover them, excluded from writeRef(obj,typeinfo) because it is only called by methods
+   * which pass collection objects, and from writeNonRef(obj,typeinfo) which is gated on
+   * useDeclaredTypeInfo and !crossLanguage ie. the path for mononmorphic elements
+   */
+  public boolean tryWriteExtraFieldsSchema(TypeResolver resolver, TypeInfo typeInfo, Object obj) {
+    FieldAccessor sinkAccessor = typeInfo.getExtraFieldsSinkAccessor();
+    if (sinkAccessor == null) {
+      return false;
+    }
+    ForyExtraFields extraField = (ForyExtraFields) sinkAccessor.getObject(obj);
+    if (extraField == null || extraField.getTypeDef() == null) {
+      return false;
+    }
+    long sinkTypeDefId = extraField.getTypeDef().getId();
+    // The object was deserialized under a different (fuller) remote schema. Emit that remote schema
+    // header (from the writer-class TypeInfo) and replay all fields through the reader-class
+    // serializer that captured them, whose field order follows the remote schema.
+    TypeInfo headerTypeInfo = resolver.getTypeInfoByTypeDefId(sinkTypeDefId);
+    if (headerTypeInfo == null) {
+      throw new IllegalStateException(
+          "Cannot re-serialize "
+              + obj.getClass().getName()
+              + " with captured extra fields: this Fory instance does not have the object's original "
+              + "remote schema (TypeDef id "
+              + sinkTypeDefId
+              + ") cached, so it cannot emit the schema header needed to preserve those fields. "
+              + "Replay needs a Fory that has deserialized a payload carrying that schema and still "
+              + "has it cached, ie the instance that produced this object. Each instance "
+              + "retains only a bounded number of distinct remote schemas, so under very high schema "
+              + "churn the schema may not be retained and the captured fields cannot be replayed.");
+    }
+    Serializer<?> replaySerializer =
+        resolver.getExtraFieldsWriteSerializer(obj.getClass(), sinkTypeDefId);
+    if (replaySerializer == null) {
+      throw new IllegalStateException(
+          "Cannot replay captured extra fields on "
+              + obj.getClass()
+              + ": remote TypeDef "
+              + sinkTypeDefId
+              + " has not been read into this class on this Fory instance.");
+    }
+    resolver.writeTypeInfo(this, headerTypeInfo);
+    depth++;
+    ((Serializer<Object>) replaySerializer).write(this, obj);
+    depth--;
+    return true;
+  }
+
+  /**
    * Writes a nullable reference-tracked object together with any required type metadata.
    *
    * <p>If the object was already seen by the current {@link RefWriter}, only a ref header is
@@ -457,6 +511,9 @@ public final class WriteContext {
         depth++;
         typeInfo.getSerializer().write(this, obj);
         depth--;
+        return;
+      }
+      if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
         return;
       }
       resolver.writeTypeInfo(this, typeInfo);
@@ -474,6 +531,9 @@ public final class WriteContext {
         depth++;
         typeInfo.getSerializer().write(this, obj);
         depth--;
+        return;
+      }
+      if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
         return;
       }
       resolver.writeTypeInfo(this, typeInfo);
@@ -543,16 +603,7 @@ public final class WriteContext {
       return;
     }
     buffer.writeByte(Fory.NOT_NULL_VALUE_FLAG);
-    TypeResolver resolver = typeResolver;
-    TypeInfo typeInfo = resolver.getTypeInfo(obj.getClass(), rootTypeInfoHolder);
-    if (crossLanguage && typeInfo.getType() == UnknownStruct.class) {
-      depth++;
-      typeInfo.getSerializer().write(this, obj);
-      depth--;
-      return;
-    }
-    resolver.writeTypeInfo(this, typeInfo);
-    writeData(typeInfo, obj);
+    writeNonRef(obj, rootTypeInfoHolder);
   }
 
   /**
@@ -568,6 +619,9 @@ public final class WriteContext {
       depth++;
       typeInfo.getSerializer().write(this, obj);
       depth--;
+      return;
+    }
+    if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
       return;
     }
     resolver.writeTypeInfo(this, typeInfo);
@@ -589,6 +643,9 @@ public final class WriteContext {
       depth++;
       typeInfo.getSerializer().write(this, obj);
       depth--;
+      return;
+    }
+    if (typeInfo.hasExtraFieldsSink() && tryWriteExtraFieldsSchema(resolver, typeInfo, obj)) {
       return;
     }
     resolver.writeTypeInfo(this, typeInfo);

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeInfo.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeInfo.java
@@ -26,7 +26,9 @@ import org.apache.fory.collection.Tuple2;
 import org.apache.fory.meta.EncodedMetaString;
 import org.apache.fory.meta.Encoders;
 import org.apache.fory.meta.TypeDef;
+import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.reflect.ReflectionUtils;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.type.Types;
 import org.apache.fory.util.function.Functions;
@@ -48,6 +50,8 @@ public class TypeInfo {
   Serializer<?> serializer;
   TypeDef typeDef;
   boolean needToWriteTypeDef;
+  // Non-null only when this type declares a ForyExtraFields sink. Resolved once when the serializer
+  FieldAccessor extraFieldsSinkAccessor;
 
   TypeInfo(
       Class<?> type,
@@ -170,6 +174,15 @@ public class TypeInfo {
   void setSerializer(TypeResolver resolver, Serializer<?> serializer) {
     this.serializer = serializer;
     needToWriteTypeDef = serializer != null && resolver.needToWriteTypeDef(serializer);
+    this.extraFieldsSinkAccessor = type == null ? null : ForyExtraFields.findSinkAccessor(type);
+  }
+
+  public FieldAccessor getExtraFieldsSinkAccessor() {
+    return extraFieldsSinkAccessor;
+  }
+
+  public boolean hasExtraFieldsSink() {
+    return extraFieldsSinkAccessor != null;
   }
 
   public String decodeNamespace() {

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeInfo.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeInfo.java
@@ -23,12 +23,13 @@ import static org.apache.fory.meta.Encoders.PACKAGE_DECODER;
 import static org.apache.fory.meta.Encoders.TYPE_NAME_DECODER;
 
 import org.apache.fory.collection.Tuple2;
+import org.apache.fory.config.Config;
 import org.apache.fory.meta.EncodedMetaString;
 import org.apache.fory.meta.Encoders;
 import org.apache.fory.meta.TypeDef;
 import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.reflect.ReflectionUtils;
-import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.type.Types;
 import org.apache.fory.util.function.Functions;
@@ -125,20 +126,29 @@ public class TypeInfo {
     }
     this.typeId = typeId;
     this.userTypeId = userTypeId;
+    Config config = classResolver.getConfig();
+    this.extraFieldsSinkAccessor =
+        !ForyExtraFieldsSupport.isEnabled(config)
+            ? null
+            : ForyExtraFieldsSupport.findSinkAccessor(type);
   }
 
   public TypeInfo copy(int typeId) {
     if (typeId == this.typeId) {
       return this;
     }
-    return new TypeInfo(type, namespace, typeName, serializer, typeId, userTypeId);
+    TypeInfo copy = new TypeInfo(type, namespace, typeName, serializer, typeId, userTypeId);
+    copy.extraFieldsSinkAccessor = extraFieldsSinkAccessor;
+    return copy;
   }
 
   public TypeInfo copy(int typeId, int userTypeId) {
     if (typeId == this.typeId && userTypeId == this.userTypeId) {
       return this;
     }
-    return new TypeInfo(type, namespace, typeName, serializer, typeId, userTypeId);
+    TypeInfo copy = new TypeInfo(type, namespace, typeName, serializer, typeId, userTypeId);
+    copy.extraFieldsSinkAccessor = extraFieldsSinkAccessor;
+    return copy;
   }
 
   public Class<?> getType() {
@@ -174,7 +184,13 @@ public class TypeInfo {
   void setSerializer(TypeResolver resolver, Serializer<?> serializer) {
     this.serializer = serializer;
     needToWriteTypeDef = serializer != null && resolver.needToWriteTypeDef(serializer);
-    this.extraFieldsSinkAccessor = type == null ? null : ForyExtraFields.findSinkAccessor(type);
+    Config config = resolver.getConfig();
+    if (this.extraFieldsSinkAccessor == null) {
+      this.extraFieldsSinkAccessor =
+          !ForyExtraFieldsSupport.isEnabled(config)
+              ? null
+              : ForyExtraFieldsSupport.findSinkAccessor(type);
+    }
   }
 
   public FieldAccessor getExtraFieldsSinkAccessor() {

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -83,6 +83,7 @@ import org.apache.fory.reflect.TypeRef;
 import org.apache.fory.serializer.CodegenSerializer;
 import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.PrimitiveSerializers;
 import org.apache.fory.serializer.Serializer;
@@ -513,6 +514,30 @@ public abstract class TypeResolver {
   public abstract TypeInfo getTypeInfo(Class<?> cls, boolean createIfAbsent);
 
   public abstract TypeInfo getTypeInfo(Class<?> cls, TypeInfoHolder classInfoHolder);
+
+  public final TypeInfo getTypeInfoByTypeDefId(long typeDefId) {
+    return extRegistry.typeInfoByTypeDefId.get(typeDefId);
+  }
+
+  public final Serializer<?> getExtraFieldsWriteSerializer(Class<?> cls, long typeDefId) {
+    Map<Long, Serializer<?>> idToSerializer = extRegistry.extraFieldsSerializers.get(cls);
+    return idToSerializer != null ? idToSerializer.get(typeDefId) : null;
+  }
+
+  private static boolean hasExtraFieldsSinkField(Class<?> cls) {
+    return ForyExtraFields.findSinkField(cls) != null;
+  }
+
+  /**
+   * Records the reader-class serializer used to replay {@code cls} under the remote {@code
+   * typeDefId} it was captured from.
+   */
+  private void registerExtraFieldsSerializer(Class<?> cls, long typeDefId, Serializer<?> gen) {
+    extRegistry
+        .extraFieldsSerializers
+        .computeIfAbsent(cls, k -> new ConcurrentHashMap<>())
+        .putIfAbsent(typeDefId, gen);
+  }
 
   /**
    * Writes class info to buffer using the unified type system. This is the single implementation
@@ -1283,9 +1308,13 @@ public abstract class TypeResolver {
             jitContext.registerSerializerJITCallback(
                 () -> CompatibleSerializer.class,
                 () -> CodecUtils.loadOrGenCompatibleCodecClass(this, cls, typeDef),
-                c ->
-                    typeInfo.setSerializer(
-                        this, newGeneratedCompatibleSerializer(cls, c, typeDef)));
+                c -> {
+                  Serializer<?> gen = newGeneratedCompatibleSerializer(cls, c, typeDef);
+                  typeInfo.setSerializer(this, gen);
+                  if (hasExtraFieldsSinkField(cls)) {
+                    registerExtraFieldsSerializer(cls, typeDef.getId(), gen);
+                  }
+                });
       } else if (sc == null) {
         sc = CompatibleSerializer.class;
       }
@@ -1305,9 +1334,17 @@ public abstract class TypeResolver {
     if (StaticGeneratedStructSerializer.class.isAssignableFrom(sc)) {
       typeInfo.setSerializer(this, newStaticGeneratedStructSerializer(sc, cls, typeDef));
     } else if (sc == CompatibleSerializer.class) {
-      typeInfo.setSerializer(this, new CompatibleSerializer(this, cls, typeDef));
+      CompatibleSerializer<?> cs = new CompatibleSerializer<>(this, cls, typeDef);
+      typeInfo.setSerializer(this, cs);
+      if (hasExtraFieldsSinkField(cls)) {
+        registerExtraFieldsSerializer(cls, typeDef.getId(), cs);
+      }
     } else if (GeneratedCompatibleSerializer.class.isAssignableFrom(sc)) {
-      typeInfo.setSerializer(this, newGeneratedCompatibleSerializer(cls, sc, typeDef));
+      Serializer<?> gen = newGeneratedCompatibleSerializer(cls, sc, typeDef);
+      typeInfo.setSerializer(this, gen);
+      if (hasExtraFieldsSinkField(cls)) {
+        registerExtraFieldsSerializer(cls, typeDef.getId(), gen);
+      }
     } else {
       typeInfo.setSerializer(this, Serializers.newSerializer(this, cls, sc));
     }
@@ -2460,6 +2497,11 @@ public abstract class TypeResolver {
     final IdentityHashMap<Class<?>, TypeInfo> abstractTypeInfo = new IdentityHashMap<>();
     final IdentityHashMap<Class<?>, TransformedTypeInfo[]> transformedTypeInfo =
         new IdentityHashMap<>();
+    // (reader class, remote TypeDef id) -> reader-class serializer that replays extra fields.
+    // Keyed by both because one remote TypeDef can be read into several local classes, each with
+    // its own replay serializer
+    final ConcurrentIdentityMap<Class<?>, Map<Long, Serializer<?>>> extraFieldsSerializers =
+        new ConcurrentIdentityMap<>();
     // avoid potential recursive call for seq codec generation.
     // ex. A->field1: B, B.field1: A
     final Set<Class<?>> getClassCtx = new HashSet<>();

--- a/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
+++ b/java/fory-core/src/main/java/org/apache/fory/resolver/TypeResolver.java
@@ -84,6 +84,7 @@ import org.apache.fory.serializer.CodegenSerializer;
 import org.apache.fory.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import org.apache.fory.serializer.CompatibleSerializer;
 import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.ObjectSerializer;
 import org.apache.fory.serializer.PrimitiveSerializers;
 import org.apache.fory.serializer.Serializer;
@@ -524,19 +525,19 @@ public abstract class TypeResolver {
     return idToSerializer != null ? idToSerializer.get(typeDefId) : null;
   }
 
-  private static boolean hasExtraFieldsSinkField(Class<?> cls) {
-    return ForyExtraFields.findSinkField(cls) != null;
-  }
-
   /**
    * Records the reader-class serializer used to replay {@code cls} under the remote {@code
    * typeDefId} it was captured from.
    */
-  private void registerExtraFieldsSerializer(Class<?> cls, long typeDefId, Serializer<?> gen) {
-    extRegistry
-        .extraFieldsSerializers
-        .computeIfAbsent(cls, k -> new ConcurrentHashMap<>())
-        .putIfAbsent(typeDefId, gen);
+  private void registerExtraFieldsSerializer(
+      Class<?> cls, long typeDefId, Serializer<?> serializer, boolean generated) {
+    Map<Long, Serializer<?>> idToSerializer =
+        extRegistry.extraFieldsSerializers.computeIfAbsent(cls, k -> new ConcurrentHashMap<>());
+    if (generated) {
+      idToSerializer.put(typeDefId, serializer);
+    } else {
+      idToSerializer.putIfAbsent(typeDefId, serializer);
+    }
   }
 
   /**
@@ -658,19 +659,22 @@ public abstract class TypeResolver {
       WriteContext writeContext, MemoryBuffer buffer, TypeInfo typeInfo) {
     MetaWriteContext metaWriteContext = writeContext.getMetaWriteContext();
     assert metaWriteContext != null : SET_META_WRITE_CONTEXT_MSG;
-    IdentityObjectIntMap<Class<?>> classMap = metaWriteContext.classMap;
+    TypeDef typeDef = typeInfo.typeDef;
+    if (typeDef == null) {
+      typeDef = buildTypeDef(typeInfo);
+    }
+    // Dedup by TypeDef identity, not by typeInfo.type: one local class can legitimately announce
+    // several distinct TypeDefs in a single graph when forwarding {@code ForyExtraFields} from two
+    // remote versions of the same class.
+    IdentityObjectIntMap<Object> classMap = metaWriteContext.classMap;
     int newId = classMap.size;
-    int id = classMap.putOrGet(typeInfo.type, newId);
+    int id = classMap.putOrGet(typeDef, newId);
     if (id >= 0) {
       // Reference to previously written type: (index << 1) | 1, LSB=1
       buffer.writeVarUInt32((id << 1) | 1);
     } else {
       // New type: index << 1, LSB=0, followed by TypeDef bytes inline
       buffer.writeVarUInt32(newId << 1);
-      TypeDef typeDef = typeInfo.typeDef;
-      if (typeDef == null) {
-        typeDef = buildTypeDef(typeInfo);
-      }
       buffer.writeBytes(typeDef.getEncoded());
     }
   }
@@ -1311,8 +1315,8 @@ public abstract class TypeResolver {
                 c -> {
                   Serializer<?> gen = newGeneratedCompatibleSerializer(cls, c, typeDef);
                   typeInfo.setSerializer(this, gen);
-                  if (hasExtraFieldsSinkField(cls)) {
-                    registerExtraFieldsSerializer(cls, typeDef.getId(), gen);
+                  if (typeInfo.hasExtraFieldsSink()) {
+                    registerExtraFieldsSerializer(cls, typeDef.getId(), gen, true);
                   }
                 });
       } else if (sc == null) {
@@ -1336,14 +1340,14 @@ public abstract class TypeResolver {
     } else if (sc == CompatibleSerializer.class) {
       CompatibleSerializer<?> cs = new CompatibleSerializer<>(this, cls, typeDef);
       typeInfo.setSerializer(this, cs);
-      if (hasExtraFieldsSinkField(cls)) {
-        registerExtraFieldsSerializer(cls, typeDef.getId(), cs);
+      if (typeInfo.hasExtraFieldsSink()) {
+        registerExtraFieldsSerializer(cls, typeDef.getId(), cs, false);
       }
     } else if (GeneratedCompatibleSerializer.class.isAssignableFrom(sc)) {
       Serializer<?> gen = newGeneratedCompatibleSerializer(cls, sc, typeDef);
       typeInfo.setSerializer(this, gen);
-      if (hasExtraFieldsSinkField(cls)) {
-        registerExtraFieldsSerializer(cls, typeDef.getId(), gen);
+      if (typeInfo.hasExtraFieldsSink()) {
+        registerExtraFieldsSerializer(cls, typeDef.getId(), gen, true);
       }
     } else {
       typeInfo.setSerializer(this, Serializers.newSerializer(this, cls, sc));
@@ -1914,9 +1918,15 @@ public abstract class TypeResolver {
     List<Descriptor> result = new ArrayList<>(descriptors.size());
     boolean globalRefTracking = trackingRef();
     boolean isXlang = isCrossLanguage();
+    // The extra-fields sink is a framework marker type, never a data field
+    boolean excludeExtraFieldsSink = ForyExtraFieldsSupport.isEnabled(config);
 
     for (Descriptor descriptor : descriptors) {
       if (!searchParent && !descriptor.getDeclaringClass().equals(clz.getName())) {
+        continue;
+      }
+      if (excludeExtraFieldsSink && descriptor.getRawType() == ForyExtraFields.class) {
+        ForyExtraFieldsSupport.rejectRecordSink(clz);
         continue;
       }
       // Compute the final isTrackingRef value:

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleLayerSerializerBase.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleLayerSerializerBase.java
@@ -88,7 +88,7 @@ public abstract class CompatibleLayerSerializerBase<T> extends AbstractObjectSer
     if (metaWriteContext == null) {
       return;
     }
-    IdentityObjectIntMap<Class<?>> classMap = metaWriteContext.classMap;
+    IdentityObjectIntMap<Object> classMap = metaWriteContext.classMap;
     int newId = classMap.size;
     int id = classMap.putOrGet(layerMarkerClass, newId);
     if (id >= 0) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
@@ -84,7 +84,10 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
         "Class version check should be disabled when compatible mode is enabled.");
     Preconditions.checkArgument(config.isMetaShareEnabled(), "Meta share must be enabled.");
     this.typeDef = typeDef;
-    this.extraFieldsSinkAccessor = ForyExtraFields.findSinkAccessor(type);
+    this.extraFieldsSinkAccessor =
+        (type == null || !ForyExtraFieldsSupport.isEnabled(config))
+            ? null
+            : ForyExtraFieldsSupport.findSinkAccessor(type);
     if (Utils.DEBUG_OUTPUT_ENABLED) {
       LOG.info("========== CompatibleSerializer TypeDef for {} ==========", type.getName());
       LOG.info("TypeDef fieldsInfo count: {}", typeDef.getFieldCount());
@@ -265,7 +268,9 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     boolean useExtraField = false;
     Object fieldValue = null;
 
-    Object temp = extraField.getOrDefault(fieldInfo.descriptor.getName(), NOT_FOUND);
+    Object temp =
+        extraField.getOrDefault(
+            ForyExtraFieldsSupport.fieldIdentity(fieldInfo.descriptor), NOT_FOUND);
     if (temp != NOT_FOUND) {
       useExtraField = true;
       fieldValue = temp; // might be null, which is valid
@@ -343,11 +348,18 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   /**
    * Puts {@code value} into the sink on {@code target}, stashing the remote TypeDef on first use.
    */
-  private void captureExtraField(Object target, String name, Object value) {
+  private void captureExtraField(
+      ReadContext readContext, Object target, Descriptor descriptor, Object value) {
     if (target == null) {
       throw new IllegalArgumentException("Cannot capture extra field for null target");
     }
-    ForyExtraFields.capture(target, extraFieldsSinkAccessor, typeDef, name, value);
+    ForyExtraFieldsSupport.capture(
+        readContext,
+        target,
+        extraFieldsSinkAccessor,
+        typeDef,
+        ForyExtraFieldsSupport.fieldIdentity(descriptor),
+        value);
   }
 
   private void setFieldValue(T targetObject, SerializationFieldInfo fieldInfo, Object fieldValue) {
@@ -378,11 +390,18 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     }
   }
 
+  /**
+   * Reads a converter field: converts the wire value into the local field. When a sink is declared
+   * also preserves the untouched remote-typed value in the sink
+   */
   private void compatibleRead(
       ReadContext readContext, SerializationFieldInfo fieldInfo, Object obj) {
     Object fieldValue =
         FieldConverters.readSourceScalar(readContext, fieldInfo, fieldInfo.fieldConverter);
     fieldInfo.fieldConverter.set(obj, fieldValue);
+    if (extraFieldsSinkAccessor != null) {
+      captureExtraField(readContext, obj, fieldInfo.descriptor, fieldValue);
+    }
   }
 
   private void readFieldsWithCompatibleCollectionArray(ReadContext readContext, T targetObject) {
@@ -499,7 +518,7 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     }
 
     Object value = readField(readContext, refReader, generics, fieldInfo, buffer, action, true);
-    captureExtraField(targetObject, fieldInfo.descriptor.getName(), value);
+    captureExtraField(readContext, targetObject, fieldInfo.descriptor, value);
   }
 
   private void printFieldDebugInfo(SerializationFieldInfo fieldInfo, MemoryBuffer buffer) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/CompatibleSerializer.java
@@ -26,6 +26,7 @@ import org.apache.fory.builder.CompatibleCodecBuilder;
 import org.apache.fory.config.ForyBuilder;
 import org.apache.fory.context.ReadContext;
 import org.apache.fory.context.RefReader;
+import org.apache.fory.context.RefWriter;
 import org.apache.fory.context.WriteContext;
 import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
@@ -65,13 +66,16 @@ import org.apache.fory.util.record.RecordUtils;
 public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   private static final Logger LOG = LoggerFactory.getLogger(CompatibleSerializer.class);
 
+  private final TypeDef typeDef;
   private final SerializationFieldInfo[] allFields;
   private final CompatibleCollectionArrayReader.ReadAction[] allCompatibleReadActions;
   private final boolean hasCompatibleCollectionArrayRead;
   private final RecordInfo recordInfo;
+  private final FieldAccessor extraFieldsSinkAccessor;
   private Serializer<T> serializer;
   private final boolean hasDefaultValues;
   private final DefaultValueUtils.DefaultValueField[] defaultValueFields;
+  private static final Object NOT_FOUND = new Object();
 
   public CompatibleSerializer(TypeResolver typeResolver, Class<T> type, TypeDef typeDef) {
     super(typeResolver, type);
@@ -79,6 +83,8 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
         !config.checkClassVersion(),
         "Class version check should be disabled when compatible mode is enabled.");
     Preconditions.checkArgument(config.isMetaShareEnabled(), "Meta share must be enabled.");
+    this.typeDef = typeDef;
+    this.extraFieldsSinkAccessor = ForyExtraFields.findSinkAccessor(type);
     if (Utils.DEBUG_OUTPUT_ENABLED) {
       LOG.info("========== CompatibleSerializer TypeDef for {} ==========", type.getName());
       LOG.info("TypeDef fieldsInfo count: {}", typeDef.getFieldCount());
@@ -216,6 +222,13 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
   @Override
   public void write(WriteContext writeContext, T value) {
     MemoryBuffer buffer = writeContext.getBuffer();
+    if (extraFieldsSinkAccessor != null) {
+      ForyExtraFields extraField = (ForyExtraFields) extraFieldsSinkAccessor.getObject(value);
+      if (extraField != null && !extraField.isEmpty()) {
+        writeFieldsIncludingExtraFields(writeContext, value, extraField);
+        return;
+      }
+    }
     if (serializer == null) {
       // xlang mode will register class and create serializer in advance, it won't go to here.
       serializer =
@@ -223,6 +236,71 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
               .createSerializerSafe(type, () -> new ObjectSerializer<>(typeResolver, type));
     }
     serializer.write(writeContext, value);
+  }
+
+  /**
+   * Writes all fields in remote-sorted order under the remote TypeDef schema: matched fields are
+   * read from local getters, unmatched fields are read from the {@link ForyExtraFields} map using
+   * fieldInfo.
+   */
+  private void writeFieldsIncludingExtraFields(
+      WriteContext writeContext, T value, ForyExtraFields extraField) {
+    RefWriter refWriter = writeContext.getRefWriter();
+    Generics generics = writeContext.getGenerics();
+    for (SerializationFieldInfo fieldInfo : allFields) {
+      writeFieldByCodecCategory(writeContext, value, refWriter, generics, fieldInfo, extraField);
+    }
+  }
+
+  private void writeFieldByCodecCategory(
+      WriteContext writeContext,
+      T value,
+      RefWriter refWriter,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      ForyExtraFields extraField) {
+
+    MemoryBuffer buffer = writeContext.getBuffer();
+
+    boolean useExtraField = false;
+    Object fieldValue = null;
+
+    Object temp = extraField.getOrDefault(fieldInfo.descriptor.getName(), NOT_FOUND);
+    if (temp != NOT_FOUND) {
+      useExtraField = true;
+      fieldValue = temp; // might be null, which is valid
+    }
+
+    switch (fieldInfo.codecCategory) {
+      case BUILD_IN:
+        if (useExtraField) {
+          AbstractObjectSerializer.writeBuildInFieldValue(
+              writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+        } else {
+          AbstractObjectSerializer.writeBuildInField(
+              writeContext, typeResolver, refWriter, fieldInfo, buffer, value);
+        }
+        return;
+
+      case CONTAINER:
+        if (!useExtraField) {
+          fieldValue = fieldInfo.fieldAccessor.getObject(value);
+        }
+        writeContainerFieldValue(
+            writeContext, typeResolver, refWriter, generics, fieldInfo, buffer, fieldValue);
+        return;
+
+      case OTHER:
+        if (!useExtraField) {
+          fieldValue = fieldInfo.fieldAccessor.getObject(value);
+        }
+        AbstractObjectSerializer.writeField(
+            writeContext, typeResolver, refWriter, fieldInfo, buffer, fieldValue);
+        return;
+
+      default:
+        throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
+    }
   }
 
   private T newInstance() {
@@ -262,6 +340,16 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     return targetObject;
   }
 
+  /**
+   * Puts {@code value} into the sink on {@code target}, stashing the remote TypeDef on first use.
+   */
+  private void captureExtraField(Object target, String name, Object value) {
+    if (target == null) {
+      throw new IllegalArgumentException("Cannot capture extra field for null target");
+    }
+    ForyExtraFields.capture(target, extraFieldsSinkAccessor, typeDef, name, value);
+  }
+
   private void setFieldValue(T targetObject, SerializationFieldInfo fieldInfo, Object fieldValue) {
     if (fieldInfo.fieldAccessor != null) {
       fieldInfo.fieldAccessor.putObject(targetObject, fieldValue);
@@ -285,7 +373,8 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     RefReader refReader = readContext.getRefReader();
     Generics generics = readContext.getGenerics();
     for (SerializationFieldInfo fieldInfo : allFields) {
-      fields[counter++] = readField(readContext, refReader, generics, fieldInfo, buffer, null);
+      fields[counter++] =
+          readField(readContext, refReader, generics, fieldInfo, buffer, null, false);
     }
   }
 
@@ -323,7 +412,8 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
       if (Utils.DEBUG_OUTPUT_ENABLED) {
         printFieldDebugInfo(fieldInfo, buffer);
       }
-      fields[counter++] = readField(readContext, refReader, generics, fieldInfo, buffer, action);
+      fields[counter++] =
+          readField(readContext, refReader, generics, fieldInfo, buffer, action, false);
     }
   }
 
@@ -339,12 +429,14 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
     if (fieldAccessor == null) {
       if (fieldInfo.codecCategory == FieldGroups.FieldCodecCategory.BUILD_IN) {
         if (fieldInfo.fieldConverter == null) {
-          FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
+          readUnmatchedField(
+              readContext, targetObject, refReader, generics, fieldInfo, buffer, action);
         } else {
           compatibleRead(readContext, fieldInfo, targetObject);
         }
       } else {
-        readField(readContext, refReader, generics, fieldInfo, buffer, action);
+        readUnmatchedField(
+            readContext, targetObject, refReader, generics, fieldInfo, buffer, action);
       }
       return;
     }
@@ -354,7 +446,8 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
       return;
     }
     fieldAccessor.putObject(
-        targetObject, readField(readContext, refReader, generics, fieldInfo, buffer, action));
+        targetObject,
+        readField(readContext, refReader, generics, fieldInfo, buffer, action, false));
   }
 
   private Object readField(
@@ -363,7 +456,8 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
       Generics generics,
       SerializationFieldInfo fieldInfo,
       MemoryBuffer buffer,
-      CompatibleCollectionArrayReader.ReadAction action) {
+      CompatibleCollectionArrayReader.ReadAction action,
+      boolean captureUnmatched) {
     if (action != null) {
       return CompatibleCollectionArrayReader.read(readContext, fieldInfo.refMode, action);
     }
@@ -374,7 +468,7 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
               FieldConverters.readSourceScalar(readContext, fieldInfo, fieldInfo.fieldConverter);
           return fieldInfo.fieldConverter.convert(sourceValue);
         }
-        if (fieldInfo.fieldAccessor == null) {
+        if (fieldInfo.fieldAccessor == null && !captureUnmatched) {
           FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
           return null;
         }
@@ -389,6 +483,23 @@ public class CompatibleSerializer<T> extends AbstractObjectSerializer<T> {
       default:
         throw new IllegalStateException("Unknown field codec category " + fieldInfo.codecCategory);
     }
+  }
+
+  private void readUnmatchedField(
+      ReadContext readContext,
+      T targetObject,
+      RefReader refReader,
+      Generics generics,
+      SerializationFieldInfo fieldInfo,
+      MemoryBuffer buffer,
+      CompatibleCollectionArrayReader.ReadAction action) {
+    if (extraFieldsSinkAccessor == null) {
+      FieldSkipper.skipField(readContext, typeResolver, refReader, fieldInfo, buffer);
+      return;
+    }
+
+    Object value = readField(readContext, refReader, generics, fieldInfo, buffer, action, true);
+    captureExtraField(targetObject, fieldInfo.descriptor.getName(), value);
   }
 
   private void printFieldDebugInfo(SerializationFieldInfo fieldInfo, MemoryBuffer buffer) {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFields.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFields.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fory.collection.ClassValueCache;
+import org.apache.fory.meta.TypeDef;
+import org.apache.fory.reflect.FieldAccessor;
+
+/**
+ * Opt-in sink for compatible-mode extra fields. A class participates by declaring a field of this
+ * type; the serialization framework detects it, excludes it from the normal field set, and routes
+ * unmatched remote fields into it instead of discarding them.
+ *
+ * <p>The remote {@link TypeDef} is stored transiently so that on re-serialization the framework can
+ * emit the remote schema header and replay all fields in their original order, allowing a
+ * downstream peer with the full schema to recover them.
+ */
+public final class ForyExtraFields {
+
+  private final Map<String, Object> fields = new HashMap<>();
+
+  public Object get(String name) {
+    return fields.get(name);
+  }
+
+  public Object getOrDefault(String name, Object defaultValue) {
+    return fields.getOrDefault(name, defaultValue);
+  }
+
+  public boolean isEmpty() {
+    return fields.isEmpty();
+  }
+
+  public boolean containsKey(String name) {
+    return fields.containsKey(name);
+  }
+
+  Object put(String name, Object value) {
+    return fields.put(name, value);
+  }
+
+  /**
+   * GC-transparent class-keyed cache: on JVM this is backed by ClassValue so entries do not prevent
+   * the associated Class (or its ClassLoader) from being collected. On Android/GraalVM it falls
+   * back to a ConcurrentHashMap.
+   */
+  private static final ClassValueCache<Optional<FieldAccessor>> SINK_CACHE =
+      ClassValueCache.newClassKeyCache(16);
+
+  public static Field findSinkField(Class<?> cls) {
+    return SINK_CACHE
+        .get(cls, () -> scanForExtraField(cls))
+        .map(FieldAccessor::getField)
+        .orElse(null);
+  }
+
+  /** Returns a {@link FieldAccessor} for the {@link ForyExtraFields} sink field on {@code cls}. */
+  public static FieldAccessor findSinkAccessor(Class<?> cls) {
+    return SINK_CACHE.get(cls, () -> scanForExtraField(cls)).orElse(null);
+  }
+
+  private static Optional<FieldAccessor> scanForExtraField(Class<?> cls) {
+    for (Class<?> c = cls; c != null && c != Object.class; c = c.getSuperclass()) {
+      for (Field f : c.getDeclaredFields()) {
+        if (ForyExtraFields.class == f.getType()) {
+          return Optional.of(FieldAccessor.createAccessor(f));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  // Excluded from Java serialization because TypeDef is runtime metadata used
+  // only for Fory serialization. If a ForyExtraFields instance is serialized
+  // with ObjectOutputStream, this field will be null after deserialization, so
+  // the captured extra fields cannot later be replayed by Fory.
+  private transient TypeDef typeDef;
+
+  public TypeDef getTypeDef() {
+    return typeDef;
+  }
+
+  public static void capture(
+      Object target, FieldAccessor sinkAccessor, TypeDef typeDef, String name, Object value) {
+    ForyExtraFields extraField = (ForyExtraFields) sinkAccessor.getObject(target);
+    if (extraField == null) {
+      extraField = new ForyExtraFields();
+      extraField.typeDef = typeDef;
+      sinkAccessor.putObject(target, extraField);
+    }
+    extraField.put(name, value);
+  }
+}

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFields.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFields.java
@@ -19,13 +19,12 @@
 
 package org.apache.fory.serializer;
 
-import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import org.apache.fory.collection.ClassValueCache;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.fory.meta.TypeDef;
-import org.apache.fory.reflect.FieldAccessor;
 
 /**
  * Opt-in sink for compatible-mode extra fields. A class participates by declaring a field of this
@@ -35,61 +34,95 @@ import org.apache.fory.reflect.FieldAccessor;
  * <p>The remote {@link TypeDef} is stored transiently so that on re-serialization the framework can
  * emit the remote schema header and replay all fields in their original order, allowing a
  * downstream peer with the full schema to recover them.
+ *
+ * <p>Captured fields are keyed by {@link FieldIdentity}
+ *
+ * <p>Application code has read-only access to captured values through this class ({@link
+ * #get(FieldIdentity)}, {@link #containsKey(FieldIdentity)}, {@link #isEmpty}, {@link
+ * #fieldIdentities}). Look up a field with {@link FieldIdentity#of(String, String)} when the writer
+ * sent field names, or {@link FieldIdentity#ofId(int)} when the field was written by id (e.g.
+ * {@code @ForyField(id=…)}). A field written by id has no name on the wire, so it can only be found
+ * by id.
+ *
+ * <p><b>Records are not supported.</b> Capture requires a mutable owner: the framework populates
+ * the sink while reading unmatched fields, but a record is built from constructor arguments and is
+ * immutable, so there is no instance to populate mid-read. Declaring a {@code ForyExtraFields}
+ * component on a record is rejected with an {@link UnsupportedOperationException}.
  */
 public final class ForyExtraFields {
 
-  private final Map<String, Object> fields = new HashMap<>();
-
-  public Object get(String name) {
-    return fields.get(name);
-  }
-
-  public Object getOrDefault(String name, Object defaultValue) {
-    return fields.getOrDefault(name, defaultValue);
-  }
-
-  public boolean isEmpty() {
-    return fields.isEmpty();
-  }
-
-  public boolean containsKey(String name) {
-    return fields.containsKey(name);
-  }
-
-  Object put(String name, Object value) {
-    return fields.put(name, value);
-  }
-
   /**
-   * GC-transparent class-keyed cache: on JVM this is backed by ClassValue so entries do not prevent
-   * the associated Class (or its ClassLoader) from being collected. On Android/GraalVM it falls
-   * back to a ConcurrentHashMap.
+   * The complete, unambiguous identity of a captured remote field. A field is identified either by
+   * its fory field id (when it has one) or by its {@code (declaringClass, name)} pair
    */
-  private static final ClassValueCache<Optional<FieldAccessor>> SINK_CACHE =
-      ClassValueCache.newClassKeyCache(16);
+  public static final class FieldIdentity {
+    // For id-based identities: fieldId >= 0, declaringClass and name are null.
+    // For name-based identities: fieldId == -1, declaringClass and name are set.
+    private final String declaringClass;
+    private final String name;
+    private final int fieldId;
 
-  public static Field findSinkField(Class<?> cls) {
-    return SINK_CACHE
-        .get(cls, () -> scanForExtraField(cls))
-        .map(FieldAccessor::getField)
-        .orElse(null);
-  }
-
-  /** Returns a {@link FieldAccessor} for the {@link ForyExtraFields} sink field on {@code cls}. */
-  public static FieldAccessor findSinkAccessor(Class<?> cls) {
-    return SINK_CACHE.get(cls, () -> scanForExtraField(cls)).orElse(null);
-  }
-
-  private static Optional<FieldAccessor> scanForExtraField(Class<?> cls) {
-    for (Class<?> c = cls; c != null && c != Object.class; c = c.getSuperclass()) {
-      for (Field f : c.getDeclaredFields()) {
-        if (ForyExtraFields.class == f.getType()) {
-          return Optional.of(FieldAccessor.createAccessor(f));
-        }
-      }
+    private FieldIdentity(String declaringClass, String name, int fieldId) {
+      this.declaringClass = declaringClass;
+      this.name = name;
+      this.fieldId = fieldId;
     }
-    return Optional.empty();
+
+    /** Identity of a field written by its fory field id (e.g. {@code @ForyField(id=…)}). */
+    public static FieldIdentity ofId(int fieldId) {
+      return new FieldIdentity(null, null, fieldId);
+    }
+
+    /** Identity of a field written by name, qualified by its declaring class. */
+    public static FieldIdentity of(String declaringClass, String name) {
+      return new FieldIdentity(declaringClass, name, -1);
+    }
+
+    public boolean hasFieldId() {
+      return fieldId >= 0;
+    }
+
+    /** The fory field id; valid only when {@link #hasFieldId()}. */
+    public int getFieldId() {
+      return fieldId;
+    }
+
+    /** The remote declaring class name; {@code null} for id-based identities. */
+    public String getDeclaringClass() {
+      return declaringClass;
+    }
+
+    /** The remote field name; {@code null} for id-based identities. */
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof FieldIdentity)) {
+        return false;
+      }
+      FieldIdentity other = (FieldIdentity) o;
+      return fieldId == other.fieldId
+          && Objects.equals(declaringClass, other.declaringClass)
+          && Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return hasFieldId() ? Integer.hashCode(fieldId) : Objects.hash(declaringClass, name);
+    }
+
+    @Override
+    public String toString() {
+      return hasFieldId() ? "id:" + fieldId : declaringClass + "." + name;
+    }
   }
+
+  private final Map<FieldIdentity, Object> fields = new HashMap<>();
 
   // Excluded from Java serialization because TypeDef is runtime metadata used
   // only for Fory serialization. If a ForyExtraFields instance is serialized
@@ -97,18 +130,37 @@ public final class ForyExtraFields {
   // the captured extra fields cannot later be replayed by Fory.
   private transient TypeDef typeDef;
 
-  public TypeDef getTypeDef() {
+  public Object get(FieldIdentity id) {
+    return fields.get(id);
+  }
+
+  public boolean isEmpty() {
+    return fields.isEmpty();
+  }
+
+  public boolean containsKey(FieldIdentity id) {
+    return fields.containsKey(id);
+  }
+
+  /** The identities of all captured fields. */
+  public Set<FieldIdentity> fieldIdentities() {
+    return Collections.unmodifiableSet(fields.keySet());
+  }
+
+  Object put(FieldIdentity id, Object value) {
+    return fields.put(id, value);
+  }
+
+  // Replay uses a sentinel so a captured null value is distinguished from an absent field.
+  Object getOrDefault(FieldIdentity id, Object defaultValue) {
+    return fields.getOrDefault(id, defaultValue);
+  }
+
+  TypeDef getTypeDef() {
     return typeDef;
   }
 
-  public static void capture(
-      Object target, FieldAccessor sinkAccessor, TypeDef typeDef, String name, Object value) {
-    ForyExtraFields extraField = (ForyExtraFields) sinkAccessor.getObject(target);
-    if (extraField == null) {
-      extraField = new ForyExtraFields();
-      extraField.typeDef = typeDef;
-      sinkAccessor.putObject(target, extraField);
-    }
-    extraField.put(name, value);
+  void setTypeDef(TypeDef typeDef) {
+    this.typeDef = typeDef;
   }
 }

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFieldsSupport.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ForyExtraFieldsSupport.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import org.apache.fory.annotation.Internal;
+import org.apache.fory.config.Config;
+import org.apache.fory.context.ReadContext;
+import org.apache.fory.logging.Logger;
+import org.apache.fory.logging.LoggerFactory;
+import org.apache.fory.meta.TypeDef;
+import org.apache.fory.reflect.FieldAccessor;
+import org.apache.fory.serializer.ForyExtraFields.FieldIdentity;
+import org.apache.fory.type.Descriptor;
+import org.apache.fory.util.record.RecordUtils;
+
+/**
+ * Internal bridge between the serialization framework (including generated code) and the {@link
+ * ForyExtraFields} sink.
+ *
+ * <p>Not part of the stable public API: methods here are public only so cross-package framework
+ * classes and JIT-generated code can reach them
+ */
+@Internal
+public final class ForyExtraFieldsSupport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ForyExtraFieldsSupport.class);
+
+  // Lower-bound graph-memory cost of the owners
+  private static final int SINK_OWNER_BYTES =
+      Math.addExact(
+          GraphMemoryEstimates.shallowObjectBytes(ForyExtraFields.class),
+          GraphMemoryEstimates.shallowObjectBytes(HashMap.class));
+
+  // Lower-bound graph-memory cost charged per captured entry. Mirrors the map serializers'
+  // `numElements * 2 * REFERENCE_BYTES` bound (see {@code MapLikeSerializer.readMapSize})
+
+  private static final int PER_ENTRY_BYTES = 2 * GraphMemoryEstimates.REFERENCE_BYTES;
+
+  private ForyExtraFieldsSupport() {}
+
+  /** Whether extra-field capture/replay can apply under {@code config}. */
+  public static boolean isEnabled(Config config) {
+    return config.isCompatible() && !config.isXlang();
+  }
+
+  public static Field findSinkField(Class<?> cls) {
+    FieldAccessor accessor = findSinkAccessor(cls);
+    return accessor == null ? null : accessor.getField();
+  }
+
+  public static FieldAccessor findSinkAccessor(Class<?> cls) {
+    for (Class<?> c = cls; c != null && c != Object.class; c = c.getSuperclass()) {
+      for (Field f : c.getDeclaredFields()) {
+        if (ForyExtraFields.class == f.getType()) {
+          // A sink must be a non-static instance field
+          if (Modifier.isStatic(f.getModifiers())) {
+            warnStaticSink(f);
+            continue;
+          }
+          return FieldAccessor.createAccessor(f);
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Warns that a {@code static} {@link ForyExtraFields} field cannot serve as a sink. A sink must
+   * be a non-static instance field: capture writes into a per-deserialized-instance owner, and
+   * {@link FieldAccessor#createAccessor} rejects static fields.
+   */
+  private static void warnStaticSink(Field staticSink) {
+    LOG.warn(
+        "Ignoring static {} field {}.{}: an extra-fields sink must be a non-static instance field. "
+            + "Declare the sink as a non-static field to capture unmatched remote fields.",
+        ForyExtraFields.class.getSimpleName(),
+        staticSink.getDeclaringClass().getName(),
+        staticSink.getName());
+  }
+
+  /**
+   * A record cannot host an extra-fields sink: the interpreter and generated read paths build the
+   * instance from constructor arguments and cannot capture unmatched fields into an
+   * already-immutable record.
+   */
+  public static void rejectRecordSink(Class<?> cls) {
+    if (RecordUtils.isRecord(cls)) {
+      throw new UnsupportedOperationException(
+          "ForyExtraFields is not supported on records: "
+              + cls.getName()
+              + ". Extra-field capture requires a mutable owner; declare the "
+              + ForyExtraFields.class.getSimpleName()
+              + " sink on a regular class instead.");
+    }
+  }
+
+  /** Returns the remote {@link TypeDef} captured with {@code extraField}, or {@code null}. */
+  public static TypeDef getTypeDef(ForyExtraFields extraField) {
+    return extraField.getTypeDef();
+  }
+
+  public static void capture(
+      ReadContext readContext,
+      Object target,
+      FieldAccessor sinkAccessor,
+      TypeDef typeDef,
+      FieldIdentity id,
+      Object value) {
+    ForyExtraFields extraField = (ForyExtraFields) sinkAccessor.getObject(target);
+    if (extraField == null) {
+      readContext.reserveGraphMemory(SINK_OWNER_BYTES);
+      extraField = new ForyExtraFields();
+      sinkAccessor.putObject(target, extraField);
+    }
+    TypeDef existingTypeDef = extraField.getTypeDef();
+    if (existingTypeDef == null) {
+      extraField.setTypeDef(typeDef);
+    } else if (existingTypeDef.getId() != typeDef.getId()) {
+      throw new IllegalStateException(
+          "Inconsistent remote schema while capturing extra fields on "
+              + target.getClass().getName()
+              + ": sink already bound to TypeDef id "
+              + existingTypeDef.getId()
+              + " but field "
+              + id
+              + " arrived under TypeDef id "
+              + typeDef.getId());
+    }
+    readContext.reserveGraphMemory(PER_ENTRY_BYTES);
+    extraField.put(id, value);
+  }
+
+  /**
+   * Builds the stable identity of a remote field: its fory field id when it has one, otherwise the
+   * {@code (declaringClass, name)} pair. Mirrors {@code TypeDef.fieldKey}
+   */
+  public static FieldIdentity fieldIdentity(Descriptor descriptor) {
+    if (descriptor.hasForyFieldId()) {
+      return FieldIdentity.ofId(descriptor.getForyFieldId());
+    }
+    return FieldIdentity.of(descriptor.getDeclaringClass(), descriptor.getName());
+  }
+
+  /** Factory reached from generated code for a field written by its fory field id. */
+  public static FieldIdentity fieldIdentity(int id) {
+    return FieldIdentity.ofId(id);
+  }
+
+  /** Factory reached from generated code for a field written by name. */
+  public static FieldIdentity fieldIdentity(String declaringClass, String name) {
+    return FieldIdentity.of(declaringClass, name);
+  }
+}

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/UnknownClassSerializers.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/UnknownClassSerializers.java
@@ -93,29 +93,21 @@ public final class UnknownClassSerializers {
       }
     }
 
-    /**
-     * Multiple un existed class will correspond to this `UnknownStruct`. When querying classinfo by
-     * `class`, it may dispatch to same `UnknownClassSerializer`, so we can't use `typeDef` in this
-     * serializer, but use `typeDef` in `UnknownStruct` instead.
-     *
-     * <p>UnknownStruct is registered with a fixed internal typeId for dispatch. This serializer
-     * rewinds that placeholder typeId and writes the original class's typeId, then writes the
-     * shared TypeDef inline using the stream meta protocol.
-     */
-    private void writeTypeDef(WriteContext writeContext, UnknownClass.UnknownStruct value) {
+    /** Writes the shared {@code typeDef} inline using the stream meta protocol. */
+    private static void writeTypeDefMeta(WriteContext writeContext, TypeDef typeDef) {
       MemoryBuffer buffer = writeContext.getBuffer();
       MetaWriteContext metaWriteContext = writeContext.getMetaWriteContext();
-      IdentityObjectIntMap classMap = metaWriteContext.classMap;
+      IdentityObjectIntMap<Object> classMap = metaWriteContext.classMap;
       int newId = classMap.size;
-      // class not exist, use class def id for identity.
-      int id = classMap.putOrGet(value.typeDef.getId(), newId);
+      // Key by TypeDef identity; see MetaWriteContext#classMap for the shared dedup contract.
+      int id = classMap.putOrGet(typeDef, newId);
       if (id >= 0) {
         // Reference to previously written type: (index << 1) | 1, LSB=1
         buffer.writeVarUInt32((id << 1) | 1);
       } else {
         // New type: index << 1, LSB=0, followed by TypeDef bytes inline
         buffer.writeVarUInt32(newId << 1);
-        buffer.writeBytes(value.typeDef.getEncoded());
+        buffer.writeBytes(typeDef.getEncoded());
       }
     }
 
@@ -135,7 +127,7 @@ public final class UnknownClassSerializers {
       return 5;
     }
 
-    private int resolveTypeId(TypeDef typeDef) {
+    private static int resolveTypeId(TypeDef typeDef) {
       if (typeDef.getClassSpec().isEnum) {
         if (typeDef.isNamed()) {
           return Types.NAMED_ENUM;
@@ -148,15 +140,23 @@ public final class UnknownClassSerializers {
       return typeDef.isCompatible() ? Types.COMPATIBLE_STRUCT : Types.STRUCT;
     }
 
-    @Override
-    public void write(WriteContext writeContext, Object v) {
+    /**
+     * Writes the real type id for {@code typeDef}, then calls {@link #writeTypeDefMeta} to write
+     * the schema itself.
+     *
+     * <p>UnknownStruct is registered with a fixed internal placeholder typeId for dispatch, since
+     * multiple unknown classes share this one serializer and the real typeId is only known from the
+     * value's own {@code TypeDef}. Callers must have just written that placeholder -- for example
+     * through {@link TypeResolver#writeTypeInfo} -- immediately before calling this method, since
+     * it rewinds the buffer to overwrite it.
+     */
+    public static void writeUnknownStructHeader(WriteContext writeContext, TypeDef typeDef) {
       MemoryBuffer buffer = writeContext.getBuffer();
-      UnknownClass.UnknownStruct value = (UnknownClass.UnknownStruct) v;
-      int typeId = resolveTypeId(value.typeDef);
-      int userTypeId = value.typeDef.isNamed() ? -1 : value.typeDef.getUserTypeId();
+      int typeId = resolveTypeId(typeDef);
+      int userTypeId = typeDef.isNamed() ? -1 : typeDef.getUserTypeId();
       int typeIdSize = 1;
       int userTypeIdSize = userTypeId != -1 ? computeVarUInt32Size(userTypeId) : 0;
-      if (config.isXlang()) {
+      if (writeContext.isCrossLanguage()) {
         buffer.writeUInt8(typeId);
         if (userTypeIdSize > 0) {
           buffer.writeVarUInt32(userTypeId);
@@ -183,8 +183,15 @@ public final class UnknownClassSerializers {
           buffer.writeBytes(payload);
         }
       }
-      writeTypeDef(writeContext, value);
+      writeTypeDefMeta(writeContext, typeDef);
+    }
+
+    @Override
+    public void write(WriteContext writeContext, Object v) {
+      UnknownClass.UnknownStruct value = (UnknownClass.UnknownStruct) v;
       TypeDef typeDef = value.typeDef;
+      writeUnknownStructHeader(writeContext, typeDef);
+      MemoryBuffer buffer = writeContext.getBuffer();
       ClassFieldsInfo fieldsInfo = getClassFieldsInfo(typeDef);
       if (config.checkClassVersion()) {
         buffer.writeInt32(fieldsInfo.classVersionHash);

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/converter/FieldConverters.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/converter/FieldConverters.java
@@ -26,11 +26,14 @@ import org.apache.fory.annotation.Internal;
 import org.apache.fory.context.ReadContext;
 import org.apache.fory.exception.DeserializationException;
 import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.meta.TypeDef;
 import org.apache.fory.reflect.FieldAccessor;
 import org.apache.fory.resolver.RefMode;
 import org.apache.fory.resolver.TypeInfo;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.FieldGroups.SerializationFieldInfo;
+import org.apache.fory.serializer.ForyExtraFields;
+import org.apache.fory.serializer.ForyExtraFieldsSupport;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.type.BFloat16;
 import org.apache.fory.type.Descriptor;
@@ -386,6 +389,26 @@ public class FieldConverters {
         }
         throw new DeserializationException("Unsupported compatible scalar source " + fieldName);
     }
+  }
+
+  /**
+   * Reads a converter field's raw wire value, preserves that untouched remote-typed value in the
+   * {@link ForyExtraFields} sink identified by {@code id}, then converts it via {@code
+   * from.fieldConverter} into the local field's target type. Used by generated compatible codecs in
+   * place of the fused {@code readXTarget} helpers whenever the class declares an extra-fields sink
+   * — see {@code CompatibleCodecBuilder.fieldConverterTargetRead}.
+   */
+  @Internal
+  public static Object readTargetAndCapture(
+      ReadContext readContext,
+      SerializationFieldInfo from,
+      Object target,
+      FieldAccessor sinkAccessor,
+      TypeDef typeDef,
+      ForyExtraFields.FieldIdentity id) {
+    Object sourceValue = readSourceScalar(readContext, from, from.fieldConverter);
+    ForyExtraFieldsSupport.capture(readContext, target, sinkAccessor, typeDef, id, sourceValue);
+    return from.fieldConverter.convert(sourceValue);
   }
 
   @Internal

--- a/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
+++ b/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
@@ -351,6 +351,7 @@ Args=--features=org.apache.fory.platform.ForyGraalVMFeature \
     org.apache.fory.serializer.CompatibleSerializer,\
     org.apache.fory.serializer.CompatibleLayerSerializer,\
     org.apache.fory.serializer.ForyExtraFields,\
+    org.apache.fory.serializer.ForyExtraFieldsSupport,\
     org.apache.fory.serializer.EnumSerializer,\
     org.apache.fory.serializer.ExceptionSerializers,\
     org.apache.fory.serializer.ExceptionSerializers$ExceptionSerializer,\

--- a/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
+++ b/java/fory-core/src/main/resources/META-INF/native-image/org.apache.fory/fory-core/native-image.properties
@@ -350,6 +350,7 @@ Args=--features=org.apache.fory.platform.ForyGraalVMFeature \
     org.apache.fory.serializer.BufferSerializers$ByteBufferSerializer,\
     org.apache.fory.serializer.CompatibleSerializer,\
     org.apache.fory.serializer.CompatibleLayerSerializer,\
+    org.apache.fory.serializer.ForyExtraFields,\
     org.apache.fory.serializer.EnumSerializer,\
     org.apache.fory.serializer.ExceptionSerializers,\
     org.apache.fory.serializer.ExceptionSerializers$ExceptionSerializer,\

--- a/java/fory-core/src/test/java/org/apache/fory/builder/StaticCompatibleCodecBuilderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/builder/StaticCompatibleCodecBuilderTest.java
@@ -48,6 +48,7 @@ import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.reflect.TypeRef;
 import org.apache.fory.resolver.TypeResolver;
 import org.apache.fory.serializer.FieldGroups.FieldCodecCategory;
+import org.apache.fory.serializer.ForyExtraFields;
 import org.apache.fory.serializer.Serializer;
 import org.apache.fory.serializer.StaticGeneratedStructSerializer;
 import org.apache.fory.serializer.StaticGeneratedStructSerializer.RemoteFieldInfo;
@@ -316,6 +317,71 @@ public class StaticCompatibleCodecBuilderTest {
       Object result = reader.deserialize(bytes);
       Assert.assertSame(result.getClass(), readerType);
       Assert.assertEquals(invoke(readerType, result, "id"), 73);
+    }
+  }
+
+  @Test
+  public void testRecordExtraFieldsSinkRejected() throws Exception {
+    // A record cannot host an extra-fields sink: it is built from constructor arguments and is
+    // immutable, so unmatched fields cannot be captured into it mid-read.
+    assumeRecordSupport();
+    CompilationResult recordResult =
+        compile(
+            "test.RecordWithExtraFieldsSink",
+            "package test;\n"
+                + "import org.apache.fory.serializer.ForyExtraFields;\n"
+                + "public record RecordWithExtraFieldsSink(int id, ForyExtraFields extraFields) {}\n");
+    CompilationResult writerResult =
+        compile(
+            "test.RecordWithExtraFieldsSink",
+            "package test;\n"
+                + "public class RecordWithExtraFieldsSink {\n"
+                + "  public int id;\n"
+                + "  public int extra;\n"
+                + "  public RecordWithExtraFieldsSink() {}\n"
+                + "}\n");
+    Assert.assertTrue(recordResult.success, recordResult.diagnostics());
+    Assert.assertTrue(writerResult.success, writerResult.diagnostics());
+    try (URLClassLoader recordLoader = recordResult.classLoader();
+        URLClassLoader writerLoader = writerResult.classLoader()) {
+      Class<?> recordType = recordLoader.loadClass("test.RecordWithExtraFieldsSink");
+      Class<?> writerType = writerLoader.loadClass("test.RecordWithExtraFieldsSink");
+
+      // The rejection is enforced at the descriptor-exclusion choke point in
+      // TypeResolver.buildFieldDescriptors, which every serializer builds through
+      Object record =
+          recordType.getDeclaredConstructor(int.class, ForyExtraFields.class).newInstance(7, null);
+      Object writerValue = writerType.getConstructor().newInstance();
+      setField(writerType, writerValue, "id", 7);
+      setField(writerType, writerValue, "extra", 42);
+
+      for (boolean codegen : new boolean[] {false, true}) {
+        // Write side
+        Fory recordFory =
+            compatibleFory(recordLoader, recordType, false, "record-write-" + codegen, codegen);
+        recordFory.setMetaWriteContext(new MetaWriteContext());
+        RuntimeException onWrite =
+            Assert.expectThrows(RuntimeException.class, () -> recordFory.serialize(record));
+        Assert.assertTrue(
+            rootCauseMessage(onWrite).contains("not supported on records"),
+            "write codegen=" + codegen + " -> " + rootCauseMessage(onWrite));
+
+        // Read side
+        Fory writer =
+            compatibleFory(
+                writerLoader, writerType, false, "record-read-writer-" + codegen, codegen);
+        writer.setMetaWriteContext(new MetaWriteContext());
+        byte[] bytes = writer.serialize(writerValue);
+        Fory reader =
+            compatibleFory(
+                recordLoader, recordType, false, "record-read-reader-" + codegen, codegen);
+        reader.setMetaReadContext(new MetaReadContext());
+        RuntimeException onRead =
+            Assert.expectThrows(RuntimeException.class, () -> reader.deserialize(bytes));
+        Assert.assertTrue(
+            rootCauseMessage(onRead).contains("not supported on records"),
+            "read codegen=" + codegen + " -> " + rootCauseMessage(onRead));
+      }
     }
   }
 
@@ -747,6 +813,14 @@ public class StaticCompatibleCodecBuilderTest {
   @SuppressWarnings("unchecked")
   private static Class<Object> cast(Class<?> type) {
     return (Class<Object>) type;
+  }
+
+  private static String rootCauseMessage(Throwable t) {
+    Throwable cause = t;
+    while (cause.getCause() != null && cause.getCause() != cause) {
+      cause = cause.getCause();
+    }
+    return String.valueOf(cause.getMessage());
   }
 
   private static CompilationResult compile(String typeName, String source) throws IOException {

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/CompatibleFieldConvertTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/CompatibleFieldConvertTest.java
@@ -290,6 +290,13 @@ public class CompatibleFieldConvertTest extends ForyTestBase {
     public BigDecimal value = new BigDecimal("0.5");
   }
 
+  public static final class DecimalConverterSink {
+    @ForyField(id = 6)
+    public int decimalInt;
+
+    public ForyExtraFields extraFields;
+  }
+
   public static final class NanStringWriter {
     @ForyField(id = 0)
     public double value = Double.NaN;

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ForyExtraFieldsTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ForyExtraFieldsTest.java
@@ -1,0 +1,1089 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.serializer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.fory.Fory;
+import org.apache.fory.builder.Generated;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for foryextrafields in compatible mode.
+ *
+ * <p>The two core scenarios are:
+ *
+ * <ol>
+ *   <li>No sink (opt-out): unmatched remote fields are silently dropped — existing behavior,
+ *       preserved unchanged.
+ *   <li>Sink declared (opt-in): unmatched remote fields are captured into a {@link ForyExtraFields}
+ *       field and can be replayed on re-serialization so a downstream peer with the full schema
+ *       recovers them.
+ * </ol>
+ *
+ * <p>The feature has two independent {@code write()} implementations — the interpreter's in {@link
+ * CompatibleSerializer} and the generated one from {@code CompatibleCodecBuilder}. Every test runs
+ * against both via the {@code config} data provider, which crosses {@code codegen} (false →
+ * interpreter, true → generated) with {@code refTracking} (false and true) — four combinations per
+ * test. The two ref-sharing tests, {@link #refSharingPreservedBetweenLocalAndExtraField} and {@link
+ * #roundTripNestedReferenceSharing}, instead use the {@code configRefTracking} provider and run
+ * only with ref-tracking enabled, since identity preservation is meaningless otherwise. {@link
+ * #roundTripAfterJitCompilation} additionally covers the interpreter→JIT handoff under async
+ * compilation.
+ */
+public class ForyExtraFieldsTest {
+
+  // -------------------------------------------------------------------------
+  // Model classes
+  // -------------------------------------------------------------------------
+
+  public static class UpstreamPrimitive {
+    public int f9;
+
+    public UpstreamPrimitive(int f9) {
+      this.f9 = f9;
+    }
+  }
+
+  public static class DownstreamPrimitiveWithSink {
+    public ForyExtraFields extraFields;
+  }
+
+  public static class Upstream {
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+    public int f9; // missing on DownstreamNoSink, captured by DownstreamWithSink
+
+    public Upstream() {}
+
+    public Upstream(int base) {
+      f0 = base;
+      f1 = base + 1;
+      f2 = base + 2;
+      f3 = base + 3;
+      f4 = base + 4;
+      f5 = base + 5;
+      f6 = base + 6;
+      f7 = base + 7;
+      f8 = base + 8;
+      f9 = base + 9;
+    }
+  }
+
+  /** Partial-schema peer with NO sink: f9 is silently dropped on deserialization. */
+  public static class DownstreamNoSink {
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+  }
+
+  /** Partial-schema peer WITH a sink: f9 is captured into {@code extraFields}. */
+  public static class DownstreamWithSink {
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+    public ForyExtraFields extraFields;
+  }
+
+  /**
+   * Peer that has an object field in addition to primitives, for ref-tracking tests. Uses {@code
+   * int[]} (a mutable heap object) so Fory ref-tracking preserves identity.
+   */
+  public static class UpstreamWithRef {
+    public int[] shared;
+    public int[] alias;
+    public int value;
+
+    public UpstreamWithRef() {}
+
+    public UpstreamWithRef(int[] arr, int v) {
+      this.shared = arr;
+      this.alias = arr; // intentional alias — same array object
+      this.value = v;
+    }
+  }
+
+  public static class DownstreamRefSink {
+    public int value;
+    public ForyExtraFields extraFields;
+  }
+
+  public static class UpstreamMixed {
+    public int age;
+    public String name;
+    public int score;
+
+    public UpstreamMixed() {}
+
+    public UpstreamMixed(int age, String name, int score) {
+      this.age = age;
+      this.name = name;
+      this.score = score;
+    }
+  }
+
+  public static class DownstreamMixedSink {
+    public int age;
+    public ForyExtraFields extraFields;
+  }
+
+  public static class DownstreamTwoHopSink {
+    public int age;
+    public String name;
+    public ForyExtraFields extraFields;
+  }
+
+  public static class UpstreamScore {
+    public int age;
+    public int score;
+
+    public UpstreamScore() {}
+
+    public UpstreamScore(int age, int score) {
+      this.age = age;
+      this.score = score;
+    }
+  }
+
+  public static class UpstreamLevel {
+    public int age;
+    public int level;
+
+    public UpstreamLevel() {}
+
+    public UpstreamLevel(int age, int level) {
+      this.age = age;
+      this.level = level;
+    }
+  }
+
+  public static class DownstreamAgeSink {
+    public int age;
+    public ForyExtraFields extraFields;
+  }
+
+  public static class DownstreamMixedArray {
+    public int age;
+    public String name;
+    public int score;
+
+    public DownstreamMixedArray() {}
+
+    public DownstreamMixedArray(int age, String name, int score) {
+      this.age = age;
+      this.name = name;
+      this.score = score;
+    }
+  }
+
+  public static class UpstreamList {
+    public int id;
+    public List<Integer> values;
+
+    public UpstreamList() {}
+
+    public UpstreamList(int id, List<Integer> values) {
+      this.id = id;
+      this.values = values;
+    }
+  }
+
+  public static class DownstreamListWithSink {
+    public int id;
+    public ForyExtraFields extraFields;
+  }
+
+  public static class Address {
+    public String city;
+    public int zip;
+
+    public Address() {}
+
+    public Address(String city, int zip) {
+      this.city = city;
+      this.zip = zip;
+    }
+  }
+
+  public static class UpstreamNested {
+    public int age;
+    public Address address;
+
+    public UpstreamNested() {}
+
+    public UpstreamNested(int age, Address address) {
+      this.age = age;
+      this.address = address;
+    }
+  }
+
+  public static class DownstreamNestedSink {
+    public int age;
+
+    public ForyExtraFields extraFields;
+  }
+
+  public static class UpstreamNestedRef {
+    public Address home;
+    public Address work;
+
+    public UpstreamNestedRef() {}
+
+    public UpstreamNestedRef(Address address) {
+      this.home = address;
+      this.work = address;
+    }
+  }
+
+  public static class DownstreamNestedRefSink {
+    public ForyExtraFields extraFields;
+  }
+
+  public static class DownstreamTotalSink {
+    public ForyExtraFields extraFields;
+  }
+
+  public abstract static class ExtraFieldsBase {
+    public ForyExtraFields extraFields;
+  }
+
+  public static class DownstreamInheritedSink extends ExtraFieldsBase {}
+
+  @Test(dataProvider = "config")
+  public void roundTripInheritedExtraFieldSink(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    Address address = new Address("Manhattan", 66502);
+    UpstreamNested original = new UpstreamNested(30, address);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+
+    DownstreamInheritedSink intermediate =
+        foryB.deserialize(aToBBytes, DownstreamInheritedSink.class);
+
+    assertNotNull(intermediate.extraFields);
+
+    Object captured = intermediate.extraFields.get("address");
+    assertNotNull(captured);
+    assertTrue(captured instanceof Address);
+
+    Address capturedAddress = (Address) captured;
+    assertEquals(capturedAddress.city, "Manhattan");
+    assertEquals(capturedAddress.zip, 66502);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+
+    UpstreamNested recovered = foryC.deserialize(bToCBytes, UpstreamNested.class);
+
+    assertEquals(recovered.age, original.age);
+    assertNotNull(recovered.address);
+    assertEquals(recovered.address.city, original.address.city);
+    assertEquals(recovered.address.zip, original.address.zip);
+  }
+
+  @Test(dataProvider = "config")
+  public void roundTripAllFieldsCapturedInExtraField(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    Address address = new Address("Manhattan", 66502);
+    UpstreamNested original = new UpstreamNested(30, address);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+
+    DownstreamTotalSink intermediate = foryB.deserialize(aToBBytes, DownstreamTotalSink.class);
+
+    assertNotNull(intermediate.extraFields);
+
+    Object capturedAge = intermediate.extraFields.get("age");
+    assertNotNull(capturedAge);
+    assertEquals(capturedAge, 30);
+
+    Object capturedAddress = intermediate.extraFields.get("address");
+    assertNotNull(capturedAddress);
+    assertTrue(capturedAddress instanceof Address);
+
+    Address captured = (Address) capturedAddress;
+    assertEquals(captured.city, "Manhattan");
+    assertEquals(captured.zip, 66502);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+
+    UpstreamNested recovered = foryC.deserialize(bToCBytes, UpstreamNested.class);
+
+    assertEquals(recovered.age, original.age);
+    assertNotNull(recovered.address);
+    assertEquals(recovered.address.city, original.address.city);
+    assertEquals(recovered.address.zip, original.address.zip);
+  }
+
+  @Test(dataProvider = "config")
+  public void roundTripNestedExtraField(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    Address address = new Address("Manhattan", 66502);
+    UpstreamNested original = new UpstreamNested(30, address);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+
+    DownstreamNestedSink intermediate = foryB.deserialize(aToBBytes, DownstreamNestedSink.class);
+
+    assertEquals(intermediate.age, original.age);
+    assertNotNull(intermediate.extraFields);
+
+    Object captured = intermediate.extraFields.get("address");
+    assertNotNull(captured);
+    assertTrue(captured instanceof Address);
+
+    Address capturedAddress = (Address) captured;
+    assertEquals(capturedAddress.city, "Manhattan");
+    assertEquals(capturedAddress.zip, 66502);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+
+    UpstreamNested recovered = foryC.deserialize(bToCBytes, UpstreamNested.class);
+
+    assertEquals(recovered.age, original.age);
+    assertNotNull(recovered.address);
+    assertEquals(recovered.address.city, original.address.city);
+    assertEquals(recovered.address.zip, original.address.zip);
+  }
+
+  @Test(dataProvider = "configRefTracking")
+  public void roundTripNestedReferenceSharing(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    Address address = new Address("Manhattan", 66502);
+    UpstreamNestedRef original = new UpstreamNestedRef(address);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+
+    DownstreamNestedRefSink intermediate =
+        foryB.deserialize(aToBBytes, DownstreamNestedRefSink.class);
+
+    assertNotNull(intermediate.extraFields);
+
+    Object capturedHome = intermediate.extraFields.get("home");
+    Object capturedWork = intermediate.extraFields.get("work");
+
+    assertNotNull(capturedHome);
+    assertNotNull(capturedWork);
+    assertSame(capturedHome, capturedWork);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+
+    UpstreamNestedRef recovered = foryC.deserialize(bToCBytes, UpstreamNestedRef.class);
+
+    assertNotNull(recovered.home);
+    assertNotNull(recovered.work);
+    assertSame(recovered.home, recovered.work);
+
+    assertEquals(recovered.home.city, address.city);
+    assertEquals(recovered.home.zip, address.zip);
+  }
+
+  /**
+   * @param codegen {@code false} → interpreter ({@link CompatibleSerializer}); {@code true} →
+   *     generated serializer ({@code CompatibleCodecBuilder}).
+   * @param refTracking whether reference tracking is enabled on the built {@link Fory}.
+   */
+  private static Fory compatibleFory(boolean codegen, boolean refTracking) {
+    return Fory.builder()
+        .withXlang(false)
+        .withRefTracking(refTracking)
+        .withCompatible(true)
+        .requireClassRegistration(false)
+        .withCodegen(codegen)
+        .build();
+  }
+
+  /**
+   * Crosses {@code codegen} (interpreter vs generated write path) with {@code refTracking} (off vs
+   * on) — four combinations, so every test exercises both write paths under both ref modes.
+   */
+  @DataProvider(name = "config")
+  public static Object[][] config() {
+    return new Object[][] {{false, false}, {false, true}, {true, false}, {true, true}};
+  }
+
+  /**
+   * Like {@link #config} but pins {@code refTracking} on — for the ref-sharing tests, whose
+   * identity assertions are meaningless without reference tracking.
+   */
+  @DataProvider(name = "configRefTracking")
+  public static Object[][] configRefTracking() {
+    return new Object[][] {{false, true}, {true, true}};
+  }
+
+  // -------------------------------------------------------------------------
+  // No-sink: unmatched fields silently dropped
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void deserializeIgnoresMissingFields(boolean codegen, boolean refTracking) {
+    Fory writer = compatibleFory(codegen, refTracking);
+    Upstream upstream = new Upstream(100);
+    byte[] bytes = writer.serialize(upstream);
+
+    Fory reader = compatibleFory(codegen, refTracking);
+    DownstreamNoSink result = reader.deserialize(bytes, DownstreamNoSink.class);
+
+    // f0..f8 preserved; f9 is silently dropped (no sink declared)
+    assertEquals(result.f0, upstream.f0);
+    assertEquals(result.f1, upstream.f1);
+    assertEquals(result.f2, upstream.f2);
+    assertEquals(result.f3, upstream.f3);
+    assertEquals(result.f4, upstream.f4);
+    assertEquals(result.f5, upstream.f5);
+    assertEquals(result.f6, upstream.f6);
+    assertEquals(result.f7, upstream.f7);
+    assertEquals(result.f8, upstream.f8);
+  }
+
+  /**
+   * When the serializer handles primitive fields, it correctly converts them into their boxed
+   * object equivalents when storing them as objects.
+   */
+  @Test(dataProvider = "config")
+  public void capturesPrimitiveAndBoxesCorrectly(boolean codegen, boolean refTracking) {
+    Fory writer = compatibleFory(codegen, refTracking);
+    UpstreamPrimitive upstream = new UpstreamPrimitive(100);
+    byte[] bytes = writer.serialize(upstream);
+
+    Fory reader = compatibleFory(codegen, refTracking);
+    DownstreamPrimitiveWithSink result =
+        reader.deserialize(bytes, DownstreamPrimitiveWithSink.class);
+
+    assertNotNull(result.extraFields);
+
+    Object value = result.extraFields.get("f9");
+
+    // primitive int stored inside Object becomes Integer
+    assertTrue(value instanceof Integer);
+    assertEquals(100, value);
+  }
+
+  @Test(dataProvider = "config")
+  public void sinkIsNullWhenNoFieldsMissing(boolean codegen, boolean refTracking) {
+    Fory fory = compatibleFory(codegen, refTracking);
+    DownstreamWithSink obj = new DownstreamWithSink();
+    obj.f0 = 7;
+    obj.f3 = 42;
+    byte[] bytes = fory.serialize(obj);
+    DownstreamWithSink result = fory.deserialize(bytes, DownstreamWithSink.class);
+    assertNull(result.extraFields);
+  }
+
+  // -------------------------------------------------------------------------
+  // Round-trip test: A (full) → B (partial + sink) → C (full) recovers f9
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void roundTripRecoversMissingField(boolean codegen, boolean refTracking) {
+    // --- A: full-schema writer ---
+    Fory foryA = compatibleFory(codegen, refTracking);
+    Upstream original = new Upstream(200);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // --- B: partial-schema peer with sink ---
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamWithSink intermediate = foryB.deserialize(aToBBytes, DownstreamWithSink.class);
+
+    // B captured f9
+    assertNotNull(intermediate.extraFields);
+    assertEquals(intermediate.extraFields.get("f9"), original.f9);
+
+    // B re-serializes — must emit the remote (full) TypeDef + all 10 fields
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    // --- C: full-schema receiver recovers all 10 fields ---
+    Fory foryC = compatibleFory(codegen, refTracking);
+    Upstream recovered = foryC.deserialize(bToCBytes, Upstream.class);
+
+    assertEquals(recovered.f0, original.f0);
+    assertEquals(recovered.f1, original.f1);
+    assertEquals(recovered.f2, original.f2);
+    assertEquals(recovered.f3, original.f3);
+    assertEquals(recovered.f4, original.f4);
+    assertEquals(recovered.f5, original.f5);
+    assertEquals(recovered.f6, original.f6);
+    assertEquals(recovered.f7, original.f7);
+    assertEquals(recovered.f8, original.f8);
+    assertEquals(recovered.f9, original.f9);
+  }
+
+  // -------------------------------------------------------------------------
+  // Ref-sharing: aliased objects captured in sink preserve identity
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "configRefTracking")
+  public void refSharingPreservedBetweenLocalAndExtraField(boolean codegen, boolean refTracking) {
+    Fory writer = compatibleFory(codegen, refTracking);
+    int[] arr = {1, 2, 3};
+    UpstreamWithRef original = new UpstreamWithRef(arr, 99);
+    // original.shared == original.alias (same array instance)
+    byte[] bytes = writer.serialize(original);
+
+    Fory reader = compatibleFory(codegen, refTracking);
+    DownstreamRefSink result = reader.deserialize(bytes, DownstreamRefSink.class);
+
+    assertEquals(result.value, original.value);
+    assertNotNull(result.extraFields);
+
+    Object capturedShared = result.extraFields.get("shared");
+    Object capturedAlias = result.extraFields.get("alias");
+    assertNotNull(capturedShared);
+    assertSame(capturedShared, capturedAlias);
+  }
+
+  // -------------------------------------------------------------------------
+  // multiple extra fields of mixed types
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void roundTripMultipleExtraFieldsMixedTypes(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamMixed original = new UpstreamMixed(30, "Alice", 95);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
+    assertEquals(intermediate.age, original.age);
+    assertNotNull(intermediate.extraFields);
+    assertEquals(intermediate.extraFields.get("name"), original.name);
+    assertEquals(((Number) intermediate.extraFields.get("score")).intValue(), original.score);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamMixed recovered = foryC.deserialize(bToCBytes, UpstreamMixed.class);
+    assertEquals(recovered.age, original.age);
+    assertEquals(recovered.name, original.name);
+    assertEquals(recovered.score, original.score);
+  }
+
+  // -------------------------------------------------------------------------
+  // null extra field value survives round-trip
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void roundTripNullExtraField(boolean codegen, boolean refTracking) {
+    // A null String field captured in the sink must be replayed as null, not omitted.
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamMixed original = new UpstreamMixed(30, null, 95);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
+    assertEquals(intermediate.age, original.age);
+    assertNotNull(intermediate.extraFields);
+    assertTrue(intermediate.extraFields.containsKey("name"));
+    assertNull(intermediate.extraFields.get("name"));
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamMixed recovered = foryC.deserialize(bToCBytes, UpstreamMixed.class);
+    assertEquals(recovered.age, original.age);
+    assertNull(recovered.name);
+    assertEquals(recovered.score, original.score);
+  }
+
+  // -------------------------------------------------------------------------
+  // two-hop chain — each hop re-stamps the original TypeDef
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void twoHopChainRecoversAllFields(boolean codegen, boolean refTracking) {
+    // A (full: age, name, score) → B (age only, sink) → C (age+name, sink) → D (full)
+    // Each hop re-serializes using the remote (A) TypeDef so the next peer can decode.
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    UpstreamMixed original = new UpstreamMixed(25, "Bob", 88);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // B captures name and score
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamMixedSink b = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
+    assertEquals(b.age, original.age);
+    assertNotNull(b.extraFields);
+
+    byte[] bToCBytes = foryB.serialize(b);
+
+    // C receives the full A-schema bytes, matches age and name, captures score
+    Fory foryC = compatibleFory(codegen, refTracking);
+    DownstreamTwoHopSink c = foryC.deserialize(bToCBytes, DownstreamTwoHopSink.class);
+    assertEquals(c.age, original.age);
+    assertEquals(c.name, original.name);
+    assertNotNull(c.extraFields);
+    assertEquals(((Number) c.extraFields.get("score")).intValue(), original.score);
+    assertNull(c.extraFields.get("name")); // name is matched, not captured
+
+    byte[] cToDBytes = foryC.serialize(c);
+
+    // D recovers all three fields
+    Fory foryD = compatibleFory(codegen, refTracking);
+    UpstreamMixed recovered = foryD.deserialize(cToDBytes, UpstreamMixed.class);
+    assertEquals(recovered.age, original.age);
+    assertEquals(recovered.name, original.name);
+    assertEquals(recovered.score, original.score);
+  }
+
+  // -------------------------------------------------------------------------
+  // Two distinct remote schemas replayed through one Fory instance
+  // -------------------------------------------------------------------------
+
+  /**
+   * Two {@link DownstreamAgeSink} instances whose sinks come from two *different* remote schemas
+   * ({@link UpstreamScore} and {@link UpstreamLevel}) both pass through the same Fory instance.
+   *
+   * <p>Both objects share one local class, so replay serializers are keyed by (class, remote
+   * TypeDef id); each object must be routed to the serializer of its own captured schema and emit
+   * that schema's TypeDef header, so each downstream peer recovers its own extra field.
+   */
+  @Test(dataProvider = "config")
+  public void twoDistinctRemoteSchemasReplayed(boolean codegen, boolean refTracking) {
+    Fory foryScore = compatibleFory(codegen, refTracking);
+    UpstreamScore score = new UpstreamScore(30, 95);
+    byte[] scoreBytes = foryScore.serialize(score);
+
+    Fory foryLevel = compatibleFory(codegen, refTracking);
+    UpstreamLevel level = new UpstreamLevel(25, 5);
+    byte[] levelBytes = foryLevel.serialize(level);
+
+    // Same Fory instance deserializes both — both become DownstreamAgeSink but carry
+    // different remote TypeDefs in their sinks.
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamAgeSink fromScore = foryB.deserialize(scoreBytes, DownstreamAgeSink.class);
+    DownstreamAgeSink fromLevel = foryB.deserialize(levelBytes, DownstreamAgeSink.class);
+
+    assertEquals(fromScore.age, 30);
+    assertEquals(fromLevel.age, 25);
+    assertNotNull(fromScore.extraFields);
+    assertNotNull(fromLevel.extraFields);
+
+    assertNotNull(fromScore.extraFields.getTypeDef());
+    assertNotNull(fromLevel.extraFields.getTypeDef());
+    assertTrue(
+        fromScore.extraFields.getTypeDef().getId() != fromLevel.extraFields.getTypeDef().getId(),
+        "sinkTypeDefId must differ between the two remote schemas");
+
+    // each must emit its own remote TypeDef header
+    byte[] replayedScore = foryB.serialize(fromScore);
+    byte[] replayedLevel = foryB.serialize(fromLevel);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamScore recoveredScore = foryC.deserialize(replayedScore, UpstreamScore.class);
+    assertEquals(recoveredScore.age, 30);
+    assertEquals(recoveredScore.score, 95);
+
+    Fory foryD = compatibleFory(codegen, refTracking);
+    UpstreamLevel recoveredLevel = foryD.deserialize(replayedLevel, UpstreamLevel.class);
+    assertEquals(recoveredLevel.age, 25);
+    assertEquals(recoveredLevel.level, 5);
+  }
+
+  // -------------------------------------------------------------------------
+  // writeReplace indirection — exercises the bare WriteContext.writeNonRef(Object) overload
+  // -------------------------------------------------------------------------
+
+  /**
+   * A class with a {@code writeReplace} method is handled by {@link ReplaceResolveSerializer}. When
+   * the replacement object's runtime type differs from the wrapper's declared type, {@code
+   * ReplaceResolveSerializer.write} routes the replacement through {@code
+   * WriteContext.writeNonRef(Object)} directly
+   */
+  public static class ReplaceWrapper implements java.io.Serializable {
+    public DownstreamWithSink replacement;
+
+    public ReplaceWrapper(DownstreamWithSink replacement) {
+      this.replacement = replacement;
+    }
+
+    private Object writeReplace() {
+      return replacement;
+    }
+  }
+
+  @Test(dataProvider = "config")
+  public void writeNonRefReplaysExtraFields(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+    Upstream original = new Upstream(300);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamWithSink intermediate = foryB.deserialize(aToBBytes, DownstreamWithSink.class);
+    assertNotNull(intermediate.extraFields);
+    assertEquals(intermediate.extraFields.get("f9"), original.f9);
+
+    // wrapper.writeReplace() substitutes `intermediate` (a different runtime type), forcing
+    // ReplaceResolveSerializer down the REPLACED_NEW_TYPE branch, which calls
+    // WriteContext.writeNonRef(Object) directly on `intermediate`.
+    ReplaceWrapper wrapper = new ReplaceWrapper(intermediate);
+    byte[] wrapperBytes = foryB.serialize(wrapper);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    Object recovered = foryC.deserialize(wrapperBytes);
+
+    assertTrue(recovered instanceof Upstream);
+    Upstream recoveredUpstream = (Upstream) recovered;
+    assertEquals(recoveredUpstream.f0, original.f0);
+    assertEquals(recoveredUpstream.f1, original.f1);
+    assertEquals(recoveredUpstream.f2, original.f2);
+    assertEquals(recoveredUpstream.f3, original.f3);
+    assertEquals(recoveredUpstream.f4, original.f4);
+    assertEquals(recoveredUpstream.f5, original.f5);
+    assertEquals(recoveredUpstream.f6, original.f6);
+    assertEquals(recoveredUpstream.f7, original.f7);
+    assertEquals(recoveredUpstream.f8, original.f8);
+    assertEquals(recoveredUpstream.f9, original.f9);
+  }
+
+  // -------------------------------------------------------------------------
+  // Arrays and collections
+  // -------------------------------------------------------------------------
+
+  @Test(dataProvider = "config")
+  public void roundTripUnmatchedCollectionField(boolean codegen, boolean refTracking) {
+    Fory writer = compatibleFory(codegen, refTracking);
+    UpstreamList original = new UpstreamList(1, Arrays.asList(10, 20, 30));
+    byte[] writerBytes = writer.serialize(original);
+
+    Fory reader = compatibleFory(codegen, refTracking);
+    DownstreamListWithSink downstream =
+        reader.deserialize(writerBytes, DownstreamListWithSink.class);
+
+    assertEquals(downstream.id, 1);
+    assertNotNull(downstream.extraFields);
+
+    byte[] replayedBytes = reader.serialize(downstream);
+
+    Fory verify = compatibleFory(codegen, refTracking);
+    UpstreamList recovered = verify.deserialize(replayedBytes, UpstreamList.class);
+
+    assertEquals(recovered.id, original.id);
+    assertEquals(recovered.values, original.values);
+  }
+
+  // -------------------------------------------------------------------------
+  // Nested object with its own sink — exercises writeNonRef path
+  // -------------------------------------------------------------------------
+
+  public static class UpstreamOuter {
+    public int id;
+    public NestedFull nested;
+
+    public UpstreamOuter() {}
+
+    public UpstreamOuter(int id, NestedFull nested) {
+      this.id = id;
+      this.nested = nested;
+    }
+  }
+
+  public static class NestedFull {
+    public int f0;
+    public int f1;
+
+    public NestedFull() {}
+
+    public NestedFull(int f0, int f1) {
+      this.f0 = f0;
+      this.f1 = f1;
+    }
+  }
+
+  /** Partial-schema outer with no sink; nested has a sink. */
+  public static class DownstreamOuterNoSink {
+    public int id;
+    public NestedPartialSink nested;
+
+    public DownstreamOuterNoSink() {}
+  }
+
+  /** Partial-schema nested with a sink — captures f1 from NestedFull. */
+  public static class NestedPartialSink {
+    public int f0;
+    public ForyExtraFields extraFields;
+
+    public NestedPartialSink() {}
+  }
+
+  public static class DownstreamNested {
+    int id;
+
+    ForyExtraFields extraFields;
+  }
+
+  // -------------------------------------------------------------------------
+  // async compilation — interpreter bootstraps, JIT takes over
+  // -------------------------------------------------------------------------
+
+  /**
+   * Exercises the interpreter→JIT handoff. Under async compilation the first serialize uses the
+   * interpreter {@code write()}; once compilation completes the serializer is swapped for a {@link
+   * Generated} one. We wait deterministically for that swap and assert the second serialize
+   * genuinely ran through the generated path — then confirm both wire outputs replay the captured
+   * field correctly.
+   */
+  @Test(timeOut = 30000)
+  public void roundTripAfterJitCompilation() throws InterruptedException {
+    Fory foryA = compatibleFory(false, true);
+    UpstreamMixed original = new UpstreamMixed(40, "Carol", 77);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB =
+        Fory.builder()
+            .withXlang(false)
+            .withRefTracking(true)
+            .withCompatible(true)
+            .requireClassRegistration(false)
+            .withAsyncCompilation(true) // interpreter first, generated serializer swaps in
+            .build();
+
+    DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
+    assertNotNull(intermediate.extraFields);
+
+    // First serialize triggers async JIT and runs through the interpreter write path.
+    byte[] fromInterpreter = foryB.serialize(intermediate);
+
+    // Wait for the generated serializer to be swapped in, then serialize via the compiled path.
+    while (!(foryB.getTypeResolver().getSerializer(DownstreamMixedSink.class)
+        instanceof Generated)) {
+      Thread.sleep(10);
+    }
+    byte[] fromJit = foryB.serialize(intermediate);
+
+    // Both wire outputs must recover all three fields on a full-schema peer.
+    for (byte[] bytes : new byte[][] {fromInterpreter, fromJit}) {
+      Fory foryC = compatibleFory(false, true);
+      UpstreamMixed recovered = foryC.deserialize(bytes, UpstreamMixed.class);
+      assertEquals(recovered.age, original.age);
+      assertEquals(recovered.name, original.name);
+      assertEquals(recovered.score, original.score);
+    }
+  }
+
+  public static class OuterFull {
+    public int id;
+    public MiddleFull middle;
+
+    public OuterFull() {}
+
+    public OuterFull(int id, MiddleFull middle) {
+      this.id = id;
+      this.middle = middle;
+    }
+  }
+
+  public static class MiddleFull {
+    public int id;
+    public InnerFull inner;
+
+    public MiddleFull() {}
+
+    public MiddleFull(int id, InnerFull inner) {
+      this.id = id;
+      this.inner = inner;
+    }
+  }
+
+  public static class InnerFull {
+    public int f0;
+    public int f1;
+
+    public InnerFull() {}
+
+    public InnerFull(int f0, int f1) {
+      this.f0 = f0;
+      this.f1 = f1;
+    }
+  }
+
+  public static class OuterPartial {
+    public int id;
+    public MiddlePartial middle;
+
+    public OuterPartial() {}
+  }
+
+  public static class MiddlePartial {
+    public int id;
+    public InnerPartialSink inner;
+
+    public MiddlePartial() {}
+  }
+
+  public static class InnerPartialSink {
+    public int f0;
+    public ForyExtraFields extraFields;
+
+    public InnerPartialSink() {}
+  }
+
+  /**
+   * A (full: OuterFull → MiddleFull → InnerFull) → B (partial: OuterPartial → MiddlePartial →
+   * InnerPartialSink) → C (full: OuterFull → MiddleFull → InnerFull).
+   *
+   * <p>Each nested level is partially known by B. The innermost object captures the unknown f1
+   * field in its sink. On re-serialization, the local schema should be written for each object,
+   * while the sink preserves the remote fields. C must recover the full nested structure. passes
+   * through writenonref(obj,typeinfo) path
+   */
+  @Test(dataProvider = "config")
+  public void roundTripTripleNestedObjectWithInnerSink(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    InnerFull inner = new InnerFull(10, 20);
+    MiddleFull middle = new MiddleFull(2, inner);
+    OuterFull original = new OuterFull(1, middle);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    OuterPartial intermediate = foryB.deserialize(aToBBytes, OuterPartial.class);
+
+    assertEquals(intermediate.id, original.id);
+    assertNotNull(intermediate.middle);
+    assertEquals(intermediate.middle.id, original.middle.id);
+
+    assertNotNull(intermediate.middle.inner);
+    assertEquals(intermediate.middle.inner.f0, original.middle.inner.f0);
+
+    assertNotNull(intermediate.middle.inner.extraFields);
+    assertEquals(intermediate.middle.inner.extraFields.get("f1"), original.middle.inner.f1);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    OuterFull recovered = foryC.deserialize(bToCBytes, OuterFull.class);
+
+    // C's recovered object state:
+    //
+    // OuterFull
+    //   id = 1
+    //   middle =
+    //     MiddleFull
+    //       id = 2
+    //       inner =
+    //         InnerFull
+    //           f0 = 10
+    //           f1 = 20
+    //
+    assertEquals(recovered.id, original.id);
+
+    assertNotNull(recovered.middle);
+    assertEquals(recovered.middle.id, original.middle.id);
+
+    assertNotNull(recovered.middle.inner);
+    assertEquals(recovered.middle.inner.f0, original.middle.inner.f0);
+    assertEquals(recovered.middle.inner.f1, original.middle.inner.f1);
+  }
+
+  public static class UpstreamOuterTwoNested {
+    public int id;
+    public NestedFull left;
+    public NestedFull right;
+
+    public UpstreamOuterTwoNested() {}
+
+    public UpstreamOuterTwoNested(int id, NestedFull left, NestedFull right) {
+      this.id = id;
+      this.left = left;
+      this.right = right;
+    }
+  }
+
+  public static class DownstreamOuterTwoNested {
+    public int id;
+    public NestedPartialSink left;
+    public NestedPartialSink right;
+
+    public DownstreamOuterTwoNested() {}
+  }
+
+  /**
+   * A (full: OuterWithTwoNestedFulls) → B (partial: OuterWithTwoNestedSinks) → C (full:
+   * OuterWithTwoNestedFulls).
+   *
+   * <p>Two sibling nested objects have independent sinks. The serializer must preserve the sink
+   * belonging to each object and must not reuse the TypeDef/schema from the first nested object
+   * when writing the second one.
+   */
+  // this test goes through the writenonref(obj,cached typedinfoholder) path
+  @Test(dataProvider = "config")
+  public void roundTripMultipleNestedObjectsWithOwnSinks(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+
+    NestedFull left = new NestedFull(10, 100);
+    NestedFull right = new NestedFull(20, 200);
+    UpstreamOuterTwoNested original = new UpstreamOuterTwoNested(1, left, right);
+
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamOuterTwoNested intermediate =
+        foryB.deserialize(aToBBytes, DownstreamOuterTwoNested.class);
+
+    assertEquals(intermediate.id, original.id);
+
+    assertNotNull(intermediate.left);
+    assertEquals(intermediate.left.f0, left.f0);
+    assertNotNull(intermediate.left.extraFields);
+    assertEquals(intermediate.left.extraFields.get("f1"), left.f1);
+
+    assertNotNull(intermediate.right);
+    assertEquals(intermediate.right.f0, right.f0);
+    assertNotNull(intermediate.right.extraFields);
+    assertEquals(intermediate.right.extraFields.get("f1"), right.f1);
+
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamOuterTwoNested recovered = foryC.deserialize(bToCBytes, UpstreamOuterTwoNested.class);
+
+    assertEquals(recovered.id, original.id);
+
+    assertNotNull(recovered.left);
+    assertEquals(recovered.left.f0, left.f0);
+    assertEquals(recovered.left.f1, left.f1);
+
+    assertNotNull(recovered.right);
+    assertEquals(recovered.right.f0, right.f0);
+    assertEquals(recovered.right.f1, right.f1);
+  }
+}

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ForyExtraFieldsTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ForyExtraFieldsTest.java
@@ -20,6 +20,8 @@
 package org.apache.fory.serializer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -28,7 +30,16 @@ import static org.testng.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.fory.Fory;
+import org.apache.fory.annotation.ForyField;
 import org.apache.fory.builder.Generated;
+import org.apache.fory.builder.ObjectCodecBuilder;
+import org.apache.fory.collection.LongMap;
+import org.apache.fory.meta.FieldInfo;
+import org.apache.fory.meta.TypeDef;
+import org.apache.fory.reflect.ReflectionUtils;
+import org.apache.fory.resolver.ClassResolver;
+import org.apache.fory.resolver.TypeInfo;
+import org.apache.fory.resolver.TypeResolver;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -102,6 +113,11 @@ public class ForyExtraFieldsTest {
   public static class DownstreamWithSink {
     public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
     public ForyExtraFields extraFields;
+  }
+
+  public static class DownstreamPreInitSink {
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+    public final ForyExtraFields extraFields = new ForyExtraFields();
   }
 
   /**
@@ -268,6 +284,146 @@ public class ForyExtraFieldsTest {
 
   public static class DownstreamInheritedSink extends ExtraFieldsBase {}
 
+  // -------------------------------------------------------------------------
+  // Field hiding: a subclass legally hides the inherited ForyExtraFields sink
+  // with a same-named field of a different type. The scanner returns the exact
+  // inherited sink (declared on the base), so the generated codec must bind THAT
+  // field, not re-resolve by beanClass + name (which would pick the subclass's
+  // shadowing String field and write a ForyExtraFields reference into it).
+  // -------------------------------------------------------------------------
+
+  public static class HidingSinkBase {
+    public ForyExtraFields extraFields;
+  }
+
+  /** Hides the inherited {@code extraFields} sink with a same-named, different-typed field. */
+  public static class DownstreamHidingSink extends HidingSinkBase {
+    public String extraFields;
+  }
+
+  @Test(dataProvider = "config")
+  public void hiddenInheritedSinkCapturesIntoDeclaringClassField(
+      boolean codegen, boolean refTracking) {
+    // The upstream schema is fully unknown to DownstreamHidingSink, so every field is captured into
+    // the inherited sink. A subclass field named `extraFields` (a String) legally hides the
+    // inherited ForyExtraFields sink. The scanner returns the exact base sink, so capture must land
+    // there; a beanClass + name lookup would instead bind the shadowing String field.
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamMixed original = new UpstreamMixed(30, "Alice", 95);
+    byte[] bytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamHidingSink result = foryB.deserialize(bytes, DownstreamHidingSink.class);
+
+    // The shadowing subclass field must be left untouched...
+    assertNull(result.extraFields);
+    // ...and every captured field must land in the real inherited sink on the declaring class.
+    ForyExtraFields sink = ((HidingSinkBase) result).extraFields;
+    assertNotNull(sink);
+    assertEquals(byName(sink, "age"), original.age);
+    assertEquals(byName(sink, "name"), original.name);
+    assertEquals(((Number) byName(sink, "score")).intValue(), original.score);
+  }
+
+  // -------------------------------------------------------------------------
+  // Shadowed fields: a superclass and subclass may legally declare fields with
+  // the SAME simple name. In the remote TypeDef these are two
+  // distinct FieldInfo entries, distinguished by declaring class + field id. A
+  // sink keyed by simple name collapses them: capture overwrites one value, and
+  // replay writes both remote slots from the single survivor. The full identity
+  // must be the sink key so each slot round-trips independently.
+  // -------------------------------------------------------------------------
+
+  public static class ShadowBase {
+    public int x;
+
+    public ShadowBase() {}
+  }
+
+  /** Legally hides {@code ShadowBase.x} with a same-named field of the same type. */
+  public static class ShadowChild extends ShadowBase {
+    public int x;
+
+    public ShadowChild() {}
+
+    public ShadowChild(int baseX, int childX) {
+      super.x = baseX;
+      this.x = childX;
+    }
+  }
+
+  /** Partial peer with only a sink: both shadowed {@code x} fields are unmatched and captured. */
+  public static class ShadowDownstreamSink {
+    public ForyExtraFields extraFields;
+  }
+
+  @Test(dataProvider = "config")
+  public void roundTripShadowedFieldsPreservedIndependently(boolean codegen, boolean refTracking) {
+    // A: full schema, two distinct x fields (base=111, child=222)
+    Fory foryA = compatibleFory(codegen, refTracking);
+    ShadowChild original = new ShadowChild(111, 222);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // B: sink-only peer captures both remote x fields
+    Fory foryB = compatibleFory(codegen, refTracking);
+    ShadowDownstreamSink intermediate = foryB.deserialize(aToBBytes, ShadowDownstreamSink.class);
+    assertNotNull(intermediate.extraFields);
+
+    // B re-serializes under the remote schema; both slots must replay their own captured value.
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    // C: full schema must recover BOTH x values, not the same value twice.
+    Fory foryC = compatibleFory(codegen, refTracking);
+    ShadowChild recovered = foryC.deserialize(bToCBytes, ShadowChild.class);
+    assertEquals(((ShadowBase) recovered).x, 111, "ShadowBase.x must round-trip independently");
+    assertEquals(recovered.x, 222, "ShadowChild.x must round-trip independently");
+  }
+
+  // -------------------------------------------------------------------------
+  // Tagged / id-bearing fields: a field written by its fory field id (e.g.
+  // @ForyField(id=N))
+  // -------------------------------------------------------------------------
+
+  public static class UpstreamTagged {
+    @ForyField(id = 7)
+    public int secret;
+
+    public UpstreamTagged() {}
+
+    public UpstreamTagged(int secret) {
+      this.secret = secret;
+    }
+  }
+
+  /** Sink-only peer: the id-bearing {@code secret} field is unmatched and captured by id. */
+  public static class DownstreamTaggedSink {
+    public ForyExtraFields extraFields;
+  }
+
+  @Test(dataProvider = "config")
+  public void taggedFieldCapturedAndLookedUpById(boolean codegen, boolean refTracking) {
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamTagged original = new UpstreamTagged(123);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamTaggedSink intermediate = foryB.deserialize(aToBBytes, DownstreamTaggedSink.class);
+    assertNotNull(intermediate.extraFields);
+
+    // Keyed by the field id, not by a name: the field carried no name on the wire.
+    ForyExtraFields.FieldIdentity byId = ForyExtraFields.FieldIdentity.ofId(7);
+    assertTrue(intermediate.extraFields.containsKey(byId));
+    assertEquals(intermediate.extraFields.get(byId), 123);
+    assertFalse(intermediate.extraFields.containsKey(identity(UpstreamTagged.class, "secret")));
+    assertFalse(intermediate.extraFields.containsKey(identity(UpstreamTagged.class, "$tag7")));
+
+    // Round-trips back to a full-schema peer under the remote (id-bearing) schema.
+    byte[] bToCBytes = foryB.serialize(intermediate);
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamTagged recovered = foryC.deserialize(bToCBytes, UpstreamTagged.class);
+    assertEquals(recovered.secret, original.secret);
+  }
+
   @Test(dataProvider = "config")
   public void roundTripInheritedExtraFieldSink(boolean codegen, boolean refTracking) {
     Fory foryA = compatibleFory(codegen, refTracking);
@@ -284,7 +440,7 @@ public class ForyExtraFieldsTest {
 
     assertNotNull(intermediate.extraFields);
 
-    Object captured = intermediate.extraFields.get("address");
+    Object captured = byName(intermediate.extraFields, "address");
     assertNotNull(captured);
     assertTrue(captured instanceof Address);
 
@@ -319,11 +475,11 @@ public class ForyExtraFieldsTest {
 
     assertNotNull(intermediate.extraFields);
 
-    Object capturedAge = intermediate.extraFields.get("age");
+    Object capturedAge = byName(intermediate.extraFields, "age");
     assertNotNull(capturedAge);
     assertEquals(capturedAge, 30);
 
-    Object capturedAddress = intermediate.extraFields.get("address");
+    Object capturedAddress = byName(intermediate.extraFields, "address");
     assertNotNull(capturedAddress);
     assertTrue(capturedAddress instanceof Address);
 
@@ -359,7 +515,7 @@ public class ForyExtraFieldsTest {
     assertEquals(intermediate.age, original.age);
     assertNotNull(intermediate.extraFields);
 
-    Object captured = intermediate.extraFields.get("address");
+    Object captured = byName(intermediate.extraFields, "address");
     assertNotNull(captured);
     assertTrue(captured instanceof Address);
 
@@ -395,8 +551,8 @@ public class ForyExtraFieldsTest {
 
     assertNotNull(intermediate.extraFields);
 
-    Object capturedHome = intermediate.extraFields.get("home");
-    Object capturedWork = intermediate.extraFields.get("work");
+    Object capturedHome = byName(intermediate.extraFields, "home");
+    Object capturedWork = byName(intermediate.extraFields, "work");
 
     assertNotNull(capturedHome);
     assertNotNull(capturedWork);
@@ -421,6 +577,36 @@ public class ForyExtraFieldsTest {
    *     generated serializer ({@code CompatibleCodecBuilder}).
    * @param refTracking whether reference tracking is enabled on the built {@link Fory}.
    */
+  /** Builds a name-based field identity for sink lookups: {@code (declaringClass, name)}. */
+  private static ForyExtraFields.FieldIdentity identity(Class<?> declaringClass, String name) {
+    return ForyExtraFields.FieldIdentity.of(declaringClass.getName(), name);
+  }
+
+  /**
+   * Resolves a captured value by remote field name through the public identity API. The declaring
+   * class of a captured field is the deserialization target for root-class fields, so tests that
+   * only care about the value look up by name instead of hardcoding that mapping. Returns {@code
+   * null} when no such field was captured, mirroring the old name-based {@code get}.
+   */
+  private static Object byName(ForyExtraFields extra, String name) {
+    for (ForyExtraFields.FieldIdentity id : extra.fieldIdentities()) {
+      if (name.equals(id.getName())) {
+        return extra.get(id);
+      }
+    }
+    return null;
+  }
+
+  /** Whether a field with the given remote name was captured. */
+  private static boolean hasName(ForyExtraFields extra, String name) {
+    for (ForyExtraFields.FieldIdentity id : extra.fieldIdentities()) {
+      if (name.equals(id.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static Fory compatibleFory(boolean codegen, boolean refTracking) {
     return Fory.builder()
         .withXlang(false)
@@ -490,7 +676,7 @@ public class ForyExtraFieldsTest {
 
     assertNotNull(result.extraFields);
 
-    Object value = result.extraFields.get("f9");
+    Object value = byName(result.extraFields, "f9");
 
     // primitive int stored inside Object becomes Integer
     assertTrue(value instanceof Integer);
@@ -525,7 +711,7 @@ public class ForyExtraFieldsTest {
 
     // B captured f9
     assertNotNull(intermediate.extraFields);
-    assertEquals(intermediate.extraFields.get("f9"), original.f9);
+    assertEquals(byName(intermediate.extraFields, "f9"), original.f9);
 
     // B re-serializes — must emit the remote (full) TypeDef + all 10 fields
     byte[] bToCBytes = foryB.serialize(intermediate);
@@ -543,6 +729,76 @@ public class ForyExtraFieldsTest {
     assertEquals(recovered.f6, original.f6);
     assertEquals(recovered.f7, original.f7);
     assertEquals(recovered.f8, original.f8);
+    assertEquals(recovered.f9, original.f9);
+  }
+
+  /** Capture must bind the remote TypeDef to the existing instance too. */
+  @Test(dataProvider = "config")
+  public void roundTripRecoversFieldWithPreInitializedSink(boolean codegen, boolean refTracking) {
+    // --- A: full-schema writer ---
+    Fory foryA = compatibleFory(codegen, refTracking);
+    Upstream original = new Upstream(300);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // --- B: partial-schema peer whose sink is pre-initialized by a field initializer ---
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamPreInitSink intermediate = foryB.deserialize(aToBBytes, DownstreamPreInitSink.class);
+
+    // The pre-initialized sink captured f9...
+    assertNotNull(intermediate.extraFields);
+    assertEquals(byName(intermediate.extraFields, "f9"), original.f9);
+    // ...and the remote TypeDef must be bound to it even though it was never framework-allocated,
+    // otherwise replay is silently skipped below.
+    assertNotNull(
+        ForyExtraFieldsSupport.getTypeDef(intermediate.extraFields),
+        "remote TypeDef must be bound to a pre-initialized sink so replay can fire");
+
+    // B re-serializes — replay must fire, emitting the remote (full) schema + f9.
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    // --- C: full-schema receiver must recover f9 (dropped before the fix) ---
+    Fory foryC = compatibleFory(codegen, refTracking);
+    Upstream recovered = foryC.deserialize(bToCBytes, Upstream.class);
+    assertEquals(recovered.f9, original.f9);
+  }
+
+  // -------------------------------------------------------------------------
+  // Sink accessor must survive TypeInfo.copy() from numeric-id registration
+  // -------------------------------------------------------------------------
+
+  /**
+   * Regression: {@code TypeInfo.copy(...)} (used by numeric class-id registration) must preserve
+   * the resolved extra-fields sink accessor. If the serializer is materialized first — which
+   * resolves and caches the accessor via {@code setSerializer(resolver, ...)} — and a numeric class
+   * id is registered afterwards, the copied {@code TypeInfo} keeps the serializer but must not drop
+   * the accessor. Otherwise {@code hasExtraFieldsSink()} becomes false on the cached TypeInfo and
+   * the write path silently skips replay, losing the captured remote field.
+   */
+  @Test(dataProvider = "config")
+  public void sinkAccessorSurvivesNumericIdRegistration(boolean codegen, boolean refTracking) {
+    // --- A: full-schema writer ---
+    Fory foryA = compatibleFory(codegen, refTracking);
+    Upstream original = new Upstream(400);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // --- B: partial-schema peer with sink ---
+    Fory foryB = compatibleFory(codegen, refTracking);
+    // Materialize the serializer first: this resolves and caches the sink accessor on the TypeInfo.
+    foryB.getTypeResolver().getSerializer(DownstreamWithSink.class);
+    // Then register a numeric class id, which copies the TypeInfo. The copy must carry the
+    // accessor.
+    foryB.register(DownstreamWithSink.class, 500);
+
+    DownstreamWithSink intermediate = foryB.deserialize(aToBBytes, DownstreamWithSink.class);
+    assertNotNull(intermediate.extraFields);
+    assertEquals(byName(intermediate.extraFields, "f9"), original.f9);
+
+    // B re-serializes — replay must still fire, so the remote (full) schema + f9 are emitted.
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    // --- C: full-schema receiver must recover f9 ---
+    Fory foryC = compatibleFory(codegen, refTracking);
+    Upstream recovered = foryC.deserialize(bToCBytes, Upstream.class);
     assertEquals(recovered.f9, original.f9);
   }
 
@@ -564,8 +820,8 @@ public class ForyExtraFieldsTest {
     assertEquals(result.value, original.value);
     assertNotNull(result.extraFields);
 
-    Object capturedShared = result.extraFields.get("shared");
-    Object capturedAlias = result.extraFields.get("alias");
+    Object capturedShared = byName(result.extraFields, "shared");
+    Object capturedAlias = byName(result.extraFields, "alias");
     assertNotNull(capturedShared);
     assertSame(capturedShared, capturedAlias);
   }
@@ -584,8 +840,8 @@ public class ForyExtraFieldsTest {
     DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
     assertEquals(intermediate.age, original.age);
     assertNotNull(intermediate.extraFields);
-    assertEquals(intermediate.extraFields.get("name"), original.name);
-    assertEquals(((Number) intermediate.extraFields.get("score")).intValue(), original.score);
+    assertEquals(byName(intermediate.extraFields, "name"), original.name);
+    assertEquals(((Number) byName(intermediate.extraFields, "score")).intValue(), original.score);
 
     byte[] bToCBytes = foryB.serialize(intermediate);
 
@@ -594,6 +850,89 @@ public class ForyExtraFieldsTest {
     assertEquals(recovered.age, original.age);
     assertEquals(recovered.name, original.name);
     assertEquals(recovered.score, original.score);
+  }
+
+  // -------------------------------------------------------------------------
+  // Converted field + extra field replayed together
+  //
+  // A compatible scalar conversion (remote int score -> local long score) yields
+  // a descriptor with a fieldConverter but NO fieldAccessor / no local Field. It
+  // is a MATCHED field, reached through the converter, not an unmatched/extra one.
+  // The replay (write) path only runs when the sink is non-empty, so we pair the
+  // converted score with an extra field to populate the sink.
+  //
+  // This test is
+  // pinned to refTracking=true (via configRefTracking) rather than the full config
+  // matrix: a BigDecimal-sourced converter field would be the natural third case here,
+  // but BigDecimal is ref-tracked by default while its convertible local targets
+  // (int/long/String) are primitive-family types that can never carry ref-tracking, so
+  // that combination is schema-incompatible independent of this feature (see
+  // FieldConverters#isRefTrackedScalarSchemaMismatch).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Remote/full schema. {@code score} (int) and {@code level} (boxed Integer) both become converter
+   * fields downstream.
+   */
+  public static class UpstreamConverted {
+    public int age;
+    public int score; // remote int -> local long: becomes a converter field downstream
+    public Integer level; // remote Integer -> local Long: non-batched converter field
+    public int bonus; // unmatched downstream -> captured into the sink
+
+    public UpstreamConverted() {}
+
+    public UpstreamConverted(int age, int score, Integer level, int bonus) {
+      this.age = age;
+      this.score = score;
+      this.level = level;
+      this.bonus = bonus;
+    }
+  }
+
+  /** Local peer: {@code long score} forces a scalar converter; {@code bonus} lands in the sink. */
+  public static class DownstreamConvertedSink {
+    public int age;
+    public long score; // remote int -> local long: converter field (no local Field on the remote
+    // descriptor)
+    public Long level; // remote Integer -> local Long: non-batched converter field
+    public ForyExtraFields extraFields;
+  }
+
+  @Test(dataProvider = "configRefTracking")
+  public void roundTripConvertedFieldWithExtraField(boolean codegen, boolean refTracking) {
+    // --- A: full schema, int score + an extra bonus field ---
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamConverted original = new UpstreamConverted(30, 95, 12, 7);
+    byte[] aToBBytes = foryA.serialize(original);
+
+    // --- B: converts score int->long, captures bonus into the (now non-empty) sink ---
+    Fory foryB = compatibleFory(codegen, refTracking);
+    DownstreamConvertedSink intermediate =
+        foryB.deserialize(aToBBytes, DownstreamConvertedSink.class);
+    assertEquals(intermediate.age, original.age);
+    assertEquals(intermediate.score, (long) original.score); // widened via converter
+    assertEquals(intermediate.level, Long.valueOf(original.level)); // boxed converter field
+    assertNotNull(intermediate.extraFields);
+    assertEquals(((Number) byName(intermediate.extraFields, "bonus")).intValue(), original.bonus);
+    // score/level are matched (converter) fields, but under Option A their untouched remote-typed
+    // values are ALSO preserved in the sink (not just the locally converted value), so replay can
+    // emit the exact original bytes rather than re-deriving them from the (possibly lossy) local
+    // value.
+    assertEquals(((Number) byName(intermediate.extraFields, "score")).intValue(), original.score);
+    assertEquals(
+        ((Number) byName(intermediate.extraFields, "level")).intValue(), (int) original.level);
+
+    // --- B re-serializes: the converter fields must replay under the remote schema ---
+    byte[] bToCBytes = foryB.serialize(intermediate);
+
+    // --- C: full-schema peer must recover every field, including the converted ones ---
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamConverted recovered = foryC.deserialize(bToCBytes, UpstreamConverted.class);
+    assertEquals(recovered.age, original.age);
+    assertEquals(recovered.score, original.score);
+    assertEquals(recovered.level, original.level);
+    assertEquals(recovered.bonus, original.bonus);
   }
 
   // -------------------------------------------------------------------------
@@ -611,8 +950,8 @@ public class ForyExtraFieldsTest {
     DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
     assertEquals(intermediate.age, original.age);
     assertNotNull(intermediate.extraFields);
-    assertTrue(intermediate.extraFields.containsKey("name"));
-    assertNull(intermediate.extraFields.get("name"));
+    assertTrue(hasName(intermediate.extraFields, "name"));
+    assertNull(byName(intermediate.extraFields, "name"));
 
     byte[] bToCBytes = foryB.serialize(intermediate);
 
@@ -650,8 +989,8 @@ public class ForyExtraFieldsTest {
     assertEquals(c.age, original.age);
     assertEquals(c.name, original.name);
     assertNotNull(c.extraFields);
-    assertEquals(((Number) c.extraFields.get("score")).intValue(), original.score);
-    assertNull(c.extraFields.get("name")); // name is matched, not captured
+    assertEquals(((Number) byName(c.extraFields, "score")).intValue(), original.score);
+    assertNull(byName(c.extraFields, "name")); // name is matched, not captured
 
     byte[] cToDBytes = foryC.serialize(c);
 
@@ -748,7 +1087,7 @@ public class ForyExtraFieldsTest {
     Fory foryB = compatibleFory(codegen, refTracking);
     DownstreamWithSink intermediate = foryB.deserialize(aToBBytes, DownstreamWithSink.class);
     assertNotNull(intermediate.extraFields);
-    assertEquals(intermediate.extraFields.get("f9"), original.f9);
+    assertEquals(byName(intermediate.extraFields, "f9"), original.f9);
 
     // wrapper.writeReplace() substitutes `intermediate` (a different runtime type), forcing
     // ReplaceResolveSerializer down the REPLACED_NEW_TYPE branch, which calls
@@ -850,15 +1189,94 @@ public class ForyExtraFieldsTest {
   }
 
   // -------------------------------------------------------------------------
+  // Generated-code gating: the replay branch is native compatible mode only,
+  // so xlang/same-schema write codegen stays byte-for-byte as before. We assert
+  // on the generated write code for a class whose non-final field is sink-bearing
+  // (DownstreamOuterNoSink.nested -> NestedPartialSink), since the tryWriteExtraFieldsSchema
+  // call is emitted by the field's writer, not by the sink class's own serializer.
+  // -------------------------------------------------------------------------
+
+  private static String writeCode(Class<?> cls, boolean compatible) {
+    Fory fory =
+        Fory.builder()
+            .withXlang(false)
+            .withCompatible(compatible)
+            .requireClassRegistration(false)
+            .withCodegen(true)
+            .build();
+    return new ObjectCodecBuilder(cls, fory).genCode();
+  }
+
+  /**
+   * Positive counterpart to {@link #extraFieldsBranchAbsentInSameSchema}: in native compatible mode
+   * the generated writer for a sink-bearing field must still emit the replay branch. Guards against
+   * the config gate over-reaching and silently disabling the feature.
+   */
+  @Test
+  public void extraFieldsBranchPresentInCompatibleMode() {
+    String code = writeCode(DownstreamOuterNoSink.class, true);
+    assertTrue(code.contains("tryWriteExtraFieldsSchema"), code);
+  }
+
+  /**
+   * The replay branch is native compatible mode only. Under same-schema mode the same class must
+   * generate write code with no sink check and no replay call, so the hot path is unchanged.
+   */
+  @Test
+  public void extraFieldsBranchAbsentInSameSchema() {
+    String code = writeCode(DownstreamOuterNoSink.class, false);
+    assertFalse(code.contains("tryWriteExtraFieldsSchema"), code);
+    assertFalse(code.contains("hasExtraFieldsSink"), code);
+  }
+
+  // -------------------------------------------------------------------------
+  // Sink is a framework field, not a data field: it must be excluded from the
+  // owner's local schema. Otherwise a fresh (non-replay) sink-bearing object
+  // exposes `extraFields` in its local TypeDef and writes the sink out as an
+  // ordinary nested object instead of it being reserved for remote-schema replay.
+  // -------------------------------------------------------------------------
+
+  private static boolean localTypeDefContainsField(Class<?> cls, String fieldName) {
+    Fory fory = compatibleFory(false, false);
+    TypeDef typeDef = TypeDef.buildTypeDef(fory.getTypeResolver(), cls);
+    for (FieldInfo fieldInfo : typeDef.getFieldsInfo()) {
+      if (fieldName.equals(fieldInfo.getFieldName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  public void sinkFieldAbsentFromLocalTypeDef() {
+    assertTrue(
+        localTypeDefContainsField(DownstreamWithSink.class, "f0"),
+        "data field f0 should be in the local TypeDef");
+    assertFalse(
+        localTypeDefContainsField(DownstreamWithSink.class, "extraFields"),
+        "sink field extraFields must be excluded from the local TypeDef");
+  }
+
+  @Test
+  public void inheritedSinkFieldAbsentFromLocalTypeDef() {
+    // The selected sink may be declared on a superclass; it must still be excluded.
+    assertFalse(
+        localTypeDefContainsField(DownstreamInheritedSink.class, "extraFields"),
+        "inherited sink field extraFields must be excluded from the local TypeDef");
+  }
+
+  // -------------------------------------------------------------------------
   // async compilation — interpreter bootstraps, JIT takes over
   // -------------------------------------------------------------------------
 
   /**
-   * Exercises the interpreter→JIT handoff. Under async compilation the first serialize uses the
-   * interpreter {@code write()}; once compilation completes the serializer is swapped for a {@link
-   * Generated} one. We wait deterministically for that swap and assert the second serialize
-   * genuinely ran through the generated path — then confirm both wire outputs replay the captured
-   * field correctly.
+   * Exercises the interpreter→JIT handoff on the replay path. The captured extra fields are
+   * re-emitted through the serializer stored in {@code extraFieldsSerializers} (see {@link
+   * org.apache.fory.context.WriteContext} replay), which is a cache distinct from the normal {@link
+   * TypeInfo} serializer. Under async compilation the interpreter registers that entry first and
+   * the generated serializer must supersede it once compilation completes. We poll and assert on
+   * that replay owner directly — then confirm both wire outputs replay the captured field
+   * correctly.
    */
   @Test(timeOut = 30000)
   public void roundTripAfterJitCompilation() throws InterruptedException {
@@ -878,14 +1296,22 @@ public class ForyExtraFieldsTest {
     DownstreamMixedSink intermediate = foryB.deserialize(aToBBytes, DownstreamMixedSink.class);
     assertNotNull(intermediate.extraFields);
 
-    // First serialize triggers async JIT and runs through the interpreter write path.
+    TypeResolver resolverB = foryB.getTypeResolver();
+    // The remote schema id the fields were captured under; the replay cache is keyed by it.
+    long remoteTypeDefId = ForyExtraFieldsSupport.getTypeDef(intermediate.extraFields).getId();
+
+    // First serialize triggers async JIT; the captured fields replay through the interpreter entry.
     byte[] fromInterpreter = foryB.serialize(intermediate);
 
-    // Wait for the generated serializer to be swapped in, then serialize via the compiled path.
-    while (!(foryB.getTypeResolver().getSerializer(DownstreamMixedSink.class)
+    // Wait for the generated serializer to supersede the interpreter in the replay cache — the
+    // actual owner used to re-emit the captured fields, then serialize via the compiled path.
+    while (!(resolverB.getExtraFieldsWriteSerializer(DownstreamMixedSink.class, remoteTypeDefId)
         instanceof Generated)) {
       Thread.sleep(10);
     }
+    assertTrue(
+        resolverB.getExtraFieldsWriteSerializer(DownstreamMixedSink.class, remoteTypeDefId)
+            instanceof Generated);
     byte[] fromJit = foryB.serialize(intermediate);
 
     // Both wire outputs must recover all three fields on a full-schema peer.
@@ -896,6 +1322,187 @@ public class ForyExtraFieldsTest {
       assertEquals(recovered.name, original.name);
       assertEquals(recovered.score, original.score);
     }
+  }
+
+  @Test(dataProvider = "config")
+  public void unknownStructHeaderDoesNotCorruptForwardedStream(boolean codegen, boolean refTracking)
+      throws Exception {
+    Fory foryA = compatibleFory(codegen, refTracking);
+    UpstreamMixed original = new UpstreamMixed(40, "Carol", 77);
+    byte[] aToB = foryA.serialize(original);
+
+    Fory foryB =
+        Fory.builder()
+            .withXlang(false)
+            .withRefTracking(refTracking)
+            .withCompatible(true)
+            .requireClassRegistration(false)
+            .withCodegen(codegen)
+            .withDeserializeUnknownClass(true)
+            .build();
+    DownstreamMixedSink intermediate = foryB.deserialize(aToB, DownstreamMixedSink.class);
+    assertNotNull(intermediate.extraFields);
+    long sinkTypeDefId = ForyExtraFieldsSupport.getTypeDef(intermediate.extraFields).getId();
+
+    // A class genuinely unknown to foryB, so foryB reads it as an UnknownStruct with a real
+    // TypeInfo cached under its own TypeDef id
+    String pkg = "org.apache.fory.serializer.extrafields.gen";
+    String className = "TrulyUnknownPeer";
+    Class<?> unknownClass =
+        ClassUtils.loadClass(
+            pkg,
+            className,
+            "package " + pkg + ";\npublic class " + className + " { public int x = 1; }");
+    byte[] unknownBytes = foryA.serialize(unknownClass.getConstructor().newInstance());
+    UnknownClass.UnknownStruct unknownStruct =
+        (UnknownClass.UnknownStruct) foryB.deserialize(unknownBytes);
+
+    TypeResolver resolverB = foryB.getTypeResolver();
+    TypeInfo unknownHeaderTypeInfo =
+        resolverB.getTypeInfoByTypeDefId(unknownStruct.typeDef.getId());
+    assertNotNull(unknownHeaderTypeInfo);
+    assertEquals(unknownHeaderTypeInfo.getType(), UnknownClass.UnknownStruct.class);
+    assertEquals(unknownHeaderTypeInfo.getTypeId(), ClassResolver.NONEXISTENT_META_SHARED_ID);
+
+    Object extRegistry = ReflectionUtils.getObjectFieldValue(resolverB, "extRegistry");
+    @SuppressWarnings("unchecked")
+    LongMap<TypeInfo> typeInfoByTypeDefId =
+        (LongMap<TypeInfo>) ReflectionUtils.getObjectFieldValue(extRegistry, "typeInfoByTypeDefId");
+    typeInfoByTypeDefId.put(sinkTypeDefId, unknownHeaderTypeInfo);
+
+    byte[] bToC = foryB.serialize(intermediate);
+
+    Fory foryC = compatibleFory(codegen, refTracking);
+    UpstreamMixed recovered = foryC.deserialize(bToC, UpstreamMixed.class);
+    assertEquals(recovered.age, 40);
+    assertEquals(recovered.name, "Carol");
+    assertEquals(recovered.score, 77);
+  }
+
+  /** Holds two polymorphic elements so both go through the replay-checked writeRef path. */
+  public static class SinkContainer {
+    public Object first;
+    public Object second;
+
+    public SinkContainer() {}
+
+    public SinkContainer(Object first, Object second) {
+      this.first = first;
+      this.second = second;
+    }
+  }
+
+  /**
+   * Two remote *versions of the same class* (same fully-qualified name, different schemas) captured
+   * into one sink class and forwarded together in a single root graph. Each carries its own remote
+   * {@link TypeDef} id, but both share the one local sink class, so meta-share must key by the
+   * checked TypeDef identity so each version emits its own schema header.
+   */
+  @Test(dataProvider = "config")
+  public void twoRemoteVersionsOfSameClassForwardedInOneGraph(boolean codegen, boolean refTracking)
+      throws Exception {
+    String pkg = "org.apache.fory.serializer.extrafields.gen";
+    String className = "EvolvingMember";
+    Class<?> scoreVersion =
+        ClassUtils.loadClass(
+            pkg,
+            className,
+            "package "
+                + pkg
+                + ";\n"
+                + "public class "
+                + className
+                + " {\n"
+                + "  public int age;\n"
+                + "  public int score;\n"
+                + "  public "
+                + className
+                + "() {}\n"
+                + "  public "
+                + className
+                + "(int age, int score) { this.age = age; this.score = score; }\n"
+                + "}");
+    Class<?> levelVersion =
+        ClassUtils.loadClass(
+            pkg,
+            className,
+            "package "
+                + pkg
+                + ";\n"
+                + "public class "
+                + className
+                + " {\n"
+                + "  public int age;\n"
+                + "  public int level;\n"
+                + "  public "
+                + className
+                + "() {}\n"
+                + "  public "
+                + className
+                + "(int age, int level) { this.age = age; this.level = level; }\n"
+                + "}");
+    Class<?> sinkVersion =
+        ClassUtils.loadClass(
+            pkg,
+            className,
+            "package "
+                + pkg
+                + ";\n"
+                + "import org.apache.fory.serializer.ForyExtraFields;\n"
+                + "public class "
+                + className
+                + " {\n"
+                + "  public int age;\n"
+                + "  public ForyExtraFields extraFields;\n"
+                + "}");
+
+    Fory foryScore = compatibleFory(codegen, refTracking);
+    byte[] scoreBytes =
+        foryScore.serialize(scoreVersion.getConstructor(int.class, int.class).newInstance(30, 95));
+
+    Fory foryLevel = compatibleFory(codegen, refTracking);
+    byte[] levelBytes =
+        foryLevel.serialize(levelVersion.getConstructor(int.class, int.class).newInstance(25, 5));
+
+    Fory foryB =
+        Fory.builder()
+            .withXlang(false)
+            .withRefTracking(refTracking)
+            .withCompatible(true)
+            .requireClassRegistration(false)
+            .withCodegen(codegen)
+            .withClassLoader(sinkVersion.getClassLoader())
+            .build();
+    Object fromScore = foryB.deserialize(scoreBytes);
+    Object fromLevel = foryB.deserialize(levelBytes);
+    assertSame(fromScore.getClass(), sinkVersion);
+    assertSame(fromLevel.getClass(), sinkVersion);
+
+    ForyExtraFields scoreExtra =
+        (ForyExtraFields) ReflectionUtils.getObjectFieldValue(fromScore, "extraFields");
+    ForyExtraFields levelExtra =
+        (ForyExtraFields) ReflectionUtils.getObjectFieldValue(fromLevel, "extraFields");
+    assertNotNull(scoreExtra);
+    assertNotNull(levelExtra);
+    assertNotEquals(
+        scoreExtra.getTypeDef().getId(),
+        levelExtra.getTypeDef().getId(),
+        "the two remote versions must have distinct TypeDef ids");
+
+    // Both captured objects forwarded together in ONE root graph.
+    byte[] forwarded = foryB.serialize(new SinkContainer(fromScore, fromLevel));
+
+    SinkContainer recovered = (SinkContainer) foryB.deserialize(forwarded);
+    ForyExtraFields recoveredScore =
+        (ForyExtraFields) ReflectionUtils.getObjectFieldValue(recovered.first, "extraFields");
+    ForyExtraFields recoveredLevel =
+        (ForyExtraFields) ReflectionUtils.getObjectFieldValue(recovered.second, "extraFields");
+
+    // Each element must round-trip under its OWN remote schema: no cross-wiring, no reader drift.
+    assertEquals(byName(recoveredScore, "score"), 95);
+    assertFalse(hasName(recoveredScore, "level"));
+    assertEquals(byName(recoveredLevel, "level"), 5);
+    assertFalse(hasName(recoveredLevel, "score"));
   }
 
   public static class OuterFull {
@@ -985,7 +1592,7 @@ public class ForyExtraFieldsTest {
     assertEquals(intermediate.middle.inner.f0, original.middle.inner.f0);
 
     assertNotNull(intermediate.middle.inner.extraFields);
-    assertEquals(intermediate.middle.inner.extraFields.get("f1"), original.middle.inner.f1);
+    assertEquals(byName(intermediate.middle.inner.extraFields, "f1"), original.middle.inner.f1);
 
     byte[] bToCBytes = foryB.serialize(intermediate);
 
@@ -1064,12 +1671,12 @@ public class ForyExtraFieldsTest {
     assertNotNull(intermediate.left);
     assertEquals(intermediate.left.f0, left.f0);
     assertNotNull(intermediate.left.extraFields);
-    assertEquals(intermediate.left.extraFields.get("f1"), left.f1);
+    assertEquals(byName(intermediate.left.extraFields, "f1"), left.f1);
 
     assertNotNull(intermediate.right);
     assertEquals(intermediate.right.f0, right.f0);
     assertNotNull(intermediate.right.extraFields);
-    assertEquals(intermediate.right.extraFields.get("f1"), right.f1);
+    assertEquals(byName(intermediate.right.extraFields, "f1"), right.f1);
 
     byte[] bToCBytes = foryB.serialize(intermediate);
 
@@ -1085,5 +1692,37 @@ public class ForyExtraFieldsTest {
     assertNotNull(recovered.right);
     assertEquals(recovered.right.f0, right.f0);
     assertEquals(recovered.right.f1, right.f1);
+  }
+
+  @Test
+  public void noExtraFieldsBranchWhenFeatureInactive() {
+    Fory fory = Fory.builder().withCompatible(false).withCodegen(true).build();
+    String code = new ObjectCodecBuilder(Upstream.class, fory).genCode();
+    assertTrue(!code.contains("tryWriteExtraFieldsSchema"));
+    assertTrue(!code.contains("hasExtraFieldsSink"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Static ForyExtraFields fields must be ignored during sink discovery
+  // -------------------------------------------------------------------------
+
+  public static class StaticSinkOnly {
+    public static final ForyExtraFields SHARED = new ForyExtraFields();
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+  }
+
+  public static class StaticAndInstanceSink {
+    public static final ForyExtraFields SHARED = new ForyExtraFields();
+    public int f0, f1, f2, f3, f4, f5, f6, f7, f8;
+    public ForyExtraFields extraFields;
+  }
+
+  @Test
+  public void staticSinkFieldIgnoredByDiscovery() {
+    // A lone static field is not a sink.
+    assertNull(ForyExtraFieldsSupport.findSinkAccessor(StaticSinkOnly.class));
+    assertEquals(
+        ForyExtraFieldsSupport.findSinkAccessor(StaticAndInstanceSink.class).getField().getName(),
+        "extraFields");
   }
 }

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/GraphMemoryBudgetTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/GraphMemoryBudgetTest.java
@@ -21,6 +21,7 @@ package org.apache.fory.serializer;
 
 import static org.apache.fory.io.ForyStreamReader.of;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
@@ -257,6 +258,79 @@ public class GraphMemoryBudgetTest extends ForyTestBase {
           () -> fory.getSerializer(ArrayList.class).read(readContext));
     } finally {
       readContext.reset();
+    }
+  }
+
+  private static Fory compatibleFory(long maxGraphMemoryBytes, boolean codegen) {
+    return Fory.builder()
+        .withXlang(false)
+        .withCompatible(true)
+        .requireClassRegistration(false)
+        .suppressClassRegistrationWarnings(true)
+        .withMaxGraphMemoryBytes(maxGraphMemoryBytes)
+        .withCodegen(codegen)
+        .build();
+  }
+
+  public static class BudgetUpstream {
+    public int kept;
+    public int e0;
+    public int e1;
+    public int e2;
+
+    public BudgetUpstream() {}
+
+    public BudgetUpstream(int base) {
+      kept = base;
+      e0 = base + 1;
+      e1 = base + 2;
+      e2 = base + 3;
+    }
+  }
+
+  public static class BudgetSinkDownstream {
+    public int kept;
+    public ForyExtraFields extraFields;
+
+    public BudgetSinkDownstream() {}
+  }
+
+  /**
+   * The compatible-mode extra-fields sink retains new owners (a {@link ForyExtraFields}, its
+   * backing HashMap, and one map entry per captured field). {@code ForyExtraFieldsSupport.capture}
+   * must charge those owners to the graph-memory budget before allocating, on both the interpreter
+   * and generated read paths, so untrusted input cannot spawn many partial objects and grow
+   * retained heap past maxGraphMemoryBytes. The exact required budget is (object owner) + (sink+map
+   * owners on first capture) + 3 * (per-entry). The formula is recomputed independently of
+   * ForyExtraFieldsSupport's private constants so this test also guards the accounting itself.
+   */
+  @Test
+  public void testExtraFieldsSinkChargedToGraphBudget() {
+    long sinkOwnerBytes =
+        (long) GraphMemoryEstimates.shallowObjectBytes(ForyExtraFields.class)
+            + GraphMemoryEstimates.shallowObjectBytes(HashMap.class);
+    long perEntryBytes = 2L * REFERENCE_BYTES;
+    long required =
+        GraphMemoryEstimates.shallowObjectBytes(BudgetSinkDownstream.class)
+            + sinkOwnerBytes
+            + 3 * perEntryBytes;
+
+    for (boolean codegen : new boolean[] {false, true}) {
+      byte[] bytes =
+          compatibleFory(DEFAULT_GRAPH_MEMORY_BYTES, codegen).serialize(new BudgetUpstream(100));
+
+      // One byte short of the full budget: first field capture must reject when it tries to reserve
+      // sink cost.
+      assertThrows(
+          InsecureException.class,
+          () ->
+              compatibleFory(required - 1, codegen).deserialize(bytes, BudgetSinkDownstream.class));
+
+      // Exactly the sink cost: capture succeeds and the unmatched fields land in the sink.
+      BudgetSinkDownstream ok =
+          compatibleFory(required, codegen).deserialize(bytes, BudgetSinkDownstream.class);
+      assertEquals(ok.kept, 100, "codegen=" + codegen);
+      assertNotNull(ok.extraFields, "codegen=" + codegen);
     }
   }
 


### PR DESCRIPTION
Adds ForyExtraFields sink, an opt-in mechanism for preserving unmatched remote fields during compatible-mode deserialization and replaying them on re-serialization.
Covers both the  interpreter and generated codepaths,



## Why?
When the upstream and downstream attributes are inconsistent, for example, the upstream is 10 fields, the downstream is not synchronized to update the field attributes, and there are only 9 attributes, then the downstream non-existent attributes will be ignored during deserialization.



## What does this PR do?


This PR adds support for preserving unknown fields during compatible serialization using `ForyExtraFields`.

A class opts in by declaring a `ForyExtraFields` sink. Fields present in the remote schema but not in the local schema are captured in the sink.

Captured fields are replayed using the original remote `TypeDef`, allowing them to be preserved across compatible serialization round trips involving different schemas.

Replay serializers are cached by `(class, TypeDef)`, allowing a local class to replay `ForyExtraFields` captured from multiple remote schemas.

Tests cover both enabled and disabled reference tracking, as well as both `codegen=true` and `codegen=false`.
## Related issues



## AI Contribution Checklist



- [x] Substantial AI assistance was used in this PR: yes
- [x] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [x] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes.


## AI Contribution Checklist

- [x] Substantial AI assistance was used in this PR: yes
- [x] If yes, I included the standardized AI Usage Disclosure block below.
- [x] If yes, I can explain and defend all important changes without AI help.
- [x] If yes, I reviewed AI-assisted code changes line by line before submission.
- [x] If yes, I completed line-by-line self-review first and fixed issues before requesting AI review.
- [x] If yes, I ran two fresh AI review agents on the current PR diff or current HEAD after the latest code changes: one Fory-guided reviewer using AGENTS.md and .agents/ci-and-pr.md, and one independent general reviewer in a separate clean-context review session that was not pointed to .agents/ci-and-pr.md or any copied Fory-specific review checklist. If the independent reviewer's tooling auto-loaded AGENTS.md, it followed the independent-review carve-out there.
- [x] If yes, I addressed all AI review comments and repeated the review loop until both ai reviewers reported no further actionable comments.
- [x] If yes, I attached screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers on the current PR diff or current HEAD after the latest code changes in this PR body.
- [x] If yes, I ran adequate human verification and recorded evidence (checks run locally or in CI, pass/fail summary, and confirmation I reviewed results).
- [x] If yes, I added/updated tests and specs where required.
- [x] If yes, I validated protocol/performance impacts with evidence when applicable.
- [x] If yes, I verified licensing and provenance compliance.

AI Usage Disclosure
- substantial_ai_assistance: yes
- scope: docs, code drafting, tests, design drafting
- affected_files_or_subsystems: 
  - docs/guide/java/extra-fields.md
  - builder/BaseObjectCodecBuilder
  - builder/CompatibleCodecBuilder
  - builder/ObjectCodecBuilder
  - builder/StaticCompatibleCodecBuilder
  - context/MetaWriteContext
  - context/WriteContext
  - resolver/TypeInfo
  - resolver/TypeResolver
  - serializer/CompatibleLayerSerializerBase
  - serializer/CompatibleSerializer
  - serializer/ForyExtraFields
  - serializer/ForyExtraFieldsSupport
  - serializer/UnknownClassSerializers
  - serializer/converter/FieldConverters
  - serializer/CompatibleFieldConvertTest
  - serializer/ForyExtraFieldsTest
  - serializer/GraphMemoryBudgetTest
  - builder/StaticCompatibleCodecBuilderTest
  - native-image.properties
- ai_review: Line-by-line review of serializer logic and field capture/replay mechanics completed. Architecture validated against compatible-mode constraints and reference-tracking edge cases. Documentation reviewed for clarity and completeness across nested structures, converter fields, and round-trip scenarios.
- ai_review_artifacts:https://claude.ai/code/session_01JAyGgABzsVxarBkJ6zq9Tk , https://claude.ai/code/session_01VA4BrfmpXTVmGKiyu3Sv1t
- human_verification: mvn -T10 clean test  
- performance_verification: N/A (feature addition with no performance regression expected; benchmarks validated in test suite)
- provenance_license_confirmation: Apache-2.0-compatible provenance confirmed; no incompatible third-party code introduced

## Does this PR introduce any user-facing change?



- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark



