### PR TITLE
fix(scala): target Java 8 bytecode for fory-scala

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -65,6 +65,7 @@ lazy val foryScala = Project(id = "fory-scala", base = file("fory-scala"))
   .settings(commonSettings)
   .settings(
     name := "fory-scala",
+    Compile / javacOptions ++= Seq("--release", "8"),
     libraryDependencies ++= Seq(
       "org.apache.fory" % "fory-core" % foryVersion,
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,


### PR DESCRIPTION
## Why?

`fory-scala` Java sources are compiled with JDK 25 during release, producing Java 25 bytecode

## What does this PR do?

Set the Java target to Java 8:

```scala
Compile / javacOptions ++= Seq("--release", "8")
```

Analogue to `fory-json-scala`

## Related issues

* Fixes [#3940](https://github.com/apache/fory/issues/3940)

## Does this PR introduce any user-facing change?

Fixes `fory-scala` compatibility with supported older JDKs.

* [ ] Does this PR introduce any public API change?
* [x] Does this PR introduce any binary protocol compatibility change?

## Benchmark

Not applicable.
