### PR TITLE
chore(ci): pin android-emulator-runner to v2.38.0 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run Android instrumented tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d  # v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64


### PR DESCRIPTION
## What

Pin `reactivecircus/android-emulator-runner` in `.github/workflows/ci.yml` from the floating `v2` tag to the v2.38.0 commit SHA `a421e43855164a8197daf9d8d40fe71c6996bb0d`.

## Why

Every GitHub Action used by an ASF project must be on the ASF infrastructure allowlist. apache/infrastructure-actions#1100 replaces the `reactivecircus/android-emulator-runner@*` wildcard entry with the v2.38.0 SHA as the permanent, Dependabot-maintained pin. The floating `v2` tag stays allowlisted only as a temporary grace entry until 2026-08-25, after which `remove_expired.yml` drops it automatically.

That PR lists `apache/fory` (`.github/workflows/ci.yml`) among the repos still using the floating `v2` tag and therefore needing migration. Without this change, the Android instrumented test job would start failing once the temporary allowlist entry expires.

v2.38.0 is the current latest release, so this is a pin, not a downgrade. CI itself is the test.

