### PR TITLE
perf(scala): streamline exact List JSON writes

### DIFF
--- a/docs/json/scala.md
+++ b/docs/json/scala.md
@@ -74,27 +74,29 @@ the same case-class schema.
 
 ## Supported Scala types
 
-| Scala type                                                  | JSON representation                                    |
-| ----------------------------------------------------------- | ------------------------------------------------------ |
-| `Unit`                                                      | `null`                                                 |
-| case class                                                  | object                                                 |
-| singleton object                                            | empty object                                           |
-| value class                                                 | underlying value                                       |
-| `Option[A]`, `Some[A]`, `None`                              | contained value or `null`                              |
-| `Either[L, R]`                                              | object containing exactly one `left` or `right` member |
-| `List`, `Seq`, `Vector`, `Queue`, `ArraySeq`, buffers, sets | array                                                  |
-| Scala maps, `IntMap`, `LongMap`                             | object                                                 |
-| immutable and mutable `BitSet`                              | ascending integer array                                |
-| `Tuple1` through `Tuple22`                                  | fixed-length array                                     |
-| Scala 3 `EmptyTuple`                                        | empty array                                            |
-| `BigInt`, `BigDecimal`                                      | JSON number                                            |
-| Scala `StringBuilder`                                       | string                                                 |
-| `Range`, supported `NumericRange`                           | realized value array                                   |
-| `FiniteDuration`, `Duration`                                | fixed `length`/`unit` or `special` object              |
-| parameterless Scala 3 enum                                  | string case name                                       |
-| Scala 2 `Enumeration`                                       | string through an owner-bound codec                    |
+| Scala type                                                  | JSON representation                             |
+| ----------------------------------------------------------- | ----------------------------------------------- |
+| `Unit`                                                      | `null`                                          |
+| case class                                                  | object                                          |
+| singleton object                                            | empty object                                    |
+| value class                                                 | underlying value                                |
+| `Option[A]`, `Some[A]`, `None`                              | contained value or `null`                       |
+| `Either[L, R]`                                              | object containing exactly one `l` or `r` member |
+| `List`, `Seq`, `Vector`, `Queue`, `ArraySeq`, buffers, sets | array                                           |
+| Scala maps, `IntMap`, `LongMap`                             | object                                          |
+| immutable and mutable `BitSet`                              | ascending integer array                         |
+| `Tuple1` through `Tuple22`                                  | fixed-length array                              |
+| Scala 3 `EmptyTuple`                                        | empty array                                     |
+| `BigInt`, `BigDecimal`                                      | JSON number                                     |
+| Scala `StringBuilder`                                       | string                                          |
+| `Range`, supported `NumericRange`                           | realized value array                            |
+| `FiniteDuration`, `Duration`                                | fixed `length`/`unit` or `special` object       |
+| parameterless Scala 3 enum                                  | string case name                                |
+| Scala 2 `Enumeration`                                       | string through an owner-bound codec             |
 
 Strict standard-library collections are reconstructed through their standard Scala builders.
+`Either` writes compact `l` and `r` member names. Readers also accept the legacy `left` and
+`right` member names.
 Fory does not add a Scala-specific collection-size limit; the codecs use the same input-length,
 depth, graph-memory, and read-progress limits as Fory JSON core. A sparse `BitSet` whose highest
 index would require backing storage disproportionate to the available JSON input is rejected.

--- a/scala/fory-json-scala/src/main/scala/org/apache/fory/json/scala/internal/ScalaAlgebraicCodecs.scala
+++ b/scala/fory-json-scala/src/main/scala/org/apache/fory/json/scala/internal/ScalaAlgebraicCodecs.scala
@@ -22,6 +22,7 @@ package org.apache.fory.json.scala.internal
 import org.apache.fory.json.ForyJsonException
 import org.apache.fory.json.annotation.JsonCodec
 import org.apache.fory.json.codec.CompositeJsonCodec
+import org.apache.fory.json.meta.JsonFieldNameHash
 import org.apache.fory.json.reader.{Latin1JsonReader, Utf16JsonReader, Utf8JsonReader}
 import org.apache.fory.json.resolver.{JsonTypeInfo, JsonTypeResolver}
 import org.apache.fory.json.writer.{StringJsonWriter, Utf8JsonWriter}
@@ -140,10 +141,10 @@ private[scala] final class ScalaEitherCodec(branch: Int)
     writer.writeObjectStart()
     value match {
       case Left(left) =>
-        writer.writeFieldName("left")
+        writer.writeFieldName("l")
         leftInfo.stringWriter().writeString(writer, left)
       case Right(right) =>
-        writer.writeFieldName("right")
+        writer.writeFieldName("r")
         rightInfo.stringWriter().writeString(writer, right)
     }
     writer.writeObjectEnd()
@@ -157,10 +158,10 @@ private[scala] final class ScalaEitherCodec(branch: Int)
     writer.writeObjectStart()
     value match {
       case Left(left) =>
-        writer.writeFieldName("left")
+        writer.writeFieldName("l")
         leftInfo.utf8Writer().writeUtf8(writer, left)
       case Right(right) =>
-        writer.writeFieldName("right")
+        writer.writeFieldName("r")
         rightInfo.utf8Writer().writeUtf8(writer, right)
     }
     writer.writeObjectEnd()
@@ -171,11 +172,15 @@ private[scala] final class ScalaEitherCodec(branch: Int)
     reader.enterDepth()
     reader.expectNextToken('{')
     if (reader.consumeNextToken('}')) throw invalid()
-    val name = reader.readFieldName()
+    val nameHash = reader.readFieldNameHash()
     reader.expectNextToken(':')
     val value =
-      if (name == "left") newLeft(reader, leftInfo.latin1Reader().readLatin1(reader))
-      else if (name == "right") newRight(reader, rightInfo.latin1Reader().readLatin1(reader))
+      if (nameHash == ScalaEitherCodec.LeftHash || nameHash == ScalaEitherCodec.LegacyLeftHash)
+        newLeft(reader, leftInfo.latin1Reader().readLatin1(reader))
+      else if (
+        nameHash == ScalaEitherCodec.RightHash || nameHash == ScalaEitherCodec.LegacyRightHash
+      )
+        newRight(reader, rightInfo.latin1Reader().readLatin1(reader))
       else throw invalid()
     if (reader.consumeNextCommaOrEndObject()) throw invalid()
     reader.exitDepth()
@@ -187,11 +192,15 @@ private[scala] final class ScalaEitherCodec(branch: Int)
     reader.enterDepth()
     reader.expectNextToken('{')
     if (reader.consumeNextToken('}')) throw invalid()
-    val name = reader.readFieldName()
+    val nameHash = reader.readFieldNameHash()
     reader.expectNextToken(':')
     val value =
-      if (name == "left") newLeft(reader, leftInfo.utf16Reader().readUtf16(reader))
-      else if (name == "right") newRight(reader, rightInfo.utf16Reader().readUtf16(reader))
+      if (nameHash == ScalaEitherCodec.LeftHash || nameHash == ScalaEitherCodec.LegacyLeftHash)
+        newLeft(reader, leftInfo.utf16Reader().readUtf16(reader))
+      else if (
+        nameHash == ScalaEitherCodec.RightHash || nameHash == ScalaEitherCodec.LegacyRightHash
+      )
+        newRight(reader, rightInfo.utf16Reader().readUtf16(reader))
       else throw invalid()
     if (reader.consumeNextCommaOrEndObject()) throw invalid()
     reader.exitDepth()
@@ -203,11 +212,15 @@ private[scala] final class ScalaEitherCodec(branch: Int)
     reader.enterDepth()
     reader.expectNextToken('{')
     if (reader.consumeNextToken('}')) throw invalid()
-    val name = reader.readFieldName()
+    val nameHash = reader.readFieldNameHash()
     reader.expectNextToken(':')
     val value =
-      if (name == "left") newLeft(reader, leftInfo.utf8Reader().readUtf8(reader))
-      else if (name == "right") newRight(reader, rightInfo.utf8Reader().readUtf8(reader))
+      if (nameHash == ScalaEitherCodec.LeftHash || nameHash == ScalaEitherCodec.LegacyLeftHash)
+        newLeft(reader, leftInfo.utf8Reader().readUtf8(reader))
+      else if (
+        nameHash == ScalaEitherCodec.RightHash || nameHash == ScalaEitherCodec.LegacyRightHash
+      )
+        newRight(reader, rightInfo.utf8Reader().readUtf8(reader))
       else throw invalid()
     if (reader.consumeNextCommaOrEndObject()) throw invalid()
     reader.exitDepth()
@@ -230,10 +243,14 @@ private[scala] final class ScalaEitherCodec(branch: Int)
   }
 
   private def invalid(): ForyJsonException =
-    new ForyJsonException("Scala Either JSON must contain exactly one left or right member")
+    new ForyJsonException("Scala Either JSON must contain exactly one l or r member")
 }
 
 private[scala] object ScalaEitherCodec {
+  private val LeftHash = JsonFieldNameHash.hash("l")
+  private val RightHash = JsonFieldNameHash.hash("r")
+  private val LegacyLeftHash = JsonFieldNameHash.hash("left")
+  private val LegacyRightHash = JsonFieldNameHash.hash("right")
   private val LeftOwnerBytes = GraphMemoryEstimates.shallowObjectBytes(classOf[Left[_, _]])
   private val RightOwnerBytes = GraphMemoryEstimates.shallowObjectBytes(classOf[Right[_, _]])
 }

--- a/scala/fory-json-scala/src/main/scala/org/apache/fory/json/scala/internal/ScalaCollectionCodecs.scala
+++ b/scala/fory-json-scala/src/main/scala/org/apache/fory/json/scala/internal/ScalaCollectionCodecs.scala
@@ -30,6 +30,8 @@ import org.apache.fory.serializer.GraphMemoryEstimates
 
 import scala.reflect.ClassTag
 
+// Scala List is sealed to Nil and ::, so exact List codecs traverse nodes without
+// runtime-family checks.
 private[scala] final class ScalaListCodec(nonEmptyOnly: Boolean, nilOnly: Boolean)
     extends CompositeJsonCodec[List[Any]] {
   private var elementInfo: JsonTypeInfo = _
@@ -67,15 +69,15 @@ private[scala] final class ScalaListCodec(nonEmptyOnly: Boolean, nilOnly: Boolea
       writer.writeNull()
       return
     }
-    ScalaCollectionCodecs.requireSupportedRuntime(value.getClass)
     val codec = elementInfo.stringWriter()
     writer.writeArrayStart()
     var current = value
     var index = 0
-    while (current.nonEmpty) {
+    while (current ne Nil) {
+      val node = current.asInstanceOf[scala.collection.immutable.::[Any]]
       writer.writeComma(index)
-      codec.writeString(writer, current.head)
-      current = current.tail
+      codec.writeString(writer, node.head)
+      current = node.tail
       index += 1
     }
     writer.writeArrayEnd()
@@ -86,15 +88,15 @@ private[scala] final class ScalaListCodec(nonEmptyOnly: Boolean, nilOnly: Boolea
       writer.writeNull()
       return
     }
-    ScalaCollectionCodecs.requireSupportedRuntime(value.getClass)
     val codec = elementInfo.utf8Writer()
     writer.writeArrayStart()
     var current = value
     var index = 0
-    while (current.nonEmpty) {
+    while (current ne Nil) {
+      val node = current.asInstanceOf[scala.collection.immutable.::[Any]]
       writer.writeComma(index)
-      codec.writeUtf8(writer, current.head)
-      current = current.tail
+      codec.writeUtf8(writer, node.head)
+      current = node.tail
       index += 1
     }
     writer.writeArrayEnd()

--- a/scala/fory-json-scala/src/test/scala/org/apache/fory/json/scala/ScalaJsonSuite.scala
+++ b/scala/fory-json-scala/src/test/scala/org/apache/fory/json/scala/ScalaJsonSuite.scala
@@ -19,6 +19,9 @@
 
 package org.apache.fory.json.scala
 
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.apache.fory.json.ForyJsonException
 import org.apache.fory.json.annotation.{JsonIgnore, JsonProperty, JsonUnwrapped}
 import org.apache.fory.json.codec.AbstractJsonValueCodec
 import org.apache.fory.json.reader.JsonReader
@@ -187,9 +190,6 @@ class ScalaJsonSuite extends AnyFunSuite {
     val value = Map("a" -> Some(1), "b" -> None)
     assert(json.fromJson(json.toJson(value, mapType), mapType) == value)
 
-    val eitherType = new TypeRef[Either[Int, String]]() {}
-    assert(json.fromJson(json.toJson(Right("ok"), eitherType), eitherType) == Right("ok"))
-
     val someType = new TypeRef[Some[Int]]() {}
     assert(json.fromJson("1", someType) == Some(1))
     assertThrows[org.apache.fory.json.ForyJsonException](json.fromJson("null", someType))
@@ -197,6 +197,46 @@ class ScalaJsonSuite extends AnyFunSuite {
     val optionType = new TypeRef[Option[Int]]() {}
     assert(json.fromJson("null", optionType) == None)
     assert(json.fromJson(json.toJson(None), classOf[None.type]) == None)
+  }
+
+  test("Either uses compact branch names and reads legacy names") {
+    val json = ForyJsonScala.builder().withCodegen(false).build()
+    val eitherType = new TypeRef[Either[Int, String]]() {}
+    val leftType = new TypeRef[Left[Int, String]]() {}
+    val rightType = new TypeRef[Right[Int, String]]() {}
+    val left: Either[Int, String] = Left(7)
+    val right: Either[Int, String] = Right("ok")
+
+    assert(json.toJson(left, eitherType) == "{\"l\":7}")
+    assert(json.toJson(right, eitherType) == "{\"r\":\"ok\"}")
+    assert(new String(json.toJsonBytes(left, eitherType), UTF_8) == "{\"l\":7}")
+    assert(new String(json.toJsonBytes(right, eitherType), UTF_8) == "{\"r\":\"ok\"}")
+
+    assert(json.fromJson("{\"l\":7}", eitherType) == left)
+    assert(json.fromJson("{\"left\":7}", eitherType) == left)
+    assert(json.fromJson("{\"r\":\"ok\"}", eitherType) == right)
+    assert(json.fromJson("{\"right\":\"ok\"}", eitherType) == right)
+    assert(json.fromJson("{\"r\":\"中文\"}", eitherType) == Right("中文"))
+    assert(json.fromJson("{\"l\":7}".getBytes(UTF_8), eitherType) == left)
+    assert(json.fromJson("{\"left\":7}".getBytes(UTF_8), eitherType) == left)
+    assert(json.fromJson("{\"r\":\"ok\"}".getBytes(UTF_8), eitherType) == right)
+    assert(json.fromJson("{\"right\":\"ok\"}".getBytes(UTF_8), eitherType) == right)
+
+    assert(json.fromJson("null", eitherType) == null)
+    assert(json.toJson(null.asInstanceOf[Either[Int, String]], eitherType) == "null")
+    assert(json.fromJson("{\"l\":7}", leftType) == Left(7))
+    assert(json.fromJson("{\"r\":\"ok\"}".getBytes(UTF_8), rightType) == Right("ok"))
+    assertThrows[ForyJsonException](json.fromJson("{\"r\":\"ok\"}", leftType))
+    assertThrows[ForyJsonException](json.fromJson("{\"left\":7}".getBytes(UTF_8), rightType))
+
+    val nullableType = new TypeRef[Either[String, String]]() {}
+    assert(json.toJson(Left[String, String](null), nullableType) == "{\"l\":null}")
+    assert(json.fromJson("{\"r\":null}", nullableType) == Right(null))
+
+    for (invalid <- Seq("{}", "{\"l\":7,\"r\":\"ok\"}", "{\"x\":7}", "[7]")) {
+      assertThrows[ForyJsonException](json.fromJson(invalid, eitherType))
+      assertThrows[ForyJsonException](json.fromJson(invalid.getBytes(UTF_8), eitherType))
+    }
   }
 
   test("range and duration shapes") {

--- a/scala/fory-json-scala/src/test/scala/org/apache/fory/json/scala/ScalaJsonSuite.scala
+++ b/scala/fory-json-scala/src/test/scala/org/apache/fory/json/scala/ScalaJsonSuite.scala
@@ -181,6 +181,7 @@ class ScalaJsonSuite extends AnyFunSuite {
     val json = ForyJsonScala.builder().withCodegen(false).build()
     val listType = new TypeRef[List[Int]]() {}
     assert(json.fromJson(json.toJson(List(1, 2, 3), listType), listType) == List(1, 2, 3))
+    assert(json.toJson(List.empty[Int], listType) == "[]")
 
     val mapType = new TypeRef[Map[String, Option[Int]]]() {}
     val value = Map("a" -> Some(1), "b" -> None)


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

