### PR TITLE
fix(ci): pin Ruff version to 0.15.22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ mvn checkstyle:check
 ```bash
 cd python
 # install dependencies for formatting
-pip install ruff
+pip install ruff==0.15.22
 # format python code
 ruff format
 ```

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -26,7 +26,7 @@ install_nodejs() {
 
 # Check for ruff
 if ! [ -x "$(command -v ruff)" ]; then
-    echo "ruff not installed. Install with: pip install ruff"
+    echo "ruff not installed. Install with: pip install ruff==0.15.22"
     exit 1
 fi
 
@@ -197,7 +197,7 @@ format_python() {
       git ls-files -- '*.py' "${GIT_LS_EXCLUDES[@]}" | xargs ruff check --fix
       echo "$(date)" "Python formatting done!"
     else
-      echo "ERROR: ruff is not installed! Install with: pip install ruff"
+      echo "ERROR: ruff is not installed! Install with: pip install ruff==0.15.22"
       exit 1
     fi
 }

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -460,7 +460,7 @@ case $1 in
     ;;
     format)
       echo "Install format tools"
-      pip install ruff
+      pip install ruff==0.15.22
       echo "Executing format check"
       bash ci/format.sh
       cd "$ROOT/java"

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -37,7 +37,7 @@ pytest -v -s pyfory/tests/test_serializer.py
 
 ```bash
 cd python
-pip install ruff
+pip install ruff==0.15.22
 ruff format .
 ruff check --fix .
 ```


### PR DESCRIPTION
## Why?

Pin Ruff version so existing Python files are not affected by breaking changes brought by Ruff 0.16.0.

## What does this PR do?

Pin Ruff version to 0.15.22, the last version before 0.16.0.

## Related issues

Closes https://github.com/apache/fory/issues/3899.

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

