### PR TITLE
docs: update jackson annotations license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -251,6 +251,21 @@ The text of each license is the standard Apache 2.0 license.
     Files:
       cpp/fory/thirdparty/flat_hash_map.h
 
+* jackson-annotations (https://github.com/FasterXML/jackson-annotations)
+    Fory JSON implementations of the following annotation APIs are based on Jackson annotations.
+    Files:
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonAnyGetter.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonAnySetter.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonCreator.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonFormat.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonIgnore.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonProperty.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonPropertyOrder.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonRawValue.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonSubTypes.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonUnwrapped.java
+      java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonValue.java
+
 
 ================================================================
 BSD-3-Clause licenses

--- a/LICENSE
+++ b/LICENSE
@@ -266,6 +266,12 @@ The text of each license is the standard Apache 2.0 license.
       java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonUnwrapped.java
       java/fory-json/src/main/java/org/apache/fory/json/annotation/JsonValue.java
 
+* jackson-module-scala (https://github.com/FasterXML/jackson-module-scala)
+    Fory JSON's Scala JsonEnumeration annotation implementation is based on Jackson's
+    JsonScalaEnumeration annotation.
+    Files:
+      scala/fory-json-scala/src/main/java/org/apache/fory/json/scala/JsonEnumeration.java
+
 
 ================================================================
 BSD-3-Clause licenses


### PR DESCRIPTION


## Why?



## What does this PR do?

Document the Fory JSON annotations derived from Jackson Annotations in LICENSE, including their source files and Apache-2.0 attribution.


## Related issues

Closes #3942 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark


