### PR TITLE
ci: update sbt setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,7 @@ jobs:
         with:
           java-version: 11
           distribution: "temurin"
-      - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1.5.1
+      - uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
         with:
           disk-cache: false
       - name: Install fory java
@@ -695,7 +695,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1.5.1
+      - uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
         with:
           disk-cache: false
       - name: Run Scala Xlang Test
@@ -723,7 +723,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1.5.1
+      - uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
         with:
           disk-cache: false
       - name: Install Fory Java


### PR DESCRIPTION
## Why?

The three Scala jobs in Fory CI fail during job setup because `sbt/setup-sbt` v1.5.1 reaches a transitive `carabiner-dev/actions/install/ampel` commit that expired from the Apache GitHub Actions allowlist.

## What does this PR do?

Update the existing `sbt/setup-sbt` pin from v1.5.1 to v1.5.7 in Scala CI, Scala Xlang Test, and Scala IDL Tests. The new action and its full transitive dependency chain are present in the Apache allowlist. Existing JDK versions, test commands, and `disk-cache: false` behavior remain unchanged.

Local checks:

- `ENABLE_FORY_DEBUG_OUTPUT=1 ci/format.sh`
- `ENABLE_FORY_DEBUG_OUTPUT=1 sbt clean +test` from `scala/` (136/136 tests passed across Scala 2.13 and Scala 3)
- `git diff --check`

## Related issues

N/A.

## AI Contribution Checklist

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

N/A; workflow-only change.