### PR TITLE
feat(dart): add external-type serialization

### DIFF
--- a/.agents/docs-and-formatting.md
+++ b/.agents/docs-and-formatting.md
@@ -18,11 +18,13 @@ Load this file when changing documentation, public APIs, protocol specs, benchma
 - Update the relevant docs under `docs/` when important public APIs change.
 - Update `docs/specification/**` when protocol behavior changes.
 - Keep examples working and aligned with the current API and protocol behavior.
+- Published guides and specifications describe only the current supported API.
+  Keep migration history, removed API names, and before/after narratives in
+  task-local design records, not in final guides or specifications.
 - Do not use emoji in documentation, including headings, feature lists, status
   tables, callouts, or READMEs. Use plain words such as "Supported" or
   "Unsupported" instead.
 - Provide or update working examples when adding new features or materially changing workflows.
-- Add migration guidance when a change is breaking or materially changes workflow.
 - `docs/DEVELOPMENT.md` plus updates under `docs/guide/` and `docs/benchmarks/` are synced to `apache/fory-site`; other website content should be changed there instead of this repo.
 - When benchmark logic, scripts, config, or compared serializers change, rerun the relevant benchmarks and refresh the report and plots under `docs/benchmarks/**`.
 - Never manually edit generated code for compiler or IDL outputs; regenerate from the source schema or IDL.

--- a/.agents/languages/dart.md
+++ b/.agents/languages/dart.md
@@ -19,6 +19,10 @@ Load this file when changing `dart/`.
   existing resolver, field, carrier, reference, and compatible-read paths. Do
   not add runtime declaration instances, callbacks, member lookup, target-copy
   objects, a second registration API, or a second carrier/root flow.
+- Constructor-based external structural serializers must reject every
+  statically provable reference-tracked path back to the target, including
+  paths through supported list, set, and map type arguments. Do not simulate
+  early publication with placeholders or final-field patching.
 - Keep root numeric wrapper defaults separate from generated field metadata. Root wrapper resolution belongs in the builtin resolver, while annotations and generated metadata choose fixed, tagged, or declared-field encodings.
 - Dart 64-bit carriers are optimized for each platform. Do not replace native extension-type wrappers with allocation-heavy classes or route web/native hot paths through `BigInt` unless the user approves a representation change.
 - In `Buffer`, cursor, serializer, and generated-code hot paths, prefer direct byte/local integer operations and conditional import/export files over callbacks, records, holder objects, wrapper round-trips, or runtime platform branches.

--- a/.agents/languages/dart.md
+++ b/.agents/languages/dart.md
@@ -10,7 +10,15 @@ Load this file when changing `dart/`.
 - Do not design different user-facing generated-registration behavior for Dart VM and Flutter/no-mirrors. Cross-platform registration flow must stay consistent.
 - Users must never be required to call private generated helpers such as `_ensure...` or `_install...`.
 - If `Fory.register(...)` cannot be made self-sufficient across Dart platforms, use an explicit public wrapper API rather than splitting VM and Flutter behavior.
-- Generated registration is ownership-based: generated types register through `Fory.register(...)`, manual or custom serializers use `Fory.registerSerializer(...)`, and generated descriptors/support helpers stay internal.
+- Generated registration is ownership-based: generated types register through `Fory.register(...)`, manual serializers use `Fory.registerSerializer(...)`, and generated descriptors/support helpers stay internal.
+- Dart external-type serialization uses `ForyStruct.target` on an `abstract final`
+  schema declaration. The declaration is compile-time input only; generated
+  serializers, schemas, and module dispatch are parameterized and registered
+  by the target type. Keep ordinary and external structs in one analyzed model
+  and emitter, with direct target getter/constructor/setter code and the
+  existing resolver, field, carrier, reference, and compatible-read paths. Do
+  not add runtime declaration instances, callbacks, member lookup, target-copy
+  objects, a second registration API, or a second carrier/root flow.
 - Keep root numeric wrapper defaults separate from generated field metadata. Root wrapper resolution belongs in the builtin resolver, while annotations and generated metadata choose fixed, tagged, or declared-field encodings.
 - Dart 64-bit carriers are optimized for each platform. Do not replace native extension-type wrappers with allocation-heavy classes or route web/native hot paths through `BigInt` unless the user approves a representation change.
 - In `Buffer`, cursor, serializer, and generated-code hot paths, prefer direct byte/local integer operations and conditional import/export files over callbacks, records, holder objects, wrapper round-trips, or runtime platform branches.

--- a/dart/README.md
+++ b/dart/README.md
@@ -3,7 +3,7 @@
 Apache Fory™ Dart is the Dart xlang implementation for Apache Fory™. It reads and
 writes Fory's cross-language wire format and works in both Dart and Flutter
 applications. Because Flutter prohibits `dart:mirrors`, Fory Dart uses static
-code generation for type handling.
+code generation for annotated models and external structural serializers.
 
 The publishable package lives at `packages/fory/`. See its
 [README](packages/fory/README.md) for the full user-facing documentation
@@ -11,13 +11,14 @@ including getting started, API reference, and code examples.
 
 ## Project Structure
 
-| Directory                        | Description                             |
-| -------------------------------- | --------------------------------------- |
-| `packages/fory/lib/`             | Core implementation and public API      |
-| `packages/fory/lib/src/codegen/` | Build-runner code generator             |
-| `packages/fory/example/`         | Annotated example with generated output |
-| `packages/fory/test/`            | Unit and integration tests              |
-| `test/`                          | Cross-language integration tests        |
+| Directory                             | Description                                         |
+| ------------------------------------- | --------------------------------------------------- |
+| `packages/fory/lib/`                  | Core implementation and public API                  |
+| `packages/fory/lib/src/codegen/`      | Build-runner code generator                         |
+| `packages/fory/example/`              | Annotated example with generated output             |
+| `packages/fory/test/`                 | Unit and integration tests                          |
+| `packages/external-type-test-models/` | Fory-free dependency models for external-type tests |
+| `test/`                               | Cross-language integration tests                    |
 
 ## Type Mapping
 

--- a/dart/packages/external-type-test-models/lib/models.dart
+++ b/dart/packages/external-type-test-models/lib/models.dart
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+library;
+
+import 'dart:typed_data';
+
+final class User {
+  const User({required this.name, required this.age});
+
+  final String name;
+  final int age;
+}
+
+final class Point {
+  const Point(this.x, this.y);
+
+  final int x;
+  final int y;
+}
+
+final class Money {
+  const Money.fromParts({required this.currency, required this.units});
+
+  final String currency;
+  final int units;
+}
+
+final class MutableProfile {
+  MutableProfile();
+
+  String name = '';
+  int score = 0;
+}
+
+final class NamedMutableProfile {
+  NamedMutableProfile.empty();
+
+  String name = '';
+  int score = 0;
+}
+
+class ValueBase<T> {
+  ValueBase({required this.value});
+
+  T value;
+}
+
+final class DerivedValue extends ValueBase<String> {
+  DerivedValue({required super.value, required this.count});
+
+  int count;
+}
+
+final class Box<T> {
+  const Box(this.value);
+
+  final T value;
+}
+
+final class Node {
+  Node.empty();
+
+  String label = '';
+  Node? next;
+}
+
+final class LinkA {
+  LinkA();
+
+  String label = '';
+  LinkB? link;
+}
+
+final class LinkB {
+  LinkB();
+
+  String label = '';
+  LinkA? link;
+}
+
+final class Envelope {
+  Envelope();
+
+  User? user;
+  List<User> users = <User>[];
+  Set<User> userSet = <User>{};
+  Map<String, User> usersByName = <String, User>{};
+  Map<User, String> namesByUser = <User, String>{};
+  List<Map<String, List<User>>> nested = <Map<String, List<User>>>[];
+  Object? value;
+  List<Object?> values = <Object?>[];
+}
+
+final class ScalarValues {
+  const ScalarValues({
+    required this.flag,
+    required this.int8,
+    required this.int16,
+    required this.int32,
+    required this.int64,
+    required this.uint8,
+    required this.uint16,
+    required this.uint32,
+    required this.uint64,
+    required this.float16,
+    required this.bfloat16,
+    required this.float32,
+    required this.float64,
+    required this.text,
+    required this.timestamp,
+    required this.duration,
+    required this.binary,
+  });
+
+  final bool flag;
+  final int int8;
+  final int int16;
+  final int int32;
+  final int int64;
+  final int uint8;
+  final int uint16;
+  final int uint32;
+  final int uint64;
+  final double float16;
+  final double bfloat16;
+  final double float32;
+  final double float64;
+  final String text;
+  final DateTime timestamp;
+  final Duration duration;
+  final Uint8List binary;
+}
+
+final class ContactVersion1 {
+  const ContactVersion1({required this.firstName, this.nickname});
+
+  final String firstName;
+  final String? nickname;
+}
+
+final class ContactVersion2 {
+  const ContactVersion2({required this.fullName, this.nickname, this.email});
+
+  final String? email;
+  final String fullName;
+  final String? nickname;
+}
+
+final class EquivalentUser {
+  const EquivalentUser({required this.name, required this.age});
+
+  final String name;
+  final int age;
+}

--- a/dart/packages/external-type-test-models/pubspec.yaml
+++ b/dart/packages/external-type-test-models/pubspec.yaml
@@ -15,21 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: fory_test
-description: Apache Fory Dart consumer and integration tests
-version: 1.5.0-dev
+name: external_type_test_models
+description: Dependency-owned Dart models used to test external-type serialization.
+version: 1.0.0
+publish_to: none
 
 resolution: workspace
 
 environment:
   sdk: ^3.7.0
-
-dependencies:
-  external_type_test_models: 1.0.0
-  fory: 1.5.0-dev
-
-dev_dependencies:
-  build_runner: '>=2.7.0 <3.0.0'
-  lints: ^6.1.0
-  test: ^1.31.1
-  vm_service: ^15.0.0

--- a/dart/packages/fory-test/README.md
+++ b/dart/packages/fory-test/README.md
@@ -1,4 +1,23 @@
 # Fory Dart Tests
 
-This package exercises the generated registration flow and consumer-side integration for the
-rewritten Dart runtime.
+This package exercises Dart generated serializers, registration, external-type
+serialization, and consumer-side xlang integration.
+
+## External-Type Benchmark
+
+Compile and run the paired ordinary/external throughput benchmark in AOT mode:
+
+```bash
+mkdir -p build
+dart compile exe \
+  -S build/external_type_benchmark.debug \
+  -o build/external_type_benchmark \
+  benchmark/external_type_benchmark.dart
+build/external_type_benchmark
+```
+
+Check equivalent-path object allocations with:
+
+```bash
+dart run benchmark/external_type_benchmark.dart --check-allocations
+```

--- a/dart/packages/fory-test/benchmark/external_type_benchmark.dart
+++ b/dart/packages/fory-test/benchmark/external_type_benchmark.dart
@@ -1,0 +1,559 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:external_type_test_models/models.dart' as third_party;
+import 'package:fory/fory.dart';
+import 'package:fory_test/model/external_serializers.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+Object? _sink;
+
+final class _BenchmarkPair {
+  _BenchmarkPair({
+    required this.name,
+    required this.ordinaryFory,
+    required this.targetFory,
+    required this.ordinaryValue,
+    required this.targetValue,
+  }) : ordinaryBytes = ordinaryFory.serialize(ordinaryValue),
+       targetBytes = targetFory.serialize(targetValue) {
+    if (!_sameBytes(ordinaryBytes, targetBytes)) {
+      throw StateError('$name ordinary and target bytes differ.');
+    }
+  }
+
+  final String name;
+  final Fory ordinaryFory;
+  final Fory targetFory;
+  final Object ordinaryValue;
+  final Object targetValue;
+  final Uint8List ordinaryBytes;
+  final Uint8List targetBytes;
+}
+
+void _registerPair(
+  Fory ordinaryFory,
+  Fory targetFory, {
+  Type? ordinaryHolder,
+  Type? targetHolder,
+}) {
+  ExternalSerializersForyModule.register(
+    ordinaryFory,
+    OrdinaryEquivalentUser,
+    id: 101,
+  );
+  ExternalSerializersForyModule.register(
+    targetFory,
+    third_party.EquivalentUser,
+    id: 101,
+  );
+  if (ordinaryHolder != null && targetHolder != null) {
+    ExternalSerializersForyModule.register(
+      ordinaryFory,
+      ordinaryHolder,
+      id: 102,
+    );
+    ExternalSerializersForyModule.register(targetFory, targetHolder, id: 102);
+  }
+}
+
+_BenchmarkPair _pair({
+  required String name,
+  required Object ordinaryValue,
+  required Object targetValue,
+  Type? ordinaryHolder,
+  Type? targetHolder,
+}) {
+  final ordinaryFory = Fory(compatible: false);
+  final targetFory = Fory(compatible: false);
+  _registerPair(
+    ordinaryFory,
+    targetFory,
+    ordinaryHolder: ordinaryHolder,
+    targetHolder: targetHolder,
+  );
+  return _BenchmarkPair(
+    name: name,
+    ordinaryFory: ordinaryFory,
+    targetFory: targetFory,
+    ordinaryValue: ordinaryValue,
+    targetValue: targetValue,
+  );
+}
+
+List<_BenchmarkPair> _createPairs() {
+  const targetUser = third_party.EquivalentUser(name: 'Ada', age: 36);
+  const ordinaryUser = OrdinaryEquivalentUser(name: 'Ada', age: 36);
+  final targetUsers = List<third_party.EquivalentUser>.filled(
+    32,
+    targetUser,
+    growable: false,
+  );
+  final ordinaryUsers = List<OrdinaryEquivalentUser>.filled(
+    32,
+    ordinaryUser,
+    growable: false,
+  );
+  final targetMap = <String, third_party.EquivalentUser>{
+    for (var index = 0; index < 32; index += 1) 'user$index': targetUser,
+  };
+  final ordinaryMap = <String, OrdinaryEquivalentUser>{
+    for (var index = 0; index < 32; index += 1) 'user$index': ordinaryUser,
+  };
+  return <_BenchmarkPair>[
+    _pair(name: 'root', ordinaryValue: ordinaryUser, targetValue: targetUser),
+    _pair(
+      name: 'direct_field',
+      ordinaryValue: const OrdinaryDirectHolder(ordinaryUser),
+      targetValue: const TargetDirectHolder(targetUser),
+      ordinaryHolder: OrdinaryDirectHolder,
+      targetHolder: TargetDirectHolder,
+    ),
+    _pair(
+      name: 'list_field',
+      ordinaryValue: OrdinaryListHolder(ordinaryUsers),
+      targetValue: TargetListHolder(targetUsers),
+      ordinaryHolder: OrdinaryListHolder,
+      targetHolder: TargetListHolder,
+    ),
+    _pair(
+      name: 'map_field',
+      ordinaryValue: OrdinaryMapHolder(ordinaryMap),
+      targetValue: TargetMapHolder(targetMap),
+      ordinaryHolder: OrdinaryMapHolder,
+      targetHolder: TargetMapHolder,
+    ),
+  ];
+}
+
+bool _sameBytes(Uint8List left, Uint8List right) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index += 1) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+double _measure(Object? Function() action, Duration duration) {
+  final stopwatch = Stopwatch()..start();
+  var operations = 0;
+  do {
+    _sink = action();
+    operations += 1;
+  } while (stopwatch.elapsed < duration);
+  stopwatch.stop();
+  return operations *
+      Duration.microsecondsPerSecond /
+      stopwatch.elapsedMicroseconds;
+}
+
+void _warmUp(
+  Object? Function() ordinary,
+  Object? Function() target,
+  Duration duration,
+) {
+  final half = Duration(microseconds: duration.inMicroseconds ~/ 2);
+  _measure(ordinary, half);
+  _measure(target, half);
+}
+
+double _median(List<double> values) {
+  values.sort();
+  return values[values.length ~/ 2];
+}
+
+bool _runLane({
+  required String name,
+  required Object? Function() ordinary,
+  required Object? Function() target,
+  required int samples,
+  required Duration duration,
+  required Duration warmup,
+  required double threshold,
+}) {
+  _warmUp(ordinary, target, warmup);
+  final deltas = <double>[];
+  for (var sample = 0; sample < samples; sample += 1) {
+    late final double ordinaryOps;
+    late final double targetOps;
+    if (sample.isEven) {
+      ordinaryOps = _measure(ordinary, duration);
+      targetOps = _measure(target, duration);
+    } else {
+      targetOps = _measure(target, duration);
+      ordinaryOps = _measure(ordinary, duration);
+    }
+    final delta = targetOps / ordinaryOps - 1;
+    deltas.add(delta);
+    stdout.writeln(
+      '$name sample=${sample + 1} '
+      'ordinary=${ordinaryOps.toStringAsFixed(0)} '
+      'target=${targetOps.toStringAsFixed(0)} '
+      'delta=${(delta * 100).toStringAsFixed(2)}%',
+    );
+  }
+  final retained = _median(deltas);
+  stdout.writeln(
+    '$name retained_median_delta=${(retained * 100).toStringAsFixed(2)}%',
+  );
+  return retained >= -threshold;
+}
+
+int _readInt(List<String> arguments, String option, int fallback) {
+  final index = arguments.indexOf(option);
+  return index == -1 ? fallback : int.parse(arguments[index + 1]);
+}
+
+double _readDouble(List<String> arguments, String option, double fallback) {
+  final index = arguments.indexOf(option);
+  return index == -1 ? fallback : double.parse(arguments[index + 1]);
+}
+
+String? _readString(List<String> arguments, String option) {
+  final index = arguments.indexOf(option);
+  return index == -1 ? null : arguments[index + 1];
+}
+
+Object? Function() _operation(
+  _BenchmarkPair pair, {
+  required bool target,
+  required bool deserialize,
+}) {
+  if (target) {
+    return deserialize
+        ? () => pair.targetFory.deserialize<Object?>(pair.targetBytes)
+        : () => pair.targetFory.serialize(pair.targetValue);
+  }
+  return deserialize
+      ? () => pair.ordinaryFory.deserialize<Object?>(pair.ordinaryBytes)
+      : () => pair.ordinaryFory.serialize(pair.ordinaryValue);
+}
+
+Future<void> _allocationWorker(List<String> arguments) async {
+  final pairName = arguments[1];
+  final deserialize = arguments[2] == 'deserialize';
+  final target = arguments[3] == 'target';
+  final iterations = int.parse(arguments[4]);
+  final pair = _createPairs().firstWhere((item) => item.name == pairName);
+  final action = _operation(pair, target: target, deserialize: deserialize);
+  for (var index = 0; index < 10000; index += 1) {
+    _sink = action();
+  }
+  final serviceInfo = await Service.getInfo();
+  final serverUri = serviceInfo.serverUri;
+  if (serverUri == null) {
+    throw StateError('Allocation worker requires the Dart VM service.');
+  }
+  stdout.writeln('SERVICE $serverUri');
+  stdout.writeln('READY');
+  await stdout.flush();
+  debugger(message: 'allocation-ready');
+  for (var index = 0; index < iterations; index += 1) {
+    _sink = action();
+  }
+  debugger(message: 'allocation-done');
+}
+
+Future<String> _nextWorkerLine(StreamIterator<String> lines) async {
+  while (await lines.moveNext()) {
+    final line = lines.current;
+    if (line == 'READY' || line.startsWith('SERVICE ')) {
+      return line;
+    }
+  }
+  throw StateError('Allocation worker exited before completing its command.');
+}
+
+Map<String, (int, int)> _allocationSnapshot(AllocationProfile profile) {
+  return <String, (int, int)>{
+    for (final member in profile.members ?? const <ClassHeapStats>[])
+      if (member.classRef?.name != null)
+        member.classRef!.name!: (
+          member.instancesAccumulated ?? 0,
+          member.accumulatedSize ?? 0,
+        ),
+  };
+}
+
+String _normalizedAllocationClass(String name) {
+  return switch (name) {
+    'OrdinaryEquivalentUser' => 'EquivalentUser',
+    'OrdinaryDirectHolder' => 'TargetDirectHolder',
+    'OrdinaryListHolder' => 'TargetListHolder',
+    'OrdinaryMapHolder' => 'TargetMapHolder',
+    _ => name,
+  };
+}
+
+Map<String, (int, int)> _allocationDelta(
+  Map<String, (int, int)> profile,
+  Map<String, (int, int)> baseline,
+) {
+  final result = <String, (int, int)>{};
+  for (final entry in profile.entries) {
+    final before = baseline[entry.key] ?? (0, 0);
+    final instances = entry.value.$1 - before.$1;
+    final bytes = entry.value.$2 - before.$2;
+    if (instances <= 0 && bytes <= 0) {
+      continue;
+    }
+    final name = _normalizedAllocationClass(entry.key);
+    final current = result[name] ?? (0, 0);
+    result[name] = (
+      current.$1 + (instances < 0 ? 0 : instances),
+      current.$2 + (bytes < 0 ? 0 : bytes),
+    );
+  }
+  return result;
+}
+
+bool _sameAllocationCounts(
+  Map<String, (int, int)> ordinary,
+  Map<String, (int, int)> target,
+) {
+  final names = <String>{...ordinary.keys, ...target.keys};
+  var same = true;
+  for (final name in names) {
+    final ordinaryValue = ordinary[name] ?? (0, 0);
+    final targetValue = target[name] ?? (0, 0);
+    if (ordinaryValue.$1 != targetValue.$1) {
+      same = false;
+      stderr.writeln(
+        'allocation-count mismatch $name '
+        'ordinary=${ordinaryValue.$1}/${ordinaryValue.$2} '
+        'target=${targetValue.$1}/${targetValue.$2}',
+      );
+    }
+  }
+  return same;
+}
+
+Future<Map<String, (int, int)>> _allocationProfile(
+  String pairName,
+  String operation,
+  int iterations, {
+  required bool target,
+}) async {
+  final process = await Process.start(Platform.resolvedExecutable, <String>[
+    '--deterministic',
+    '--no-background-compilation',
+    '--no-inline-alloc',
+    '--optimization-counter-threshold=10',
+    '--enable-vm-service=0',
+    '--disable-service-auth-codes',
+    Platform.script.toFilePath(),
+    '--allocation-worker',
+    pairName,
+    operation,
+    target ? 'target' : 'ordinary',
+    '$iterations',
+  ]);
+  final lineController = StreamController<String>();
+  var openStreams = 2;
+  void closeStream() {
+    openStreams -= 1;
+    if (openStreams == 0) {
+      lineController.close();
+    }
+  }
+
+  process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(lineController.add, onDone: closeStream);
+  process.stderr
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(lineController.add, onDone: closeStream);
+  final lines = StreamIterator<String>(lineController.stream);
+  Uri? serviceUri;
+  while (serviceUri == null) {
+    final line = await _nextWorkerLine(lines);
+    if (line.startsWith('SERVICE ')) {
+      serviceUri = Uri.parse(line.substring('SERVICE '.length));
+    }
+  }
+  while (await _nextWorkerLine(lines) != 'READY') {}
+  final websocketUri = serviceUri.replace(
+    scheme: 'ws',
+    path: '${serviceUri.path}ws',
+  );
+  final service = await vmServiceConnectUri(websocketUri.toString());
+  try {
+    final vm = await service.getVM();
+    final isolate = vm.isolates!.firstWhere((item) => item.name == 'main');
+    final isolateId = isolate.id!;
+    await service.streamListen(EventStreams.kDebug);
+    final initialState = await service.getIsolate(isolateId);
+    if (initialState.pauseEvent?.kind != EventKind.kPauseBreakpoint) {
+      await service.onDebugEvent.firstWhere(
+        (event) =>
+            event.isolate?.id == isolateId &&
+            event.kind == EventKind.kPauseBreakpoint,
+      );
+    }
+    await service.getAllocationProfile(isolateId, reset: true, gc: true);
+    final completed = service.onDebugEvent.firstWhere(
+      (event) =>
+          event.isolate?.id == isolateId &&
+          event.kind == EventKind.kPauseBreakpoint,
+    );
+    await service.resume(isolateId);
+    await completed;
+    final profile = await service.getAllocationProfile(isolateId, gc: true);
+    await service.resume(isolateId);
+    return _allocationSnapshot(profile);
+  } finally {
+    await service.dispose();
+    await process.exitCode;
+    await lines.cancel();
+  }
+}
+
+Future<bool> _checkAllocationLane(
+  String pairName,
+  String operation,
+  int iterations,
+) async {
+  final ordinaryBaseline = await _allocationProfile(
+    pairName,
+    operation,
+    0,
+    target: false,
+  );
+  final ordinary = await _allocationProfile(
+    pairName,
+    operation,
+    iterations,
+    target: false,
+  );
+  final targetBaseline = await _allocationProfile(
+    pairName,
+    operation,
+    0,
+    target: true,
+  );
+  final target = await _allocationProfile(
+    pairName,
+    operation,
+    iterations,
+    target: true,
+  );
+  final same = _sameAllocationCounts(
+    _allocationDelta(ordinary, ordinaryBaseline),
+    _allocationDelta(target, targetBaseline),
+  );
+  stdout.writeln(
+    '$pairName/$operation allocation_counts='
+    '${same ? 'identical' : 'different'} '
+    'iterations=$iterations',
+  );
+  return same;
+}
+
+Future<bool> _checkAllocations(int iterations) async {
+  var passed = true;
+  for (final pairName in <String>[
+    'root',
+    'direct_field',
+    'list_field',
+    'map_field',
+  ]) {
+    for (final operation in <String>['serialize', 'deserialize']) {
+      passed =
+          await _checkAllocationLane(pairName, operation, iterations) && passed;
+    }
+  }
+  return passed;
+}
+
+Future<void> main(List<String> arguments) async {
+  if (arguments.firstOrNull == '--allocation-worker') {
+    await _allocationWorker(arguments);
+    return;
+  }
+  if (arguments.contains('--check-allocations')) {
+    final iterations = _readInt(arguments, '--allocation-iterations', 1000);
+    if (!await _checkAllocations(iterations)) {
+      exitCode = 1;
+    }
+    return;
+  }
+  final samples = _readInt(arguments, '--samples', 7);
+  final duration = Duration(
+    milliseconds: _readInt(arguments, '--duration-ms', 1000),
+  );
+  final warmup = Duration(
+    milliseconds: _readInt(arguments, '--warmup-ms', 1000),
+  );
+  final threshold = _readDouble(arguments, '--threshold', 0.01);
+  final selectedData = _readString(arguments, '--data');
+  final selectedOperation = _readString(arguments, '--operation');
+  var passed = true;
+  for (final pair in _createPairs().where(
+    (pair) => selectedData == null || pair.name == selectedData,
+  )) {
+    if (selectedOperation == null || selectedOperation == 'serialize') {
+      passed =
+          _runLane(
+            name: '${pair.name}/serialize',
+            ordinary: () => pair.ordinaryFory.serialize(pair.ordinaryValue),
+            target: () => pair.targetFory.serialize(pair.targetValue),
+            samples: samples,
+            duration: duration,
+            warmup: warmup,
+            threshold: threshold,
+          ) &&
+          passed;
+    }
+    if (selectedOperation == null || selectedOperation == 'deserialize') {
+      passed =
+          _runLane(
+            name: '${pair.name}/deserialize',
+            ordinary:
+                () =>
+                    pair.ordinaryFory.deserialize<Object?>(pair.ordinaryBytes),
+            target:
+                () => pair.targetFory.deserialize<Object?>(pair.targetBytes),
+            samples: samples,
+            duration: duration,
+            warmup: warmup,
+            threshold: threshold,
+          ) &&
+          passed;
+    }
+  }
+  if (!passed) {
+    exitCode = 1;
+  }
+  if (_sink == null) {
+    throw StateError('Benchmark produced no value.');
+  }
+}

--- a/dart/packages/fory-test/lib/model/external_serializers.dart
+++ b/dart/packages/fory-test/lib/model/external_serializers.dart
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+library;
+
+import 'dart:typed_data';
+
+import 'package:external_type_test_models/models.dart' as third_party;
+import 'package:fory/fory.dart';
+
+part 'external_serializers.fory.dart';
+
+@ForyStruct(target: third_party.User)
+abstract final class UserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int age;
+}
+
+@ForyStruct(target: third_party.Point)
+abstract final class PointSerializer {
+  @ForyField(id: 1, type: Int32Type())
+  late final int x;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int y;
+}
+
+@ForyStruct(target: third_party.Money, constructor: 'fromParts')
+abstract final class MoneySerializer {
+  @ForyField(id: 1)
+  late final String currency;
+
+  @ForyField(id: 2, type: Int64Type())
+  late final int units;
+}
+
+@ForyStruct(target: third_party.MutableProfile)
+abstract final class MutableProfileSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int score;
+}
+
+@ForyStruct(target: third_party.NamedMutableProfile, constructor: 'empty')
+abstract final class NamedMutableProfileSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int score;
+}
+
+@ForyStruct(target: third_party.DerivedValue)
+abstract final class DerivedValueSerializer {
+  @ForyField(id: 1)
+  late final String value;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int count;
+}
+
+@ForyStruct(target: third_party.Box<String>)
+abstract final class StringBoxSerializer {
+  @ForyField(id: 1)
+  late final String value;
+}
+
+@ForyStruct(target: third_party.Node, constructor: 'empty')
+abstract final class NodeSerializer {
+  @ForyField(id: 1)
+  late final String label;
+
+  @ForyField(id: 2, ref: true)
+  late final third_party.Node? next;
+}
+
+@ForyStruct(target: third_party.LinkA)
+abstract final class LinkASerializer {
+  @ForyField(id: 1)
+  late final String label;
+
+  @ForyField(id: 2, ref: true)
+  late final third_party.LinkB? link;
+}
+
+@ForyStruct(target: third_party.LinkB)
+abstract final class LinkBSerializer {
+  @ForyField(id: 1)
+  late final String label;
+
+  @ForyField(id: 2, ref: true)
+  late final third_party.LinkA? link;
+}
+
+@ForyStruct(target: third_party.Envelope)
+abstract final class EnvelopeSerializer {
+  @ForyField(id: 1)
+  late final third_party.User? user;
+
+  @ListField(id: 2, ref: true, element: DeclaredType(ref: true))
+  late final List<third_party.User> users;
+
+  @SetField(id: 3, element: DeclaredType())
+  late final Set<third_party.User> userSet;
+
+  @MapField(id: 4, value: DeclaredType())
+  late final Map<String, third_party.User> usersByName;
+
+  @MapField(id: 5, key: DeclaredType())
+  late final Map<third_party.User, String> namesByUser;
+
+  @ForyField(
+    id: 6,
+    type: ListType(element: MapType(value: ListType(element: DeclaredType()))),
+  )
+  late final List<Map<String, List<third_party.User>>> nested;
+
+  @ForyField(id: 7, dynamic: true)
+  late final Object? value;
+
+  @ListField(id: 8, dynamic: true, element: DeclaredType(dynamic: true))
+  late final List<Object?> values;
+}
+
+@ForyStruct(target: third_party.ScalarValues, evolving: false)
+abstract final class ScalarValuesSerializer {
+  @ForyField(id: 1, type: BoolType())
+  late final bool flag;
+
+  @ForyField(id: 2, type: Int8Type())
+  late final int int8;
+
+  @ForyField(id: 3, type: Int16Type())
+  late final int int16;
+
+  @ForyField(id: 4, type: Int32Type())
+  late final int int32;
+
+  @ForyField(id: 5, type: Int64Type())
+  late final int int64;
+
+  @ForyField(id: 6, type: Uint8Type())
+  late final int uint8;
+
+  @ForyField(id: 7, type: Uint16Type())
+  late final int uint16;
+
+  @ForyField(id: 8, type: Uint32Type())
+  late final int uint32;
+
+  @ForyField(id: 9, type: Uint64Type())
+  late final int uint64;
+
+  @ForyField(id: 10, type: Float16Type())
+  late final double float16;
+
+  @ForyField(id: 11, type: Bfloat16Type())
+  late final double bfloat16;
+
+  @ForyField(id: 12, type: Float32Type())
+  late final double float32;
+
+  @ForyField(id: 13, type: Float64Type())
+  late final double float64;
+
+  @ForyField(id: 14, type: StringType())
+  late final String text;
+
+  @ForyField(id: 15, type: TimestampType())
+  late final DateTime timestamp;
+
+  @ForyField(id: 16, type: DurationType())
+  late final Duration duration;
+
+  @ForyField(id: 17, type: BinaryType())
+  late final Uint8List binary;
+}
+
+@ForyStruct(target: third_party.ContactVersion1)
+abstract final class ContactVersion1Serializer {
+  @ForyField(id: 1)
+  late final String firstName;
+
+  @ForyField(id: 2)
+  late final String? nickname;
+}
+
+@ForyStruct(target: third_party.ContactVersion2)
+abstract final class ContactVersion2Serializer {
+  @ForyField(id: 3)
+  late final String? email;
+
+  @ForyField(id: 1)
+  late final String fullName;
+
+  @ForyField(id: 2)
+  late final String? nickname;
+}
+
+@ForyStruct(target: third_party.EquivalentUser)
+abstract final class EquivalentUserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int age;
+}
+
+@ForyStruct()
+final class OrdinaryEquivalentUser {
+  const OrdinaryEquivalentUser({required this.name, required this.age});
+
+  @ForyField(id: 1)
+  final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  final int age;
+}
+
+@ForyStruct()
+final class UserHolder {
+  UserHolder();
+
+  @ForyField(id: 1)
+  third_party.User? user;
+
+  @ListField(id: 2, ref: true, element: DeclaredType(ref: true))
+  List<third_party.User> users = <third_party.User>[];
+
+  @SetField(id: 3, element: DeclaredType())
+  Set<third_party.User> userSet = <third_party.User>{};
+
+  @MapField(id: 4, value: DeclaredType())
+  Map<String, third_party.User> usersByName = <String, third_party.User>{};
+
+  @MapField(id: 5, key: DeclaredType())
+  Map<third_party.User, String> namesByUser = <third_party.User, String>{};
+
+  @ForyField(
+    id: 6,
+    type: ListType(element: MapType(value: ListType(element: DeclaredType()))),
+  )
+  List<Map<String, List<third_party.User>>> nested =
+      <Map<String, List<third_party.User>>>[];
+
+  @ForyField(id: 7, dynamic: true)
+  Object? value;
+
+  @ListField(id: 8, dynamic: true, element: DeclaredType(dynamic: true))
+  List<Object?> values = <Object?>[];
+}
+
+@ForyStruct(evolving: false)
+final class TargetDirectHolder {
+  const TargetDirectHolder(this.value);
+
+  @ForyField(id: 1)
+  final third_party.EquivalentUser value;
+}
+
+@ForyStruct(evolving: false)
+final class OrdinaryDirectHolder {
+  const OrdinaryDirectHolder(this.value);
+
+  @ForyField(id: 1)
+  final OrdinaryEquivalentUser value;
+}
+
+@ForyStruct(evolving: false)
+final class TargetListHolder {
+  const TargetListHolder(this.values);
+
+  @ListField(id: 1, element: DeclaredType())
+  final List<third_party.EquivalentUser> values;
+}
+
+@ForyStruct(evolving: false)
+final class OrdinaryListHolder {
+  const OrdinaryListHolder(this.values);
+
+  @ListField(id: 1, element: DeclaredType())
+  final List<OrdinaryEquivalentUser> values;
+}
+
+@ForyStruct(evolving: false)
+final class TargetMapHolder {
+  const TargetMapHolder(this.values);
+
+  @MapField(id: 1, value: DeclaredType())
+  final Map<String, third_party.EquivalentUser> values;
+}
+
+@ForyStruct(evolving: false)
+final class OrdinaryMapHolder {
+  const OrdinaryMapHolder(this.values);
+
+  @MapField(id: 1, value: DeclaredType())
+  final Map<String, OrdinaryEquivalentUser> values;
+}

--- a/dart/packages/fory-test/test/cross_lang_test/xlang_test_main.dart
+++ b/dart/packages/fory-test/test/cross_lang_test/xlang_test_main.dart
@@ -21,9 +21,11 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:external_type_test_models/models.dart' as third_party;
 import 'package:fory/fory.dart';
 import 'package:fory/src/util/hash_util.dart';
 import 'package:fory_test/entity/xlang_test_models.dart';
+import 'package:fory_test/model/external_serializers.dart';
 
 String _dataFilePath() {
   final path = Platform.environment['DATA_FILE'];
@@ -305,6 +307,21 @@ void _registerNamedCustomTypes(Fory fory) {
   registerXlangType(fory, MyWrapper, name: 'my_wrapper');
 }
 
+void _runExternalUser({int? id, String? name}) {
+  final fory = _newFory(compatible: true);
+  ExternalSerializersForyModule.register(
+    fory,
+    third_party.User,
+    id: id,
+    name: name,
+  );
+  final user = fory.deserialize<third_party.User>(_readFile());
+  if (user.name != 'Ada' || user.age != 36) {
+    throw StateError('Unexpected external user: ${user.name}/${user.age}.');
+  }
+  _writeFile(fory.serialize(user));
+}
+
 void _runCollectionElementRefOverride() {
   final fory = _newFory();
   registerXlangType(fory, RefOverrideElement, id: 701);
@@ -445,6 +462,12 @@ void _runCase(String caseName) {
       final fory = _newFory(compatible: true);
       _registerStructEvolvingOverrideByName(fory);
       _roundTripFory(fory);
+      return;
+    case 'test_external_struct_id':
+      _runExternalUser(id: 1001);
+      return;
+    case 'test_external_struct_name':
+      _runExternalUser(name: 'test.external_user');
       return;
     case 'test_list':
     case 'test_map':

--- a/dart/packages/fory-test/test/external_type_serialization_test.dart
+++ b/dart/packages/fory-test/test/external_type_serialization_test.dart
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import 'dart:typed_data';
+
+import 'package:external_type_test_models/models.dart' as third_party;
+import 'package:fory/fory.dart';
+import 'package:fory_test/model/external_serializers.dart';
+import 'package:test/test.dart';
+
+void _registerUser(Fory fory, {int? id, String? name}) {
+  ExternalSerializersForyModule.register(
+    fory,
+    third_party.User,
+    id: id,
+    name: name,
+  );
+}
+
+void _registerGraphTypes(Fory fory) {
+  _registerUser(fory, id: 101);
+  ExternalSerializersForyModule.register(fory, UserHolder, id: 102);
+  ExternalSerializersForyModule.register(fory, third_party.Envelope, id: 103);
+  ExternalSerializersForyModule.register(fory, third_party.Node, id: 104);
+  ExternalSerializersForyModule.register(fory, third_party.LinkA, id: 105);
+  ExternalSerializersForyModule.register(fory, third_party.LinkB, id: 106);
+}
+
+void main() {
+  group('external structural serializer', () {
+    test('round-trips immutable and mutable root targets', () {
+      final fory = Fory();
+      _registerUser(fory, id: 101);
+      ExternalSerializersForyModule.register(fory, third_party.Point, id: 102);
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.Money,
+        name: 'example.Money',
+      );
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.MutableProfile,
+        id: 104,
+      );
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.NamedMutableProfile,
+        id: 105,
+      );
+
+      final user = fory.deserialize<third_party.User>(
+        fory.serialize(const third_party.User(name: 'Ada', age: 36)),
+      );
+      final point = fory.deserialize<third_party.Point>(
+        fory.serialize(const third_party.Point(4, 9)),
+      );
+      final money = fory.deserialize<third_party.Money>(
+        fory.serialize(
+          const third_party.Money.fromParts(currency: 'USD', units: 42),
+        ),
+      );
+      final mutable =
+          third_party.MutableProfile()
+            ..name = 'mutable'
+            ..score = 7;
+      final mutableResult = fory.deserialize<third_party.MutableProfile>(
+        fory.serialize(mutable),
+      );
+      final namedMutable =
+          third_party.NamedMutableProfile.empty()
+            ..name = 'named'
+            ..score = 8;
+      final namedMutableResult = fory
+          .deserialize<third_party.NamedMutableProfile>(
+            fory.serialize(namedMutable),
+          );
+
+      expect((user.name, user.age), ('Ada', 36));
+      expect((point.x, point.y), (4, 9));
+      expect((money.currency, money.units), ('USD', 42));
+      expect((mutableResult.name, mutableResult.score), ('mutable', 7));
+      expect((namedMutableResult.name, namedMutableResult.score), ('named', 8));
+    });
+
+    test('specializes inherited and closed generic members', () {
+      final fory = Fory();
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.DerivedValue,
+        id: 101,
+      );
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.Box<String>,
+        id: 102,
+      );
+
+      final derived = fory.deserialize<third_party.DerivedValue>(
+        fory.serialize(third_party.DerivedValue(value: 'base', count: 3)),
+      );
+      final box = fory.deserialize<third_party.Box<String>>(
+        fory.serialize(const third_party.Box<String>('value')),
+      );
+
+      expect((derived.value, derived.count), ('base', 3));
+      expect(box.value, 'value');
+    });
+
+    test('uses existing scalar field annotations', () {
+      final fory = Fory();
+      ExternalSerializersForyModule.register(
+        fory,
+        third_party.ScalarValues,
+        id: 101,
+      );
+      final value = third_party.ScalarValues(
+        flag: true,
+        int8: -8,
+        int16: -1600,
+        int32: -320000,
+        int64: -640000,
+        uint8: 8,
+        uint16: 1600,
+        uint32: 320000,
+        uint64: 640000,
+        float16: 1.5,
+        bfloat16: 2.5,
+        float32: 3.5,
+        float64: 4.5,
+        text: 'scalars',
+        timestamp: DateTime.utc(2026, 7, 27, 12, 30),
+        duration: Duration(microseconds: 123456),
+        binary: Uint8List.fromList(<int>[1, 2, 3]),
+      );
+
+      final result = fory.deserialize<third_party.ScalarValues>(
+        fory.serialize(value),
+      );
+
+      expect(result.flag, isTrue);
+      expect(
+        (
+          result.int8,
+          result.int16,
+          result.int32,
+          result.int64,
+          result.uint8,
+          result.uint16,
+          result.uint32,
+          result.uint64,
+        ),
+        (-8, -1600, -320000, -640000, 8, 1600, 320000, 640000),
+      );
+      expect(result.float16, closeTo(1.5, 0.01));
+      expect(result.bfloat16, closeTo(2.5, 0.02));
+      expect(result.float32, closeTo(3.5, 0.0001));
+      expect(result.float64, 4.5);
+      expect(result.text, 'scalars');
+      expect(result.timestamp, DateTime.utc(2026, 7, 27, 12, 30));
+      expect(result.duration, const Duration(microseconds: 123456));
+      expect(result.binary, <int>[1, 2, 3]);
+    });
+  });
+
+  group('composition', () {
+    test('round-trips direct and recursive carrier fields', () {
+      final fory = Fory();
+      _registerGraphTypes(fory);
+      const ada = third_party.User(name: 'Ada', age: 36);
+      const grace = third_party.User(name: 'Grace', age: 37);
+      final holder =
+          UserHolder()
+            ..user = ada
+            ..users = <third_party.User>[ada, ada]
+            ..userSet = <third_party.User>{grace}
+            ..usersByName = <String, third_party.User>{'Ada': ada}
+            ..namesByUser = <third_party.User, String>{grace: 'Grace'}
+            ..nested = <Map<String, List<third_party.User>>>[
+              <String, List<third_party.User>>{
+                'users': <third_party.User>[ada, grace],
+              },
+            ]
+            ..value = grace
+            ..values = <Object?>[ada, 'text', 7, null];
+
+      final result = fory.deserialize<UserHolder>(fory.serialize(holder));
+
+      expect((result.user!.name, result.user!.age), ('Ada', 36));
+      expect(result.users.map((user) => user.name), ['Ada', 'Ada']);
+      expect(identical(result.users[0], result.users[1]), isTrue);
+      expect(result.userSet.single.name, 'Grace');
+      expect(result.usersByName['Ada']!.age, 36);
+      expect(result.namesByUser.keys.single.name, 'Grace');
+      expect(result.nested.single['users']!.map((user) => user.name), [
+        'Ada',
+        'Grace',
+      ]);
+      expect((result.value as third_party.User).name, 'Grace');
+      expect((result.values.first as third_party.User).name, 'Ada');
+      expect(result.values.sublist(1), <Object?>['text', 7, null]);
+    });
+
+    test('round-trips external target carrier fields', () {
+      final fory = Fory();
+      _registerGraphTypes(fory);
+      const user = third_party.User(name: 'Ada', age: 36);
+      final envelope =
+          third_party.Envelope()
+            ..user = user
+            ..users = <third_party.User>[user]
+            ..userSet = <third_party.User>{user}
+            ..usersByName = <String, third_party.User>{'Ada': user}
+            ..namesByUser = <third_party.User, String>{user: 'Ada'}
+            ..nested = <Map<String, List<third_party.User>>>[
+              <String, List<third_party.User>>{
+                'users': <third_party.User>[user],
+              },
+            ]
+            ..value = user
+            ..values = <Object?>[user, 'value'];
+
+      final result = fory.deserialize<third_party.Envelope>(
+        fory.serialize(envelope),
+      );
+
+      expect(result.user!.name, 'Ada');
+      expect(result.users.single.age, 36);
+      expect(result.userSet.single.name, 'Ada');
+      expect(result.usersByName['Ada']!.age, 36);
+      expect(result.namesByUser.keys.single.name, 'Ada');
+      expect(result.nested.single['users']!.single.name, 'Ada');
+      expect((result.value as third_party.User).name, 'Ada');
+      expect((result.values.first as third_party.User).name, 'Ada');
+    });
+
+    test('round-trips non-empty and empty root carriers', () {
+      final fory = Fory();
+      _registerUser(fory, id: 101);
+      const user = third_party.User(name: 'Ada', age: 36);
+
+      final users =
+          fory.deserialize<Object?>(fory.serialize(<third_party.User>[user]))
+              as List<Object?>;
+      final userSet =
+          fory.deserialize<Object?>(fory.serialize(<third_party.User>{user}))
+              as Set<Object?>;
+      final byName =
+          fory.deserialize<Object?>(
+                fory.serialize(<String, third_party.User>{'Ada': user}),
+              )
+              as Map<Object?, Object?>;
+      final byUser =
+          fory.deserialize<Object?>(
+                fory.serialize(<third_party.User, String>{user: 'Ada'}),
+              )
+              as Map<Object?, Object?>;
+
+      expect((users.single as third_party.User).name, 'Ada');
+      expect((userSet.single as third_party.User).age, 36);
+      expect((byName['Ada'] as third_party.User).age, 36);
+      expect((byUser.keys.single as third_party.User).name, 'Ada');
+      expect(
+        fory.deserialize<Object?>(fory.serialize(<third_party.User>[])),
+        isEmpty,
+      );
+      expect(
+        fory.deserialize<Object?>(fory.serialize(<third_party.User>{})),
+        isEmpty,
+      );
+      expect(
+        fory.deserialize<Object?>(fory.serialize(<String, third_party.User>{})),
+        isEmpty,
+      );
+    });
+  });
+
+  group('references and compatibility', () {
+    test('preserves mutable self and indirect cycles', () {
+      final fory = Fory();
+      _registerGraphTypes(fory);
+      final node = third_party.Node.empty()..label = 'self';
+      node.next = node;
+      final a = third_party.LinkA()..label = 'a';
+      final b = third_party.LinkB()..label = 'b';
+      a.link = b;
+      b.link = a;
+
+      final nodeResult = fory.deserialize<third_party.Node>(
+        fory.serialize(node),
+      );
+      final linkResult = fory.deserialize<third_party.LinkA>(fory.serialize(a));
+
+      expect(identical(nodeResult, nodeResult.next), isTrue);
+      expect(linkResult.link!.label, 'b');
+      expect(identical(linkResult, linkResult.link!.link), isTrue);
+    });
+
+    test(
+      'reads added, removed, reordered, nullable, and renamed-id fields',
+      () {
+        final version1Writer = Fory(compatible: true);
+        final version2Reader = Fory(compatible: true);
+        ExternalSerializersForyModule.register(
+          version1Writer,
+          third_party.ContactVersion1,
+          name: 'example.Contact',
+        );
+        ExternalSerializersForyModule.register(
+          version2Reader,
+          third_party.ContactVersion2,
+          name: 'example.Contact',
+        );
+
+        final version2 = version2Reader
+            .deserialize<third_party.ContactVersion2>(
+              version1Writer.serialize(
+                const third_party.ContactVersion1(
+                  firstName: 'Ada',
+                  nickname: null,
+                ),
+              ),
+            );
+
+        expect(version2.fullName, 'Ada');
+        expect(version2.nickname, isNull);
+        expect(version2.email, isNull);
+
+        final version2Writer = Fory(compatible: true);
+        final version1Reader = Fory(compatible: true);
+        ExternalSerializersForyModule.register(
+          version2Writer,
+          third_party.ContactVersion2,
+          name: 'example.Contact',
+        );
+        ExternalSerializersForyModule.register(
+          version1Reader,
+          third_party.ContactVersion1,
+          name: 'example.Contact',
+        );
+        final version1 = version1Reader
+            .deserialize<third_party.ContactVersion1>(
+              version2Writer.serialize(
+                const third_party.ContactVersion2(
+                  fullName: 'Grace',
+                  nickname: 'Amazing',
+                  email: 'grace@example.test',
+                ),
+              ),
+            );
+
+        expect(version1.firstName, 'Grace');
+        expect(version1.nickname, 'Amazing');
+      },
+    );
+  });
+
+  test('matches equivalent ordinary generated bytes', () {
+    final externalFory = Fory();
+    final ordinaryFory = Fory();
+    ExternalSerializersForyModule.register(
+      externalFory,
+      third_party.EquivalentUser,
+      name: 'example.EquivalentUser',
+    );
+    ExternalSerializersForyModule.register(
+      ordinaryFory,
+      OrdinaryEquivalentUser,
+      name: 'example.EquivalentUser',
+    );
+
+    final externalBytes = externalFory.serialize(
+      const third_party.EquivalentUser(name: 'Ada', age: 36),
+    );
+    final ordinaryBytes = ordinaryFory.serialize(
+      const OrdinaryEquivalentUser(name: 'Ada', age: 36),
+    );
+
+    expect(externalBytes, ordinaryBytes);
+    final external = externalFory.deserialize<third_party.EquivalentUser>(
+      externalBytes,
+    );
+    final ordinary = ordinaryFory.deserialize<OrdinaryEquivalentUser>(
+      ordinaryBytes,
+    );
+    expect((external.name, external.age), (ordinary.name, ordinary.age));
+  });
+}

--- a/dart/packages/fory-test/tool/external_type_js_smoke.dart
+++ b/dart/packages/fory-test/tool/external_type_js_smoke.dart
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import 'package:external_type_test_models/models.dart' as third_party;
+import 'package:fory/fory.dart';
+import 'package:fory_test/model/external_serializers.dart';
+
+void main() {
+  final fory = Fory();
+  ExternalSerializersForyModule.register(fory, third_party.User, id: 101);
+  final value = fory.deserialize<third_party.User>(
+    fory.serialize(const third_party.User(name: 'Ada', age: 36)),
+  );
+  if (value.name != 'Ada' || value.age != 36) {
+    throw StateError('External structural serializer round trip failed.');
+  }
+}

--- a/dart/packages/fory/CHANGELOG.md
+++ b/dart/packages/fory/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.5.0-dev
 
 - Start the next development cycle after the 1.4.0 release.
+- Add generated external-type serialization with direct target construction
+  and existing registration, carrier, reference, and schema-evolution support.
 
 ## 1.4.0
 

--- a/dart/packages/fory/README.md
+++ b/dart/packages/fory/README.md
@@ -3,7 +3,7 @@
 Apache Fory™ Dart is the Dart xlang implementation for
 [Apache Fory™](https://github.com/apache/fory). It reads and writes Fory's
 cross-language wire format and is designed around generated serializers for
-annotated Dart models, with customized serializers available for advanced use
+annotated Dart models, with manual serializers available for advanced use
 cases.
 
 ## Features
@@ -11,9 +11,10 @@ cases.
 - Cross-language serialization with the Fory xlang format
 - Dart VM/AOT, Flutter, and web platform support
 - Generated serializers for annotated structs and enums
+- External structural serializers for classes owned by another package
 - Compatible mode for schema evolution
 - Optional reference tracking for shared and circular object graphs
-- Manual serializers for external types, custom payloads, and unions
+- Manual serializers for custom payloads, construction, and unions
 - Explicit exact-width value classes for `Int64`, `Uint64`, `Float32`,
   `LocalDate`, and `Timestamp`, plus `Duration` support
 
@@ -88,6 +89,44 @@ Generate the companion file before running the program:
 ```bash
 dart run build_runner build --delete-conflicting-outputs
 ```
+
+## External-Type Serialization
+
+Use `ForyStruct.target` when another package owns a class whose public schema
+can be read and reconstructed directly:
+
+```dart
+import 'package:fory/fory.dart';
+import 'package:third_party/models.dart' as third_party;
+
+part 'external_serializers.fory.dart';
+
+@ForyStruct(target: third_party.User)
+abstract final class UserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int age;
+}
+```
+
+The declaration is schema-only. Register and serialize the target:
+
+```dart
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.User,
+  name: 'example.User',
+);
+
+final bytes = fory.serialize(user);
+final decoded = fory.deserialize<third_party.User>(bytes);
+```
+
+Fields and nested `List`, `Set`, and `Map` values use the same target
+registration. Select a public named generative constructor with
+`constructor: 'name'` when the unnamed constructor is not appropriate.
 
 ## Type Registration
 
@@ -178,10 +217,10 @@ class NodeList {
 Map<String, List<int?>> nested = <String, List<int?>>{};
 ```
 
-## Customized Serializers
+## Manual Serializers
 
-Use `Serializer<T>` when a type cannot use generated struct support or when you
-need custom wire behavior.
+Use `Serializer<T>` when a type needs custom wire behavior, field conversion,
+or construction that an external structural serializer cannot express.
 
 ```dart
 import 'package:fory/fory.dart';
@@ -278,7 +317,8 @@ The main exported API includes:
 
 - `Fory` — main serialization facade
 - `Config` — Fory configuration
-- `ForyStruct`, `ForyField`, `ListField`, `SetField`, `MapField` — struct annotations
+- `ForyStruct`, including `target` and `constructor`, plus `ForyField`,
+  `ListField`, `SetField`, and `MapField` — struct annotations
 - `ForyUnion` — union type annotation
 - `Serializer`, `UnionSerializer`, `EnumSerializer` — serializer base classes
 - `Buffer`, `WriteContext`, `ReadContext` — low-level I/O

--- a/dart/packages/fory/lib/fory.dart
+++ b/dart/packages/fory/lib/fory.dart
@@ -21,7 +21,7 @@
 ///
 /// Most applications only need [Fory], [Config], [ForyStruct], and [ForyField].
 /// [Buffer], [WriteContext], [ReadContext], and [Serializer] are advanced APIs
-/// used by generated code, custom serializers, and low-level integrations.
+/// used by generated code, manual serializers, and low-level integrations.
 // ignore_for_file: invalid_export_of_internal_element
 library;
 

--- a/dart/packages/fory/lib/src/annotation/fory_struct.dart
+++ b/dart/packages/fory/lib/src/annotation/fory_struct.dart
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/// Marks a class for Fory struct code generation.
+/// Configures Fory struct code generation for the annotated class or [target].
 final class ForyStruct {
   /// Whether the generated struct should use evolving field metadata.
   ///
@@ -25,6 +25,20 @@ final class ForyStruct {
   /// field evolution.
   final bool evolving;
 
+  /// The external Dart class serialized by this declaration.
+  ///
+  /// Leave this unset when annotating the class that Fory serializes. When it
+  /// is set, the annotated class is a schema-only external structural
+  /// serializer declaration and generated code reads and constructs [target]
+  /// directly.
+  final Type? target;
+
+  /// The named generative constructor used to rebuild [target].
+  ///
+  /// Leave this unset to use the unnamed constructor. This option is valid only
+  /// with [target].
+  final String? constructor;
+
   /// Creates struct-level generation options.
-  const ForyStruct({this.evolving = true});
+  const ForyStruct({this.evolving = true, this.target, this.constructor});
 }

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -823,14 +823,22 @@ final class ForyGenerator extends Generator {
       }
     }
 
+    // Constructor arguments are read before the target can be published, so a
+    // tracked path through carrier metadata cannot resolve back to this target.
     final selfRefField =
         fields
-            .where((field) => field.ref)
-            .where((field) => _sameType(field.type, targetType))
+            .where(
+              (field) => _hasTrackedTargetReference(
+                field.type,
+                field.fieldType,
+                targetType,
+              ),
+            )
             .firstOrNull;
     if (selfRefField != null) {
       throw InvalidGenerationSourceError(
-        'Constructor-based generated serializers cannot bind self references early. '
+        'Constructor-based generated serializers cannot bind '
+        'reference-tracked self paths before construction. '
         'Use a writable zero-required-argument generative constructor for '
         '$targetTypeLiteral or a manual serializer. Offending field: '
         '${declaration.displayName}.${selfRefField.name}.',
@@ -4008,6 +4016,35 @@ GeneratedFieldType(
 
   bool _sameType(DartType left, DartType right) =>
       _withoutNullability(left) == _withoutNullability(right);
+
+  bool _hasTrackedTargetReference(
+    DartType type,
+    _GeneratedFieldTypeSpec fieldType,
+    InterfaceType targetType,
+  ) {
+    if (fieldType.ref && _sameType(type, targetType)) {
+      return true;
+    }
+    final nonNullable = _withoutNullability(type);
+    if (nonNullable is! InterfaceType) {
+      return false;
+    }
+    final typeArguments = nonNullable.typeArguments;
+    final argumentCount =
+        typeArguments.length < fieldType.arguments.length
+            ? typeArguments.length
+            : fieldType.arguments.length;
+    for (var index = 0; index < argumentCount; index++) {
+      if (_hasTrackedTargetReference(
+        typeArguments[index],
+        fieldType.arguments[index],
+        targetType,
+      )) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   bool? _autoDynamic(DartType type) {
     final nonNullable = _withoutNullability(type);

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -4119,11 +4119,12 @@ GeneratedFieldType(
   }
 
   String _typeReferenceLiteral(DartType type) {
-    final nonNullable = _withoutNullability(type);
-    if (nonNullable is DynamicType || nonNullable is InvalidType) {
+    if (type is DynamicType || type is InvalidType) {
       return 'Object';
     }
-    final alias = nonNullable.alias;
+    // Rebuilding a nullable interface type drops its alias, so preserve the
+    // visible alias before removing nullability from the underlying type.
+    final alias = type.alias;
     if (alias != null) {
       final aliasElement = alias.element;
       final prefix = _importPrefixByElement[aliasElement];
@@ -4135,6 +4136,7 @@ GeneratedFieldType(
       final typeArguments = alias.typeArguments.map(_typeCodeString).join(', ');
       return '$baseName<$typeArguments>';
     }
+    final nonNullable = _withoutNullability(type);
     if (nonNullable is InterfaceType) {
       final element = nonNullable.element;
       final prefix = _importPrefixByElement[element];

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -86,8 +86,6 @@ final class ForyGenerator extends Generator {
     inPackage: 'fory',
   );
 
-  final Map<String, String> _importPrefixByLibraryIdentifier =
-      <String, String>{};
   final Map<Element, String?> _importPrefixByElement = <Element, String?>{};
 
   @override
@@ -481,7 +479,6 @@ final class ForyGenerator extends Generator {
   }
 
   void _buildImportPrefixMap(LibraryReader library) {
-    _importPrefixByLibraryIdentifier.clear();
     _importPrefixByElement.clear();
     for (final import in library.element.firstFragment.libraryImports) {
       final importedLibrary = import.importedLibrary;
@@ -490,10 +487,6 @@ final class ForyGenerator extends Generator {
         continue;
       }
       final normalizedPrefix = prefix == null || prefix.isEmpty ? null : prefix;
-      if (normalizedPrefix != null) {
-        _importPrefixByLibraryIdentifier[importedLibrary.identifier] =
-            normalizedPrefix;
-      }
       for (final importedElement in import.namespace.definedNames2.values) {
         if (!_importPrefixByElement.containsKey(importedElement) ||
             normalizedPrefix == null) {
@@ -4093,10 +4086,21 @@ GeneratedFieldType(
     if (nonNullable is DynamicType || nonNullable is InvalidType) {
       return 'Object';
     }
+    final alias = nonNullable.alias;
+    if (alias != null) {
+      final aliasElement = alias.element;
+      final prefix = _importPrefixByElement[aliasElement];
+      final elementName = aliasElement.displayName;
+      final baseName = prefix == null ? elementName : '$prefix.$elementName';
+      if (alias.typeArguments.isEmpty) {
+        return baseName;
+      }
+      final typeArguments = alias.typeArguments.map(_typeCodeString).join(', ');
+      return '$baseName<$typeArguments>';
+    }
     if (nonNullable is InterfaceType) {
       final element = nonNullable.element;
-      final prefix =
-          _importPrefixByLibraryIdentifier[element.library.identifier];
+      final prefix = _importPrefixByElement[element];
       final elementName = element.displayName;
       final baseName = prefix == null ? elementName : '$prefix.$elementName';
       if (nonNullable.typeArguments.isEmpty) {

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -88,6 +88,7 @@ final class ForyGenerator extends Generator {
 
   final Map<String, String> _importPrefixByLibraryIdentifier =
       <String, String>{};
+  final Map<Element, String?> _importPrefixByElement = <Element, String?>{};
 
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
@@ -108,9 +109,23 @@ final class ForyGenerator extends Generator {
         !_declaresGeneratedApiOwner(library, buildStep, generatedApiName);
 
     final enumSpecs = enumElements.map(_analyzeEnum).toList(growable: false);
-    final structSpecs = annotatedClasses
-        .map(_analyzeStruct)
-        .toList(growable: false);
+    final structSpecs = <_GeneratedStructSpec>[];
+    for (final element in annotatedClasses) {
+      final structSpec = _analyzeStruct(element);
+      final duplicate =
+          structSpecs
+              .where((existing) => existing.targetType == structSpec.targetType)
+              .firstOrNull;
+      if (duplicate != null) {
+        throw InvalidGenerationSourceError(
+          'Fory struct declarations ${duplicate.name} and ${structSpec.name} '
+          'both target ${structSpec.targetTypeLiteral}. Declare exactly one '
+          'structural schema for each target type in a library.',
+          element: element,
+        );
+      }
+      structSpecs.add(structSpec);
+    }
     final output =
         StringBuffer()
           ..writeln(
@@ -153,34 +168,338 @@ final class ForyGenerator extends Generator {
     final objectAnnotation = _foryStructChecker.firstAnnotationOf(element);
     final objectReader = ConstantReader(objectAnnotation);
     final evolving = objectReader.peek('evolving')?.boolValue ?? true;
+    final targetReader = objectReader.peek('target');
+    final annotatedTarget =
+        targetReader == null || targetReader.isNull
+            ? null
+            : targetReader.typeValue;
+    final constructorReader = objectReader.peek('constructor');
+    final constructorName =
+        constructorReader == null || constructorReader.isNull
+            ? null
+            : constructorReader.stringValue;
+    if (annotatedTarget == null && constructorName != null) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.constructor is valid only when ForyStruct.target is set.',
+        element: element,
+      );
+    }
+
+    final targetType =
+        annotatedTarget == null
+            ? element.thisType
+            : _validateExternalTarget(element, annotatedTarget);
+    if (annotatedTarget != null) {
+      _validateExternalDeclaration(element, targetType);
+    }
+    final targetTypeLiteral =
+        annotatedTarget == null
+            ? _typeReferenceLiteral(targetType)
+            : _externalTargetTypeLiteral(targetType, element);
+    final selectedConstructor = _selectConstructor(
+      element,
+      targetType,
+      targetTypeLiteral,
+      constructorName,
+      external: annotatedTarget != null,
+    );
 
     final fields = element.fields
         .where(
           (field) => !field.isStatic && identical(field.nonSynthetic, field),
         )
         .where((field) => !_isSkipped(field))
-        .map(_analyzeField)
+        .map(
+          (field) =>
+              _analyzeField(element, targetType, targetTypeLiteral, field),
+        )
         .toList(growable: false);
 
     final sortedFields = _sortFields(fields);
-    final constructionModel = _buildConstructionModel(element, sortedFields);
+    final constructionModel = _buildConstructionModel(
+      element,
+      targetType,
+      targetTypeLiteral,
+      selectedConstructor,
+      constructorName,
+      sortedFields,
+    );
     return _GeneratedStructSpec(
       name: element.displayName,
+      targetType: targetType,
+      targetTypeLiteral: targetTypeLiteral,
       evolving: evolving,
       fields: sortedFields,
       constructionModel: constructionModel,
     );
   }
 
+  InterfaceType _validateExternalTarget(
+    ClassElement declaration,
+    DartType annotatedTarget,
+  ) {
+    if (annotatedTarget is! InterfaceType ||
+        annotatedTarget.element is! ClassElement) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target on ${declaration.displayName} must name a concrete '
+        'Dart class. Built-in values, carriers, enums, unions, records, '
+        'functions, extension types, and type parameters are not external '
+        'struct targets.',
+        element: declaration,
+      );
+    }
+    final targetType = annotatedTarget;
+    final targetElement = targetType.element as ClassElement;
+    final targetName = targetType.getDisplayString();
+    if (targetType == declaration.thisType) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target on ${declaration.displayName} must name another '
+        'class. Remove target to serialize the annotated class itself.',
+        element: declaration,
+      );
+    }
+    if (targetType.nullabilitySuffix != NullabilitySuffix.none) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target on ${declaration.displayName} must be non-nullable; '
+        '$targetName is not a valid structural target.',
+        element: declaration,
+      );
+    }
+    if (_containsTypeParameter(targetType)) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target $targetName on ${declaration.displayName} must be a '
+        'closed type with no unresolved type parameters.',
+        element: declaration,
+      );
+    }
+    final targetLibrary = targetElement.library;
+    final targetUri = targetLibrary.uri;
+    final foryBuiltin =
+        targetUri.scheme == 'package' &&
+        targetUri.pathSegments.firstOrNull == 'fory' &&
+        _typeIdFor(targetType) != TypeIds.compatibleStruct;
+    if (targetLibrary.isDartCore ||
+        targetUri.toString() == 'dart:typed_data' ||
+        foryBuiltin ||
+        _isList(targetType) ||
+        _isSet(targetType) ||
+        _isMap(targetType) ||
+        _foryUnionChecker.hasAnnotationOf(targetElement)) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target $targetName on ${declaration.displayName} is owned '
+        'by an existing built-in, carrier, enum, or union serializer. Use that '
+        'serializer directly.',
+        element: declaration,
+      );
+    }
+    if (targetElement.isAbstract || !targetElement.isConstructable) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target $targetName on ${declaration.displayName} must be a '
+        'concrete constructable Dart class.',
+        element: declaration,
+      );
+    }
+    return targetType;
+  }
+
+  void _validateExternalDeclaration(
+    ClassElement declaration,
+    InterfaceType targetType,
+  ) {
+    final targetName = targetType.getDisplayString();
+    if (!declaration.isAbstract || !declaration.isFinal) {
+      throw InvalidGenerationSourceError(
+        'External structural serializer declaration '
+        '${declaration.displayName} for $targetName must be declared '
+        'abstract final.',
+        element: declaration,
+      );
+    }
+    if (declaration.typeParameters.isNotEmpty) {
+      throw InvalidGenerationSourceError(
+        'External structural serializer declaration '
+        '${declaration.displayName} for $targetName cannot declare type '
+        'parameters. Target one closed generic instantiation instead.',
+        element: declaration,
+      );
+    }
+    for (final field in declaration.fields.where(
+      (field) =>
+          !field.isStatic &&
+          identical(field.nonSynthetic, field) &&
+          !_isSkipped(field),
+    )) {
+      if (!field.isLate || !field.isFinal || field.hasInitializer) {
+        throw InvalidGenerationSourceError(
+          'Schema field ${declaration.displayName}.${field.displayName} for '
+          '$targetName must be a late final field without an initializer.',
+          element: field,
+        );
+      }
+    }
+  }
+
+  ConstructorElement _selectConstructor(
+    ClassElement declaration,
+    InterfaceType targetType,
+    String targetTypeLiteral,
+    String? constructorName, {
+    required bool external,
+  }) {
+    if (constructorName != null &&
+        (constructorName.isEmpty || constructorName.startsWith('_'))) {
+      throw InvalidGenerationSourceError(
+        'ForyStruct.constructor on ${declaration.displayName} must name a '
+        'public named generative constructor on $targetTypeLiteral.',
+        element: declaration,
+      );
+    }
+    final constructor = targetType.lookUpConstructor(
+      constructorName,
+      declaration.library,
+    );
+    if (constructor == null) {
+      final selected =
+          constructorName == null ? 'unnamed constructor' : '.$constructorName';
+      final remedy =
+          external
+              ? 'Expose that constructor, select another public named '
+                  'generative constructor, or use a manual serializer.'
+              : 'Add an accessible generative constructor.';
+      throw InvalidGenerationSourceError(
+        'Target $targetTypeLiteral for ${declaration.displayName} has no '
+        'accessible $selected. $remedy',
+        element: declaration,
+      );
+    }
+    if (!constructor.isGenerative || constructor.isFactory) {
+      final selected =
+          constructorName == null ? 'unnamed constructor' : '.$constructorName';
+      throw InvalidGenerationSourceError(
+        'Target constructor $targetTypeLiteral$selected selected by '
+        '${declaration.displayName} must be generative, not a factory. Select '
+        'a public generative constructor or use a manual serializer.',
+        element: declaration,
+      );
+    }
+    return constructor;
+  }
+
+  bool _containsTypeParameter(DartType type) {
+    if (type is TypeParameterType || type is InvalidType) {
+      return true;
+    }
+    if (type is InterfaceType) {
+      return type.typeArguments.any(_containsTypeParameter);
+    }
+    if (type is FunctionType) {
+      if (type.typeParameters.isNotEmpty ||
+          _containsTypeParameter(type.returnType)) {
+        return true;
+      }
+      return type.formalParameters.any(
+        (parameter) => _containsTypeParameter(parameter.type),
+      );
+    }
+    if (type is RecordType) {
+      return type.positionalFields.any(
+            (field) => _containsTypeParameter(field.type),
+          ) ||
+          type.namedFields.any((field) => _containsTypeParameter(field.type));
+    }
+    return false;
+  }
+
+  String _externalTargetTypeLiteral(
+    InterfaceType targetType,
+    ClassElement declaration,
+  ) {
+    String render(DartType type) {
+      final alias = type.alias;
+      if (alias != null) {
+        final base = _visibleTypeName(alias.element, declaration, targetType);
+        final arguments =
+            alias.typeArguments.isEmpty
+                ? ''
+                : '<${alias.typeArguments.map(render).join(', ')}>';
+        final nullable =
+            alias.nullabilitySuffix == NullabilitySuffix.question ? '?' : '';
+        return '$base$arguments$nullable';
+      }
+      if (type is DynamicType) {
+        return 'dynamic';
+      }
+      if (type is NeverType) {
+        return 'Never';
+      }
+      if (type is VoidType) {
+        return 'void';
+      }
+      if (type is InterfaceType) {
+        final base = _visibleTypeName(type.element, declaration, targetType);
+        final arguments =
+            type.typeArguments.isEmpty
+                ? ''
+                : '<${type.typeArguments.map(render).join(', ')}>';
+        final nullable =
+            type.nullabilitySuffix == NullabilitySuffix.question ? '?' : '';
+        return '$base$arguments$nullable';
+      }
+      throw InvalidGenerationSourceError(
+        'ForyStruct.target ${targetType.getDisplayString()} on '
+        '${declaration.displayName} contains a type that cannot be rendered '
+        'from the declaration library. Import a public closed class type '
+        'directly or use a manual serializer.',
+        element: declaration,
+      );
+    }
+
+    return render(targetType);
+  }
+
+  String _visibleTypeName(
+    Element typeElement,
+    ClassElement declaration,
+    InterfaceType targetType,
+  ) {
+    if (typeElement.library == declaration.library ||
+        typeElement.library?.isDartCore == true) {
+      return typeElement.displayName;
+    }
+    if (_importPrefixByElement.containsKey(typeElement)) {
+      final prefix = _importPrefixByElement[typeElement];
+      return prefix == null
+          ? typeElement.displayName
+          : '$prefix.${typeElement.displayName}';
+    }
+    throw InvalidGenerationSourceError(
+      'ForyStruct.target ${targetType.getDisplayString()} on '
+      '${declaration.displayName} cannot be rendered from this library. '
+      'Import the public target and every generic argument directly.',
+      element: declaration,
+    );
+  }
+
   void _buildImportPrefixMap(LibraryReader library) {
     _importPrefixByLibraryIdentifier.clear();
+    _importPrefixByElement.clear();
     for (final import in library.element.firstFragment.libraryImports) {
       final importedLibrary = import.importedLibrary;
       final prefix = import.prefix?.element.displayName;
-      if (importedLibrary == null || prefix == null || prefix.isEmpty) {
+      if (importedLibrary == null) {
         continue;
       }
-      _importPrefixByLibraryIdentifier[importedLibrary.identifier] = prefix;
+      final normalizedPrefix = prefix == null || prefix.isEmpty ? null : prefix;
+      if (normalizedPrefix != null) {
+        _importPrefixByLibraryIdentifier[importedLibrary.identifier] =
+            normalizedPrefix;
+      }
+      for (final importedElement in import.namespace.definedNames2.values) {
+        if (!_importPrefixByElement.containsKey(importedElement) ||
+            normalizedPrefix == null) {
+          _importPrefixByElement[importedElement] = normalizedPrefix;
+        }
+      }
     }
   }
 
@@ -191,7 +510,12 @@ final class ForyGenerator extends Generator {
     );
   }
 
-  _GeneratedFieldSpec _analyzeField(FieldElement field) {
+  _GeneratedFieldSpec _analyzeField(
+    ClassElement declaration,
+    InterfaceType targetType,
+    String targetTypeLiteral,
+    FieldElement field,
+  ) {
     final annotation = _fieldAnnotationOf(field);
     final reader = annotation == null ? null : ConstantReader(annotation);
     final idValue = reader?.peek('id');
@@ -216,6 +540,51 @@ final class ForyGenerator extends Generator {
             : dynamicValue.boolValue;
     final ref = reader?.peek('ref')?.boolValue ?? false;
     final typeSpec = _analyzeTypeSpecAnnotation(field, reader);
+    final getter = targetType.lookUpGetter(
+      field.displayName,
+      declaration.library,
+    );
+    if (getter == null || getter.isStatic) {
+      throw InvalidGenerationSourceError(
+        'Fory struct declaration ${declaration.displayName} targets '
+        '$targetTypeLiteral, which must expose an accessible '
+        'instance getter named ${field.displayName}. Expose the getter or use '
+        'a manual serializer.',
+        element: field,
+      );
+    }
+    if (getter.returnType != field.type) {
+      throw InvalidGenerationSourceError(
+        'Getter ${field.displayName} on target '
+        '$targetTypeLiteral has type '
+        '${_typeCodeString(getter.returnType)}, but serializer declaration '
+        '${declaration.displayName}.${field.displayName} has type '
+        '${_typeCodeString(field.type)}. The types must match exactly.',
+        element: field,
+      );
+    }
+    final setter = targetType.lookUpSetter(
+      field.displayName,
+      declaration.library,
+    );
+    if (setter != null) {
+      final parameters = setter.formalParameters;
+      if (parameters.length != 1 || parameters.single.type != field.type) {
+        final setterType =
+            parameters.length == 1
+                ? _typeCodeString(parameters.single.type)
+                : 'an invalid parameter list';
+        throw InvalidGenerationSourceError(
+          'Setter ${field.displayName} on target '
+          '$targetTypeLiteral accepts $setterType, but '
+          'serializer declaration '
+          '${declaration.displayName}.${field.displayName} has type '
+          '${_typeCodeString(field.type)}. Getter, setter, and declaration '
+          'types must match exactly.',
+          element: field,
+        );
+      }
+    }
 
     return _GeneratedFieldSpec(
       name: field.displayName,
@@ -227,7 +596,7 @@ final class ForyGenerator extends Generator {
       nullable: nullable,
       ref: ref,
       dynamic: dynamic,
-      writable: field.setter != null,
+      writable: setter != null,
       fieldType: _fieldTypeForType(
         field.type,
         nullable: nullable,
@@ -378,26 +747,18 @@ final class ForyGenerator extends Generator {
   }
 
   _ConstructionModel _buildConstructionModel(
-    ClassElement element,
+    ClassElement declaration,
+    InterfaceType targetType,
+    String targetTypeLiteral,
+    ConstructorElement constructor,
+    String? constructorName,
     List<_GeneratedFieldSpec> fields,
   ) {
-    final unnamedConstructor = element.unnamedConstructor;
-    final hasZeroArgConstructor =
-        unnamedConstructor != null &&
-        !unnamedConstructor.isFactory &&
-        unnamedConstructor.formalParameters.every(
-          (parameter) => parameter.isOptional,
-        );
+    final hasZeroArgConstructor = constructor.formalParameters.every(
+      (parameter) => parameter.isOptional,
+    );
     if (hasZeroArgConstructor && fields.every((field) => field.writable)) {
-      return const _ConstructionModel.mutable();
-    }
-
-    if (unnamedConstructor == null || unnamedConstructor.isFactory) {
-      throw InvalidGenerationSourceError(
-        'Generated Fory serializers require either a writable zero-argument constructor '
-        'or an unnamed generative constructor whose parameters map to fields.',
-        element: element,
-      );
+      return _ConstructionModel.mutable(constructorName: constructorName);
     }
 
     final fieldByName = <String, _GeneratedFieldSpec>{
@@ -405,17 +766,46 @@ final class ForyGenerator extends Generator {
     };
     final arguments = <_ConstructorArgumentSpec>[];
     final constructorFieldNames = <String>{};
-    for (final parameter in unnamedConstructor.formalParameters) {
+    var omittedOptionalPositional = false;
+    for (final parameter in constructor.formalParameters) {
       final parameterName = parameter.displayName;
       final field = fieldByName[parameterName];
       if (field == null) {
         if (parameter.isRequiredNamed || parameter.isRequiredPositional) {
           throw InvalidGenerationSourceError(
-            'Constructor parameter $parameterName does not match a serializable field.',
-            element: parameter,
+            'Required constructor parameter $parameterName on '
+            '$targetTypeLiteral does not match a field in serializer '
+            'declaration ${declaration.displayName}. Add an exact matching '
+            'schema field or select another constructor.',
+            element: declaration,
+          );
+        }
+        if (parameter.isOptionalPositional) {
+          omittedOptionalPositional = true;
+        }
+        continue;
+      }
+      if (parameter.isPositional && omittedOptionalPositional) {
+        if (!field.writable) {
+          throw InvalidGenerationSourceError(
+            'Constructor ${_constructorReference(targetTypeLiteral, constructorName)} '
+            'cannot map positional field $parameterName after an omitted '
+            'optional positional parameter, and the target has no matching '
+            'setter. Add the earlier schema field, expose a setter, or select '
+            'another constructor.',
+            element: declaration,
           );
         }
         continue;
+      }
+      if (parameter.type != field.type) {
+        throw InvalidGenerationSourceError(
+          'Constructor parameter $parameterName on $targetTypeLiteral has type '
+          '${_typeCodeString(parameter.type)}, but serializer declaration '
+          '${declaration.displayName}.$parameterName has type '
+          '${_typeCodeString(field.type)}. The types must match exactly.',
+          element: declaration,
+        );
       }
       constructorFieldNames.add(field.name);
       arguments.add(
@@ -430,8 +820,12 @@ final class ForyGenerator extends Generator {
     for (final field in fields) {
       if (!constructorFieldNames.contains(field.name) && !field.writable) {
         throw InvalidGenerationSourceError(
-          'Field ${field.name} must be writable or provided by the unnamed constructor.',
-          element: element,
+          'Field ${declaration.displayName}.${field.name} is not consumed by '
+          '${_constructorReference(targetTypeLiteral, constructorName)} and '
+          'target $targetTypeLiteral has no accessible exact-type setter. '
+          'Expose a matching setter, map the field through the constructor, or '
+          'use a manual serializer.',
+          element: declaration,
         );
       }
     }
@@ -439,13 +833,15 @@ final class ForyGenerator extends Generator {
     final selfRefField =
         fields
             .where((field) => field.ref)
-            .where((field) => _sameType(field.type, element.thisType))
+            .where((field) => _sameType(field.type, targetType))
             .firstOrNull;
     if (selfRefField != null) {
       throw InvalidGenerationSourceError(
         'Constructor-based generated serializers cannot bind self references early. '
-        'Use a writable zero-argument constructor for ${element.displayName}.',
-        element: selfRefField.type.element,
+        'Use a writable zero-required-argument generative constructor for '
+        '$targetTypeLiteral or a manual serializer. Offending field: '
+        '${declaration.displayName}.${selfRefField.name}.',
+        element: declaration,
       );
     }
 
@@ -455,10 +851,19 @@ final class ForyGenerator extends Generator {
         .toList(growable: false);
 
     return _ConstructionModel.constructor(
+      constructorName: constructorName,
       arguments: arguments,
       postConstructionFieldNames: postConstructionFields,
     );
   }
+
+  String _constructorReference(
+    String targetTypeLiteral,
+    String? constructorName,
+  ) =>
+      constructorName == null
+          ? targetTypeLiteral
+          : '$targetTypeLiteral.$constructorName';
 
   void _writeEnum(StringBuffer output, _GeneratedEnumSpec enumSpec) {
     final serializerClassName = '_${enumSpec.name}ForySerializer';
@@ -529,10 +934,10 @@ final class ForyGenerator extends Generator {
       ..writeln('];')
       ..writeln()
       ..writeln(
-        'final GeneratedStructSchema<${structSpec.name}> $schemaName = GeneratedStructSchema<${structSpec.name}>(',
+        'final GeneratedStructSchema<${structSpec.targetTypeLiteral}> $schemaName = GeneratedStructSchema<${structSpec.targetTypeLiteral}>(',
       );
     output
-      ..writeln('  type: ${structSpec.name},')
+      ..writeln('  type: ${structSpec.targetTypeLiteral},')
       ..writeln('  serializerFactory: _${structSpec.name}ForySerializer.new,')
       ..writeln('  evolving: ${structSpec.evolving},')
       ..writeln(
@@ -545,7 +950,7 @@ final class ForyGenerator extends Generator {
       ..writeln(');')
       ..writeln()
       ..writeln(
-        'final class $serializerClassName extends Serializer<${structSpec.name}> implements GeneratedStructSerializer<${structSpec.name}> {',
+        'final class $serializerClassName extends Serializer<${structSpec.targetTypeLiteral}> implements GeneratedStructSerializer<${structSpec.targetTypeLiteral}> {',
       )
       ..writeln('  List<GeneratedStructFieldDescriptor>? _fieldDescriptors;')
       ..writeln()
@@ -574,7 +979,7 @@ final class ForyGenerator extends Generator {
       ..writeln('  }')
       ..writeln('  @override')
       ..writeln(
-        '  void write(WriteContext context, ${structSpec.name} value) {',
+        '  void write(WriteContext context, ${structSpec.targetTypeLiteral} value) {',
       );
     if (writeUsesBuffer) {
       output.writeln('      final buffer = context.buffer;');
@@ -632,13 +1037,17 @@ final class ForyGenerator extends Generator {
       ..writeln('  }')
       ..writeln()
       ..writeln('  @override')
-      ..writeln('  ${structSpec.name} read(ReadContext context) {');
+      ..writeln(
+        '  ${structSpec.targetTypeLiteral} read(ReadContext context) {',
+      );
     final graphObjectBytes = _graphObjectBytes(structSpec);
 
     switch (structSpec.constructionModel.mode) {
       case _ConstructorMode.mutable:
         output.writeln('    context.reserveGraphMemory($graphObjectBytes);');
-        output.writeln('    final value = ${structSpec.name}();');
+        output.writeln(
+          '    final value = ${_constructorReference(structSpec.targetTypeLiteral, structSpec.constructionModel.constructorName)}();',
+        );
         if (_structNeedsEarlyReadReference(structSpec)) {
           output
             ..writeln('    if (context.hasPreservedRefId) {')
@@ -813,14 +1222,16 @@ final class ForyGenerator extends Generator {
       ..writeln()
       ..writeln('  @override')
       ..writeln(
-        '  ${structSpec.name} readCompatibleStruct(ReadContext context, CompatibleStructReadLayout layout) {',
+        '  ${structSpec.targetTypeLiteral} readCompatibleStruct(ReadContext context, CompatibleStructReadLayout layout) {',
       );
     switch (structSpec.constructionModel.mode) {
       case _ConstructorMode.mutable:
         output.writeln(
           '    context.reserveGraphMemory(${_graphObjectBytes(structSpec)});',
         );
-        output.writeln('    final value = ${structSpec.name}();');
+        output.writeln(
+          '    final value = ${_constructorReference(structSpec.targetTypeLiteral, structSpec.constructionModel.constructorName)}();',
+        );
         if (_structNeedsEarlyReadReference(structSpec)) {
           output
             ..writeln('    if (context.hasPreservedRefId) {')
@@ -874,12 +1285,13 @@ final class ForyGenerator extends Generator {
   }) {
     final mutable =
         structSpec.constructionModel.mode == _ConstructorMode.mutable;
-    final valueParameter = mutable ? ', ${structSpec.name} value' : '';
+    final valueParameter =
+        mutable ? ', ${structSpec.targetTypeLiteral} value' : '';
     output
       ..writeln()
       ..writeln("  @pragma('vm:never-inline')")
       ..writeln(
-        '  ${structSpec.name} _readCompatibleStructFallback(ReadContext context, CompatibleStructReadLayout layout$valueParameter) {',
+        '  ${structSpec.targetTypeLiteral} _readCompatibleStructFallback(ReadContext context, CompatibleStructReadLayout layout$valueParameter) {',
       );
     if (readUsesBuffer) {
       output.writeln('    final buffer = context.buffer;');
@@ -938,7 +1350,7 @@ final class ForyGenerator extends Generator {
     output
       ..writeln('        default:')
       ..writeln(
-        "          throw StateError('Compatible matched id is out of range for ${structSpec.name}.');",
+        "          throw StateError('Compatible matched id is out of range for ${structSpec.targetTypeLiteral}.');",
       )
       ..writeln('      }')
       ..writeln('    }')
@@ -997,7 +1409,7 @@ final class ForyGenerator extends Generator {
     output
       ..writeln('        default:')
       ..writeln(
-        "          throw StateError('Compatible matched id is out of range for ${structSpec.name}.');",
+        "          throw StateError('Compatible matched id is out of range for ${structSpec.targetTypeLiteral}.');",
       )
       ..writeln('      }')
       ..writeln('    }');
@@ -1192,7 +1604,7 @@ final class ForyGenerator extends Generator {
     }
     for (final structSpec in structSpecs) {
       final schemaName = '_${_toCamelCase(structSpec.name)}ForySchema';
-      output.writeln('  if (type == ${structSpec.name}) {');
+      output.writeln('  if (type == ${structSpec.targetTypeLiteral}) {');
       output.writeln('    registerGeneratedStruct(');
       output.writeln('      fory,');
       output.writeln('      $schemaName,');
@@ -1229,7 +1641,7 @@ final class ForyGenerator extends Generator {
       ...positionalArguments,
       ...namedArguments,
     ].join(', ');
-    return '${structSpec.name}($arguments)';
+    return '${_constructorReference(structSpec.targetTypeLiteral, structSpec.constructionModel.constructorName)}($arguments)';
   }
 
   int _graphObjectBytes(_GeneratedStructSpec structSpec) =>
@@ -3602,8 +4014,7 @@ GeneratedFieldType(
   }
 
   bool _sameType(DartType left, DartType right) =>
-      _typeLiteral(_withoutNullability(left)) ==
-      _typeLiteral(_withoutNullability(right));
+      _withoutNullability(left) == _withoutNullability(right);
 
   bool? _autoDynamic(DartType type) {
     final nonNullable = _withoutNullability(type);
@@ -3785,12 +4196,16 @@ final class _GeneratedEnumSpec {
 
 final class _GeneratedStructSpec {
   final String name;
+  final InterfaceType targetType;
+  final String targetTypeLiteral;
   final bool evolving;
   final List<_GeneratedFieldSpec> fields;
   final _ConstructionModel constructionModel;
 
   const _GeneratedStructSpec({
     required this.name,
+    required this.targetType,
+    required this.targetTypeLiteral,
     required this.evolving,
     required this.fields,
     required this.constructionModel,
@@ -3867,15 +4282,17 @@ enum _ConstructorMode { mutable, constructor }
 
 final class _ConstructionModel {
   final _ConstructorMode mode;
+  final String? constructorName;
   final List<_ConstructorArgumentSpec> arguments;
   final List<String> postConstructionFieldNames;
 
-  const _ConstructionModel.mutable()
+  const _ConstructionModel.mutable({required this.constructorName})
     : mode = _ConstructorMode.mutable,
       arguments = const <_ConstructorArgumentSpec>[],
       postConstructionFieldNames = const <String>[];
 
   const _ConstructionModel.constructor({
+    required this.constructorName,
     required this.arguments,
     required this.postConstructionFieldNames,
   }) : mode = _ConstructorMode.constructor;

--- a/dart/packages/fory/pubspec.yaml
+++ b/dart/packages/fory/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: fory
-description: Cross-language Apache Fory runtime for Dart with generated serializers, schema evolution, and custom type support.
+description: Cross-language Apache Fory runtime for Dart with generated serializers, schema evolution, and manual serializer support.
 version: 1.5.0-dev
 homepage: https://fory.apache.org
 repository: https://github.com/apache/fory/tree/main/dart/packages/fory
@@ -36,5 +36,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=2.7.0 <3.0.0'
+  build_test: '>=3.3.1 <3.5.16'
   lints: ^6.1.0
   test: ^1.31.1

--- a/dart/packages/fory/test/external_type_generator_test.dart
+++ b/dart/packages/fory/test/external_type_generator_test.dart
@@ -29,6 +29,7 @@ import 'package:test/test.dart';
 const String _fixtureHeader = '''
 import 'package:fory/src/annotation/fory_field.dart';
 import 'package:fory/src/annotation/fory_struct.dart';
+import 'package:fory/src/annotation/type_spec.dart';
 import 'external_target_fixture.dart';
 
 part 'external_serializer_fixture.fory.dart';
@@ -648,7 +649,83 @@ abstract final class TargetSerializer {
   late final Target? next;
 }
 ''',
-      message: 'cannot bind self references early',
+      message: 'cannot bind reference-tracked self paths',
+    );
+  });
+
+  test('rejects nested constructor self reference', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.children);
+  final List<Target> children;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  @ListField(element: DeclaredType(ref: true))
+  late final List<Target> children;
+}
+''',
+      message: 'cannot bind reference-tracked self paths',
+    );
+  });
+
+  test('rejects set constructor self reference', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.children);
+  final Set<Target> children;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  @SetField(element: DeclaredType(ref: true))
+  late final Set<Target> children;
+}
+''',
+      message: 'cannot bind reference-tracked self paths',
+    );
+  });
+
+  test('rejects map-key constructor self reference', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.children);
+  final Map<Target, String> children;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  @MapField(key: DeclaredType(ref: true))
+  late final Map<Target, String> children;
+}
+''',
+      message: 'cannot bind reference-tracked self paths',
+    );
+  });
+
+  test('rejects map-value constructor self reference', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.children);
+  final Map<String, List<Target>> children;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  @MapField(value: ListType(element: DeclaredType(ref: true)))
+  late final Map<String, List<Target>> children;
+}
+''',
+      message: 'cannot bind reference-tracked self paths',
     );
   });
 }

--- a/dart/packages/fory/test/external_type_generator_test.dart
+++ b/dart/packages/fory/test/external_type_generator_test.dart
@@ -81,14 +81,17 @@ Future<void> _expectGenerationOutput({
   required String targetSource,
   required String declarationSource,
   required Matcher output,
+  String fixtureHeader = _fixtureHeader,
+  Map<String, String> additionalAssets = const <String, String>{},
 }) async {
   await testBuilder(
     foryBuilder(BuilderOptions.empty),
     <String, String>{
       ...(await _annotationAssets),
       'fory|test/external_target_fixture.dart': targetSource,
+      ...additionalAssets,
       'fory|test/external_serializer_fixture.dart':
-          '$_fixtureHeader\n$declarationSource',
+          '$fixtureHeader\n$declarationSource',
     },
     rootPackage: 'fory',
     generateFor: <String>{'fory|test/external_serializer_fixture.dart'},
@@ -544,6 +547,46 @@ abstract final class TargetSerializer {
       output: allOf(
         contains('final value = Target(_firstValue);'),
         contains('value.third = _thirdValue;'),
+      ),
+    );
+  });
+
+  test('renders prefixed re-exported generic target types', () async {
+    await _expectGenerationOutput(
+      targetSource: '''
+class User {
+  User(this.name);
+  final String name;
+}
+
+typedef UserAlias = User;
+
+class Box<T> {
+  Box(this.value);
+  final T value;
+}
+''',
+      additionalAssets: const <String, String>{
+        'fory|test/external_target_barrel.dart':
+            "export 'external_target_fixture.dart';",
+      },
+      fixtureHeader: '''
+import 'package:fory/src/annotation/fory_struct.dart';
+import 'external_target_barrel.dart' as api;
+
+part 'external_serializer_fixture.fory.dart';
+''',
+      declarationSource: '''
+@ForyStruct(target: api.Box<api.UserAlias>)
+abstract final class UserBoxSerializer {
+  late final api.UserAlias value;
+}
+''',
+      output: allOf(
+        contains('GeneratedStructSchema<api.Box<api.UserAlias>>'),
+        contains('type: api.UserAlias,'),
+        contains('api.UserAlias _valueValue'),
+        contains('final value = api.Box<api.UserAlias>(_valueValue);'),
       ),
     );
   });

--- a/dart/packages/fory/test/external_type_generator_test.dart
+++ b/dart/packages/fory/test/external_type_generator_test.dart
@@ -1,0 +1,611 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:fory/src/codegen/fory_builder.dart';
+import 'package:test/test.dart';
+
+const String _fixtureHeader = '''
+import 'package:fory/src/annotation/fory_field.dart';
+import 'package:fory/src/annotation/fory_struct.dart';
+import 'external_target_fixture.dart';
+
+part 'external_serializer_fixture.fory.dart';
+''';
+
+final Future<Map<String, String>> _annotationAssets = _loadAnnotationAssets();
+
+Future<Map<String, String>> _loadAnnotationAssets() async {
+  const paths = <String>[
+    'src/annotation/fory_field.dart',
+    'src/annotation/fory_struct.dart',
+    'src/annotation/fory_union.dart',
+    'src/annotation/type_spec.dart',
+  ];
+  final assets = <String, String>{};
+  for (final path in paths) {
+    final uri = await Isolate.resolvePackageUri(
+      Uri.parse('package:fory/$path'),
+    );
+    if (uri == null) {
+      throw StateError('Could not resolve package:fory/$path.');
+    }
+    assets['fory|lib/$path'] = await File.fromUri(uri).readAsString();
+  }
+  return assets;
+}
+
+Future<void> _expectGenerationError({
+  required String targetSource,
+  required String declarationSource,
+  required String message,
+}) async {
+  final logs = <String>[];
+  await testBuilder(
+    foryBuilder(BuilderOptions.empty),
+    <String, String>{
+      ...(await _annotationAssets),
+      'fory|test/external_target_fixture.dart': targetSource,
+      'fory|test/external_serializer_fixture.dart':
+          '$_fixtureHeader\n$declarationSource',
+    },
+    rootPackage: 'fory',
+    generateFor: <String>{'fory|test/external_serializer_fixture.dart'},
+    onLog: (record) => logs.add(record.message),
+  );
+  expect(logs, contains(contains(message)));
+}
+
+Future<void> _expectGenerationOutput({
+  required String targetSource,
+  required String declarationSource,
+  required Matcher output,
+}) async {
+  await testBuilder(
+    foryBuilder(BuilderOptions.empty),
+    <String, String>{
+      ...(await _annotationAssets),
+      'fory|test/external_target_fixture.dart': targetSource,
+      'fory|test/external_serializer_fixture.dart':
+          '$_fixtureHeader\n$declarationSource',
+    },
+    rootPackage: 'fory',
+    generateFor: <String>{'fory|test/external_serializer_fixture.dart'},
+    outputs: <String, Matcher>{
+      'fory|test/external_serializer_fixture.fory.dart': decodedMatches(output),
+    },
+  );
+}
+
+void main() {
+  test('rejects constructor without target', () async {
+    await _expectGenerationError(
+      targetSource: 'class Target {}',
+      declarationSource: '''
+@ForyStruct(constructor: 'named')
+final class Value {
+  Value.named();
+}
+''',
+      message: 'valid only when ForyStruct.target is set',
+    );
+  });
+
+  test('rejects non-class target', () async {
+    await _expectGenerationError(
+      targetSource: 'class Target {}',
+      declarationSource: '''
+@ForyStruct(target: Never)
+abstract final class TargetSerializer {}
+''',
+      message: 'must name a concrete Dart class',
+    );
+  });
+
+  test('rejects carrier target', () async {
+    await _expectGenerationError(
+      targetSource: 'class Target {}',
+      declarationSource: '''
+@ForyStruct(target: List<String>)
+abstract final class ListSerializer {}
+''',
+      message: 'owned by an existing built-in',
+    );
+  });
+
+  test('rejects self target', () async {
+    await _expectGenerationError(
+      targetSource: 'class Target {}',
+      declarationSource: '''
+@ForyStruct(target: TargetSerializer)
+abstract final class TargetSerializer {}
+''',
+      message: 'must name another class',
+    );
+  });
+
+  test('rejects extension target', () async {
+    await _expectGenerationError(
+      targetSource: 'extension type Target(int value) {}',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {}
+''',
+      message: 'owned by an existing built-in',
+    );
+  });
+
+  test('rejects builtin target', () async {
+    await _expectGenerationError(
+      targetSource: 'class Target {}',
+      declarationSource: '''
+@ForyStruct(target: String)
+abstract final class StringSerializer {}
+''',
+      message: 'owned by an existing built-in',
+    );
+  });
+
+  test('rejects enum target', () async {
+    await _expectGenerationError(
+      targetSource: 'enum Target { value }',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {}
+''',
+      message: 'must name a concrete Dart class',
+    );
+  });
+
+  test('rejects abstract target', () async {
+    await _expectGenerationError(
+      targetSource: '''
+abstract class Target {
+  String get value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'must be a concrete constructable Dart class',
+    );
+  });
+
+  test('rejects union target', () async {
+    await _expectGenerationError(
+      targetSource: '''
+import 'package:fory/src/annotation/fory_union.dart';
+
+@ForyUnion()
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'owned by an existing built-in',
+    );
+  });
+
+  test('rejects declaration shape', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'must be declared abstract final',
+    );
+  });
+
+  test('rejects generic declaration', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer<T> {
+  late final String value;
+}
+''',
+      message: 'cannot declare type parameters',
+    );
+  });
+
+  test('rejects unresolved target type parameter', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target<T> {
+  Target(this.value);
+  final T value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target<T>)
+abstract final class TargetSerializer<T> {
+  late final T value;
+}
+''',
+      message: 'must be a closed type',
+    );
+  });
+
+  test('rejects non-schema field shape', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late String value;
+}
+''',
+      message: 'must be a late final field without an initializer',
+    );
+  });
+
+  test('rejects schema field initializer', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value = '';
+}
+''',
+      message: 'must be a late final field without an initializer',
+    );
+  });
+
+  test('rejects duplicate target', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class FirstSerializer {
+  late final String value;
+}
+
+@ForyStruct(target: Target)
+abstract final class SecondSerializer {
+  late final String value;
+}
+''',
+      message: 'both target Target',
+    );
+  });
+
+  test('rejects inaccessible getter', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this._value);
+  final String _value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String _value;
+}
+''',
+      message: 'must expose an accessible instance getter named _value',
+    );
+  });
+
+  test('rejects getter type mismatch', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final int value;
+}
+''',
+      message: 'types must match exactly',
+    );
+  });
+
+  test('rejects getter nullability mismatch', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.value);
+  final String? value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'types must match exactly',
+    );
+  });
+
+  test('rejects inaccessible constructor', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target._();
+  String get value => '';
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'has no accessible unnamed constructor',
+    );
+  });
+
+  test('rejects missing named constructor', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target();
+  String get value => '';
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target, constructor: 'missing')
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'has no accessible .missing',
+    );
+  });
+
+  test('rejects empty constructor selection', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target();
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target, constructor: '')
+abstract final class TargetSerializer {}
+''',
+      message: 'must name a public named generative constructor',
+    );
+  });
+
+  test('rejects private constructor selection', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target._hidden();
+  String get value => '';
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target, constructor: '_hidden')
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'must name a public named generative constructor',
+    );
+  });
+
+  test('rejects factory constructor', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  factory Target() => Target._();
+  Target._();
+  String get value => '';
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'must be generative, not a factory',
+    );
+  });
+
+  test('rejects missing required constructor field', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target({required String hidden}) : value = hidden;
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'Required constructor parameter hidden',
+    );
+  });
+
+  test('rejects constructor type mismatch', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(Object value) : value = value as String;
+  final String value;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'Constructor parameter value',
+    );
+  });
+
+  test('rejects optional positional gap', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target([String first = '', this.second = '']);
+  final String second;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String second;
+}
+''',
+      message: 'after an omitted optional positional parameter',
+    );
+  });
+
+  test('uses setter after optional positional gap', () async {
+    await _expectGenerationOutput(
+      targetSource: '''
+class Target {
+  Target([this.first = '', String ignored = '', this.third = '']);
+  final String first;
+  String third;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String first;
+  late final String third;
+}
+''',
+      output: allOf(
+        contains('final value = Target(_firstValue);'),
+        contains('value.third = _thirdValue;'),
+      ),
+    );
+  });
+
+  test('rejects missing post-construction setter', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target({required this.name}) : score = 0;
+  final String name;
+  final int score;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String name;
+  late final int score;
+}
+''',
+      message: 'has no accessible exact-type setter',
+    );
+  });
+
+  test('rejects setter type mismatch', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target();
+  String _value = '';
+  String get value => _value;
+  set value(Object value) {
+    _value = value as String;
+  }
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  late final String value;
+}
+''',
+      message: 'Getter, setter, and declaration types must match exactly',
+    );
+  });
+
+  test('rejects constructor self reference', () async {
+    await _expectGenerationError(
+      targetSource: '''
+class Target {
+  Target(this.next);
+  final Target? next;
+}
+''',
+      declarationSource: '''
+@ForyStruct(target: Target)
+abstract final class TargetSerializer {
+  @ForyField(ref: true)
+  late final Target? next;
+}
+''',
+      message: 'cannot bind self references early',
+    );
+  });
+}

--- a/dart/packages/fory/test/external_type_generator_test.dart
+++ b/dart/packages/fory/test/external_type_generator_test.dart
@@ -552,7 +552,7 @@ abstract final class TargetSerializer {
     );
   });
 
-  test('renders prefixed re-exported generic target types', () async {
+  test('renders nullable prefixed re-exported types', () async {
     await _expectGenerationOutput(
       targetSource: '''
 class User {
@@ -564,12 +564,12 @@ typedef UserAlias = User;
 
 class Box<T> {
   Box(this.value);
-  final T value;
+  final T? value;
 }
 ''',
       additionalAssets: const <String, String>{
         'fory|test/external_target_barrel.dart':
-            "export 'external_target_fixture.dart';",
+            "export 'external_target_fixture.dart' show Box, UserAlias;",
       },
       fixtureHeader: '''
 import 'package:fory/src/annotation/fory_struct.dart';
@@ -580,13 +580,13 @@ part 'external_serializer_fixture.fory.dart';
       declarationSource: '''
 @ForyStruct(target: api.Box<api.UserAlias>)
 abstract final class UserBoxSerializer {
-  late final api.UserAlias value;
+  late final api.UserAlias? value;
 }
 ''',
       output: allOf(
         contains('GeneratedStructSchema<api.Box<api.UserAlias>>'),
         contains('type: api.UserAlias,'),
-        contains('api.UserAlias _valueValue'),
+        contains('api.UserAlias? _valueValue'),
         contains('final value = api.Box<api.UserAlias>(_valueValue);'),
       ),
     );

--- a/dart/packages/fory/test/manual_registration_test.dart
+++ b/dart/packages/fory/test/manual_registration_test.dart
@@ -112,7 +112,7 @@ final class RefValueFlagValueSerializer extends Serializer<RefValueFlagValue> {
 }
 
 void main() {
-  test('registers custom serializer through public registerSerializer api', () {
+  test('registers manual serializer through public api', () {
     final fory = Fory();
     fory.registerSerializer(
       ManualValue,

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -31,5 +31,6 @@ dev_dependencies:
   lints: ^6.1.0
   test: ^1.31.1
 workspace:
+  - packages/external-type-test-models
   - packages/fory
   - packages/fory-test

--- a/docs/guide/dart/code-generation.md
+++ b/docs/guide/dart/code-generation.md
@@ -52,6 +52,10 @@ class User {
 
 Enums defined in the same file are automatically included in the generated registration.
 
+For a class owned by another library, define an
+[external structural serializer](external-types.md) with
+`@ForyStruct(target: ExternalType)`.
+
 ## Step 2 — Run the Generator
 
 From the directory that contains your `pubspec.yaml`:
@@ -103,12 +107,16 @@ class Event {
 
 When using evolving structs, also assign stable field IDs with `@ForyField(id: ...)` before you ship your first payload — those IDs are how Fory matches fields after a schema change.
 
-## When Not to Use Code Generation
+## Choosing Generated or Manual Serialization
 
-If you cannot annotate a type (e.g., it comes from a package you do not own), write a [Custom Serializer](custom-serializers.md) instead.
+Use an [external structural serializer](external-types.md) when another
+package's class exposes matching public getters and a safe public construction
+path. Use a [manual serializer](custom-serializers.md) when the wire body,
+field names, values, or construction need custom logic.
 
 ## Related Topics
 
 - [Type Registration](type-registration.md)
+- [External-Type Serialization](external-types.md)
 - [Schema Metadata](schema-metadata.md)
 - [Schema Evolution](schema-evolution.md)

--- a/docs/guide/dart/custom-serializers.md
+++ b/docs/guide/dart/custom-serializers.md
@@ -1,6 +1,6 @@
 ---
-title: Custom Serializers
-sidebar_position: 9
+title: Manual Serializers
+sidebar_position: 10
 id: custom_serializers
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -19,13 +19,18 @@ license: |
   limitations under the License.
 ---
 
-A custom serializer lets you control exactly how a type is encoded and decoded. You only need one when:
+A manual serializer lets you control exactly how a type is encoded and decoded.
+Use one when:
 
-- the type comes from a package you cannot modify and cannot be annotated with `@ForyStruct()`
 - you need a completely custom binary layout
+- the target requires field-name translation or value conversion
+- the target exposes only factory or private construction
+- the target's complete state is not available through matching public members
 - you are implementing a union/discriminated type
 
-For your own models, `@ForyStruct()` with code generation is almost always the better choice.
+Use `@ForyStruct()` for your own models. For a structurally matching class in
+another package, use an
+[external structural serializer](external-types.md).
 
 ## Implement `Serializer<T>`
 
@@ -113,7 +118,7 @@ final class ShapeSerializer extends UnionSerializer<Shape> {
 }
 ```
 
-## Circular References in Custom Serializers
+## Circular References in Manual Serializers
 
 If your serializer can encounter circular object graphs, bind the object to the reference tracker **before** reading its nested fields:
 
@@ -134,5 +139,6 @@ Skipping this step causes back-references to that object to resolve to `null`.
 ## Related Topics
 
 - [Type Registration](type-registration.md)
+- [External-Type Serialization](external-types.md)
 - [Xlang Serialization](xlang-serialization.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/guide/dart/external-types.md
+++ b/docs/guide/dart/external-types.md
@@ -104,7 +104,21 @@ Without a `constructor` option, generation uses the target's public unnamed
 generative constructor. Constructor parameters map to schema fields by name
 and must use exactly the same Dart types.
 
-Select a public named generative constructor when needed:
+For example, suppose the dependency exposes this immutable class:
+
+```dart
+final class Money {
+  const Money.fromParts({
+    required this.currency,
+    required this.units,
+  });
+
+  final String currency;
+  final int units;
+}
+```
+
+Select its public named generative constructor in the serializer declaration:
 
 ```dart
 @ForyStruct(
@@ -119,10 +133,24 @@ abstract final class MoneySerializer {
 }
 ```
 
+After decoding the fields, the generated serializer calls
+`third_party.Money.fromParts(currency: ..., units: ...)`.
+
 For a mutable target, a public generative constructor with no required
 arguments plus matching setters allows Fory to construct the target first and
 then assign its fields. This also supports cycles when reference tracking is
-enabled:
+enabled. For example, suppose the dependency exposes:
+
+```dart
+final class Node {
+  Node.empty();
+
+  late String label;
+  Node? next;
+}
+```
+
+Select `Node.empty` in the serializer declaration:
 
 ```dart
 @ForyStruct(
@@ -136,6 +164,9 @@ abstract final class NodeSerializer {
   late final third_party.Node? next;
 }
 ```
+
+The generated serializer can call `third_party.Node.empty()`, publish the new
+node for reference tracking, and then assign `label` and `next`.
 
 A constructor-based target cannot decode a statically known reference-tracked
 path back to itself because the target does not exist until its constructor

--- a/docs/guide/dart/external-types.md
+++ b/docs/guide/dart/external-types.md
@@ -252,10 +252,27 @@ abstract final class StringBoxSerializer {
 ```
 
 The generated serializer reconstructs values with
-`third_party.Box<String>(...)` and applies only to `Box<String>`. Register
-`third_party.Box<String>` as the target. A different instantiation such as
-`Box<int>` needs its own serializer declaration and registration; one
-declaration does not cover every `Box<T>`.
+`third_party.Box<String>(...)` and applies only to `Box<String>`. Register and
+use that exact target type directly:
+
+```dart
+final fory = Fory();
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.Box<String>,
+  id: 102,
+);
+
+final input = const third_party.Box<String>('hello');
+final bytes = fory.serialize(input);
+final output = fory.deserialize<third_party.Box<String>>(bytes);
+
+print(output.value); // hello
+```
+
+Register `third_party.Box<String>`, not `StringBoxSerializer`. A different
+instantiation such as `Box<int>` needs its own serializer declaration and
+registration; one declaration does not cover every `Box<T>`.
 
 ## Schema Evolution
 

--- a/docs/guide/dart/external-types.md
+++ b/docs/guide/dart/external-types.md
@@ -230,7 +230,19 @@ An empty root collection contains no element type identity.
 
 ## Closed Generic Targets
 
-A serializer declaration can target one closed generic instantiation:
+Suppose the dependency exposes this generic class:
+
+```dart
+final class Box<T> {
+  const Box(this.value);
+
+  final T value;
+}
+```
+
+`Box<T>` is open because `T` is unresolved. Supplying a concrete type argument,
+such as `Box<String>`, produces a closed generic instantiation that code
+generation can analyze:
 
 ```dart
 @ForyStruct(target: third_party.Box<String>)
@@ -239,8 +251,11 @@ abstract final class StringBoxSerializer {
 }
 ```
 
-Register `third_party.Box<String>`. A different instantiation needs its own
-serializer declaration and registration.
+The generated serializer reconstructs values with
+`third_party.Box<String>(...)` and applies only to `Box<String>`. Register
+`third_party.Box<String>` as the target. A different instantiation such as
+`Box<int>` needs its own serializer declaration and registration; one
+declaration does not cover every `Box<T>`.
 
 ## Schema Evolution
 

--- a/docs/guide/dart/external-types.md
+++ b/docs/guide/dart/external-types.md
@@ -137,9 +137,13 @@ abstract final class NodeSerializer {
 }
 ```
 
-A constructor-based target cannot decode a direct self-reference because the
-target does not exist until its constructor arguments have been read. Use a
-mutable two-phase target or a manual serializer for that shape.
+A constructor-based target cannot decode a statically known reference-tracked
+path back to itself because the target does not exist until its constructor
+arguments have been read. This includes the target nested as a `List` or `Set`
+element or as a `Map` key or value. Generation rejects these schemas. Use a
+mutable two-phase target or a manual serializer when cycles are required.
+Indirect cycles that cannot be determined from the declaration are also
+unsupported for constructor-based targets.
 
 Factory constructors, private constructors, abstract targets, external enums,
 external unions, records, extension types, and built-in collection types are

--- a/docs/guide/dart/external-types.md
+++ b/docs/guide/dart/external-types.md
@@ -1,0 +1,243 @@
+---
+title: External-Type Serialization
+sidebar_position: 4
+id: external_types
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+External-type serialization generates a Fory struct serializer for a class
+owned by another Dart library or package. Define a local serializer declaration
+with the same fields and name the external class with `ForyStruct.target`.
+
+## Define an External Structural Serializer
+
+Suppose a dependency owns this class:
+
+```dart
+final class User {
+  const User({
+    required this.name,
+    required this.age,
+  });
+
+  final String name;
+  final int age;
+}
+```
+
+Add the serializer declaration in your package:
+
+```dart
+import 'package:fory/fory.dart';
+import 'package:third_party/models.dart' as third_party;
+
+part 'external_serializers.fory.dart';
+
+@ForyStruct(target: third_party.User)
+abstract final class UserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int age;
+}
+```
+
+The declaration must be `abstract final`, cannot have type parameters, and
+must declare each schema field as `late final` without an initializer. Each
+field name and Dart type, including nullability and generic arguments, must
+exactly match an accessible getter on the target.
+
+Run the generator as usual:
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+## Register and Use the Target
+
+Register the external target through the generated module:
+
+```dart
+final fory = Fory();
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.User,
+  name: 'example.User',
+);
+
+final bytes = fory.serialize(
+  const third_party.User(name: 'Ada', age: 36),
+);
+final user = fory.deserialize<third_party.User>(bytes);
+```
+
+Numeric IDs work the same way:
+
+```dart
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.User,
+  id: 100,
+);
+```
+
+Register the target `third_party.User`, not `UserSerializer`.
+
+## Constructors and Mutable Targets
+
+Without a `constructor` option, generation uses the target's public unnamed
+generative constructor. Constructor parameters map to schema fields by name
+and must use exactly the same Dart types.
+
+Select a public named generative constructor when needed:
+
+```dart
+@ForyStruct(
+  target: third_party.Money,
+  constructor: 'fromParts',
+)
+abstract final class MoneySerializer {
+  late final String currency;
+
+  @ForyField(type: Int64Type())
+  late final int units;
+}
+```
+
+For a mutable target, a public generative constructor with no required
+arguments plus matching setters allows Fory to construct the target first and
+then assign its fields. This also supports cycles when reference tracking is
+enabled:
+
+```dart
+@ForyStruct(
+  target: third_party.Node,
+  constructor: 'empty',
+)
+abstract final class NodeSerializer {
+  late final String label;
+
+  @ForyField(ref: true)
+  late final third_party.Node? next;
+}
+```
+
+A constructor-based target cannot decode a direct self-reference because the
+target does not exist until its constructor arguments have been read. Use a
+mutable two-phase target or a manual serializer for that shape.
+
+Factory constructors, private constructors, abstract targets, external enums,
+external unions, records, extension types, and built-in collection types are
+not external struct targets.
+
+## Fields and Collections
+
+After registration, the target works anywhere an ordinary registered struct
+works. A containing generated class does not select the serializer declaration:
+
+```dart
+@ForyStruct()
+final class Group {
+  Group();
+
+  third_party.User? owner;
+
+  @ListField(element: DeclaredType())
+  List<third_party.User> users = <third_party.User>[];
+
+  @MapField(value: DeclaredType())
+  Map<String, third_party.User> usersByName =
+      <String, third_party.User>{};
+}
+```
+
+Nested lists, sets, and maps resolve the registered target recursively.
+Dynamic fields and heterogeneous collections also resolve each concrete target
+by its registered type:
+
+```dart
+@ForyField(dynamic: true)
+Object? value;
+```
+
+Register every concrete external type that can appear dynamically.
+
+Non-empty root lists, sets, and maps decode their elements, keys, and values as
+the registered external targets. Dart root collections retain their existing
+runtime shapes, so read a root collection as `Object?` and cast its outer
+carrier:
+
+```dart
+final decoded =
+    fory.deserialize<Object?>(
+          fory.serialize(<third_party.User>[user]),
+        )
+        as List<Object?>;
+final first = decoded.first as third_party.User;
+```
+
+An empty root collection contains no element type identity.
+
+## Closed Generic Targets
+
+A serializer declaration can target one closed generic instantiation:
+
+```dart
+@ForyStruct(target: third_party.Box<String>)
+abstract final class StringBoxSerializer {
+  late final String value;
+}
+```
+
+Register `third_party.Box<String>`. A different instantiation needs its own
+serializer declaration and registration.
+
+## Schema Evolution
+
+`evolving` and field IDs work exactly as they do for an ordinary generated
+struct:
+
+```dart
+@ForyStruct(
+  target: third_party.User,
+  evolving: true,
+)
+abstract final class UserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+}
+```
+
+Keep field IDs and the registered type identity stable across peers. A field
+name must still match the corresponding property on the local target class.
+
+## When to Use a Manual Serializer
+
+Use a [manual serializer](custom-serializers.md) when the target needs a custom
+wire body, field-name translation, value conversion, factory-only
+construction, private state, or any reconstruction rule that cannot be
+expressed through matching public getters, constructor parameters, and
+setters.
+
+## Related Topics
+
+- [Code Generation](code-generation.md)
+- [Type Registration](type-registration.md)
+- [Schema Metadata](schema-metadata.md)
+- [Schema Evolution](schema-evolution.md)
+- [Manual Serializers](custom-serializers.md)

--- a/docs/guide/dart/grpc-support.md
+++ b/docs/guide/dart/grpc-support.md
@@ -1,6 +1,6 @@
 ---
 title: gRPC Support
-sidebar_position: 12
+sidebar_position: 13
 id: grpc_support
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/dart/index.md
+++ b/docs/guide/dart/index.md
@@ -37,7 +37,7 @@ languages.
 
 ### Requirements
 
-- Dart SDK 3.6 or later
+- Dart SDK 3.7 or later
 - `build_runner` (generates the serializer code)
 
 ### Install
@@ -117,6 +117,7 @@ dart run build_runner build --delete-conflicting-outputs
 - `fory.serialize(value)` — returns `Uint8List` bytes
 - `fory.deserialize<T>(bytes)` — returns a `T`
 - `@ForyStruct()` — marks a class for code generation
+- `@ForyStruct(target: Type)` — generates an external structural serializer
 - `@ForyField(...)` — per-field options and canonical `type:` overrides
 - `@ListField(...)`, `@SetField(...)`, `@MapField(...)` — container sugar for nested `type:` trees
 - Exact-value wrappers: `Int64`, `Uint64`, `Float32`
@@ -126,20 +127,21 @@ dart run build_runner build --delete-conflicting-outputs
 
 ## Documentation
 
-| Topic                                           | Description                                                     |
-| ----------------------------------------------- | --------------------------------------------------------------- |
-| [Configuration](configuration.md)               | Fory options, compatible mode, and safety limits                |
-| [Basic Serialization](basic-serialization.md)   | `serialize`, `deserialize`, generated registration, root graphs |
-| [Code Generation](code-generation.md)           | `@ForyStruct`, build runner, and generated modules              |
-| [Xlang Serialization](xlang-serialization.md)   | Interoperability rules and field alignment                      |
-| [Schema Metadata](schema-metadata.md)           | `@ForyField`, field IDs, nullability, references, polymorphism  |
-| [Type Registration](type-registration.md)       | ID-based vs name-based registration and registration rules      |
-| [Custom Serializers](custom-serializers.md)     | Manual `Serializer<T>` implementations and unions               |
-| [Supported Types](supported-types.md)           | Built-in xlang values, wrappers, collections, and structs       |
-| [Schema Evolution](schema-evolution.md)         | Compatible structs and evolving schemas                         |
-| [Web Platform Support](web-platform-support.md) | Dart VM/AOT, Flutter, and web support, limits, and validation   |
-| [gRPC Support](grpc-support.md)                 | Generated Fory-backed gRPC service companions                   |
-| [Troubleshooting](troubleshooting.md)           | Common errors, diagnostics, and validation steps                |
+| Topic                                            | Description                                                     |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| [Configuration](configuration.md)                | Fory options, compatible mode, and safety limits                |
+| [Basic Serialization](basic-serialization.md)    | `serialize`, `deserialize`, generated registration, root graphs |
+| [Code Generation](code-generation.md)            | `@ForyStruct`, build runner, and generated modules              |
+| [External-Type Serialization](external-types.md) | Generated serializers for classes owned by another package      |
+| [Xlang Serialization](xlang-serialization.md)    | Interoperability rules and field alignment                      |
+| [Schema Metadata](schema-metadata.md)            | `@ForyField`, field IDs, nullability, references, polymorphism  |
+| [Type Registration](type-registration.md)        | ID-based vs name-based registration and registration rules      |
+| [Manual Serializers](custom-serializers.md)      | Manual `Serializer<T>` implementations and unions               |
+| [Supported Types](supported-types.md)            | Built-in xlang values, wrappers, collections, and structs       |
+| [Schema Evolution](schema-evolution.md)          | Compatible structs and evolving schemas                         |
+| [Web Platform Support](web-platform-support.md)  | Dart VM/AOT, Flutter, and web support, limits, and validation   |
+| [gRPC Support](grpc-support.md)                  | Generated Fory-backed gRPC service companions                   |
+| [Troubleshooting](troubleshooting.md)            | Common errors, diagnostics, and validation steps                |
 
 ## Related Resources
 

--- a/docs/guide/dart/schema-evolution.md
+++ b/docs/guide/dart/schema-evolution.md
@@ -1,6 +1,6 @@
 ---
 title: Schema Evolution
-sidebar_position: 8
+sidebar_position: 9
 id: schema_evolution
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -62,6 +62,10 @@ class UserProfile {
 
 If you add field IDs after payloads are already in production, existing stored messages won't have them and evolution won't work correctly.
 
+For an [external structural serializer](external-types.md), the local
+serializer declaration supplies the evolving schema and each declaration field
+must match the corresponding target property.
+
 ## What You Can Safely Change
 
 **Safe changes** (compatible on both sides):
@@ -101,5 +105,6 @@ final fory = Fory(compatible: false);
 ## Related Topics
 
 - [Configuration](configuration.md)
+- [External-Type Serialization](external-types.md)
 - [Schema Metadata](schema-metadata.md)
 - [Xlang Serialization](xlang-serialization.md)

--- a/docs/guide/dart/schema-metadata.md
+++ b/docs/guide/dart/schema-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Schema Metadata
-sidebar_position: 5
+sidebar_position: 6
 id: schema_metadata
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -20,6 +20,9 @@ license: |
 ---
 
 Add `@ForyField(...)` to a field inside a `@ForyStruct()` class to change how that field is serialized.
+
+The same annotations apply to fields in an
+[external structural serializer declaration](external-types.md).
 
 ## Quick Reference
 
@@ -141,5 +144,6 @@ When the same model is defined in multiple languages:
 ## Related Topics
 
 - [Code Generation](code-generation.md)
+- [External-Type Serialization](external-types.md)
 - [Schema Evolution](schema-evolution.md)
 - [Xlang Serialization](xlang-serialization.md)

--- a/docs/guide/dart/supported-types.md
+++ b/docs/guide/dart/supported-types.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Types
-sidebar_position: 7
+sidebar_position: 8
 id: supported_types
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -131,6 +131,10 @@ class User {
 ```
 
 See [Code Generation](code-generation.md).
+
+Classes owned by another library can use an
+[external structural serializer](external-types.md) when their public fields
+and construction match a local Fory schema declaration.
 
 ## Collections
 

--- a/docs/guide/dart/troubleshooting.md
+++ b/docs/guide/dart/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-sidebar_position: 11
+sidebar_position: 12
 id: troubleshooting
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -48,6 +48,22 @@ dart run build_runner build --delete-conflicting-outputs
 
 If you moved files or renamed types, rebuild before re-running analysis or tests.
 
+## External target generation fails
+
+An external structural serializer requires:
+
+- an `abstract final` serializer declaration with `late final` schema fields;
+- a concrete imported target class;
+- an accessible target getter with the same name and exact Dart type for every
+  field;
+- a public generative constructor whose parameters map to fields, or a
+  zero-required-argument constructor plus matching setters.
+
+Select a public named constructor with
+`@ForyStruct(target: Type, constructor: 'name')`. Use a
+[manual serializer](custom-serializers.md) when the target requires a factory,
+private state, field conversion, or name translation.
+
 ## `Deserialized value has type ..., expected ...`
 
 The payload describes a different type than `T` in `deserialize<T>`. Common causes:
@@ -64,7 +80,7 @@ To preserve identity:
 
 - For fields inside a `@ForyStruct`, add `@ForyField(ref: true)` to those fields.
 - For a top-level collection, pass `trackRef: true` to `fory.serialize(...)`.
-- In a custom serializer, use `context.writeRef` / `context.readRef` and call `context.reference(obj)` before reading nested fields.
+- In a manual serializer, use `context.writeRef` / `context.readRef` and call `context.reference(obj)` before reading nested fields.
 
 ## Cross-language field mismatch (missing data or wrong values)
 
@@ -158,6 +174,6 @@ separate protobuf service endpoint for generic protobuf clients.
 
 - [Xlang Serialization](xlang-serialization.md)
 - [Code Generation](code-generation.md)
-- [Custom Serializers](custom-serializers.md)
+- [Manual Serializers](custom-serializers.md)
 - [Web Platform Support](web-platform-support.md)
 - [gRPC Support](grpc-support.md)

--- a/docs/guide/dart/type-registration.md
+++ b/docs/guide/dart/type-registration.md
@@ -1,6 +1,6 @@
 ---
 title: Type Registration
-sidebar_position: 6
+sidebar_position: 7
 id: type_registration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -65,9 +65,23 @@ Call the generated `register` function from the `.fory.dart` file. It installs a
 UserModelsForyModule.register(fory, User, id: 100);
 ```
 
-## Registering a Custom Serializer
+External structural serializers use the same generated registration API. Pass
+the external target type:
 
-For types that you cannot annotate with `@ForyStruct()`, pass a serializer instance directly:
+```dart
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.User,
+  id: 100,
+);
+```
+
+See [External-Type Serialization](external-types.md) for the declaration.
+
+## Registering a Manual Serializer
+
+Pass a serializer instance directly when a type needs custom wire or
+construction logic:
 
 ```dart
 fory.registerSerializer(
@@ -77,7 +91,7 @@ fory.registerSerializer(
 );
 ```
 
-See [Custom Serializers](custom-serializers.md) for how to implement a serializer.
+See [Manual Serializers](custom-serializers.md) for how to implement a serializer.
 
 ## Rules to Follow
 
@@ -93,5 +107,6 @@ The same numeric ID or name must be used in every peer that reads or writes the 
 ## Related Topics
 
 - [Code Generation](code-generation.md)
+- [External-Type Serialization](external-types.md)
 - [Xlang Serialization](xlang-serialization.md)
-- [Custom Serializers](custom-serializers.md)
+- [Manual Serializers](custom-serializers.md)

--- a/docs/guide/dart/web-platform-support.md
+++ b/docs/guide/dart/web-platform-support.md
@@ -1,6 +1,6 @@
 ---
 title: Web Platform Support
-sidebar_position: 10
+sidebar_position: 11
 id: web_platform_support
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -36,6 +36,7 @@ Fory Dart supports:
 - Flutter web applications.
 - Generated `@ForyStruct` serializers and manually registered serializers on
   all supported targets.
+- External structural serializers generated with `@ForyStruct(target: ...)`.
 
 ## Code Generation Is Required
 
@@ -135,9 +136,9 @@ class StorageExtent {
 }
 ```
 
-## Custom Serializers
+## Manual Serializers
 
-Custom serializers can use the same `Buffer`, `WriteContext`, and `ReadContext`
+Manual serializers can use the same `Buffer`, `WriteContext`, and `ReadContext`
 APIs on VM/AOT, Flutter, and web. For 64-bit values:
 
 - Use `buffer.writeInt64(Int64(...))` and `buffer.readInt64()` for full-range

--- a/docs/guide/dart/xlang-serialization.md
+++ b/docs/guide/dart/xlang-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Xlang Serialization
-sidebar_position: 4
+sidebar_position: 5
 id: xlang_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
@@ -58,6 +58,32 @@ ModelsForyModule.register(
 ```
 
 Do not mix the two strategies for the same type across implementations.
+
+## External Types
+
+For a struct class owned by another Dart package, define an
+[external structural serializer](external-types.md) and register the target
+with the same ID or name used by every peer:
+
+```dart
+@ForyStruct(target: third_party.User)
+abstract final class UserSerializer {
+  @ForyField(id: 1)
+  late final String name;
+
+  @ForyField(id: 2, type: Int32Type())
+  late final int age;
+}
+
+ExternalSerializersForyModule.register(
+  fory,
+  third_party.User,
+  id: 100,
+);
+```
+
+The declaration's field IDs, names, nullability, and wire-width annotations
+define the Dart-side xlang schema.
 
 ## Dart to Java Example
 
@@ -215,5 +241,6 @@ dart test
 ## Related Topics
 
 - [Type Registration](type-registration.md)
+- [External-Type Serialization](external-types.md)
 - [Schema Evolution](schema-evolution.md)
 - [Xlang guide](../xlang/index.md)

--- a/docs/specification/xlang_implementation_guide.md
+++ b/docs/specification/xlang_implementation_guide.md
@@ -1001,8 +1001,10 @@ For each declaration field, resolve an accessible target getter with the same
 name and exact instantiated Dart type. Constructor parameters and any
 post-construction setter must also match exactly. A public named generative
 constructor is selected only when the annotation names it. Factory
-constructors, abstract targets, open target types, and constructor-based direct
-self-references are rejected during generation.
+constructors, abstract targets, open target types, and constructor-based
+reference-tracked paths back to the target are rejected during generation.
+The recursive check includes target elements, keys, and values nested in the
+supported list, set, and map field metadata.
 
 Generated code reads getters and invokes target constructors or setters
 directly. It must not allocate the declaration, copy values through an

--- a/docs/specification/xlang_implementation_guide.md
+++ b/docs/specification/xlang_implementation_guide.md
@@ -984,6 +984,38 @@ The public helper should be a thin generated wrapper around the Fory
 registration API, not a public global registry or a second unrelated
 registration API family.
 
+### Dart External Structural Serializers
+
+Dart external-type serialization extends `ForyStruct` with an optional
+compile-time `target` and named generative `constructor`. The annotated
+`abstract final` class is a schema declaration only. It has no runtime value or
+registration identity.
+
+The generator must analyze ordinary and external structs through one struct
+model and one emitter. Private generated symbol names come from the declaration
+name. Every runtime type position uses the target type: `Serializer<Target>`,
+`GeneratedStructSchema<Target>`, read and write signatures, constructor calls,
+schema `type`, and generated-module dispatch.
+
+For each declaration field, resolve an accessible target getter with the same
+name and exact instantiated Dart type. Constructor parameters and any
+post-construction setter must also match exactly. A public named generative
+constructor is selected only when the annotation names it. Factory
+constructors, abstract targets, open target types, and constructor-based direct
+self-references are rejected during generation.
+
+Generated code reads getters and invokes target constructors or setters
+directly. It must not allocate the declaration, copy values through an
+intermediate object, invoke runtime callbacks, perform member-name lookup, or
+branch on whether the struct is external. The existing generated struct,
+registration, resolver, field, collection, map, compatible-read, and reference
+paths remain the only runtime paths.
+
+Registration is keyed by `Target` through the generated module and the existing
+generated registration API. Direct roots, generated fields, dynamic values,
+and recursive collection/map children resolve the same target registration.
+Dart root collections retain their existing untyped outer runtime shapes.
+
 ## Directory Layout
 
 Under each Dart package `lib/` tree, only one nested source layer is allowed.

--- a/java/fory-core/src/test/java/org/apache/fory/xlang/DartXlangTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/xlang/DartXlangTest.java
@@ -27,7 +27,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import lombok.Data;
+import org.apache.fory.Fory;
+import org.apache.fory.annotation.ForyField;
+import org.apache.fory.annotation.ForyStruct;
+import org.apache.fory.memory.MemoryBuffer;
+import org.apache.fory.memory.MemoryUtils;
 import org.apache.fory.test.TestUtils;
+import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -42,6 +49,10 @@ public class DartXlangTest extends XlangTestBase {
       new File(DART_FORY_TEST_WORK_DIR, "lib/entity/xlang_test_models.dart");
   private static final File DART_XLANG_GENERATED_FILE =
       new File(DART_FORY_TEST_WORK_DIR, "lib/entity/xlang_test_models.fory.dart");
+  private static final File DART_EXTERNAL_SOURCE_FILE =
+      new File(DART_FORY_TEST_WORK_DIR, "lib/model/external_serializers.dart");
+  private static final File DART_EXTERNAL_GENERATED_FILE =
+      new File(DART_FORY_TEST_WORK_DIR, "lib/model/external_serializers.fory.dart");
   private static final String DART_MODULE =
       "packages/fory-test/test/cross_lang_test/xlang_test_main.dart";
   private static final List<String> DART_CODEGEN_COMMAND =
@@ -89,7 +100,10 @@ public class DartXlangTest extends XlangTestBase {
 
   private static synchronized void ensureGeneratedXlangSpecs() {
     if (DART_XLANG_GENERATED_FILE.isFile()
-        && DART_XLANG_GENERATED_FILE.lastModified() >= DART_XLANG_SOURCE_FILE.lastModified()) {
+        && DART_XLANG_GENERATED_FILE.lastModified() >= DART_XLANG_SOURCE_FILE.lastModified()
+        && DART_EXTERNAL_GENERATED_FILE.isFile()
+        && DART_EXTERNAL_GENERATED_FILE.lastModified()
+            >= DART_EXTERNAL_SOURCE_FILE.lastModified()) {
       return;
     }
     if (!TestUtils.executeCommand(
@@ -106,6 +120,48 @@ public class DartXlangTest extends XlangTestBase {
   // ============================================================================
   // Test methods - duplicated from XlangTestBase for Maven Surefire discovery
   // ============================================================================
+
+  @Data
+  @ForyStruct
+  static class ExternalUser {
+    @ForyField(id = 1)
+    String name;
+
+    @ForyField(id = 2)
+    int age;
+  }
+
+  private void runExternalUser(boolean enableCodegen, boolean named) throws IOException {
+    Fory fory =
+        Fory.builder().withXlang(true).withCompatible(true).withCodegen(enableCodegen).build();
+    String caseName;
+    if (named) {
+      caseName = "test_external_struct_name";
+      fory.register(ExternalUser.class, "test", "external_user");
+    } else {
+      caseName = "test_external_struct_id";
+      fory.register(ExternalUser.class, 1001);
+    }
+    ExternalUser user = new ExternalUser();
+    user.name = "Ada";
+    user.age = 36;
+    MemoryBuffer buffer = MemoryUtils.buffer(64);
+    fory.serialize(buffer, user);
+
+    ExecutionContext ctx = prepareExecution(caseName, buffer.getBytes(0, buffer.writerIndex()));
+    runPeer(ctx);
+    Assert.assertEquals(fory.deserialize(readBuffer(ctx.dataFile())), user);
+  }
+
+  @Test(groups = "xlang", dataProvider = "enableCodegenParallel")
+  public void testExternalStructId(boolean enableCodegen) throws IOException {
+    runExternalUser(enableCodegen, false);
+  }
+
+  @Test(groups = "xlang", dataProvider = "enableCodegenParallel")
+  public void testExternalStructName(boolean enableCodegen) throws IOException {
+    runExternalUser(enableCodegen, true);
+  }
 
   @Test(groups = "xlang")
   public void testBuffer() throws java.io.IOException {


### PR DESCRIPTION
## Why?

Dart classes owned by dependencies cannot carry Fory annotations. Applications
need generated serializers for those types without copying values into local
models or adding a second registration, carrier, root, or polymorphic path.

## What does this PR do?

- Adds `ForyStruct.target` and constructor selection so an `abstract final`
  local schema declaration generates a direct serializer for a closed external
  class.
- Uses the existing generated struct model, target-keyed schema/module
  registration, field descriptors, carrier codecs, root APIs, reference
  resolver, compatible reads, and polymorphic registration.
- Generates direct target getters, generative constructor calls, and setters;
  validates the external contract at generation time, including generic type
  rendering, re-exported nullable aliases, and constructor-cycle constraints.
- Covers roots, fields, nested list/set/map fields, named and numeric
  registration, polymorphism, references, compatible mode, generic targets,
  Java-to-Dart xlang exchange, and JavaScript compilation.
- Documents the current external-type serialization and manual serializer
  APIs without migration or removed-API material.

## Related issues

N/A

## AI Contribution Checklist


### AI Usage Disclosure


## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

The public Dart annotation API adds optional `target` and `constructor`
arguments to `ForyStruct`. The wire format is unchanged.

## Verification

- `cd dart/packages/fory && dart run build_runner build && dart analyze && dart test`
  - generation: 98 outputs, no tracked changes
  - analysis: clean
  - tests: 232/232 passed
- `cd dart/packages/fory-test && dart run build_runner build && dart analyze && dart test`
  - generation: 3 outputs, no tracked changes
  - analysis: clean
  - tests: 18/18 passed
- `cd dart && dart analyze && dart test`
  - analysis: clean
  - tests: 1/1 passed
- `cd dart/packages/external-type-test-models && dart analyze`
  - analysis: clean
- `dart compile js` for
  `dart/packages/fory-test/tool/external_type_js_smoke.dart`, followed by Node
  execution
  - compiled successfully and exited successfully
- `FORY_DART_JAVA_CI=1 ENABLE_FORY_DEBUG_OUTPUT=1 mvn -T16 --no-transfer-progress test -Dtest=org.apache.fory.xlang.DartXlangTest`
  - 101/101 passed with no failures, errors, or skips

## Benchmark

Fresh `apache/main` ordinary benchmarks were run in adjacent baseline/current
pairs. Every retained median met the less-than-1% slowdown gate, and the
generated ordinary benchmark source was byte-identical.

Equivalent ordinary/external generated paths were measured in AOT mode with
split debugging data:

| Path                    | Retained delta |
| ----------------------- | -------------: |
| Root serialize          |         +0.02% |
| Root deserialize        |         +0.04% |
| Direct field serialize  |         +0.53% |
| Direct field deserialize |         -0.82% |
| List field serialize    |         +1.47% |
| List field deserialize  |         -0.02% |
| Map field serialize     |         +0.09% |
| Map field deserialize   |         +0.90% |

Negative values are slowdowns; every slowdown is below 1%. Serialized bytes
and normalized generated serializer bodies matched. The fixed-iteration VM
allocation check reported identical per-class object counts for all eight
serialize/deserialize lanes at 1,000 iterations.
