### PR TITLE
fix(cpp): validate tagged struct field reads

### DIFF
--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -4080,10 +4080,8 @@ FORY_ALWAYS_INLINE FieldType read_configurable_int_at_checked(Buffer &buffer,
       return read_fixed_primitive_at_checked<FieldType>(buffer, offset, error);
     }
     if constexpr (enc == Encoding::Tagged) {
-      if constexpr (is_configurable_int64_v<FieldType>) {
-        return static_cast<FieldType>(
-            read_tagged_int64_at_checked(buffer, offset, error));
-      }
+      return static_cast<FieldType>(
+          read_tagged_int64_at_checked(buffer, offset, error));
     }
     return read_varint_at_checked<FieldType>(buffer, offset, error);
   } else {
@@ -4115,8 +4113,9 @@ FORY_ALWAYS_INLINE T read_primitive_at_checked(Buffer &buffer, uint32_t &offset,
 /// No lambda overhead - direct function call that will be inlined.
 /// Handles both standard varint and tagged encoding based on field config.
 template <typename T, size_t SortedPos>
-FORY_ALWAYS_INLINE void read_single_varint_field(T &obj, Buffer &buffer,
-                                                 uint32_t &offset) {
+FORY_ALWAYS_INLINE bool read_single_varint_field(T &obj, Buffer &buffer,
+                                                 uint32_t &offset,
+                                                 Error &error) {
   using Helpers = CompileTimeFieldHelpers<T>;
   constexpr size_t original_index = Helpers::sorted_indices[SortedPos];
   const auto field_info = fory_field_info(obj);
@@ -4129,8 +4128,19 @@ FORY_ALWAYS_INLINE void read_single_varint_field(T &obj, Buffer &buffer,
 
   FieldType result;
   if constexpr (is_configurable_int_v<FieldType>) {
-    result =
-        read_configurable_int_at<FieldType, T, original_index>(buffer, offset);
+    constexpr Encoding enc = field_int_encoding<FieldType, T, original_index>();
+    if constexpr (enc == Encoding::Tagged) {
+      // Tagged integers issue fixed-width loads, so the local-offset batch must
+      // use the reader that proves the 4-byte or 9-byte range first.
+      result = read_configurable_int_at_checked<FieldType, T, original_index>(
+          buffer, offset, error);
+      if (FORY_PREDICT_FALSE(!error.ok())) {
+        return false;
+      }
+    } else {
+      result = read_configurable_int_at<FieldType, T, original_index>(buffer,
+                                                                      offset);
+    }
   } else {
     result = read_varint_at<FieldType>(buffer, offset);
   }
@@ -4140,19 +4150,23 @@ FORY_ALWAYS_INLINE void read_single_varint_field(T &obj, Buffer &buffer,
   } else {
     obj.*field_ptr = result;
   }
+  return true;
 }
 
 /// Fast read consecutive varint primitive fields (int32, int64).
-/// Caller must ensure buffer bounds are pre-checked for max varint bytes.
+/// Tagged fields use checked local-offset readers; genuine varint helpers
+/// bounds-check their bulk and slow-path loads.
 /// Optimized: tracks offset locally and updates reader_index once at the end.
 /// StartIdx is the sorted index to start reading from.
 template <typename T, size_t StartIdx, size_t... Is>
-FORY_ALWAYS_INLINE void
+FORY_ALWAYS_INLINE bool
 read_varint_primitive_fields(T &obj, Buffer &buffer, uint32_t &offset,
-                             std::index_sequence<Is...>) {
+                             Error &error, std::index_sequence<Is...>) {
   // Read each varint field using helper function - no lambda overhead
   // Is are 0, 1, 2, ... so actual sorted position is StartIdx + Is
-  (read_single_varint_field<T, StartIdx + Is>(obj, buffer, offset), ...);
+  return (
+      read_single_varint_field<T, StartIdx + Is>(obj, buffer, offset, error) &&
+      ...);
 }
 
 /// Helper to read remaining fields starting from Offset
@@ -4199,8 +4213,6 @@ void read_struct_fields_impl(T &obj, ReadContext &ctx,
     }
 
     // Phase 2: Read consecutive varint primitives (int32, int64) if any
-    // Note: varint bounds checking is done per-byte during reading since
-    // varint lengths are variable (actual size << max possible size)
     if constexpr (varint_count > 0) {
       if (FORY_PREDICT_FALSE(buffer.has_input_stream())) {
         // Stream-backed buffers may not have all varint bytes materialized yet.
@@ -4210,10 +4222,11 @@ void read_struct_fields_impl(T &obj, ReadContext &ctx,
       }
       // Track offset locally for batch varint reading
       uint32_t offset = buffer.reader_index();
-      // Fast read varint primitives (bounds checking happens in
-      // get_var_uint32/64)
-      read_varint_primitive_fields<T, fixed_count>(
-          obj, buffer, offset, std::make_index_sequence<varint_count>{});
+      if (FORY_PREDICT_FALSE((!read_varint_primitive_fields<T, fixed_count>(
+              obj, buffer, offset, ctx.error(),
+              std::make_index_sequence<varint_count>{})))) {
+        return;
+      }
       // Update reader_index once after all varints
       buffer.reader_index(offset);
     }
@@ -4265,10 +4278,11 @@ read_struct_fields_impl_fast(T &obj, ReadContext &ctx,
     }
     // Track offset locally for batch varint reading
     uint32_t offset = buffer.reader_index();
-    // Fast read varint primitives (bounds checking happens in
-    // get_var_uint32/64)
-    read_varint_primitive_fields<T, fixed_count>(
-        obj, buffer, offset, std::make_index_sequence<varint_count>{});
+    if (FORY_PREDICT_FALSE((!read_varint_primitive_fields<T, fixed_count>(
+            obj, buffer, offset, ctx.error(),
+            std::make_index_sequence<varint_count>{})))) {
+      return;
+    }
     // Update reader_index once after all varints
     buffer.reader_index(offset);
   }

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -4113,7 +4113,7 @@ FORY_ALWAYS_INLINE T read_primitive_at_checked(Buffer &buffer, uint32_t &offset,
 /// No lambda overhead - direct function call that will be inlined.
 /// Handles both standard varint and tagged encoding based on field config.
 template <typename T, size_t SortedPos>
-FORY_ALWAYS_INLINE bool read_single_varint_field(T &obj, Buffer &buffer,
+FORY_ALWAYS_INLINE void read_single_varint_field(T &obj, Buffer &buffer,
                                                  uint32_t &offset,
                                                  Error &error) {
   using Helpers = CompileTimeFieldHelpers<T>;
@@ -4134,9 +4134,6 @@ FORY_ALWAYS_INLINE bool read_single_varint_field(T &obj, Buffer &buffer,
       // use the reader that proves the 4-byte or 9-byte range first.
       result = read_configurable_int_at_checked<FieldType, T, original_index>(
           buffer, offset, error);
-      if (FORY_PREDICT_FALSE(!error.ok())) {
-        return false;
-      }
     } else {
       result = read_configurable_int_at<FieldType, T, original_index>(buffer,
                                                                       offset);
@@ -4150,7 +4147,6 @@ FORY_ALWAYS_INLINE bool read_single_varint_field(T &obj, Buffer &buffer,
   } else {
     obj.*field_ptr = result;
   }
-  return true;
 }
 
 /// Fast read consecutive varint primitive fields (int32, int64).
@@ -4159,14 +4155,14 @@ FORY_ALWAYS_INLINE bool read_single_varint_field(T &obj, Buffer &buffer,
 /// Optimized: tracks offset locally and updates reader_index once at the end.
 /// StartIdx is the sorted index to start reading from.
 template <typename T, size_t StartIdx, size_t... Is>
-FORY_ALWAYS_INLINE bool
+FORY_ALWAYS_INLINE void
 read_varint_primitive_fields(T &obj, Buffer &buffer, uint32_t &offset,
                              Error &error, std::index_sequence<Is...>) {
   // Read each varint field using helper function - no lambda overhead
   // Is are 0, 1, 2, ... so actual sorted position is StartIdx + Is
-  return (
-      read_single_varint_field<T, StartIdx + Is>(obj, buffer, offset, error) &&
-      ...);
+  // Checked tagged readers set Error without advancing a failed field's
+  // offset. Preserve lazy propagation; the root read boundary observes it.
+  (read_single_varint_field<T, StartIdx + Is>(obj, buffer, offset, error), ...);
 }
 
 /// Helper to read remaining fields starting from Offset
@@ -4222,11 +4218,9 @@ void read_struct_fields_impl(T &obj, ReadContext &ctx,
       }
       // Track offset locally for batch varint reading
       uint32_t offset = buffer.reader_index();
-      if (FORY_PREDICT_FALSE((!read_varint_primitive_fields<T, fixed_count>(
-              obj, buffer, offset, ctx.error(),
-              std::make_index_sequence<varint_count>{})))) {
-        return;
-      }
+      read_varint_primitive_fields<T, fixed_count>(
+          obj, buffer, offset, ctx.error(),
+          std::make_index_sequence<varint_count>{});
       // Update reader_index once after all varints
       buffer.reader_index(offset);
     }
@@ -4278,11 +4272,9 @@ read_struct_fields_impl_fast(T &obj, ReadContext &ctx,
     }
     // Track offset locally for batch varint reading
     uint32_t offset = buffer.reader_index();
-    if (FORY_PREDICT_FALSE((!read_varint_primitive_fields<T, fixed_count>(
-            obj, buffer, offset, ctx.error(),
-            std::make_index_sequence<varint_count>{})))) {
-      return;
-    }
+    read_varint_primitive_fields<T, fixed_count>(
+        obj, buffer, offset, ctx.error(),
+        std::make_index_sequence<varint_count>{});
     // Update reader_index once after all varints
     buffer.reader_index(offset);
   }

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -307,6 +307,18 @@ struct UnsignedEncodingStruct {
               (tagged_u64, fory::F().tagged()));
 };
 
+struct TaggedIntStruct {
+  int64_t value;
+
+  FORY_STRUCT(TaggedIntStruct, (value, fory::F().tagged()));
+};
+
+struct TaggedUintStruct {
+  uint64_t value;
+
+  FORY_STRUCT(TaggedUintStruct, (value, fory::F().tagged()));
+};
+
 // String handling
 struct StringTestStruct {
   std::string empty;
@@ -817,6 +829,45 @@ TEST(StructComprehensiveTest, UnsignedEncodingsRoundTrip) {
       0x0405060708090aULL,
       0x05060708090a0bULL,
   });
+}
+
+TEST(StructComprehensiveTest, TaggedIntTruncationFails) {
+  const bool compatible_modes[] = {false, true};
+  for (bool compatible : compatible_modes) {
+    SCOPED_TRACE(::testing::Message() << "compatible=" << compatible);
+    auto check_truncation = [&](auto original, uint32_t type_id,
+                                const char *kind) {
+      using StructType = decltype(original);
+      SCOPED_TRACE(::testing::Message() << "kind=" << kind);
+      auto fory = Fory::builder()
+                      .xlang(true)
+                      .compatible(compatible)
+                      .track_ref(false)
+                      .build();
+      ASSERT_TRUE(fory.register_struct<StructType>(type_id).ok());
+
+      auto serialized = fory.serialize(original);
+      ASSERT_TRUE(serialized.ok()) << serialized.error().to_string();
+      const std::vector<uint8_t> bytes = std::move(serialized).value();
+      ASSERT_GE(bytes.size(), 9u);
+      ASSERT_EQ(bytes[bytes.size() - 9] & 1u, 1u);
+      ASSERT_TRUE(fory.deserialize<StructType>(bytes).ok());
+
+      for (size_t missing_bytes = 1; missing_bytes <= 9; ++missing_bytes) {
+        SCOPED_TRACE(::testing::Message() << "missing_bytes=" << missing_bytes);
+        std::vector<uint8_t> truncated(bytes.begin(),
+                                       bytes.end() - missing_bytes);
+        auto result =
+            fory.deserialize<StructType>(truncated.data(), truncated.size());
+        ASSERT_FALSE(result.ok());
+        EXPECT_EQ(result.error().code(), ErrorCode::BufferOutOfBound);
+      }
+    };
+    check_truncation(TaggedIntStruct{std::numeric_limits<int64_t>::max()}, 612,
+                     "signed");
+    check_truncation(TaggedUintStruct{std::numeric_limits<uint64_t>::max()},
+                     613, "unsigned");
+  }
 }
 
 TEST(StructComprehensiveTest, UnsignedEncodingFieldMeta) {


### PR DESCRIPTION
## What changed

- route tagged integer fields in the C++ struct batch reader through the checked local-offset decoder
- preserve the existing fast path for ordinary varints
- reject truncated signed and unsigned tagged fields in schema-consistent and exact-compatible modes

## Why

The primitive struct batch reader used unchecked fixed-width loads for tagged integer fields. A truncated input could reach those loads before the declared buffer boundary was validated.

## Validation

- `ENABLE_FORY_DEBUG_OUTPUT=1 bazel test //cpp/fory/serialization:struct_test --test_filter=StructComprehensiveTest.TaggedIntTruncationFails`
- `ENABLE_FORY_DEBUG_OUTPUT=1 bazel test //cpp/fory/serialization:struct_test`
