### PR TITLE
chore(release): bump versions after 1.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "fory",
-    version = "1.5.0",
+    version = "1.6.0",
 )
 
 # Platforms (needed for platform-specific build configurations)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Slack Channel](https://img.shields.io/badge/slack-join-3f0e40?logo=slack&style=for-the-badge)](https://join.slack.com/t/fory-project/shared_invite/zt-36g0qouzm-kcQSvV_dtfbtBKHRwT5gsw)
 [![X](https://img.shields.io/badge/@ApacheFory-follow-blue?logo=x&style=for-the-badge)](https://x.com/ApacheFory)
 [![Maven Version](https://img.shields.io/maven-central/v/org.apache.fory/fory-core?style=for-the-badge)](https://search.maven.org/#search|gav|1|g:"org.apache.fory"%20AND%20a:"fory-core")
-[![Crates.io](https://img.shields.io/badge/crates.io-v1.4.0-blue?logo=rust&style=for-the-badge)](https://crates.io/crates/fory)
+[![Crates.io](https://img.shields.io/badge/crates.io-v1.5.0-blue?logo=rust&style=for-the-badge)](https://crates.io/crates/fory)
 [![PyPI](https://img.shields.io/pypi/v/pyfory.svg?logo=PyPI&style=for-the-badge)](https://pypi.org/project/pyfory/)
 [![npm](https://img.shields.io/npm/v/%40apache-fory%2Fcore?logo=npm&style=for-the-badge)](https://www.npmjs.com/package/@apache-fory/core)
 [![NuGet](https://img.shields.io/nuget/v/Apache.Fory?logo=nuget&style=for-the-badge)](https://www.nuget.org/packages/Apache.Fory)
@@ -150,14 +150,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation "org.apache.fory:fory-core:1.4.0"
+implementation "org.apache.fory:fory-core:1.5.0"
 ```
 
 On JDK25+, open `java.lang.invoke` to Fory. Use `ALL-UNNAMED` when Fory is on
@@ -178,7 +178,7 @@ Use the Fory core module name when Fory is on the module path:
 sbt:
 
 ```scala
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.4.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.5.0"
 ```
 
 **Kotlin**
@@ -186,7 +186,7 @@ libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.4.0"
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.4.0")
+implementation("org.apache.fory:fory-kotlin:1.5.0")
 ```
 
 Maven:
@@ -195,7 +195,7 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
@@ -217,7 +217,7 @@ pip install "pyfory[format]"
 
 ```toml
 [dependencies]
-fory = "1.4.0"
+fory = "1.5.0"
 ```
 
 **C++**
@@ -229,7 +229,7 @@ include(FetchContent)
 FetchContent_Declare(
   fory
   GIT_REPOSITORY https://github.com/apache/fory.git
-  GIT_TAG v1.4.0
+  GIT_TAG v1.5.0
   SOURCE_SUBDIR cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -240,8 +240,8 @@ Bazel:
 
 ```bazel
 # MODULE.bazel
-bazel_dep(name = "fory", version = "1.4.0")
-git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
+git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.5.0")
 
 # BUILD
 deps = ["@fory//cpp/fory/serialization:fory_serialization"]
@@ -274,13 +274,13 @@ npm install @apache-fory/core @apache-fory/hps
 **C#**
 
 ```bash
-dotnet add package Apache.Fory --version 1.4.0
+dotnet add package Apache.Fory --version 1.5.0
 ```
 
 **Dart**
 
 ```bash
-dart pub add fory:^1.4.0
+dart pub add fory:^1.5.0
 dart pub add dev:build_runner
 ```
 
@@ -290,7 +290,7 @@ Add Fory to `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apache/fory.git", exact: "1.4.0")
+  .package(url: "https://github.com/apache/fory.git", exact: "1.5.0")
 ],
 targets: [
   .target(
@@ -839,14 +839,14 @@ Add Fory JSON to your project:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 **Gradle**
 
 ```gradle
-implementation "org.apache.fory:fory-json:1.4.0"
+implementation "org.apache.fory:fory-json:1.5.0"
 ```
 
 Keep all Fory modules in the same application on the same version.

--- a/benchmarks/cpp/CMakeLists.txt
+++ b/benchmarks/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ if(POLICY CMP0169)
 endif()
 
 project(fory_cpp_benchmark
-    VERSION 1.5.0
+    VERSION 1.6.0
     DESCRIPTION "C++ Benchmark comparing Fory, Protobuf, and Msgpack serialization"
     LANGUAGES CXX
 )

--- a/benchmarks/go/go.mod
+++ b/benchmarks/go/go.mod
@@ -20,7 +20,7 @@ module github.com/apache/fory/benchmarks/go
 go 1.25.0
 
 require (
-	github.com/apache/fory/go/fory v1.5.0-alpha.0
+	github.com/apache/fory/go/fory v1.6.0-alpha.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	google.golang.org/protobuf v1.36.0
 )

--- a/benchmarks/java/pom.xml
+++ b/benchmarks/java/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmark</artifactId>

--- a/benchmarks/java25/pom.xml
+++ b/benchmarks/java25/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.apache.fory.benchmark</groupId>
   <artifactId>java25-memory-access-benchmark</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -20,5 +20,5 @@ members = ["local", "xlang"]
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 edition = "2021"

--- a/ci/release.py
+++ b/ci/release.py
@@ -1049,6 +1049,8 @@ def _update_dart_changelog(lines, v: str, workspace=False):
     start_index = -1
     for index, line in enumerate(lines):
         if heading_pattern.match(line):
+            if line == heading:
+                return lines
             start_index = index
             break
     if start_index == -1:
@@ -1059,7 +1061,17 @@ def _update_dart_changelog(lines, v: str, workspace=False):
         if re.match(r"^##\s+", lines[index]):
             end_index = index
             break
-    return lines[:start_index] + [heading] + body + lines[end_index:]
+    updated = list(lines)
+    updated[start_index] = heading
+    dev_cycle = re.compile(
+        r"^- Start the next (?:Dart workspace )?development cycle after "
+        r"the \S+ release\.\s*$"
+    )
+    for index in range(start_index + 1, end_index):
+        if dev_cycle.match(updated[index]):
+            updated[index] = body[1]
+            break
+    return updated
 
 
 def _update_dart_dev_changelog(lines, v: str, release_version: str, workspace=False):
@@ -1079,20 +1091,10 @@ def _update_dart_dev_changelog(lines, v: str, release_version: str, workspace=Fa
             f"- Start the next development cycle after the {release_version} release.\n",
             "\n",
         ]
-    start_index = -1
-    for index, line in enumerate(lines):
+    for line in lines:
         if line == heading:
-            start_index = index
-            break
-    if start_index == -1:
-        return [heading] + body + lines
-
-    end_index = len(lines)
-    for index in range(start_index + 1, len(lines)):
-        if re.match(r"^##\s+", lines[index]):
-            end_index = index
-            break
-    return lines[:start_index] + [heading] + body + lines[end_index:]
+            return lines
+    return [heading] + body + lines
 
 
 def _update_csharp_props_version(lines, v: str):

--- a/compiler/fory_compiler/__init__.py
+++ b/compiler/fory_compiler/__init__.py
@@ -17,7 +17,7 @@
 
 """Fory IDL compiler for Apache Fory."""
 
-__version__ = "1.5.0.dev0"
+__version__ = "1.6.0.dev0"
 
 from fory_compiler.frontend.fbs import FBSFrontend
 from fory_compiler.frontend.fdl import FDLFrontend

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-compiler"
-version = "1.5.0.dev0"
+version = "1.6.0.dev0"
 description = "FDL (Fory Definition Language) compiler for Apache Fory cross-language serialization"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(fory
-    VERSION 1.5.0
+    VERSION 1.6.0
     DESCRIPTION "Apache Fory - A blazingly fast multi-language serialization framework"
     LANGUAGES CXX
 )

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.5.0-dev</Version>
+    <Version>1.6.0-dev</Version>
     <Authors>Apache Software Foundation</Authors>
     <Company>Apache Software Foundation</Company>
     <Description>Apache Fory for .NET provides high-performance cross-language serialization with source-generated serializers and schema evolution support.</Description>

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -32,7 +32,7 @@ From NuGet, reference the single `Apache.Fory` package. It includes the Fory lib
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.4.0" />
+  <PackageReference Include="Apache.Fory" Version="1.5.0" />
 </ItemGroup>
 ```
 

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.5.0-dev
+## 1.6.0-dev
 
-- Start the next Dart workspace development cycle after the 1.4.0 release.
+- Start the next Dart workspace development cycle after the 1.5.0 release.
+
+## 1.5.0
+
+- Align the Dart workspace version with the Apache Fory 1.5.0 release.
 
 ## 1.4.0
 

--- a/dart/packages/fory-test/pubspec.yaml
+++ b/dart/packages/fory-test/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory_test
 description: Apache Fory Dart consumer and integration tests
-version: 1.5.0-dev
+version: 1.6.0-dev
 
 resolution: workspace
 
@@ -26,7 +26,7 @@ environment:
 
 dependencies:
   external_type_test_models: 1.0.0
-  fory: 1.5.0-dev
+  fory: 1.6.0-dev
   inheritance_test_models: 1.0.0
 
 dev_dependencies:

--- a/dart/packages/fory/CHANGELOG.md
+++ b/dart/packages/fory/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.5.0-dev
+## 1.6.0-dev
 
-- Start the next development cycle after the 1.4.0 release.
+- Start the next development cycle after the 1.5.0 release.
+
+## 1.5.0
+
+- Release Apache Fory Dart 1.5.0.
 - Add generated external-type serialization with direct target construction
   and existing registration, carrier, reference, and schema-evolution support.
 - Replace `ForyField.skip` with `ForyField.ignore`, remove `skip` from container

--- a/dart/packages/fory/README.md
+++ b/dart/packages/fory/README.md
@@ -25,7 +25,7 @@ Add `fory` to your package dependencies.
 
 ```yaml
 dependencies:
-  fory: ^1.4.0
+  fory: ^1.5.0
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/dart/packages/fory/pubspec.yaml
+++ b/dart/packages/fory/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory
 description: Cross-language Apache Fory runtime for Dart with generated serializers, schema evolution, and custom serializer support.
-version: 1.5.0-dev
+version: 1.6.0-dev
 homepage: https://fory.apache.org
 repository: https://github.com/apache/fory/tree/main/dart/packages/fory
 issue_tracker: https://github.com/apache/fory/issues

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -17,7 +17,7 @@
 
 name: fory_dart
 description: Apache Fory Dart workspace for the runtime package, generated serializers, and integration tests.
-version: 1.5.0-dev
+version: 1.6.0-dev
 # repository: https://github.com/my_org/my_repo
 
 environment:
@@ -25,7 +25,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  fory: 1.5.0-dev
+  fory: 1.6.0-dev
   build_runner: ">=2.7.0 <3.0.0"
 dev_dependencies:
   lints: ^6.1.0

--- a/docs/compiler/compiler-guide.md
+++ b/docs/compiler/compiler-guide.md
@@ -719,7 +719,7 @@ Add the Fory dependency to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.4.0
+  fory: ^1.5.0
 
 dev_dependencies:
   build_runner: ^2.4.0
@@ -911,5 +911,5 @@ fory = "x.y.z"
 
 ```yaml
 dependencies:
-  fory: ^1.4.0
+  fory: ^1.5.0
 ```

--- a/docs/guide/cpp/index.md
+++ b/docs/guide/cpp/index.md
@@ -63,7 +63,7 @@ include(FetchContent)
 FetchContent_Declare(
     fory
     GIT_REPOSITORY https://github.com/apache/fory.git
-    GIT_TAG        v1.4.0
+    GIT_TAG        v1.5.0
     SOURCE_SUBDIR  cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -93,11 +93,11 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.1.1")
 
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
-    commit = "v1.4.0",  # Or use a specific commit hash for reproducibility
+    commit = "v1.5.0",  # Or use a specific commit hash for reproducibility
 )
 ```
 
@@ -129,7 +129,7 @@ bazel run //:my_app
 For local development, you can use `local_path_override` instead:
 
 ```bazel
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 local_path_override(
     module_name = "fory",
     path = "/path/to/fory",

--- a/docs/guide/csharp/grpc-support.md
+++ b/docs/guide/csharp/grpc-support.md
@@ -39,7 +39,7 @@ Server project:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.4.0" />
+  <PackageReference Include="Apache.Fory" Version="1.5.0" />
   <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
 </ItemGroup>
 ```
@@ -48,7 +48,7 @@ Client project:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.4.0" />
+  <PackageReference Include="Apache.Fory" Version="1.5.0" />
   <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
   <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
 </ItemGroup>

--- a/docs/guide/csharp/index.md
+++ b/docs/guide/csharp/index.md
@@ -46,7 +46,7 @@ Reference the single `Apache.Fory` package. It includes the Fory library and the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.4.0" />
+  <PackageReference Include="Apache.Fory" Version="1.5.0" />
 </ItemGroup>
 ```
 

--- a/docs/guide/dart/grpc-support.md
+++ b/docs/guide/dart/grpc-support.md
@@ -38,7 +38,7 @@ application that compiles or runs generated service companions:
 
 ```yaml
 dependencies:
-  fory: ^1.4.0
+  fory: ^1.5.0
   grpc: ^4.0.0
 
 dev_dependencies:

--- a/docs/guide/dart/index.md
+++ b/docs/guide/dart/index.md
@@ -47,7 +47,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.4.0
+  fory: ^1.5.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/docs/guide/java/index.md
+++ b/docs/guide/java/index.md
@@ -67,7 +67,7 @@ application on the same version.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
@@ -75,7 +75,7 @@ application on the same version.
 
 ```kotlin
 // Binary object serialization
-implementation("org.apache.fory:fory-core:1.4.0")
+implementation("org.apache.fory:fory-core:1.5.0")
 ```
 
 #### JDK 25 and Later
@@ -267,14 +267,14 @@ partial reads, and analytics workloads.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```kotlin
-implementation("org.apache.fory:fory-format:1.4.0")
+implementation("org.apache.fory:fory-format:1.5.0")
 ```
 
 See [Row Format](row-format.md) for encoding, typed field access, partial
@@ -305,14 +305,14 @@ version when another dependency also brings `fory-core` into the application.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```kotlin
-implementation("org.apache.fory:fory-json:1.4.0")
+implementation("org.apache.fory:fory-json:1.5.0")
 ```
 
 On JDK 25 and later, use the same `java.lang.invoke` module open described in

--- a/docs/guide/java/json-support.md
+++ b/docs/guide/java/json-support.md
@@ -42,14 +42,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-json:1.4.0")
+implementation("org.apache.fory:fory-json:1.5.0")
 ```
 
 Keep all Fory modules on the same version.

--- a/docs/guide/kotlin/index.md
+++ b/docs/guide/kotlin/index.md
@@ -53,14 +53,14 @@ See [Java Features](../java/index.md#features) for complete feature list.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.4.0")
+implementation("org.apache.fory:fory-kotlin:1.5.0")
 ```
 
 ### JDK25+

--- a/docs/guide/rust/basic-serialization.md
+++ b/docs/guide/rust/basic-serialization.md
@@ -147,7 +147,7 @@ let later = timestamp.checked_add_duration(duration)?;
 
 ```toml
 [dependencies]
-fory = { version = "1.4.0", features = ["chrono"] }
+fory = { version = "1.5.0", features = ["chrono"] }
 ```
 
 ### Custom Types

--- a/docs/guide/rust/grpc-support.md
+++ b/docs/guide/rust/grpc-support.md
@@ -37,7 +37,7 @@ to build streaming responses or request streams.
 
 ```toml
 [dependencies]
-fory = "1.4.0"
+fory = "1.5.0"
 bytes = "1"
 tonic = { version = "0.14", features = ["transport"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/docs/guide/rust/index.md
+++ b/docs/guide/rust/index.md
@@ -38,9 +38,9 @@ The Rust implementation provides versatile and high-performance serialization wi
 
 | Crate                                                                       | Description                                               | Version                                       |
 | --------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
-| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.4.0](https://crates.io/crates/fory)        |
-| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.4.0](https://crates.io/crates/fory-core)   |
-| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.4.0](https://crates.io/crates/fory-derive) |
+| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.5.0](https://crates.io/crates/fory)        |
+| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.5.0](https://crates.io/crates/fory-core)   |
+| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.5.0](https://crates.io/crates/fory-derive) |
 
 Most applications should depend on `fory` only. It re-exports the derive
 macros and the public runtime types needed by generated code. Use `fory-core`
@@ -53,7 +53,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.4.0"
+fory = "1.5.0"
 ```
 
 ### Basic Example

--- a/docs/guide/scala/index.md
+++ b/docs/guide/scala/index.md
@@ -49,7 +49,7 @@ See [Java Features](../java/index.md#features) for complete feature list.
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.4.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.5.0"
 ```
 
 ### JDK25+

--- a/docs/guide/xlang/getting-started.md
+++ b/docs/guide/xlang/getting-started.md
@@ -31,14 +31,14 @@ This guide covers installation and basic setup for cross-language serialization 
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```gradle
-implementation 'org.apache.fory:fory-core:1.4.0'
+implementation 'org.apache.fory:fory-core:1.5.0'
 ```
 
 ### Python
@@ -57,7 +57,7 @@ go get github.com/apache/fory/go/fory
 
 ```toml
 [dependencies]
-fory = "1.4.0"
+fory = "1.5.0"
 ```
 
 ### JavaScript/TypeScript
@@ -75,13 +75,13 @@ npm install @apache-fory/core @apache-fory/hps
 ### C\#
 
 ```bash
-dotnet add package Apache.Fory --version 1.4.0
+dotnet add package Apache.Fory --version 1.5.0
 ```
 
 ### Dart
 
 ```bash
-dart pub add fory:^1.4.0
+dart pub add fory:^1.5.0
 dart pub add dev:build_runner
 ```
 
@@ -91,20 +91,20 @@ Add Fory to `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apache/fory.git", exact: "1.4.0")
+  .package(url: "https://github.com/apache/fory.git", exact: "1.5.0")
 ]
 ```
 
 ### Scala
 
 ```scala
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.4.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.5.0"
 ```
 
 ### Kotlin
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.4.0")
+implementation("org.apache.fory:fory-kotlin:1.5.0")
 ```
 
 ### C++

--- a/examples/cpp/hello_row/MODULE.bazel.example
+++ b/examples/cpp/hello_row/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.4.0")
+# bazel_dep(name = "fory", version = "1.5.0")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_row/README.md
+++ b/examples/cpp/hello_row/README.md
@@ -77,7 +77,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/examples/cpp/hello_world/MODULE.bazel.example
+++ b/examples/cpp/hello_world/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.4.0")
+# bazel_dep(name = "fory", version = "1.5.0")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_world/README.md
+++ b/examples/cpp/hello_world/README.md
@@ -70,7 +70,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.4.0")
+bazel_dep(name = "fory", version = "1.5.0")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/integration_tests/android_tests/README.md
+++ b/integration_tests/android_tests/README.md
@@ -10,9 +10,9 @@ exact rules for unannotated ordinary classes. Mixin coverage
 registers the source at runtime after R8 minification so broad application keep
 rules cannot hide missing processor output.
 
-The tests consume `org.apache.fory:fory-core:1.5.0-SNAPSHOT`,
-`org.apache.fory:fory-json:1.5.0-SNAPSHOT`, and
-`org.apache.fory:fory-annotation-processor:1.5.0-SNAPSHOT` from the local Maven
+The tests consume `org.apache.fory:fory-core:1.6.0-SNAPSHOT`,
+`org.apache.fory:fory-json:1.6.0-SNAPSHOT`, and
+`org.apache.fory:fory-annotation-processor:1.6.0-SNAPSHOT` from the local Maven
 repository, so install the Java artifacts before running Gradle:
 
 ```bash

--- a/integration_tests/android_tests/build.gradle
+++ b/integration_tests/android_tests/build.gradle
@@ -89,12 +89,12 @@ android {
 }
 
 dependencies {
-    implementation('org.apache.fory:fory-core:1.5.0-SNAPSHOT') {
+    implementation('org.apache.fory:fory-core:1.6.0-SNAPSHOT') {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'org.codehaus.janino', module: 'janino'
     }
-    implementation 'org.apache.fory:fory-json:1.5.0-SNAPSHOT'
-    annotationProcessor 'org.apache.fory:fory-annotation-processor:1.5.0-SNAPSHOT'
+    implementation 'org.apache.fory:fory-json:1.6.0-SNAPSHOT'
+    annotationProcessor 'org.apache.fory:fory-annotation-processor:1.6.0-SNAPSHOT'
     implementation 'com.google.guava:guava:32.1.2-android'
     implementation 'org.slf4j:slf4j-api:2.0.12'
 

--- a/integration_tests/graalvm_tests/pom.xml
+++ b/integration_tests/graalvm_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/grpc_tests/java/pom.xml
+++ b/integration_tests/grpc_tests/java/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/grpc_tests/kotlin/pom.xml
+++ b/integration_tests/grpc_tests/kotlin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../../kotlin/pom.xml</relativePath>
     </parent>
 

--- a/integration_tests/grpc_tests/python/pyproject.toml
+++ b/integration_tests/grpc_tests/python/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-grpc-tests"
-version = "1.5.0.dev0"
+version = "1.6.0.dev0"
 description = "gRPC compiler integration tests for Apache Fory"
 requires-python = ">=3.8"
 license = {text = "Apache-2.0"}

--- a/integration_tests/grpc_tests/rust/Cargo.toml
+++ b/integration_tests/grpc_tests/rust/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/integration_tests/idl_tests/cpp/CMakeLists.txt
+++ b/integration_tests/idl_tests/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(fory_idl_tests
-    VERSION 1.5.0
+    VERSION 1.6.0
     DESCRIPTION "Fory IDL compiler integration tests"
     LANGUAGES CXX
 )

--- a/integration_tests/idl_tests/dart/pubspec.yaml
+++ b/integration_tests/idl_tests/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: idl_dart_tests
-version: 1.5.0-dev
+version: 1.6.0-dev
 publish_to: none
 
 environment:

--- a/integration_tests/idl_tests/go/go.mod
+++ b/integration_tests/idl_tests/go/go.mod
@@ -19,7 +19,7 @@ module github.com/apache/fory/integration_tests/idl_tests/go
 
 go 1.25.0
 
-require github.com/apache/fory/go/fory v1.5.0-alpha.0
+require github.com/apache/fory/go/fory v1.6.0-alpha.0
 
 require github.com/spaolacci/murmur3 v1.1.0 // indirect
 

--- a/integration_tests/idl_tests/java/pom.xml
+++ b/integration_tests/idl_tests/java/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/idl_tests/javascript/package.json
+++ b/integration_tests/idl_tests/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fory-idl-tests",
-  "version": "1.5.0-alpha.0",
+  "version": "1.6.0-alpha.0",
   "description": "Fory IDL integration tests for JavaScript",
   "main": "index.js",
   "scripts": {

--- a/integration_tests/idl_tests/kotlin/pom.xml
+++ b/integration_tests/idl_tests/kotlin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../../kotlin/pom.xml</relativePath>
     </parent>
 

--- a/integration_tests/idl_tests/python/pyproject.toml
+++ b/integration_tests/idl_tests/python/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fory-idl-tests"
-version = "1.5.0.dev0"
+version = "1.6.0.dev0"
 description = "IDL compiler integration tests for Apache Fory"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/integration_tests/idl_tests/rust/Cargo.lock
+++ b/integration_tests/idl_tests/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fory"
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 dependencies = [
  "fory-core",
  "fory-derive",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "fory-core"
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 dependencies = [
  "byteorder",
  "chrono",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "fory-derive"
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 dependencies = [
  "fory-core",
  "proc-macro-crate",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "idl_tests"
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 dependencies = [
  "chrono",
  "fory",

--- a/integration_tests/idl_tests/rust/Cargo.toml
+++ b/integration_tests/idl_tests/rust/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "idl_tests"
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/integration_tests/jdk_compatibility_tests/pom.xml
+++ b/integration_tests/jdk_compatibility_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration_tests/jpms_tests/pom.xml
+++ b/integration_tests/jpms_tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../../java</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java/README.md
+++ b/java/README.md
@@ -95,28 +95,28 @@ aligned. `fory-json` includes `fory-core` transitively.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 
 <!-- Row format -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 
 <!-- JSON serialization -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 
 <!-- Optional: Serializers for Protobuf data -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-extensions</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
@@ -125,13 +125,13 @@ aligned. `fory-json` includes `fory-core` transitively.
 ```gradle
 dependencies {
     // Binary object serialization
-    implementation 'org.apache.fory:fory-core:1.4.0'
+    implementation 'org.apache.fory:fory-core:1.5.0'
     // Row format
-    implementation 'org.apache.fory:fory-format:1.4.0'
+    implementation 'org.apache.fory:fory-format:1.5.0'
     // JSON serialization
-    implementation 'org.apache.fory:fory-json:1.4.0'
+    implementation 'org.apache.fory:fory-json:1.5.0'
     // Optional: Protobuf serializers and metadata compression
-    implementation 'org.apache.fory:fory-extensions:1.4.0'
+    implementation 'org.apache.fory:fory-extensions:1.5.0'
 }
 ```
 

--- a/java/fory-annotation-processor/pom.xml
+++ b/java/fory-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-core/pom.xml
+++ b/java/fory-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-extensions/pom.xml
+++ b/java/fory-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-format/pom.xml
+++ b/java/fory-format/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-json/README.md
+++ b/java/fory-json/README.md
@@ -43,14 +43,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-json:1.4.0")
+implementation("org.apache.fory:fory-json:1.5.0")
 ```
 
 Use the same version for every Fory module in one application.

--- a/java/fory-json/pom.xml
+++ b/java/fory-json/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-latest-jdk-tests/pom.xml
+++ b/java/fory-latest-jdk-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>fory-latest-jdk-tests</artifactId>

--- a/java/fory-test-core/pom.xml
+++ b/java/fory-test-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/fory-testsuite/pom.xml
+++ b/java/fory-testsuite/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>fory-parent</artifactId>
     <groupId>org.apache.fory</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,7 @@
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <name>Fory Project Parent POM</name>
   <description>
     Apache Fory™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy.

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -6380,7 +6380,7 @@
     },
     "packages/core": {
       "name": "@apache-fory/core",
-      "version": "1.5.0-alpha.0",
+      "version": "1.6.0-alpha.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/hps"
@@ -6400,7 +6400,7 @@
     },
     "packages/hps": {
       "name": "@apache-fory/hps",
-      "version": "1.5.0-alpha.0",
+      "version": "1.6.0-alpha.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apache-fory/core",
-  "version": "1.5.0-alpha.0",
+  "version": "1.6.0-alpha.0",
   "description": "Apache Fory™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy",
   "homepage": "https://fory.apache.org/docs/guide/javascript",
   "main": "dist/index.js",

--- a/javascript/packages/hps/package.json
+++ b/javascript/packages/hps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apache-fory/hps",
-  "version": "1.5.0-alpha.0",
+  "version": "1.6.0-alpha.0",
   "description": "Apache Fory™ nodejs high-performance suite",
   "homepage": "https://fory.apache.org/docs/guide/javascript",
   "main": "dist/index.js",

--- a/kotlin/fory-kotlin-ksp/pom.xml
+++ b/kotlin/fory-kotlin-ksp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/fory-kotlin-tests/pom.xml
+++ b/kotlin/fory-kotlin-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/fory-kotlin/pom.xml
+++ b/kotlin/fory-kotlin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.fory</groupId>
         <artifactId>fory-kotlin-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -32,7 +32,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.fory</groupId>
     <artifactId>fory-kotlin-parent</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Fory Kotlin Project Parent POM</name>
     <description>

--- a/python/pyfory/__init__.py
+++ b/python/pyfory/__init__.py
@@ -135,7 +135,7 @@ from pyfory.type_util import (  # pylint: disable=unused-import
 )
 from pyfory.policy import DeserializationPolicy  # pylint: disable=unused-import
 
-__version__ = "1.5.0.dev0"
+__version__ = "1.6.0.dev0"
 
 __all__ = [
     "Array",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0-alpha.0"
+version = "1.6.0-alpha.0"
 rust-version = "1.70"
 description = "Apache Fory: Blazingly fast multi-language serialization framework with trait objects and reference support."
 license = "Apache-2.0"
@@ -46,5 +46,5 @@ keywords = ["serialization", "serde", "trait-object", "zero-copy", "schema-evolu
 categories = ["encoding"]
 
 [workspace.dependencies]
-fory-core = { path = "fory-core", version = "1.5.0-alpha.0" }
-fory-derive = { path = "fory-derive", version = "1.5.0-alpha.0" }
+fory-core = { path = "fory-core", version = "1.6.0-alpha.0" }
+fory-derive = { path = "fory-derive", version = "1.6.0-alpha.0" }

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # Apache Fory™ Rust
 
-[![Crates.io](https://img.shields.io/badge/crates.io-v1.4.0-blue?logo=rust)](https://crates.io/crates/fory)
+[![Crates.io](https://img.shields.io/badge/crates.io-v1.5.0-blue?logo=rust)](https://crates.io/crates/fory)
 [![Documentation](https://docs.rs/fory/badge.svg)](https://docs.rs/fory)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/apache/fory/blob/main/LICENSE)
 
@@ -23,9 +23,9 @@ The Rust implementation provides versatile and high-performance serialization wi
 
 | Crate                                                                       | Description                                               | Version                                       |
 | --------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
-| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.4.0](https://crates.io/crates/fory)        |
-| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.4.0](https://crates.io/crates/fory-core)   |
-| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.4.0](https://crates.io/crates/fory-derive) |
+| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.5.0](https://crates.io/crates/fory)        |
+| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.5.0](https://crates.io/crates/fory-core)   |
+| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.5.0](https://crates.io/crates/fory-derive) |
 
 Most applications should depend on `fory` only. It re-exports the derive
 macros and the public runtime types needed by generated code. Use `fory-core`
@@ -38,7 +38,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.4.0"
+fory = "1.5.0"
 ```
 
 ### Basic Example

--- a/scala/README.md
+++ b/scala/README.md
@@ -163,7 +163,7 @@ val fory = ForyScala.builder().withXlang(false)
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.4.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.5.0"
 ```
 
 ## Building

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-val foryVersion = "1.5.0-SNAPSHOT"
+val foryVersion = "1.6.0-SNAPSHOT"
 val scala213Version = "2.13.15"
 ThisBuild / apacheSonatypeProjectProfile := "fory"
 version := foryVersion

--- a/swift/README.md
+++ b/swift/README.md
@@ -34,7 +34,7 @@ The Swift implementation provides high-performance object graph serialization wi
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apache/fory.git", from: "1.4.0")
+    .package(url: "https://github.com/apache/fory.git", from: "1.5.0")
 ],
 targets: [
     .target(


### PR DESCRIPTION
## Summary

- move active build, package, benchmark, and integration metadata to the 1.6.0 development versions
- update installation documentation and examples to the released 1.5.0 artifacts
- promote the Dart 1.5.0 changelog without dropping accumulated release notes

## Why

Apache Fory 1.5.0 has been released. The main development tree now targets 1.6.0 while user-facing dependency examples must continue to reference the latest published release.

The Dart changelog updater previously replaced the full matching development section during promotion, which could discard release notes collected during the cycle. It now preserves those notes and only replaces the development-cycle marker.

## User impact

Users copying installation snippets receive version 1.5.0. Contributors build and test against the ecosystem-specific 1.6.0 development versions.

## Validation

- ran the release bump command twice to check idempotence
- formatted changed Markdown and Python files
- ran Ruff checks on the changed release script
- ran `git diff --check`
- full build and test coverage is delegated to pull request CI
