### PR TITLE
feat(java): add incremental JSON stream decoding

### DIFF
--- a/docs/json/getting-started.md
+++ b/docs/json/getting-started.md
@@ -152,23 +152,76 @@ must be explicit.
 
 ## Reading and writing APIs
 
-Fory JSON supports String input/output and UTF-8 byte input/output. It does not currently provide an
-`InputStream` parsing API.
+Fory JSON supports String input/output, UTF-8 byte input/output, and incremental UTF-8 input from
+`ByteBuffer` chunks. It does not currently provide a blocking `InputStream` parsing API.
 
-| Operation            | Runtime type              | Declared `Class`                | Declared `TypeRef`                 |
-| -------------------- | ------------------------- | ------------------------------- | ---------------------------------- |
-| String output        | `toJson(value)`           | `toJson(value, type)`           | `toJson(value, typeRef)`           |
-| UTF-8 bytes          | `toJsonBytes(value)`      | `toJsonBytes(value, type)`      | `toJsonBytes(value, typeRef)`      |
-| UTF-8 `OutputStream` | `writeJsonTo(value, out)` | `writeJsonTo(value, type, out)` | `writeJsonTo(value, typeRef, out)` |
-| String input         | -                         | `fromJson(text, type)`          | `fromJson(text, typeRef)`          |
-| UTF-8 input          | -                         | `fromJson(bytes, type)`         | `fromJson(bytes, typeRef)`         |
+| Operation            | Runtime type              | Declared `Class`                        | Declared `TypeRef`                         |
+| -------------------- | ------------------------- | --------------------------------------- | ------------------------------------------ |
+| String output        | `toJson(value)`           | `toJson(value, type)`                   | `toJson(value, typeRef)`                   |
+| UTF-8 bytes          | `toJsonBytes(value)`      | `toJsonBytes(value, type)`              | `toJsonBytes(value, typeRef)`              |
+| UTF-8 `OutputStream` | `writeJsonTo(value, out)` | `writeJsonTo(value, type, out)`         | `writeJsonTo(value, typeRef, out)`         |
+| String input         | -                         | `fromJson(text, type)`                  | `fromJson(text, typeRef)`                  |
+| UTF-8 input          | -                         | `fromJson(bytes, type)`                 | `fromJson(bytes, typeRef)`                 |
+| UTF-8 byte range     | -                         | `fromJson(bytes, offset, length, type)` | `fromJson(bytes, offset, length, typeRef)` |
 
 Every `fromJson` call consumes exactly one JSON value and rejects trailing non-whitespace content.
+The byte-range overloads parse exactly the requested range and ignore bytes before and after it.
 Returned Strings and byte arrays are detached from internal reusable buffers.
 
 `writeJsonTo` buffers the complete UTF-8 document, performs one `OutputStream.write`, and neither
 flushes nor closes the caller-owned stream. It is an output convenience API, not incremental JSON
 streaming. I/O failures are wrapped in `ForyJsonException`.
+
+### Incremental JSON streams
+
+`JsonStreamDecoder` incrementally decodes either the elements of one top-level JSON array or
+newline-delimited JSON (NDJSON) records. Supply arbitrary UTF-8 `ByteBuffer` chunks and drain each
+chunk before supplying the next one:
+
+```java
+import java.nio.ByteBuffer;
+import org.apache.fory.json.ForyJson;
+import org.apache.fory.json.JsonStreamDecoder;
+
+ForyJson json = ForyJson.builder().build();
+JsonStreamDecoder<User> decoder =
+    json.newArrayStreamDecoder(User.class, 64 * 1024 * 1024);
+
+for (ByteBuffer chunk : chunks) {
+  while (decoder.decodeNext(chunk)) {
+    User user = decoder.value();
+    consume(user);
+  }
+}
+decoder.finish();
+```
+
+Use `newNdjsonStreamDecoder` for LF- or CRLF-delimited records. A final NDJSON record does not need
+a line ending; `finish()` returns `true` when it decodes that final record:
+
+```java
+JsonStreamDecoder<User> decoder =
+    json.newNdjsonStreamDecoder(User.class, 64 * 1024 * 1024);
+
+for (ByteBuffer chunk : chunks) {
+  while (decoder.decodeNext(chunk)) {
+    consume(decoder.value());
+  }
+}
+if (decoder.finish()) {
+  consume(decoder.value());
+}
+```
+
+Each `decodeNext` call returns at most one value. When it returns `true`, call it again with the same
+buffer if bytes remain; when it returns `false`, that buffer has been consumed to its limit. A
+`true` result with `value() == null` represents JSON `null`.
+
+The decoder advances the supplied buffer's position, but does not retain the buffer or change its
+limit or byte order. Heap, direct, sliced, and read-only buffers are supported. One decoder owns one
+stream, is not thread-safe, and cannot be reused after `finish()` or a failure. The required
+`maxValueBytes` limit applies independently to each array element or NDJSON record rather than to
+the complete stream.
 
 ### Generic types
 

--- a/docs/json/getting-started.md
+++ b/docs/json/getting-started.md
@@ -221,7 +221,10 @@ The decoder advances the supplied buffer's position, but does not retain the buf
 limit or byte order. Heap, direct, sliced, and read-only buffers are supported. One decoder owns one
 stream, is not thread-safe, and cannot be reused after `finish()` or a failure. The required
 `maxValueBytes` limit applies independently to each array element or NDJSON record rather than to
-the complete stream.
+the complete stream. For arrays, the limit excludes the outer brackets, commas, and whitespace
+skipped before an element; whitespace after an element and before its comma or closing bracket is
+counted. For NDJSON, every byte other than the LF or CRLF line ending is counted. Whitespace-only
+lines are skipped, but an oversized whitespace-only line still fails the limit.
 
 ### Generic types
 

--- a/java/fory-json/README.md
+++ b/java/fory-json/README.md
@@ -115,21 +115,49 @@ or `JsonProperty.index` when emitted property order must be explicit.
 
 ## Core API
 
-Fory JSON supports String and UTF-8 byte input/output. It does not currently
-provide an `InputStream` parsing API.
+Fory JSON supports String and UTF-8 byte input/output plus incremental UTF-8
+input from `ByteBuffer` chunks. It does not currently provide a blocking
+`InputStream` parsing API.
 
-| Operation            | Runtime type              | Declared `Class`                | Declared `TypeRef`                 |
-| -------------------- | ------------------------- | ------------------------------- | ---------------------------------- |
-| String output        | `toJson(value)`           | `toJson(value, type)`           | `toJson(value, typeRef)`           |
-| UTF-8 bytes          | `toJsonBytes(value)`      | `toJsonBytes(value, type)`      | `toJsonBytes(value, typeRef)`      |
-| UTF-8 `OutputStream` | `writeJsonTo(value, out)` | `writeJsonTo(value, type, out)` | `writeJsonTo(value, typeRef, out)` |
-| String input         | -                         | `fromJson(text, type)`          | `fromJson(text, typeRef)`          |
-| UTF-8 input          | -                         | `fromJson(bytes, type)`         | `fromJson(bytes, typeRef)`         |
+| Operation            | Runtime type              | Declared `Class`                        | Declared `TypeRef`                         |
+| -------------------- | ------------------------- | --------------------------------------- | ------------------------------------------ |
+| String output        | `toJson(value)`           | `toJson(value, type)`                   | `toJson(value, typeRef)`                   |
+| UTF-8 bytes          | `toJsonBytes(value)`      | `toJsonBytes(value, type)`              | `toJsonBytes(value, typeRef)`              |
+| UTF-8 `OutputStream` | `writeJsonTo(value, out)` | `writeJsonTo(value, type, out)`         | `writeJsonTo(value, typeRef, out)`         |
+| String input         | -                         | `fromJson(text, type)`                  | `fromJson(text, typeRef)`                  |
+| UTF-8 input          | -                         | `fromJson(bytes, type)`                 | `fromJson(bytes, typeRef)`                 |
+| UTF-8 byte range     | -                         | `fromJson(bytes, offset, length, type)` | `fromJson(bytes, offset, length, typeRef)` |
 
 Every `fromJson` call consumes exactly one JSON value and rejects trailing
-non-whitespace content. Returned strings and byte arrays are detached from
-internal reusable buffers. `writeJsonTo` writes one complete buffered document;
-it does not flush or close the caller-owned stream.
+non-whitespace content. Byte-range overloads parse exactly the requested range.
+Returned strings and byte arrays are detached from internal reusable buffers.
+`writeJsonTo` writes one complete buffered document; it does not flush or close
+the caller-owned stream.
+
+Use `JsonStreamDecoder` to decode the elements of one top-level JSON array or
+newline-delimited JSON (NDJSON) records without buffering the complete stream:
+
+```java
+import java.nio.ByteBuffer;
+import org.apache.fory.json.ForyJson;
+import org.apache.fory.json.JsonStreamDecoder;
+
+ForyJson json = ForyJson.builder().build();
+JsonStreamDecoder<User> decoder =
+    json.newArrayStreamDecoder(User.class, 64 * 1024 * 1024);
+
+for (ByteBuffer chunk : chunks) {
+  while (decoder.decodeNext(chunk)) {
+    consume(decoder.value());
+  }
+}
+decoder.finish();
+```
+
+Drain each buffer before supplying the next one. A decoder owns one stream, is
+not thread-safe, and cannot be reused after `finish()` or a failure. See
+[Getting Started](../../docs/json/getting-started.md#incremental-json-streams)
+for NDJSON, JSON `null`, buffer ownership, and limit behavior.
 
 Use `TypeRef` when a root type contains generic arguments:
 

--- a/java/fory-json/src/main/java/org/apache/fory/json/ForyJson.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/ForyJson.java
@@ -113,6 +113,47 @@ public final class ForyJson {
     return new ForyJsonBuilder();
   }
 
+  /**
+   * Creates a single-stream decoder for the elements of one top-level UTF-8 JSON array.
+   *
+   * @param elementType declared element type
+   * @param maxValueBytes maximum UTF-8 bytes accepted for one array element
+   */
+  public <T> JsonStreamDecoder<T> newArrayStreamDecoder(Class<T> elementType, int maxValueBytes) {
+    return JsonStreamDecoder.forArray(this, elementType, maxValueBytes);
+  }
+
+  /**
+   * Creates a single-stream decoder for the elements of one top-level UTF-8 JSON array.
+   *
+   * @param elementType declared generic element type
+   * @param maxValueBytes maximum UTF-8 bytes accepted for one array element
+   */
+  public <T> JsonStreamDecoder<T> newArrayStreamDecoder(TypeRef<T> elementType, int maxValueBytes) {
+    return JsonStreamDecoder.forArray(this, elementType, maxValueBytes);
+  }
+
+  /**
+   * Creates a single-stream decoder for UTF-8 newline-delimited JSON records.
+   *
+   * @param elementType declared record type
+   * @param maxValueBytes maximum UTF-8 bytes accepted for one record, excluding its line ending
+   */
+  public <T> JsonStreamDecoder<T> newNdjsonStreamDecoder(Class<T> elementType, int maxValueBytes) {
+    return JsonStreamDecoder.forNdjson(this, elementType, maxValueBytes);
+  }
+
+  /**
+   * Creates a single-stream decoder for UTF-8 newline-delimited JSON records.
+   *
+   * @param elementType declared generic record type
+   * @param maxValueBytes maximum UTF-8 bytes accepted for one record, excluding its line ending
+   */
+  public <T> JsonStreamDecoder<T> newNdjsonStreamDecoder(
+      TypeRef<T> elementType, int maxValueBytes) {
+    return JsonStreamDecoder.forNdjson(this, elementType, maxValueBytes);
+  }
+
   JsonConfig config() {
     return config;
   }
@@ -637,6 +678,64 @@ public final class ForyJson {
     }
   }
 
+  /**
+   * Parses exactly one UTF-8 JSON value from {@code bytes[offset, offset + length)} using {@code
+   * type} as its declared Java type. Trailing non-whitespace content within that range is rejected.
+   *
+   * <p>This root API is not reentrant on the same instance. A custom codec invoked by this
+   * operation must consume nested content through the {@link Utf8JsonReader} passed to its {@code
+   * readUtf8} method instead of invoking a {@code ForyJson} root API.
+   */
+  public <T> T fromJson(byte[] bytes, int offset, int length, Class<T> type) {
+    checkByteRange(bytes, offset, length);
+    PooledState entry = acquire();
+    JsonState state = entry.state;
+    try {
+      state.typeResolver.lockJIT();
+      try {
+        return castValue(readUtf8Value(state.utf8Reader(bytes, offset, length), type, state), type);
+      } finally {
+        state.typeResolver.unlockJIT();
+      }
+    } finally {
+      try {
+        state.clearUtf8Reader();
+      } finally {
+        release(entry);
+      }
+    }
+  }
+
+  /**
+   * Parses exactly one UTF-8 JSON value from {@code bytes[offset, offset + length)} using a generic
+   * type captured by {@link TypeRef}. Trailing non-whitespace content within that range is
+   * rejected.
+   *
+   * <p>This root API is not reentrant on the same instance. A custom codec invoked by this
+   * operation must consume nested content through the {@link Utf8JsonReader} passed to its {@code
+   * readUtf8} method instead of invoking a {@code ForyJson} root API.
+   */
+  public <T> T fromJson(byte[] bytes, int offset, int length, TypeRef<T> typeRef) {
+    checkByteRange(bytes, offset, length);
+    PooledState entry = acquire();
+    JsonState state = entry.state;
+    try {
+      state.typeResolver.lockJIT();
+      try {
+        Object value = readUtf8Value(state.utf8Reader(bytes, offset, length), typeRef, state);
+        return castValue(value, typeRef);
+      } finally {
+        state.typeResolver.unlockJIT();
+      }
+    } finally {
+      try {
+        state.clearUtf8Reader();
+      } finally {
+        release(entry);
+      }
+    }
+  }
+
   private PooledState acquire() {
     PooledState[] slots = this.slots;
     if (slots.length == 1) {
@@ -824,6 +923,20 @@ public final class ForyJson {
     return new ForyJsonException("Cannot read null into primitive " + type);
   }
 
+  private static void checkByteRange(byte[] bytes, int offset, int length) {
+    // Reject invalid public input before waiting for a pooled state. Utf8JsonReader repeats this
+    // check because its independently callable reset must also protect its cursor invariants.
+    int inputLength = bytes.length;
+    if ((offset | length) < 0 || offset > inputLength - length) {
+      throwInvalidByteRange(offset, length);
+    }
+  }
+
+  private static void throwInvalidByteRange(int offset, int length) {
+    throw new IndexOutOfBoundsException(
+        "Invalid UTF-8 byte range: offset=" + offset + ", length=" + length);
+  }
+
   /** Permanently owns one execution state and leases it to at most one root operation. */
   private static final class PooledState {
     private final JsonState state;
@@ -914,7 +1027,14 @@ public final class ForyJson {
     }
 
     private Utf8JsonReader utf8Reader(byte[] input) {
+      // Keep full-array roots on the direct reset so the existing hot path does not pay the range
+      // validation branches.
       utf8Reader.reset(input);
+      return utf8Reader;
+    }
+
+    private Utf8JsonReader utf8Reader(byte[] input, int offset, int length) {
+      utf8Reader.reset(input, offset, length);
       return utf8Reader;
     }
 

--- a/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
@@ -37,6 +37,11 @@ import org.apache.fory.reflect.TypeRef;
  * retains one bounded staging array whose capacity grows with committed value bytes and is reused
  * until successful {@link #finish()} or any {@link #decodeNext(ByteBuffer) decodeNext} or {@code
  * finish} failure permanently terminates the decoder.
+ *
+ * <p>For array streams, {@code maxValueBytes} excludes outer punctuation and whitespace skipped
+ * before an element, but includes whitespace after the element and before its delimiter. For
+ * NDJSON, it counts every record byte except LF or the CRLF line ending. Whitespace-only NDJSON
+ * lines are skipped as records but remain subject to the limit.
  */
 @NotThreadSafe
 public final class JsonStreamDecoder<T> {

--- a/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
@@ -1,0 +1,596 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.json;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.fory.reflect.TypeRef;
+
+/**
+ * Incrementally decodes values from one UTF-8 JSON array or newline-delimited JSON stream.
+ *
+ * <p>One instance owns exactly one stream and is not thread-safe. Calls may move between threads
+ * only when the caller serializes them with a happens-before edge. The decoder advances each
+ * supplied {@link ByteBuffer} position but never retains the buffer or changes its limit or byte
+ * order.
+ *
+ * <p>Each returned value is parsed by an independent {@link ForyJson} root operation. The decoder
+ * retains one bounded staging array whose capacity grows to the largest value seen and is reused
+ * until successful {@link #finish()} or any {@link #decodeNext(ByteBuffer) decodeNext} or {@code
+ * finish} failure permanently terminates the decoder.
+ */
+@NotThreadSafe
+public final class JsonStreamDecoder<T> {
+  private static final byte ARRAY = 0;
+  private static final byte NDJSON = 1;
+
+  private static final byte ACTIVE = 0;
+  private static final byte FINISHED = 1;
+  private static final byte FAILED = 2;
+
+  private static final byte BEFORE_ARRAY = 0;
+  private static final byte FIRST_VALUE = 1;
+  private static final byte NEXT_VALUE = 2;
+  private static final byte IN_VALUE = 3;
+  private static final byte AFTER_ARRAY = 4;
+
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+  private static final int INITIAL_VALUE_BYTES = 8 * 1024;
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  private static final long BYTE_ONES = 0x0101010101010101L;
+  private static final long BYTE_HIGH_BITS = 0x8080808080808080L;
+  private static final long QUOTES = 0x2222222222222222L;
+  private static final long BACKSLASHES = 0x5c5c5c5c5c5c5c5cL;
+  private static final long OPEN_BRACES = 0x7b7b7b7b7b7b7b7bL;
+  private static final long CLOSE_BRACES = 0x7d7d7d7d7d7d7d7dL;
+  private static final long OPEN_BRACKETS = 0x5b5b5b5b5b5b5b5bL;
+  private static final long CLOSE_BRACKETS = 0x5d5d5d5d5d5d5d5dL;
+  private static final long COMMAS = 0x2c2c2c2c2c2c2c2cL;
+  private static final long CARRIAGE_RETURNS = 0x0d0d0d0d0d0d0d0dL;
+  private static final long LINE_FEEDS = 0x0a0a0a0a0a0a0a0aL;
+
+  private final ForyJson foryJson;
+  private final Class<T> elementClass;
+  private final TypeRef<T> elementType;
+  private final int maxValueBytes;
+  private final byte format;
+
+  private byte[] valueBytes = EMPTY_BYTES;
+  private int valueLength;
+  private int objectDepth;
+  private int arrayDepth;
+  private byte lifecycle = ACTIVE;
+  private byte arrayState = BEFORE_ARRAY;
+  private boolean inString;
+  private boolean escaped;
+  private boolean recordStarted;
+  private boolean pendingCarriageReturn;
+  private boolean valueAvailable;
+  private T currentValue;
+
+  static <T> JsonStreamDecoder<T> forArray(
+      ForyJson foryJson, Class<T> elementType, int maxValueBytes) {
+    return new JsonStreamDecoder<>(foryJson, elementType, null, maxValueBytes, ARRAY);
+  }
+
+  static <T> JsonStreamDecoder<T> forArray(
+      ForyJson foryJson, TypeRef<T> elementType, int maxValueBytes) {
+    return new JsonStreamDecoder<>(foryJson, null, elementType, maxValueBytes, ARRAY);
+  }
+
+  static <T> JsonStreamDecoder<T> forNdjson(
+      ForyJson foryJson, Class<T> elementType, int maxValueBytes) {
+    return new JsonStreamDecoder<>(foryJson, elementType, null, maxValueBytes, NDJSON);
+  }
+
+  static <T> JsonStreamDecoder<T> forNdjson(
+      ForyJson foryJson, TypeRef<T> elementType, int maxValueBytes) {
+    return new JsonStreamDecoder<>(foryJson, null, elementType, maxValueBytes, NDJSON);
+  }
+
+  private JsonStreamDecoder(
+      ForyJson foryJson,
+      Class<T> elementClass,
+      TypeRef<T> elementType,
+      int maxValueBytes,
+      byte format) {
+    this.foryJson = Objects.requireNonNull(foryJson, "foryJson");
+    this.elementClass = elementClass;
+    this.elementType = elementType;
+    if (elementClass == null && elementType == null) {
+      throw new NullPointerException("elementType");
+    }
+    if (maxValueBytes <= 0 || maxValueBytes > MAX_ARRAY_SIZE) {
+      throw new IllegalArgumentException(
+          "maxValueBytes must be between 1 and " + MAX_ARRAY_SIZE + ": " + maxValueBytes);
+    }
+    this.maxValueBytes = maxValueBytes;
+    this.format = format;
+  }
+
+  /**
+   * Advances {@code input} until one value is decoded or the buffer is exhausted.
+   *
+   * <p>A {@code true} result makes {@link #value()} available, including when the decoded JSON
+   * value is {@code null}. When this method returns {@code true} with input remaining, call it
+   * again with that same buffer before supplying a later chunk. A {@code false} result means the
+   * buffer was consumed to its limit.
+   */
+  public boolean decodeNext(ByteBuffer input) {
+    requireActive();
+    clearCurrentValue();
+    try {
+      Objects.requireNonNull(input, "input");
+      return format == ARRAY ? decodeArrayNext(input) : decodeNdjsonNext(input);
+    } catch (RuntimeException e) {
+      markFailed();
+      throw e;
+    } catch (Error e) {
+      markFailed();
+      throw e;
+    }
+  }
+
+  /**
+   * Returns the value produced when the immediately preceding decode or finish call returned true.
+   */
+  public T value() {
+    if (!valueAvailable) {
+      throw noCurrentValue();
+    }
+    return currentValue;
+  }
+
+  /**
+   * Signals end of input and validates the complete stream.
+   *
+   * @return {@code true} only when an unterminated final NDJSON record produced one last value
+   */
+  public boolean finish() {
+    requireActive();
+    clearCurrentValue();
+    try {
+      boolean produced = format == ARRAY ? finishArray() : finishNdjson();
+      lifecycle = FINISHED;
+      valueBytes = EMPTY_BYTES;
+      return produced;
+    } catch (RuntimeException e) {
+      markFailed();
+      throw e;
+    } catch (Error e) {
+      markFailed();
+      throw e;
+    }
+  }
+
+  private boolean decodeArrayNext(ByteBuffer input) {
+    while (true) {
+      if (arrayState == IN_VALUE) {
+        return scanArrayValue(input);
+      }
+      if (arrayState == AFTER_ARRAY) {
+        consumeArraySuffix(input);
+        return false;
+      }
+      int token = nextNonWhitespace(input);
+      if (token < 0) {
+        return false;
+      }
+      if (arrayState == BEFORE_ARRAY) {
+        if (token != '[') {
+          throw framingError("Expected top-level JSON array");
+        }
+        arrayState = FIRST_VALUE;
+      } else if (arrayState == FIRST_VALUE && token == ']') {
+        arrayState = AFTER_ARRAY;
+      } else {
+        if (token == ',' || token == ']') {
+          throw framingError("Expected JSON array element");
+        }
+        arrayState = IN_VALUE;
+        appendArrayByte((byte) token);
+      }
+    }
+  }
+
+  private boolean scanArrayValue(ByteBuffer input) {
+    while (input.hasRemaining()) {
+      if (escaped) {
+        appendByte(input.get());
+        escaped = false;
+        continue;
+      }
+      int start = input.position();
+      int limit = input.limit();
+      int remaining = maxValueBytes - valueLength;
+      if (limit - start > remaining) {
+        limit = start + remaining + 1;
+      }
+      int special =
+          inString ? findStringSpecial(input, start, limit) : findArraySpecial(input, start, limit);
+      appendRun(input, special - start);
+      if (special == limit) {
+        return false;
+      }
+      byte ch = input.get();
+      if (!inString && objectDepth == 0 && arrayDepth == 0 && (ch == ',' || ch == ']')) {
+        return completeArrayValue(ch);
+      }
+      appendArrayByte(ch);
+    }
+    return false;
+  }
+
+  private boolean completeArrayValue(byte delimiter) {
+    T value = readFrame(valueLength);
+    clearFrame();
+    clearArrayValueState();
+    arrayState = delimiter == ',' ? NEXT_VALUE : AFTER_ARRAY;
+    publish(value);
+    return true;
+  }
+
+  private void appendArrayByte(byte ch) {
+    appendByte(ch);
+    if (inString) {
+      if (ch == '\\') {
+        escaped = true;
+      } else if (ch == '"') {
+        inString = false;
+      }
+      return;
+    }
+    switch (ch) {
+      case '"':
+        inString = true;
+        return;
+      case '{':
+        objectDepth++;
+        return;
+      case '}':
+        if (objectDepth != 0) {
+          objectDepth--;
+        }
+        return;
+      case '[':
+        arrayDepth++;
+        return;
+      case ']':
+        if (arrayDepth != 0) {
+          arrayDepth--;
+        }
+        return;
+      default:
+    }
+  }
+
+  private void consumeArraySuffix(ByteBuffer input) {
+    while (input.hasRemaining()) {
+      int ch = input.get() & 0xff;
+      if (!isWhitespace(ch)) {
+        throw framingError("Trailing content after top-level JSON array");
+      }
+    }
+  }
+
+  private boolean finishArray() {
+    if (arrayState != AFTER_ARRAY) {
+      throw framingError("Incomplete top-level JSON array");
+    }
+    return false;
+  }
+
+  private boolean decodeNdjsonNext(ByteBuffer input) {
+    while (true) {
+      if (pendingCarriageReturn) {
+        if (!input.hasRemaining()) {
+          return false;
+        }
+        if (input.get(input.position()) == '\n') {
+          input.get();
+          pendingCarriageReturn = false;
+          if (completeNdjsonLine()) {
+            return true;
+          }
+          continue;
+        }
+        appendByte((byte) '\r');
+        pendingCarriageReturn = false;
+      }
+      int start = input.position();
+      int limit = input.limit();
+      int remaining = maxValueBytes - valueLength;
+      if (limit - start > remaining) {
+        limit = start + remaining + 1;
+      }
+      int special = findLineSpecial(input, start, limit);
+      markRecordStart(input, start, special);
+      appendRun(input, special - start);
+      if (special == limit) {
+        return false;
+      }
+      byte ch = input.get();
+      if (ch == '\r') {
+        pendingCarriageReturn = true;
+      } else if (completeNdjsonLine()) {
+        return true;
+      }
+    }
+  }
+
+  private boolean completeNdjsonLine() {
+    if (!recordStarted) {
+      clearFrame();
+      return false;
+    }
+    T value = readFrame(valueLength);
+    clearFrame();
+    recordStarted = false;
+    publish(value);
+    return true;
+  }
+
+  private boolean finishNdjson() {
+    if (pendingCarriageReturn) {
+      appendByte((byte) '\r');
+      pendingCarriageReturn = false;
+    }
+    if (!recordStarted) {
+      clearFrame();
+      return false;
+    }
+    T value = readFrame(valueLength);
+    clearFrame();
+    recordStarted = false;
+    publish(value);
+    return true;
+  }
+
+  private void markRecordStart(ByteBuffer input, int start, int end) {
+    if (recordStarted) {
+      return;
+    }
+    while (start < end) {
+      int ch = input.get(start++) & 0xff;
+      if (ch != ' ' && ch != '\t') {
+        recordStarted = true;
+        return;
+      }
+    }
+  }
+
+  private int nextNonWhitespace(ByteBuffer input) {
+    while (input.hasRemaining()) {
+      int ch = input.get() & 0xff;
+      if (!isWhitespace(ch)) {
+        return ch;
+      }
+    }
+    return -1;
+  }
+
+  private void appendRun(ByteBuffer input, int length) {
+    if (length == 0) {
+      return;
+    }
+    ensureAppend(length);
+    input.get(valueBytes, valueLength, length);
+    valueLength += length;
+  }
+
+  private void appendByte(byte value) {
+    ensureAppend(1);
+    valueBytes[valueLength++] = value;
+  }
+
+  private void ensureAppend(int length) {
+    if (length > maxValueBytes - valueLength) {
+      throw valueTooLarge();
+    }
+    int required = valueLength + length;
+    if (required > valueBytes.length) {
+      growValueBytes(required);
+    }
+  }
+
+  private void growValueBytes(int required) {
+    int current = valueBytes.length;
+    long grown = current == 0 ? INITIAL_VALUE_BYTES : (long) current + (current >> 1);
+    if (grown < required) {
+      grown = (long) required + (required >> 1);
+    }
+    int capacity = (int) Math.min((long) maxValueBytes, grown);
+    valueBytes = Arrays.copyOf(valueBytes, capacity);
+  }
+
+  private T readFrame(int length) {
+    return elementClass != null
+        ? foryJson.fromJson(valueBytes, 0, length, elementClass)
+        : foryJson.fromJson(valueBytes, 0, length, elementType);
+  }
+
+  private void publish(T value) {
+    currentValue = value;
+    valueAvailable = true;
+  }
+
+  private void clearCurrentValue() {
+    currentValue = null;
+    valueAvailable = false;
+  }
+
+  private void clearFrame() {
+    valueLength = 0;
+  }
+
+  private void clearArrayValueState() {
+    objectDepth = 0;
+    arrayDepth = 0;
+    inString = false;
+    escaped = false;
+  }
+
+  private void requireActive() {
+    if (lifecycle != ACTIVE) {
+      throw terminatedDecoder();
+    }
+  }
+
+  private void markFailed() {
+    lifecycle = FAILED;
+    clearCurrentValue();
+    valueLength = 0;
+    valueBytes = EMPTY_BYTES;
+  }
+
+  private ForyJsonException valueTooLarge() {
+    return new ForyJsonException("JSON stream value exceeds maxValueBytes " + maxValueBytes);
+  }
+
+  private static ForyJsonException framingError(String message) {
+    return new ForyJsonException(message);
+  }
+
+  private static IllegalStateException noCurrentValue() {
+    return new IllegalStateException("No decoded JSON stream value is available");
+  }
+
+  private static IllegalStateException terminatedDecoder() {
+    return new IllegalStateException("JSON stream decoder is already terminated");
+  }
+
+  private static int findStringSpecial(ByteBuffer input, int cursor, int limit) {
+    while (limit - cursor >= 16) {
+      if (stringSpecialMask(input.getLong(cursor)) != 0) {
+        return findStringSpecialScalar(input, cursor, cursor + 8);
+      }
+      if (stringSpecialMask(input.getLong(cursor + 8)) != 0) {
+        return findStringSpecialScalar(input, cursor + 8, cursor + 16);
+      }
+      cursor += 16;
+    }
+    if (limit - cursor >= 8) {
+      if (stringSpecialMask(input.getLong(cursor)) != 0) {
+        return findStringSpecialScalar(input, cursor, cursor + 8);
+      }
+      cursor += 8;
+    }
+    return findStringSpecialScalar(input, cursor, limit);
+  }
+
+  private static int findArraySpecial(ByteBuffer input, int cursor, int limit) {
+    while (limit - cursor >= 16) {
+      if (arraySpecialMask(input.getLong(cursor)) != 0) {
+        return findArraySpecialScalar(input, cursor, cursor + 8);
+      }
+      if (arraySpecialMask(input.getLong(cursor + 8)) != 0) {
+        return findArraySpecialScalar(input, cursor + 8, cursor + 16);
+      }
+      cursor += 16;
+    }
+    if (limit - cursor >= 8) {
+      if (arraySpecialMask(input.getLong(cursor)) != 0) {
+        return findArraySpecialScalar(input, cursor, cursor + 8);
+      }
+      cursor += 8;
+    }
+    return findArraySpecialScalar(input, cursor, limit);
+  }
+
+  private static int findLineSpecial(ByteBuffer input, int cursor, int limit) {
+    while (limit - cursor >= 16) {
+      if (lineSpecialMask(input.getLong(cursor)) != 0) {
+        return findLineSpecialScalar(input, cursor, cursor + 8);
+      }
+      if (lineSpecialMask(input.getLong(cursor + 8)) != 0) {
+        return findLineSpecialScalar(input, cursor + 8, cursor + 16);
+      }
+      cursor += 16;
+    }
+    if (limit - cursor >= 8) {
+      if (lineSpecialMask(input.getLong(cursor)) != 0) {
+        return findLineSpecialScalar(input, cursor, cursor + 8);
+      }
+      cursor += 8;
+    }
+    return findLineSpecialScalar(input, cursor, limit);
+  }
+
+  private static long stringSpecialMask(long word) {
+    return zeroByteMask(word ^ QUOTES) | zeroByteMask(word ^ BACKSLASHES);
+  }
+
+  private static long arraySpecialMask(long word) {
+    return zeroByteMask(word ^ QUOTES)
+        | zeroByteMask(word ^ OPEN_BRACES)
+        | zeroByteMask(word ^ CLOSE_BRACES)
+        | zeroByteMask(word ^ OPEN_BRACKETS)
+        | zeroByteMask(word ^ CLOSE_BRACKETS)
+        | zeroByteMask(word ^ COMMAS);
+  }
+
+  private static long lineSpecialMask(long word) {
+    return zeroByteMask(word ^ CARRIAGE_RETURNS) | zeroByteMask(word ^ LINE_FEEDS);
+  }
+
+  private static long zeroByteMask(long value) {
+    return (value - BYTE_ONES) & ~value & BYTE_HIGH_BITS;
+  }
+
+  private static int findStringSpecialScalar(ByteBuffer input, int cursor, int limit) {
+    while (cursor < limit) {
+      byte ch = input.get(cursor);
+      if (ch == '"' || ch == '\\') {
+        break;
+      }
+      cursor++;
+    }
+    return cursor;
+  }
+
+  private static int findArraySpecialScalar(ByteBuffer input, int cursor, int limit) {
+    while (cursor < limit) {
+      byte ch = input.get(cursor);
+      if (ch == '"' || ch == '{' || ch == '}' || ch == '[' || ch == ']' || ch == ',') {
+        break;
+      }
+      cursor++;
+    }
+    return cursor;
+  }
+
+  private static int findLineSpecialScalar(ByteBuffer input, int cursor, int limit) {
+    while (cursor < limit) {
+      byte ch = input.get(cursor);
+      if (ch == '\r' || ch == '\n') {
+        break;
+      }
+      cursor++;
+    }
+    return cursor;
+  }
+
+  private static boolean isWhitespace(int ch) {
+    return ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t';
+  }
+}

--- a/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
@@ -34,7 +34,7 @@ import org.apache.fory.reflect.TypeRef;
  * order.
  *
  * <p>Each returned value is parsed by an independent {@link ForyJson} root operation. The decoder
- * retains one bounded staging array whose capacity grows to the largest value seen and is reused
+ * retains one bounded staging array whose capacity grows with committed value bytes and is reused
  * until successful {@link #finish()} or any {@link #decodeNext(ByteBuffer) decodeNext} or {@code
  * finish} failure permanently terminates the decoder.
  */
@@ -54,7 +54,6 @@ public final class JsonStreamDecoder<T> {
   private static final byte AFTER_ARRAY = 4;
 
   private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
-  private static final int INITIAL_VALUE_BYTES = 8 * 1024;
   private static final byte[] EMPTY_BYTES = new byte[0];
 
   private static final long BYTE_ONES = 0x0101010101010101L;
@@ -200,44 +199,55 @@ public final class JsonStreamDecoder<T> {
         if (token != '[') {
           throw framingError("Expected top-level JSON array");
         }
+        input.get();
         arrayState = FIRST_VALUE;
       } else if (arrayState == FIRST_VALUE && token == ']') {
+        input.get();
         arrayState = AFTER_ARRAY;
       } else {
         if (token == ',' || token == ']') {
           throw framingError("Expected JSON array element");
         }
         arrayState = IN_VALUE;
-        appendArrayByte((byte) token);
       }
     }
   }
 
   private boolean scanArrayValue(ByteBuffer input) {
-    while (input.hasRemaining()) {
+    int segmentStart = input.position();
+    int scanCursor = segmentStart;
+    int inputLimit = input.limit();
+    int remaining = maxValueBytes - valueLength;
+    int scanLimit = inputLimit;
+    if (scanLimit - segmentStart > remaining) {
+      scanLimit = segmentStart + remaining + 1;
+    }
+    // Keep the caller-visible position at the commit cursor while absolute scans update framing.
+    // This lets the complete current-buffer value segment enter staging through one bulk copy.
+    while (scanCursor < scanLimit) {
       if (escaped) {
-        appendByte(input.get());
+        scanCursor++;
         escaped = false;
         continue;
       }
-      int start = input.position();
-      int limit = input.limit();
-      int remaining = maxValueBytes - valueLength;
-      if (limit - start > remaining) {
-        limit = start + remaining + 1;
-      }
       int special =
-          inString ? findStringSpecial(input, start, limit) : findArraySpecial(input, start, limit);
-      appendRun(input, special - start);
-      if (special == limit) {
-        return false;
+          inString
+              ? findStringSpecial(input, scanCursor, scanLimit)
+              : findArraySpecial(input, scanCursor, scanLimit);
+      scanCursor = special;
+      if (scanCursor == scanLimit) {
+        break;
       }
-      byte ch = input.get();
+      byte ch = input.get(scanCursor);
       if (!inString && objectDepth == 0 && arrayDepth == 0 && (ch == ',' || ch == ']')) {
+        appendSegment(input, scanCursor);
+        input.position(scanCursor + 1);
         return completeArrayValue(ch);
       }
-      appendArrayByte(ch);
+      updateArrayState(ch);
+      scanCursor++;
     }
+    appendSegment(input, scanCursor);
     return false;
   }
 
@@ -250,8 +260,7 @@ public final class JsonStreamDecoder<T> {
     return true;
   }
 
-  private void appendArrayByte(byte ch) {
-    appendByte(ch);
+  private void updateArrayState(byte ch) {
     if (inString) {
       if (ch == '\\') {
         escaped = true;
@@ -325,7 +334,7 @@ public final class JsonStreamDecoder<T> {
       }
       int special = findLineSpecial(input, start, limit);
       markRecordStart(input, start, special);
-      appendRun(input, special - start);
+      appendSegment(input, special);
       if (special == limit) {
         return false;
       }
@@ -380,16 +389,25 @@ public final class JsonStreamDecoder<T> {
   }
 
   private int nextNonWhitespace(ByteBuffer input) {
-    while (input.hasRemaining()) {
-      int ch = input.get() & 0xff;
+    int start = input.position();
+    int cursor = start;
+    int limit = input.limit();
+    while (cursor < limit) {
+      int ch = input.get(cursor) & 0xff;
       if (!isWhitespace(ch)) {
+        if (cursor != start) {
+          input.position(cursor);
+        }
         return ch;
       }
+      cursor++;
     }
+    input.position(limit);
     return -1;
   }
 
-  private void appendRun(ByteBuffer input, int length) {
+  private void appendSegment(ByteBuffer input, int end) {
+    int length = end - input.position();
     if (length == 0) {
       return;
     }
@@ -415,7 +433,7 @@ public final class JsonStreamDecoder<T> {
 
   private void growValueBytes(int required) {
     int current = valueBytes.length;
-    long grown = current == 0 ? INITIAL_VALUE_BYTES : (long) current + (current >> 1);
+    long grown = current == 0 ? required : (long) current + (current >> 1);
     if (grown < required) {
       grown = (long) required + (required >> 1);
     }

--- a/java/fory-json/src/main/java/org/apache/fory/json/codegen/Utf8ReaderCodegen.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/codegen/Utf8ReaderCodegen.java
@@ -157,15 +157,15 @@ final class Utf8ReaderCodegen extends JsonReaderCodegen {
             "stringStart" + id,
             new Expression.Invoke(reader, "position", TypeRef.of(int.class)).inline());
     Expression offset = new Expression.Variable("stringOffset" + id, start);
-    Expression inputLength =
+    Expression inputLimit =
         new Expression.Variable(
-            "stringInputLength" + id,
-            new Expression.Invoke(reader, "inputLength", TypeRef.of(int.class)).inline());
+            "stringInputLimit" + id,
+            new Expression.Invoke(reader, "inputLimit", TypeRef.of(int.class)).inline());
     Expression directWordEnd =
         new Expression.Variable(
             "stringDirectWordEnd" + id,
             new Expression.Subtract(
-                true, inputLength, Expression.Literal.ofInt(Long.BYTES * DIRECT_STRING_WORDS)));
+                true, inputLimit, Expression.Literal.ofInt(Long.BYTES * DIRECT_STRING_WORDS)));
     Expression state = new Expression.Variable("stringState" + id, Expression.Literal.ofLong(0L));
     Expression value = new Expression.Variable("stringValue" + id, TypeRef.of(String.class));
     Expression zero = Expression.Literal.ofLong(0L);
@@ -187,7 +187,7 @@ final class Utf8ReaderCodegen extends JsonReaderCodegen {
             new Expression.Assign(value, finishStringWord(reader, start, offset, state)),
             new Expression.Assign(value, readStringLongTail(reader, start, offset)));
     return new Expression.ListExpression(
-        start, offset, inputLength, directWordEnd, state, value, directScans, finish, value);
+        start, offset, inputLimit, directWordEnd, state, value, directScans, finish, value);
   }
 
   private static Expression tryConsumeStringQuote(Expression reader) {

--- a/java/fory-json/src/main/java/org/apache/fory/json/reader/Utf8JsonReader.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/reader/Utf8JsonReader.java
@@ -96,6 +96,7 @@ public final class Utf8JsonReader extends JsonReader {
   // JSON syntax bytes are ASCII, so hot token checks can compare signed bytes directly.
   // UTF-8 string decoding must keep unsigned byte conversion for non-ASCII content.
   private byte[] input;
+  private int inputLimit;
   private byte[] stringDecodeBuffer = new byte[INITIAL_STRING_DECODE_BUFFER_SIZE];
   // Keep the cache after hot representation fields; an inherited reference shifts their offsets.
   private final FieldNameCache fieldNameCache;
@@ -103,6 +104,7 @@ public final class Utf8JsonReader extends JsonReader {
   public Utf8JsonReader(JsonConfig config, JsonTypeResolver typeResolver) {
     super(config, typeResolver);
     input = EMPTY_BYTES;
+    inputLimit = 0;
     // The configured limit belongs to each reader; pooled-state concurrency must not divide it.
     int maxEntries = config.maxCachedFieldNames();
     fieldNameCache = maxEntries == 0 ? null : new FieldNameCache(maxEntries);
@@ -110,12 +112,12 @@ public final class Utf8JsonReader extends JsonReader {
 
   @Override
   protected int scanStringEnd(int start) {
-    int inputLength = input.length;
-    if (start >= inputLength || input[start] != '"') {
+    int inputLimit = this.inputLimit;
+    if (start >= inputLimit || input[start] != '"') {
       throw errorAt("Expected string", start);
     }
     int cursor = start + 1;
-    int wordEnd = inputLength - Long.BYTES;
+    int wordEnd = inputLimit - Long.BYTES;
     while (cursor <= wordEnd) {
       long stopMask = stringStopMask(LittleEndian.getInt64(input, cursor));
       if (stopMask == 0) {
@@ -131,12 +133,12 @@ public final class Utf8JsonReader extends JsonReader {
         throw errorAt("Control character in string", cursor);
       }
       if (raw == '\\') {
-        cursor = scanEscape(cursor, inputLength);
+        cursor = scanEscape(cursor, inputLimit);
       } else {
         cursor = (int) (scanUtf8CodePoint(cursor) >>> 32);
       }
     }
-    while (cursor < inputLength) {
+    while (cursor < inputLimit) {
       int raw = input[cursor] & 0xff;
       if (raw == '"') {
         return cursor + 1;
@@ -145,7 +147,7 @@ public final class Utf8JsonReader extends JsonReader {
         throw errorAt("Control character in string", cursor);
       }
       if (raw == '\\') {
-        cursor = scanEscape(cursor, inputLength);
+        cursor = scanEscape(cursor, inputLimit);
       } else if (raw < 0x80) {
         cursor++;
       } else {
@@ -317,9 +319,9 @@ public final class Utf8JsonReader extends JsonReader {
     return decodedQuotedText(outBytes, out, true);
   }
 
-  private int scanEscape(int slash, int inputLength) {
+  private int scanEscape(int slash, int inputLimit) {
     int cursor = slash + 1;
-    if (cursor >= inputLength) {
+    if (cursor >= inputLimit) {
       throw errorAt("Unterminated escape", slash);
     }
     int escaped = input[cursor++] & 0xff;
@@ -330,7 +332,7 @@ public final class Utf8JsonReader extends JsonReader {
     char ch = scanUnicodeEscape(cursor);
     cursor += 4;
     if (Character.isHighSurrogate(ch)) {
-      if (cursor + 6 > inputLength || input[cursor] != '\\' || input[cursor + 1] != 'u') {
+      if (cursor + 6 > inputLimit || input[cursor] != '\\' || input[cursor + 1] != 'u') {
         throw errorAt("Unpaired high surrogate escape", slash);
       }
       char low = scanUnicodeEscape(cursor + 2);
@@ -365,7 +367,7 @@ public final class Utf8JsonReader extends JsonReader {
     } else {
       throw errorAt("Invalid UTF-8 sequence", offset);
     }
-    if (offset > input.length - count) {
+    if (offset > inputLimit - count) {
       throw errorAt("Incomplete UTF-8 sequence", offset);
     }
     for (int i = 1; i < count; i++) {
@@ -384,7 +386,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private char scanUnicodeEscape(int offset) {
-    if (offset > input.length - 4) {
+    if (offset > inputLimit - 4) {
       throw errorAt("Incomplete unicode escape", offset);
     }
     int value = 0;
@@ -445,14 +447,35 @@ public final class Utf8JsonReader extends JsonReader {
 
   public Utf8JsonReader reset(byte[] input) {
     this.input = input;
+    inputLimit = input.length;
     position = 0;
     reset();
     return this;
   }
 
+  /** Resets this reader to a logical range of a borrowed byte array. */
+  @Internal
+  public Utf8JsonReader reset(byte[] input, int offset, int length) {
+    int inputLength = input.length;
+    if ((offset | length) < 0 || offset > inputLength - length) {
+      throwInvalidByteRange(offset, length);
+    }
+    this.input = input;
+    inputLimit = offset + length;
+    position = offset;
+    reset();
+    return this;
+  }
+
+  private static void throwInvalidByteRange(int offset, int length) {
+    throw new IndexOutOfBoundsException(
+        "Invalid UTF-8 byte range: offset=" + offset + ", length=" + length);
+  }
+
   public void clear() {
     reset();
     input = EMPTY_BYTES;
+    inputLimit = 0;
     position = 0;
     if (stringDecodeBuffer.length > RETAINED_STRING_DECODE_BUFFER_SIZE) {
       stringDecodeBuffer = new byte[RETAINED_STRING_DECODE_BUFFER_SIZE];
@@ -461,7 +484,7 @@ public final class Utf8JsonReader extends JsonReader {
 
   public boolean consumeToken(char expected) {
     skipWhitespaceFast();
-    if (position < input.length && input[position] == expected) {
+    if (position < inputLimit && input[position] == expected) {
       position++;
       return true;
     }
@@ -469,7 +492,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public boolean consumeNextToken(char expected) {
-    if (position < input.length && input[position] == expected) {
+    if (position < inputLimit && input[position] == expected) {
       position++;
       return true;
     }
@@ -481,7 +504,7 @@ public final class Utf8JsonReader extends JsonReader {
   public boolean tryConsumeStringQuote() {
     byte[] bytes = input;
     int offset = position;
-    if (offset < bytes.length && bytes[offset] == '"') {
+    if (offset < inputLimit && bytes[offset] == '"') {
       position = offset + 1;
       return true;
     }
@@ -495,7 +518,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public void expectNextToken(char expected) {
-    if (position < input.length && input[position] == expected) {
+    if (position < inputLimit && input[position] == expected) {
       position++;
       return;
     }
@@ -522,7 +545,7 @@ public final class Utf8JsonReader extends JsonReader {
    */
   @Internal
   public boolean tryConsumeNextComma() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       if (input[position] == ',') {
         position++;
         return true;
@@ -540,7 +563,7 @@ public final class Utf8JsonReader extends JsonReader {
    */
   @Internal
   public boolean tryConsumeNextOrderedComma() {
-    if (position < input.length && input[position] == ',') {
+    if (position < inputLimit && input[position] == ',') {
       position++;
       skipWhitespaceFast();
       return true;
@@ -557,7 +580,7 @@ public final class Utf8JsonReader extends JsonReader {
    */
   @Internal
   public boolean consumeNextObjectEndOrSlow() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       if (input[position] == '}') {
         position++;
         return false;
@@ -577,7 +600,7 @@ public final class Utf8JsonReader extends JsonReader {
 
   private boolean consumeNextCommaOrEndObjectSlow() {
     skipWhitespaceFast();
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == ',') {
         position++;
@@ -595,7 +618,7 @@ public final class Utf8JsonReader extends JsonReader {
   // separators in this owner so a still-cold end-array helper cannot reshape the whole generated
   // loop. Only whitespace, exhaustion, and malformed input belong in the cold fallback.
   public boolean consumeNextCommaOrEndArray() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == ',') {
         position++;
@@ -620,7 +643,7 @@ public final class Utf8JsonReader extends JsonReader {
   public int consumeNextStringArrayElement() {
     byte[] bytes = input;
     int offset = position;
-    if (offset < bytes.length) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == ']') {
         position = offset + 1;
@@ -628,7 +651,7 @@ public final class Utf8JsonReader extends JsonReader {
       }
       if (ch == ',') {
         offset++;
-        if (offset < bytes.length && bytes[offset] == '"') {
+        if (offset < inputLimit && bytes[offset] == '"') {
           position = offset + 1;
           return STRING_ARRAY_QUOTED;
         }
@@ -643,7 +666,7 @@ public final class Utf8JsonReader extends JsonReader {
     skipWhitespaceFast();
     byte[] bytes = input;
     int offset = position;
-    if (offset < bytes.length) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == ']') {
         position = offset + 1;
@@ -653,7 +676,7 @@ public final class Utf8JsonReader extends JsonReader {
         position = offset + 1;
         skipWhitespaceFast();
         offset = position;
-        if (offset < bytes.length && bytes[offset] == '"') {
+        if (offset < inputLimit && bytes[offset] == '"') {
           position = offset + 1;
           return STRING_ARRAY_QUOTED;
         }
@@ -665,7 +688,7 @@ public final class Utf8JsonReader extends JsonReader {
 
   private boolean consumeNextCommaOrEndArraySlow() {
     skipWhitespaceFast();
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == ',') {
         position++;
@@ -686,7 +709,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public boolean tryReadNextNullToken() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == 'n') {
         return tryReadNullLiteral();
@@ -701,7 +724,7 @@ public final class Utf8JsonReader extends JsonReader {
   private boolean tryReadNullLiteral() {
     byte[] bytes = input;
     int offset = position;
-    if (offset + 3 < bytes.length && LittleEndian.getInt32(bytes, offset) == NULL_LITERAL) {
+    if (offset + 3 < inputLimit && LittleEndian.getInt32(bytes, offset) == NULL_LITERAL) {
       position = offset + 4;
       return true;
     }
@@ -714,7 +737,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public boolean readNextBooleanValue() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readBooleanToken();
@@ -730,14 +753,14 @@ public final class Utf8JsonReader extends JsonReader {
   private boolean readBooleanToken() {
     byte[] bytes = input;
     int offset = position;
-    if (offset + 3 < bytes.length
+    if (offset + 3 < inputLimit
         && bytes[offset] == 't'
         && bytes[offset + 1] == 'r'
         && bytes[offset + 2] == 'u'
         && bytes[offset + 3] == 'e') {
       position = offset + 4;
       return true;
-    } else if (offset + 4 < bytes.length
+    } else if (offset + 4 < inputLimit
         && bytes[offset] == 'f'
         && bytes[offset + 1] == 'a'
         && bytes[offset + 2] == 'l'
@@ -755,7 +778,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public int readNextIntValue() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readIntToken();
@@ -771,8 +794,8 @@ public final class Utf8JsonReader extends JsonReader {
   private int readIntToken() {
     byte[] bytes = input;
     int offset = position;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       throw error("Expected digit");
     }
     int ch = bytes[offset];
@@ -791,8 +814,8 @@ public final class Utf8JsonReader extends JsonReader {
     int result = ch - '0';
     offset++;
     int safeEnd = offset + 8;
-    if (safeEnd > inputLength) {
-      safeEnd = inputLength;
+    if (safeEnd > inputLimit) {
+      safeEnd = inputLimit;
     }
     while (offset < safeEnd) {
       ch = bytes[offset];
@@ -802,10 +825,10 @@ public final class Utf8JsonReader extends JsonReader {
       result = result * 10 + (ch - '0');
       offset++;
     }
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       ch = bytes[offset];
       if (ch >= '0' && ch <= '9') {
-        return readPositiveIntTail(bytes, offset, inputLength, result);
+        return readPositiveIntTail(bytes, offset, inputLimit, result);
       }
     }
     position = offset;
@@ -813,7 +836,7 @@ public final class Utf8JsonReader extends JsonReader {
     return result;
   }
 
-  private int readPositiveIntTail(byte[] bytes, int offset, int inputLength, int result) {
+  private int readPositiveIntTail(byte[] bytes, int offset, int inputLimit, int result) {
     // The caller has consumed exactly nine positive digits. A Java int can contain only one more;
     // any following digit is necessarily overflow rather than another loop iteration.
     int digit = bytes[offset] - '0';
@@ -823,7 +846,7 @@ public final class Utf8JsonReader extends JsonReader {
     }
     result = result * 10 + digit;
     offset++;
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch >= '0' && ch <= '9') {
         position = offset;
@@ -839,7 +862,7 @@ public final class Utf8JsonReader extends JsonReader {
     position = start + 1;
     int result = 0;
     int limit = Integer.MIN_VALUE;
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Expected digit");
     }
     int ch = input[position];
@@ -853,7 +876,7 @@ public final class Utf8JsonReader extends JsonReader {
       throw error("Expected digit");
     }
     int multmin = limit / 10;
-    while (position < input.length) {
+    while (position < inputLimit) {
       ch = input[position];
       if (ch < '0' || ch > '9') {
         break;
@@ -879,7 +902,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public long readNextLongValue() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readLongToken();
@@ -921,7 +944,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public double readNextDoubleValue() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readDoubleToken();
@@ -935,7 +958,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public float readNextFloatValue() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readFloatToken();
@@ -958,8 +981,8 @@ public final class Utf8JsonReader extends JsonReader {
   private long readLongToken() {
     byte[] bytes = input;
     int offset = position;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       throw error("Expected digit");
     }
     int ch = bytes[offset];
@@ -978,8 +1001,8 @@ public final class Utf8JsonReader extends JsonReader {
     long result = ch - '0';
     offset++;
     int safeEnd = offset + 17;
-    if (safeEnd > inputLength) {
-      safeEnd = inputLength;
+    if (safeEnd > inputLimit) {
+      safeEnd = inputLimit;
     }
     int block = parseEightDigits(bytes, offset, safeEnd);
     if (block >= 0) {
@@ -999,10 +1022,10 @@ public final class Utf8JsonReader extends JsonReader {
       result = result * 10 + (ch - '0');
       offset++;
     }
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       ch = bytes[offset];
       if (ch >= '0' && ch <= '9') {
-        return readPositiveLongTail(bytes, offset, inputLength, result);
+        return readPositiveLongTail(bytes, offset, inputLimit, result);
       }
     }
     position = offset;
@@ -1010,8 +1033,8 @@ public final class Utf8JsonReader extends JsonReader {
     return result;
   }
 
-  private long readPositiveLongTail(byte[] bytes, int offset, int inputLength, long result) {
-    while (offset < inputLength) {
+  private long readPositiveLongTail(byte[] bytes, int offset, int inputLimit, long result) {
+    while (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch < '0' || ch > '9') {
         break;
@@ -1032,8 +1055,8 @@ public final class Utf8JsonReader extends JsonReader {
   private long readNegativeLongToken(int start) {
     byte[] bytes = input;
     int offset = start + 1;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       throw error("Expected digit");
     }
     int ch = bytes[offset];
@@ -1049,8 +1072,8 @@ public final class Utf8JsonReader extends JsonReader {
     long result = '0' - ch;
     offset++;
     int safeEnd = offset + 17;
-    if (safeEnd > inputLength) {
-      safeEnd = inputLength;
+    if (safeEnd > inputLimit) {
+      safeEnd = inputLimit;
     }
     int block = parseEightDigits(bytes, offset, safeEnd);
     if (block >= 0) {
@@ -1070,10 +1093,10 @@ public final class Utf8JsonReader extends JsonReader {
       result = result * 10 - (ch - '0');
       offset++;
     }
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       ch = bytes[offset];
       if (ch >= '0' && ch <= '9') {
-        return readNegativeLongTail(bytes, offset, inputLength, result);
+        return readNegativeLongTail(bytes, offset, inputLimit, result);
       }
     }
     position = offset;
@@ -1081,8 +1104,8 @@ public final class Utf8JsonReader extends JsonReader {
     return result;
   }
 
-  private long readNegativeLongTail(byte[] bytes, int offset, int inputLength, long result) {
-    while (offset < inputLength) {
+  private long readNegativeLongTail(byte[] bytes, int offset, int inputLimit, long result) {
+    while (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch < '0' || ch > '9') {
         break;
@@ -1179,8 +1202,8 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int offset = position;
     int start = offset;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readBigDecimalFallback(start);
     }
     int ch = bytes[offset];
@@ -1202,7 +1225,7 @@ public final class Utf8JsonReader extends JsonReader {
         }
         unscaled = unscaled * 10 + digit;
         offset++;
-        if (offset >= inputLength) {
+        if (offset >= inputLimit) {
           break;
         }
         ch = bytes[offset];
@@ -1210,10 +1233,10 @@ public final class Utf8JsonReader extends JsonReader {
     } else {
       return readBigDecimalFallback(start);
     }
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      while (offset < inputLength) {
+      while (offset < inputLimit) {
         ch = bytes[offset];
         if (ch < '0' || ch > '9') {
           break;
@@ -1231,7 +1254,7 @@ public final class Utf8JsonReader extends JsonReader {
         return readBigDecimalFallback(start);
       }
     }
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readBigDecimalExponentValue(false, unscaled, scale, offset);
@@ -1247,8 +1270,8 @@ public final class Utf8JsonReader extends JsonReader {
   private BigDecimal readSignedBigDecimalToken(int start) {
     byte[] bytes = input;
     int offset = start + 1;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readBigDecimalFallback(start);
     }
     int ch = bytes[offset];
@@ -1267,7 +1290,7 @@ public final class Utf8JsonReader extends JsonReader {
         }
         unscaled = unscaled * 10 + digit;
         offset++;
-        if (offset >= inputLength) {
+        if (offset >= inputLimit) {
           break;
         }
         ch = bytes[offset];
@@ -1275,10 +1298,10 @@ public final class Utf8JsonReader extends JsonReader {
     } else {
       return readBigDecimalFallback(start);
     }
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      while (offset < inputLength) {
+      while (offset < inputLimit) {
         ch = bytes[offset];
         if (ch < '0' || ch > '9') {
           break;
@@ -1296,7 +1319,7 @@ public final class Utf8JsonReader extends JsonReader {
         return readBigDecimalFallback(start);
       }
     }
-    if (offset < inputLength) {
+    if (offset < inputLimit) {
       ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readBigDecimalExponentValue(true, unscaled, scale, offset);
@@ -1313,7 +1336,7 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int offset = position;
     int start = offset + 1;
-    if (offset + 38 > bytes.length || bytes[offset] != '"') {
+    if (offset > inputLimit - 38 || bytes[offset] != '"') {
       throw new IllegalArgumentException();
     }
     if (bytes[start + 8] != '-'
@@ -1356,37 +1379,37 @@ public final class Utf8JsonReader extends JsonReader {
     // exponents, overflow, and precision-sensitive values use the reader-owned exact fallback.
     byte[] bytes = input;
     int offset = position;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readDoubleFallback(offset);
     }
     int ch = bytes[offset];
     if (ch == '-') {
       return readSignedDoubleToken(offset);
     }
-    return readPositiveDoubleToken(bytes, offset, inputLength, ch);
+    return readPositiveDoubleToken(bytes, offset, inputLimit, ch);
   }
 
   private float readFloatToken() {
     byte[] bytes = input;
     int offset = position;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readFloatFallback(offset);
     }
     int ch = bytes[offset];
     if (ch == '-') {
       return readSignedFloatToken(offset);
     }
-    return readPositiveFloatToken(bytes, offset, inputLength, ch);
+    return readPositiveFloatToken(bytes, offset, inputLimit, ch);
   }
 
-  private float readPositiveFloatToken(byte[] bytes, int offset, int inputLength, int ch) {
+  private float readPositiveFloatToken(byte[] bytes, int offset, int inputLimit, int ch) {
     int start = offset;
     long unscaled = 0;
     if (ch == '0') {
       offset++;
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         ch = bytes[offset];
         if (ch >= '0' && ch <= '9') {
           return readFloatFallback(start);
@@ -1395,7 +1418,7 @@ public final class Utf8JsonReader extends JsonReader {
     } else if (ch >= '1' && ch <= '9') {
       unscaled = ch - '0';
       offset++;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1409,7 +1432,7 @@ public final class Utf8JsonReader extends JsonReader {
         unscaled = unscaled * 100 + pair;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (unscaled > LONG_MAX_DIV_10
@@ -1423,21 +1446,21 @@ public final class Utf8JsonReader extends JsonReader {
     } else {
       return readFloatFallback(start);
     }
-    return readPositiveFloatTail(bytes, offset, inputLength, start, unscaled);
+    return readPositiveFloatTail(bytes, offset, inputLimit, start, unscaled);
   }
 
   private float readSignedFloatToken(int start) {
     byte[] bytes = input;
     int offset = start + 1;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readFloatFallback(start);
     }
     int ch = bytes[offset];
     long unscaled = 0;
     if (ch == '0') {
       offset++;
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         ch = bytes[offset];
         if (ch >= '0' && ch <= '9') {
           return readFloatFallback(start);
@@ -1446,7 +1469,7 @@ public final class Utf8JsonReader extends JsonReader {
     } else if (ch >= '1' && ch <= '9') {
       unscaled = ch - '0';
       offset++;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1460,7 +1483,7 @@ public final class Utf8JsonReader extends JsonReader {
         unscaled = unscaled * 100 + pair;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (unscaled > LONG_MAX_DIV_10
@@ -1474,16 +1497,16 @@ public final class Utf8JsonReader extends JsonReader {
     } else {
       return readFloatFallback(start);
     }
-    return readSignedFloatTail(bytes, offset, inputLength, start, unscaled);
+    return readSignedFloatTail(bytes, offset, inputLimit, start, unscaled);
   }
 
   private float readPositiveFloatTail(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled) {
     int scale = 0;
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1498,7 +1521,7 @@ public final class Utf8JsonReader extends JsonReader {
         scale += 2;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (unscaled > LONG_MAX_DIV_10
@@ -1514,16 +1537,16 @@ public final class Utf8JsonReader extends JsonReader {
         return readFloatFallback(start);
       }
     }
-    return finishFloatToken(bytes, offset, inputLength, start, unscaled, scale);
+    return finishFloatToken(bytes, offset, inputLimit, start, unscaled, scale);
   }
 
   private float readSignedFloatTail(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled) {
     int scale = 0;
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1538,7 +1561,7 @@ public final class Utf8JsonReader extends JsonReader {
         scale += 2;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (unscaled > LONG_MAX_DIV_10
@@ -1554,12 +1577,12 @@ public final class Utf8JsonReader extends JsonReader {
         return readFloatFallback(start);
       }
     }
-    return finishSignedFloatToken(bytes, offset, inputLength, start, unscaled, scale);
+    return finishSignedFloatToken(bytes, offset, inputLimit, start, unscaled, scale);
   }
 
   private float finishFloatToken(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled, int scale) {
-    if (offset < inputLength) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled, int scale) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readFloatExponentValue(false, unscaled, scale, start, offset);
@@ -1576,8 +1599,8 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private float finishSignedFloatToken(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled, int scale) {
-    if (offset < inputLength) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled, int scale) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readFloatExponentValue(true, unscaled, scale, start, offset);
@@ -1602,12 +1625,12 @@ public final class Utf8JsonReader extends JsonReader {
 
   // Keep the complete integer and fraction scan in one token owner. A separate inline-sized
   // fraction tail makes generated callers depend on which method C2 compiles first.
-  private double readPositiveDoubleToken(byte[] bytes, int offset, int inputLength, int ch) {
+  private double readPositiveDoubleToken(byte[] bytes, int offset, int inputLimit, int ch) {
     int start = offset;
     long unscaled = 0;
     if (ch == '0') {
       offset++;
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         ch = bytes[offset];
         if (ch >= '0' && ch <= '9') {
           return readDoubleFallback(start);
@@ -1616,7 +1639,7 @@ public final class Utf8JsonReader extends JsonReader {
     } else if (ch >= '1' && ch <= '9') {
       unscaled = ch - '0';
       offset++;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1629,7 +1652,7 @@ public final class Utf8JsonReader extends JsonReader {
         unscaled = unscaled * 100 + pair;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (!canAppendDigit(unscaled, digit)) {
@@ -1643,25 +1666,25 @@ public final class Utf8JsonReader extends JsonReader {
       return readDoubleFallback(start);
     }
     int scale = 0;
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      long appended = appendEightDigits(bytes, offset, inputLength, unscaled);
+      long appended = appendEightDigits(bytes, offset, inputLimit, unscaled);
       while (appended >= 0) {
         unscaled = appended;
         scale += 8;
         offset += 8;
-        appended = appendEightDigits(bytes, offset, inputLength, unscaled);
+        appended = appendEightDigits(bytes, offset, inputLimit, unscaled);
       }
       if (scale != 0 && unscaled < LONG_MAX_DIV_FOUR_DIGITS) {
-        appended = appendFourDigits(bytes, offset, inputLength, unscaled);
+        appended = appendFourDigits(bytes, offset, inputLimit, unscaled);
         if (appended >= 0) {
           unscaled = appended;
           scale += 4;
           offset += 4;
         }
       }
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1675,7 +1698,7 @@ public final class Utf8JsonReader extends JsonReader {
         scale += 2;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (!canAppendDigit(unscaled, digit)) {
@@ -1690,21 +1713,21 @@ public final class Utf8JsonReader extends JsonReader {
         return readDoubleFallback(start);
       }
     }
-    return finishDoubleToken(bytes, offset, inputLength, start, unscaled, scale);
+    return finishDoubleToken(bytes, offset, inputLimit, start, unscaled, scale);
   }
 
   private double readSignedDoubleToken(int start) {
     byte[] bytes = input;
     int offset = start + 1;
-    int inputLength = bytes.length;
-    if (offset >= inputLength) {
+    int inputLimit = this.inputLimit;
+    if (offset >= inputLimit) {
       return readDoubleFallback(start);
     }
     int ch = bytes[offset];
     long unscaled = 0;
     if (ch == '0') {
       offset++;
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         ch = bytes[offset];
         if (ch >= '0' && ch <= '9') {
           return readDoubleFallback(start);
@@ -1713,7 +1736,7 @@ public final class Utf8JsonReader extends JsonReader {
     } else if (ch >= '1' && ch <= '9') {
       unscaled = ch - '0';
       offset++;
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1726,7 +1749,7 @@ public final class Utf8JsonReader extends JsonReader {
         unscaled = unscaled * 100 + pair;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (!canAppendDigit(unscaled, digit)) {
@@ -1740,25 +1763,25 @@ public final class Utf8JsonReader extends JsonReader {
       return readDoubleFallback(start);
     }
     int scale = 0;
-    if (offset < inputLength && bytes[offset] == '.') {
+    if (offset < inputLimit && bytes[offset] == '.') {
       offset++;
       int fractionStart = offset;
-      long appended = appendEightDigits(bytes, offset, inputLength, unscaled);
+      long appended = appendEightDigits(bytes, offset, inputLimit, unscaled);
       while (appended >= 0) {
         unscaled = appended;
         scale += 8;
         offset += 8;
-        appended = appendEightDigits(bytes, offset, inputLength, unscaled);
+        appended = appendEightDigits(bytes, offset, inputLimit, unscaled);
       }
       if (scale != 0 && unscaled < LONG_MAX_DIV_FOUR_DIGITS) {
-        appended = appendFourDigits(bytes, offset, inputLength, unscaled);
+        appended = appendFourDigits(bytes, offset, inputLimit, unscaled);
         if (appended >= 0) {
           unscaled = appended;
           scale += 4;
           offset += 4;
         }
       }
-      while (offset + 1 < inputLength) {
+      while (offset + 1 < inputLimit) {
         int high = bytes[offset] - '0';
         int low = bytes[offset + 1] - '0';
         if (high < 0 || high > 9 || low < 0 || low > 9) {
@@ -1772,7 +1795,7 @@ public final class Utf8JsonReader extends JsonReader {
         scale += 2;
         offset += 2;
       }
-      if (offset < inputLength) {
+      if (offset < inputLimit) {
         int digit = bytes[offset] - '0';
         if (digit >= 0 && digit <= 9) {
           if (!canAppendDigit(unscaled, digit)) {
@@ -1787,12 +1810,12 @@ public final class Utf8JsonReader extends JsonReader {
         return readDoubleFallback(start);
       }
     }
-    return finishSignedDoubleToken(bytes, offset, inputLength, start, unscaled, scale);
+    return finishSignedDoubleToken(bytes, offset, inputLimit, start, unscaled, scale);
   }
 
   private double finishDoubleToken(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled, int scale) {
-    if (offset < inputLength) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled, int scale) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readDoubleExponentValue(false, unscaled, scale, start, offset);
@@ -1809,8 +1832,8 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private double finishSignedDoubleToken(
-      byte[] bytes, int offset, int inputLength, int start, long unscaled, int scale) {
-    if (offset < inputLength) {
+      byte[] bytes, int offset, int inputLimit, int start, long unscaled, int scale) {
+    if (offset < inputLimit) {
       int ch = bytes[offset];
       if (ch == 'e' || ch == 'E') {
         return readDoubleExponentValue(true, unscaled, scale, start, offset);
@@ -1837,18 +1860,18 @@ public final class Utf8JsonReader extends JsonReader {
   public int readFieldNameInt() {
     skipWhitespaceFast();
     int nameStart = position;
-    if (position >= input.length || input[position++] != '"') {
+    if (position >= inputLimit || input[position++] != '"') {
       throw error("Expected string");
     }
     int result = 0;
     int limit = -Integer.MAX_VALUE;
     boolean negative = false;
-    if (position < input.length && input[position] == '-') {
+    if (position < inputLimit && input[position] == '-') {
       negative = true;
       limit = Integer.MIN_VALUE;
       position++;
     }
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Unterminated string");
     }
     int ch = input[position];
@@ -1875,7 +1898,7 @@ public final class Utf8JsonReader extends JsonReader {
       }
       result -= digit;
       position++;
-      if (position >= input.length) {
+      if (position >= inputLimit) {
         throw error("Unterminated string");
       }
       ch = input[position];
@@ -1895,18 +1918,18 @@ public final class Utf8JsonReader extends JsonReader {
   public long readFieldNameLong() {
     skipWhitespaceFast();
     int nameStart = position;
-    if (position >= input.length || input[position++] != '"') {
+    if (position >= inputLimit || input[position++] != '"') {
       throw error("Expected string");
     }
     long result = 0;
     long limit = -Long.MAX_VALUE;
     boolean negative = false;
-    if (position < input.length && input[position] == '-') {
+    if (position < inputLimit && input[position] == '-') {
       negative = true;
       limit = Long.MIN_VALUE;
       position++;
     }
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Unterminated string");
     }
     int ch = input[position];
@@ -1933,7 +1956,7 @@ public final class Utf8JsonReader extends JsonReader {
       }
       result -= digit;
       position++;
-      if (position >= input.length) {
+      if (position >= inputLimit) {
         throw error("Unterminated string");
       }
       ch = input[position];
@@ -1951,7 +1974,7 @@ public final class Utf8JsonReader extends JsonReader {
 
   @Override
   protected int length() {
-    return input.length;
+    return inputLimit;
   }
 
   @Override
@@ -1979,12 +2002,12 @@ public final class Utf8JsonReader extends JsonReader {
   private String readCachedFieldName(FieldNameCache cache) {
     skipWhitespaceFast();
     byte[] bytes = input;
-    int inputLength = bytes.length;
-    if (position >= inputLength || bytes[position++] != '"') {
+    int inputLimit = this.inputLimit;
+    if (position >= inputLimit || bytes[position++] != '"') {
       throw error("Expected string");
     }
     int start = position;
-    if (start + Long.BYTES <= inputLength) {
+    if (start + Long.BYTES <= inputLimit) {
       long word0 = LittleEndian.getInt64(bytes, start);
       long stopMask = stringStopMask(word0);
       if (stopMask != 0) {
@@ -2006,15 +2029,15 @@ public final class Utf8JsonReader extends JsonReader {
         }
         return readFieldNameMiss(cache, start, stop, length, word0, 0, hash);
       }
-      return readFieldNameAfterWord0(cache, start, word0, inputLength);
+      return readFieldNameAfterWord0(cache, start, word0, inputLimit);
     }
     return readFieldNameTail(cache, start, start, 0, 0, 0);
   }
 
   private String readFieldNameAfterWord0(
-      FieldNameCache cache, int start, long word0, int inputLength) {
+      FieldNameCache cache, int start, long word0, int inputLimit) {
     int offset = start + Long.BYTES;
-    if (offset + Long.BYTES <= inputLength) {
+    if (offset + Long.BYTES <= inputLimit) {
       long word1 = LittleEndian.getInt64(input, offset);
       long stopMask = stringStopMask(word1);
       if (stopMask != 0) {
@@ -2029,19 +2052,19 @@ public final class Utf8JsonReader extends JsonReader {
             cache, start, stop, Long.BYTES + length, word0, fieldNameWord(word1, length));
       }
       offset += Long.BYTES;
-      if (offset < inputLength && input[offset] == '"') {
+      if (offset < inputLimit && input[offset] == '"') {
         position = offset + 1;
         return resolveFieldName(cache, start, offset, 16, word0, word1);
       }
-      return readStringTokenLongTail(start, offset, inputLength);
+      return readStringTokenLongTail(start, offset, inputLimit);
     }
     return readFieldNameTail(cache, start, offset, Long.BYTES, word0, 0);
   }
 
   private String readFieldNameTail(
       FieldNameCache cache, int start, int offset, int length, long word0, long word1) {
-    int inputLength = input.length;
-    while (offset < inputLength) {
+    int inputLimit = this.inputLimit;
+    while (offset < inputLimit) {
       int ch = input[offset] & 0xff;
       if (ch == '"') {
         position = offset + 1;
@@ -2098,7 +2121,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public String readNextNullableString() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == '"') {
         return readStringToken();
@@ -2118,7 +2141,7 @@ public final class Utf8JsonReader extends JsonReader {
     // to one byte check; only a possible null or malformed token enters the cold classifier.
     byte[] bytes = input;
     int offset = position;
-    if (offset < bytes.length && bytes[offset] == '"') {
+    if (offset < inputLimit && bytes[offset] == '"') {
       return readStringToken();
     }
     return readNullableStringTokenSlow();
@@ -2155,8 +2178,8 @@ public final class Utf8JsonReader extends JsonReader {
 
   private String readStringToken() {
     byte[] bytes = input;
-    int inputLength = bytes.length;
-    if (position >= inputLength || bytes[position++] != '"') {
+    int inputLimit = this.inputLimit;
+    if (position >= inputLimit || bytes[position++] != '"') {
       throw error("Expected string");
     }
     int start = position;
@@ -2166,43 +2189,43 @@ public final class Utf8JsonReader extends JsonReader {
     // so nullable wrappers and generated object readers cannot absorb duplicate token closures.
     // A loop or forwarding helper would shrink this owner and restore compilation-order
     // sensitivity.
-    if (offset + Long.BYTES <= inputLength) {
+    if (offset + Long.BYTES <= inputLimit) {
       long stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
       if (stopMask != 0) {
         return readStringWordStop(start, offset, stopMask);
       }
       offset += Long.BYTES;
-      if (offset + Long.BYTES <= inputLength) {
+      if (offset + Long.BYTES <= inputLimit) {
         stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
         if (stopMask != 0) {
           return readStringWordStop(start, offset, stopMask);
         }
         offset += Long.BYTES;
-        if (offset + Long.BYTES <= inputLength) {
+        if (offset + Long.BYTES <= inputLimit) {
           stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
           if (stopMask != 0) {
             return readStringWordStop(start, offset, stopMask);
           }
           offset += Long.BYTES;
-          if (offset + Long.BYTES <= inputLength) {
+          if (offset + Long.BYTES <= inputLimit) {
             stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
             if (stopMask != 0) {
               return readStringWordStop(start, offset, stopMask);
             }
             offset += Long.BYTES;
-            if (offset + Long.BYTES <= inputLength) {
+            if (offset + Long.BYTES <= inputLimit) {
               stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
               if (stopMask != 0) {
                 return readStringWordStop(start, offset, stopMask);
               }
               offset += Long.BYTES;
-              if (offset + Long.BYTES <= inputLength) {
+              if (offset + Long.BYTES <= inputLimit) {
                 stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
                 if (stopMask != 0) {
                   return readStringWordStop(start, offset, stopMask);
                 }
                 offset += Long.BYTES;
-                if (offset + Long.BYTES <= inputLength) {
+                if (offset + Long.BYTES <= inputLimit) {
                   stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
                   if (stopMask != 0) {
                     return readStringWordStop(start, offset, stopMask);
@@ -2215,7 +2238,7 @@ public final class Utf8JsonReader extends JsonReader {
         }
       }
     }
-    return readStringTokenLongTail(start, offset, inputLength);
+    return readStringTokenLongTail(start, offset, inputLimit);
   }
 
   private String readStringWordStop(int start, int offset, long stopMask) {
@@ -2228,10 +2251,10 @@ public final class Utf8JsonReader extends JsonReader {
     return readStringStop(start, stop, b);
   }
 
-  /** Returns the current UTF-8 input length to generated bounded String probes. */
+  /** Returns the exclusive UTF-8 input limit to generated bounded String probes. */
   @Internal
-  public int inputLength() {
-    return input.length;
+  public int inputLimit() {
+    return inputLimit;
   }
 
   /** Scans one in-bounds generated String word without publishing the reader cursor. */
@@ -2249,12 +2272,12 @@ public final class Utf8JsonReader extends JsonReader {
   /** Continues a String after generated bounded word probes found no stop byte. */
   @Internal
   public String readStringTokenLongTail(int start, int offset) {
-    return readStringTokenLongTail(start, offset, input.length);
+    return readStringTokenLongTail(start, offset, inputLimit);
   }
 
-  private String readStringTokenLongTail(int start, int offset, int inputLength) {
+  private String readStringTokenLongTail(int start, int offset, int inputLimit) {
     byte[] bytes = input;
-    int doubleWordEnd = inputLength - (Long.BYTES << 1);
+    int doubleWordEnd = inputLimit - (Long.BYTES << 1);
     while (offset <= doubleWordEnd) {
       long stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
       if (stopMask != 0) {
@@ -2279,7 +2302,7 @@ public final class Utf8JsonReader extends JsonReader {
       }
       offset = nextOffset + Long.BYTES;
     }
-    int wordEnd = inputLength - Long.BYTES;
+    int wordEnd = inputLimit - Long.BYTES;
     while (offset <= wordEnd) {
       long stopMask = stringStopMask(LittleEndian.getInt64(bytes, offset));
       if (stopMask == 0) {
@@ -2294,14 +2317,14 @@ public final class Utf8JsonReader extends JsonReader {
       }
       return readStringStop(start, stop, b);
     }
-    return readStringTokenTail(start, offset, inputLength);
+    return readStringTokenTail(start, offset, inputLimit);
   }
 
-  private String readStringTokenTail(int start, int offset, int inputLength) {
+  private String readStringTokenTail(int start, int offset, int inputLimit) {
     byte[] bytes = input;
     // Reached only when the whole input has fewer than eight bytes left. Keep this rare tail out
     // of the hot word scanner so C2 has more budget for common string call sites.
-    if (offset + Integer.BYTES <= inputLength) {
+    if (offset + Integer.BYTES <= inputLimit) {
       int stopMask = stringStopMask(LittleEndian.getInt32(bytes, offset));
       if (stopMask == 0) {
         offset += Integer.BYTES;
@@ -2315,7 +2338,7 @@ public final class Utf8JsonReader extends JsonReader {
         return readStringStop(start, stop, b);
       }
     }
-    while (offset < inputLength) {
+    while (offset < inputLimit) {
       int b = bytes[offset++];
       if (b == '"') {
         position = offset;
@@ -2338,8 +2361,8 @@ public final class Utf8JsonReader extends JsonReader {
   private LocalDate tryReadIsoLocalDateToken() {
     byte[] bytes = input;
     int offset = position;
-    int length = bytes.length;
-    if (offset + 12 > length || bytes[offset] != '"') {
+    int length = inputLimit;
+    if (offset > length - 12 || bytes[offset] != '"') {
       return null;
     }
     offset++;
@@ -2370,8 +2393,8 @@ public final class Utf8JsonReader extends JsonReader {
   private OffsetDateTime tryReadIsoOffsetDateTimeToken() {
     byte[] bytes = input;
     int offset = position;
-    int length = bytes.length;
-    if (offset + 19 > length || bytes[offset] != '"') {
+    int length = inputLimit;
+    if (offset > length - 19 || bytes[offset] != '"') {
       return null;
     }
     offset++;
@@ -2452,7 +2475,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private int tryScanSimpleStringTail(byte[] bytes, int offset) {
-    int length = bytes.length;
+    int length = inputLimit;
     while (offset < length) {
       int b = bytes[offset++];
       if (b == '"') {
@@ -2599,7 +2622,7 @@ public final class Utf8JsonReader extends JsonReader {
   public int readFieldNamePrefix() {
     skipWhitespaceFast();
     int offset = position;
-    if (offset <= input.length - Integer.BYTES) {
+    if (offset <= inputLimit - Integer.BYTES) {
       return LittleEndian.getInt32(input, offset);
     }
     return 0;
@@ -2614,7 +2637,7 @@ public final class Utf8JsonReader extends JsonReader {
   public boolean tryReadNextFieldNameColon(
       long expectedHash, long expectedMask, int expectedLength) {
     int mark = position;
-    if (mark < input.length) {
+    if (mark < inputLimit) {
       int ch = input[mark];
       if (ch == '"') {
         return tryReadFieldNameColonAt(mark, expectedHash, expectedMask, expectedLength);
@@ -2637,7 +2660,7 @@ public final class Utf8JsonReader extends JsonReader {
   private boolean tryReadNextRawToken0(long prefix, long prefixMask, int tokenLength) {
     byte[] bytes = input;
     int mark = position;
-    if (mark + Long.BYTES <= bytes.length
+    if (mark <= inputLimit - Long.BYTES
         && (LittleEndian.getInt64(bytes, mark) & prefixMask) == prefix) {
       position = mark + tokenLength;
       return true;
@@ -2659,7 +2682,7 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int mark = position;
     int suffixOffset = mark + Long.BYTES;
-    if (mark + tokenLength <= bytes.length
+    if (tokenLength <= inputLimit - mark
         && (LittleEndian.getInt64(bytes, mark) & prefixMask) == prefix
         && bytes[suffixOffset] == suffix) {
       position = mark + tokenLength;
@@ -2682,7 +2705,7 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int mark = position;
     int suffixOffset = mark + Long.BYTES;
-    if (mark + tokenLength <= bytes.length
+    if (tokenLength <= inputLimit - mark
         && (LittleEndian.getInt64(bytes, mark) & prefixMask) == prefix
         && ((bytes[suffixOffset] & 0xFF) | ((bytes[suffixOffset + 1] & 0xFF) << 8)) == suffix) {
       position = mark + tokenLength;
@@ -2705,7 +2728,7 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int mark = position;
     int suffixOffset = mark + Long.BYTES;
-    if (mark + tokenLength <= bytes.length
+    if (tokenLength <= inputLimit - mark
         && (LittleEndian.getInt64(bytes, mark) & prefixMask) == prefix
         && ((bytes[suffixOffset] & 0xFF)
                 | ((bytes[suffixOffset + 1] & 0xFF) << 8)
@@ -2726,9 +2749,9 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int mark = position;
     int suffixOffset = mark + Long.BYTES;
-    if (mark + tokenLength <= bytes.length
+    if (tokenLength <= inputLimit - mark
         && LittleEndian.getInt64(bytes, mark) == prefix
-        && readTokenSuffix(bytes, suffixOffset, tokenLength, suffixMask) == suffix) {
+        && readTokenSuffix(bytes, suffixOffset, tokenLength, suffixMask, inputLimit) == suffix) {
       position = mark + tokenLength;
       return true;
     }
@@ -2736,8 +2759,8 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private static long readTokenSuffix(
-      byte[] bytes, int suffixOffset, int tokenLength, long suffixMask) {
-    if (suffixOffset + Long.BYTES <= bytes.length) {
+      byte[] bytes, int suffixOffset, int tokenLength, long suffixMask, int inputLimit) {
+    if (suffixOffset <= inputLimit - Long.BYTES) {
       return LittleEndian.getInt64(bytes, suffixOffset) & suffixMask;
     }
     int suffixLength = tokenLength - Long.BYTES;
@@ -2754,12 +2777,12 @@ public final class Utf8JsonReader extends JsonReader {
     int offset = position;
     int nameOffset = offset + 1;
     int quoteOffset = nameOffset + expectedLength;
-    if (quoteOffset < bytes.length && bytes[offset] == '"') {
-      if (nameOffset + Long.BYTES <= bytes.length) {
+    if (quoteOffset < inputLimit && bytes[offset] == '"') {
+      if (nameOffset <= inputLimit - Long.BYTES) {
         if ((LittleEndian.getInt64(bytes, nameOffset) & expectedMask) == expectedHash
             && bytes[quoteOffset] == '"') {
           int colonOffset = quoteOffset + 1;
-          if (colonOffset < bytes.length && bytes[colonOffset] == ':') {
+          if (colonOffset < inputLimit && bytes[colonOffset] == ':') {
             position = colonOffset + 1;
           } else {
             readFieldNameColon(colonOffset);
@@ -2783,7 +2806,7 @@ public final class Utf8JsonReader extends JsonReader {
       }
       if (value == expectedHash && bytes[offset] == '"') {
         int colonOffset = offset + 1;
-        if (colonOffset < bytes.length && bytes[colonOffset] == ':') {
+        if (colonOffset < inputLimit && bytes[colonOffset] == ':') {
           position = colonOffset + 1;
         } else {
           readFieldNameColon(colonOffset);
@@ -2811,7 +2834,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   public long readNextPackedStringHash() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ' || !isWhitespace(ch)) {
         return readPackedStringHashToken();
@@ -2827,7 +2850,7 @@ public final class Utf8JsonReader extends JsonReader {
   private long readPackedStringHashToken() {
     int mark = position;
     byte[] bytes = input;
-    int length = bytes.length;
+    int length = inputLimit;
     int offset = position;
     if (offset < length && bytes[offset++] == '"') {
       long value = 0;
@@ -2864,7 +2887,7 @@ public final class Utf8JsonReader extends JsonReader {
     byte[] bytes = input;
     int mark = position;
     int nameOffset = mark + 1;
-    if (nameOffset + Long.BYTES < bytes.length && bytes[mark] == '"') {
+    if (nameOffset < inputLimit - Long.BYTES && bytes[mark] == '"') {
       long word = LittleEndian.getInt64(bytes, nameOffset);
       long stopMask = stringStopMask(word);
       if (stopMask == 0) {
@@ -2885,7 +2908,7 @@ public final class Utf8JsonReader extends JsonReader {
 
   private long readQuotedStringHashSlow() {
     byte[] bytes = input;
-    int length = bytes.length;
+    int length = inputLimit;
     if (position >= length || bytes[position++] != '"') {
       throw error("Expected string");
     }
@@ -3072,7 +3095,7 @@ public final class Utf8JsonReader extends JsonReader {
           return readStringUtf16Tail(bytes, out);
         }
       }
-      if (position >= input.length) {
+      if (position >= inputLimit) {
         throw error("Unterminated string");
       }
       b = input[position++] & 0xFF;
@@ -3082,12 +3105,12 @@ public final class Utf8JsonReader extends JsonReader {
   private String readStringUtf16Tail(byte[] bytes, int out) {
     byte[] input = this.input;
     int position = this.position;
-    int inputLength = input.length;
+    int inputLimit = this.inputLimit;
     int capacity = bytes.length;
-    while (position < inputLength) {
+    while (position < inputLimit) {
       int b = input[position++] & 0xFF;
       if ((b & 0xF0) == 0xE0) {
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3096,7 +3119,7 @@ public final class Utf8JsonReader extends JsonReader {
           this.position = position;
           throw error("Invalid UTF-8 continuation");
         }
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3150,7 +3173,7 @@ public final class Utf8JsonReader extends JsonReader {
         }
         out = putUtf16Char(bytes, out, (char) b);
       } else if ((b & 0xE0) == 0xC0) {
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3170,7 +3193,7 @@ public final class Utf8JsonReader extends JsonReader {
         }
         out = putUtf16Char(bytes, out, (char) codePoint);
       } else if ((b & 0xF8) == 0xF0) {
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3179,7 +3202,7 @@ public final class Utf8JsonReader extends JsonReader {
           this.position = position;
           throw error("Invalid UTF-8 continuation");
         }
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3188,7 +3211,7 @@ public final class Utf8JsonReader extends JsonReader {
           this.position = position;
           throw error("Invalid UTF-8 continuation");
         }
-        if (position >= inputLength) {
+        if (position >= inputLimit) {
           this.position = position;
           throw error("Short UTF-8 sequence");
         }
@@ -3222,8 +3245,8 @@ public final class Utf8JsonReader extends JsonReader {
     if ((first & 0xF0) == 0xE0) {
       byte[] input = this.input;
       int position = this.position;
-      int inputLength = input.length;
-      if (position >= inputLength) {
+      int inputLimit = this.inputLimit;
+      if (position >= inputLimit) {
         this.position = position;
         throw error("Short UTF-8 sequence");
       }
@@ -3232,7 +3255,7 @@ public final class Utf8JsonReader extends JsonReader {
         this.position = position;
         throw error("Invalid UTF-8 continuation");
       }
-      if (position >= inputLength) {
+      if (position >= inputLimit) {
         this.position = position;
         throw error("Short UTF-8 sequence");
       }
@@ -3263,7 +3286,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private char readEscapedStringChar() {
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Unterminated escape");
     }
     char escaped = (char) (input[position++] & 0xFF);
@@ -3290,7 +3313,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private char readLowSurrogateEscape() {
-    if (position + 2 > input.length || input[position] != '\\' || input[position + 1] != 'u') {
+    if (position + 2 > inputLimit || input[position] != '\\' || input[position + 1] != 'u') {
       throw error("Unpaired high surrogate escape");
     }
     position += 2;
@@ -3345,7 +3368,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private int continuation() {
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Short UTF-8 sequence");
     }
     int value = input[position++] & 0xFF;
@@ -3356,7 +3379,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private void skipWhitespaceFast() {
-    while (position < input.length) {
+    while (position < inputLimit) {
       int ch = input[position];
       if (ch > ' ') {
         return;
@@ -3374,7 +3397,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private void rejectLeadingDigitFast() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch >= '0' && ch <= '9') {
         throw error("Leading zero in number");
@@ -3383,7 +3406,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private void rejectFractionOrExponentFast() {
-    if (position < input.length) {
+    if (position < inputLimit) {
       int ch = input[position];
       if (ch == '.' || ch == 'e' || ch == 'E') {
         throw error("Expected integer");
@@ -3392,7 +3415,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private int readZeroIntName(int nameStart) {
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Unterminated string");
     }
     int ch = input[position];
@@ -3411,7 +3434,7 @@ public final class Utf8JsonReader extends JsonReader {
   }
 
   private long readZeroLongName(int nameStart) {
-    if (position >= input.length) {
+    if (position >= inputLimit) {
       throw error("Unterminated string");
     }
     int ch = input[position];

--- a/java/fory-json/src/test/java/org/apache/fory/json/ForyJsonByteRangeTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/ForyJsonByteRangeTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.json;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.fory.reflect.TypeRef;
+import org.testng.annotations.Test;
+
+public class ForyJsonByteRangeTest {
+  private final ForyJson json =
+      ForyJson.builder().withAsyncCompilation(false).withConcurrencyLevel(1).build();
+
+  @Test
+  public void readClassRange() {
+    String name = repeat('a', 80);
+    String document = "{\"name\":\"" + name + "\",\"count\":7}";
+    byte[] bytes = ("prefix" + document + "suffix").getBytes(StandardCharsets.UTF_8);
+
+    RangeValue value = json.fromJson(bytes, "prefix".length(), document.length(), RangeValue.class);
+
+    assertEquals(value.name, name);
+    assertEquals(value.count, 7);
+  }
+
+  @Test
+  public void readGenericRange() {
+    byte[] bytes = "xx[1,2,3]yy".getBytes(StandardCharsets.UTF_8);
+    List<Integer> values = json.fromJson(bytes, 2, 7, new TypeRef<List<Integer>>() {});
+    assertEquals(values, Arrays.asList(1, 2, 3));
+  }
+
+  @Test
+  public void ignoreBytesOutsideRange() {
+    byte[] number = "xx12 999yy".getBytes(StandardCharsets.UTF_8);
+    assertEquals(json.fromJson(number, 2, 2, Integer.class), Integer.valueOf(12));
+
+    byte[] string = "xx\"abc\"yy".getBytes(StandardCharsets.UTF_8);
+    assertThrows(ForyJsonException.class, () -> json.fromJson(string, 2, 4, String.class));
+
+    byte[] bool = "xxtrueyy".getBytes(StandardCharsets.UTF_8);
+    assertThrows(ForyJsonException.class, () -> json.fromJson(bool, 2, 3, Boolean.class));
+  }
+
+  @Test
+  public void rejectInvalidRange() {
+    byte[] bytes = "null".getBytes(StandardCharsets.UTF_8);
+    assertThrows(
+        NullPointerException.class, () -> json.fromJson((byte[]) null, -1, 1, Object.class));
+    assertThrows(IndexOutOfBoundsException.class, () -> json.fromJson(bytes, -1, 1, Object.class));
+    assertThrows(IndexOutOfBoundsException.class, () -> json.fromJson(bytes, 0, -1, Object.class));
+    assertThrows(IndexOutOfBoundsException.class, () -> json.fromJson(bytes, 3, 2, Object.class));
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> json.fromJson(bytes, Integer.MAX_VALUE, 1, Object.class));
+  }
+
+  private static String repeat(char value, int count) {
+    char[] chars = new char[count];
+    Arrays.fill(chars, value);
+    return new String(chars);
+  }
+
+  public static final class RangeValue {
+    public String name;
+    public int count;
+
+    public RangeValue() {}
+  }
+}

--- a/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
@@ -213,6 +213,19 @@ public class JsonStreamDecoderTest {
         decode(cumulative, Collections.singletonList(utf8("[1,2,3,4]"))),
         Arrays.asList(1, 2, 3, 4));
 
+    JsonStreamDecoder<Integer> leadingWhitespace = json.newArrayStreamDecoder(Integer.class, 1);
+    assertEquals(
+        decode(leadingWhitespace, Collections.singletonList(utf8("[ \t1]"))),
+        Collections.singletonList(1));
+
+    JsonStreamDecoder<Integer> trailingWhitespace = json.newArrayStreamDecoder(Integer.class, 1);
+    assertThrows(ForyJsonException.class, () -> trailingWhitespace.decodeNext(utf8("[1 ]")));
+
+    JsonStreamDecoder<Integer> exactBlankLine = json.newNdjsonStreamDecoder(Integer.class, 2);
+    assertEquals(
+        decode(exactBlankLine, Collections.singletonList(utf8(" \t\n1\n"))),
+        Collections.singletonList(1));
+
     JsonStreamDecoder<Integer> splitExact = json.newArrayStreamDecoder(Integer.class, 3);
     ByteBuffer valueChunk = utf8("[123");
     assertFalse(splitExact.decodeNext(valueChunk));

--- a/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
@@ -56,6 +56,33 @@ public class JsonStreamDecoderTest {
   }
 
   @Test
+  public void decodeArrayBoundaries() {
+    JsonStreamDecoder<Integer> delimiterAtEnd = json.newArrayStreamDecoder(Integer.class, 16);
+    ByteBuffer first = utf8("[1,");
+    assertTrue(delimiterAtEnd.decodeNext(first));
+    assertEquals(delimiterAtEnd.value(), Integer.valueOf(1));
+    assertEquals(first.position(), first.limit());
+    ByteBuffer second = utf8("2]");
+    assertTrue(delimiterAtEnd.decodeNext(second));
+    assertEquals(delimiterAtEnd.value(), Integer.valueOf(2));
+    assertEquals(second.position(), second.limit());
+    assertFalse(delimiterAtEnd.finish());
+
+    JsonStreamDecoder<Integer> delimiterAtStart = json.newArrayStreamDecoder(Integer.class, 16);
+    first = utf8("[1");
+    assertFalse(delimiterAtStart.decodeNext(first));
+    assertEquals(first.position(), first.limit());
+    second = utf8(",2]");
+    assertTrue(delimiterAtStart.decodeNext(second));
+    assertEquals(delimiterAtStart.value(), Integer.valueOf(1));
+    assertEquals(second.position(), 1);
+    assertTrue(delimiterAtStart.decodeNext(second));
+    assertEquals(delimiterAtStart.value(), Integer.valueOf(2));
+    assertEquals(second.position(), second.limit());
+    assertFalse(delimiterAtStart.finish());
+  }
+
+  @Test
   public void decodeNestedArrayValues() {
     String document =
         "[{\"text\":\"a,]}\",\"nested\":[1,{\"x\":2}]}," + "{\"text\":\"z\",\"nested\":[]}]";
@@ -112,6 +139,33 @@ public class JsonStreamDecoderTest {
   }
 
   @Test
+  public void decodeNdjsonBoundaries() {
+    JsonStreamDecoder<Integer> splitCrlf = json.newNdjsonStreamDecoder(Integer.class, 16);
+    ByteBuffer first = utf8("1\r");
+    assertFalse(splitCrlf.decodeNext(first));
+    assertEquals(first.position(), first.limit());
+    ByteBuffer second = utf8("\n2\n");
+    assertTrue(splitCrlf.decodeNext(second));
+    assertEquals(splitCrlf.value(), Integer.valueOf(1));
+    assertEquals(second.position(), 1);
+    assertTrue(splitCrlf.decodeNext(second));
+    assertEquals(splitCrlf.value(), Integer.valueOf(2));
+    assertEquals(second.position(), second.limit());
+    assertFalse(splitCrlf.finish());
+
+    JsonStreamDecoder<Integer> splitBlankLine = json.newNdjsonStreamDecoder(Integer.class, 16);
+    first = utf8("3\n");
+    assertTrue(splitBlankLine.decodeNext(first));
+    assertEquals(splitBlankLine.value(), Integer.valueOf(3));
+    assertEquals(first.position(), first.limit());
+    second = utf8("\n4");
+    assertFalse(splitBlankLine.decodeNext(second));
+    assertEquals(second.position(), second.limit());
+    assertTrue(splitBlankLine.finish());
+    assertEquals(splitBlankLine.value(), Integer.valueOf(4));
+  }
+
+  @Test
   public void distinguishNullValue() {
     JsonStreamDecoder<String> decoder = json.newArrayStreamDecoder(String.class, 16);
     ByteBuffer input = utf8("[null]");
@@ -158,6 +212,16 @@ public class JsonStreamDecoderTest {
     assertEquals(
         decode(cumulative, Collections.singletonList(utf8("[1,2,3,4]"))),
         Arrays.asList(1, 2, 3, 4));
+
+    JsonStreamDecoder<Integer> splitExact = json.newArrayStreamDecoder(Integer.class, 3);
+    ByteBuffer valueChunk = utf8("[123");
+    assertFalse(splitExact.decodeNext(valueChunk));
+    assertEquals(valueChunk.position(), valueChunk.limit());
+    ByteBuffer delimiterChunk = utf8("]");
+    assertTrue(splitExact.decodeNext(delimiterChunk));
+    assertEquals(splitExact.value(), Integer.valueOf(123));
+    assertEquals(delimiterChunk.position(), delimiterChunk.limit());
+    assertFalse(splitExact.finish());
   }
 
   @Test
@@ -183,6 +247,10 @@ public class JsonStreamDecoderTest {
     JsonStreamDecoder<Boolean> invalid = json.newArrayStreamDecoder(Boolean.class, 16);
     assertThrows(ForyJsonException.class, () -> invalid.decodeNext(utf8("[truX]")));
     assertEquals(json.fromJson("7", Integer.class), Integer.valueOf(7));
+
+    JsonStreamDecoder<Integer> standaloneCr = json.newNdjsonStreamDecoder(Integer.class, 16);
+    assertFalse(standaloneCr.decodeNext(utf8("1\r")));
+    assertThrows(ForyJsonException.class, () -> standaloneCr.decodeNext(utf8("2\n")));
   }
 
   @Test
@@ -207,8 +275,10 @@ public class JsonStreamDecoderTest {
     ByteBuffer input = utf8("[1,2]");
     assertTrue(decoder.decodeNext(input));
     assertEquals(decoder.value(), Integer.valueOf(1));
+    assertEquals(input.position(), 3);
     assertTrue(decoder.decodeNext(input));
     assertEquals(decoder.value(), Integer.valueOf(2));
+    assertEquals(input.position(), input.limit());
     assertFalse(decoder.decodeNext(input));
     assertThrows(IllegalStateException.class, decoder::value);
     assertFalse(decoder.finish());

--- a/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.json;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.fory.reflect.TypeRef;
+import org.testng.annotations.Test;
+
+public class JsonStreamDecoderTest {
+  private final ForyJson json =
+      ForyJson.builder().withAsyncCompilation(false).withConcurrencyLevel(1).build();
+
+  @Test
+  public void decodeArrayAtEverySplit() {
+    String document = "[\"a,]}\",\"b\\\"c\",\"d\\\\e\",\"你好\"]";
+    byte[] bytes = document.getBytes(StandardCharsets.UTF_8);
+    List<String> expected = Arrays.asList("a,]}", "b\"c", "d\\e", "你好");
+    for (int split = 0; split <= bytes.length; split++) {
+      JsonStreamDecoder<String> decoder = json.newArrayStreamDecoder(String.class, 1024);
+      List<String> values = new ArrayList<>();
+      drain(decoder, ByteBuffer.wrap(bytes, 0, split), values);
+      drain(decoder, ByteBuffer.wrap(bytes, split, bytes.length - split), values);
+      assertFalse(decoder.finish());
+      assertEquals(values, expected, "split=" + split);
+    }
+  }
+
+  @Test
+  public void decodeNestedArrayValues() {
+    String document =
+        "[{\"text\":\"a,]}\",\"nested\":[1,{\"x\":2}]}," + "{\"text\":\"z\",\"nested\":[]}]";
+    TypeRef<Map<String, Object>> type = new TypeRef<Map<String, Object>>() {};
+    JsonStreamDecoder<Map<String, Object>> decoder = json.newArrayStreamDecoder(type, 4096);
+    List<Map<String, Object>> values = decode(decoder, buffers(document, 3, 11, 19, 37));
+
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).get("text"), "a,]}");
+    assertEquals(values.get(1).get("text"), "z");
+  }
+
+  @Test
+  public void decodeBufferVariants() {
+    byte[] bytes = "[1,2,3]".getBytes(StandardCharsets.UTF_8);
+    List<ByteBuffer> inputs = new ArrayList<>();
+    inputs.add(ByteBuffer.wrap(bytes.clone()));
+
+    ByteBuffer direct = ByteBuffer.allocateDirect(bytes.length);
+    direct.put(bytes).flip();
+    inputs.add(direct);
+
+    byte[] padded = new byte[bytes.length + 4];
+    System.arraycopy(bytes, 0, padded, 2, bytes.length);
+    inputs.add(ByteBuffer.wrap(padded, 2, bytes.length).slice());
+    inputs.add(ByteBuffer.wrap(bytes.clone()).asReadOnlyBuffer());
+
+    for (ByteBuffer input : inputs) {
+      input.order(ByteOrder.LITTLE_ENDIAN);
+      JsonStreamDecoder<Integer> decoder = json.newArrayStreamDecoder(Integer.class, 32);
+      assertEquals(decode(decoder, Collections.singletonList(input)), Arrays.asList(1, 2, 3));
+      assertEquals(input.order(), ByteOrder.LITTLE_ENDIAN);
+      assertEquals(input.position(), input.limit());
+    }
+  }
+
+  @Test
+  public void decodeNdjsonAtEverySplit() {
+    String document = "\n {\"v\":1}\r\n\t\r\n{\"v\":2}\n{\"v\":3}";
+    byte[] bytes = document.getBytes(StandardCharsets.UTF_8);
+    TypeRef<Map<String, Integer>> type = new TypeRef<Map<String, Integer>>() {};
+    for (int split = 0; split <= bytes.length; split++) {
+      JsonStreamDecoder<Map<String, Integer>> decoder = json.newNdjsonStreamDecoder(type, 128);
+      List<Map<String, Integer>> values = new ArrayList<>();
+      drain(decoder, ByteBuffer.wrap(bytes, 0, split), values);
+      drain(decoder, ByteBuffer.wrap(bytes, split, bytes.length - split), values);
+      if (decoder.finish()) {
+        values.add(decoder.value());
+      }
+      assertEquals(values.size(), 3, "split=" + split);
+      assertEquals(values.get(0).get("v"), Integer.valueOf(1));
+      assertEquals(values.get(2).get("v"), Integer.valueOf(3));
+    }
+  }
+
+  @Test
+  public void distinguishNullValue() {
+    JsonStreamDecoder<String> decoder = json.newArrayStreamDecoder(String.class, 16);
+    ByteBuffer input = utf8("[null]");
+    assertTrue(decoder.decodeNext(input));
+    assertNull(decoder.value());
+    assertFalse(decoder.finish());
+
+    JsonStreamDecoder<String> ndjson = json.newNdjsonStreamDecoder(String.class, 16);
+    assertFalse(ndjson.decodeNext(utf8("null")));
+    assertTrue(ndjson.finish());
+    assertNull(ndjson.value());
+  }
+
+  @Test
+  public void decodeEmptyAndScalarArrays() {
+    JsonStreamDecoder<Object> empty = json.newArrayStreamDecoder(Object.class, 8);
+    assertEquals(
+        decode(empty, Collections.singletonList(utf8(" \t[ ]\r\n"))), Collections.emptyList());
+
+    JsonStreamDecoder<Object> scalars = json.newArrayStreamDecoder(Object.class, 5);
+    assertEquals(
+        decode(scalars, Collections.singletonList(utf8("[true,false,null]"))),
+        Arrays.asList(Boolean.TRUE, Boolean.FALSE, null));
+  }
+
+  @Test
+  public void enforceValueLimit() {
+    JsonStreamDecoder<Integer> exact = json.newArrayStreamDecoder(Integer.class, 3);
+    assertEquals(decode(exact, Collections.singletonList(utf8("[123]"))), Arrays.asList(123));
+
+    JsonStreamDecoder<Integer> oversized = json.newArrayStreamDecoder(Integer.class, 2);
+    ByteBuffer input = utf8("[123]");
+    assertThrows(ForyJsonException.class, () -> oversized.decodeNext(input));
+    assertTrue(input.position() > 0);
+    assertThrows(IllegalStateException.class, () -> oversized.decodeNext(input));
+
+    JsonStreamDecoder<Integer> crlf = json.newNdjsonStreamDecoder(Integer.class, 3);
+    assertEquals(decode(crlf, Collections.singletonList(utf8("123\r\n"))), Arrays.asList(123));
+
+    JsonStreamDecoder<Integer> blank = json.newNdjsonStreamDecoder(Integer.class, 2);
+    assertThrows(ForyJsonException.class, () -> blank.decodeNext(utf8("   \n")));
+
+    JsonStreamDecoder<Integer> cumulative = json.newArrayStreamDecoder(Integer.class, 1);
+    assertEquals(
+        decode(cumulative, Collections.singletonList(utf8("[1,2,3,4]"))),
+        Arrays.asList(1, 2, 3, 4));
+  }
+
+  @Test
+  public void rejectInvalidConfiguration() {
+    assertThrows(
+        NullPointerException.class, () -> json.newArrayStreamDecoder((Class<Object>) null, 1));
+    assertThrows(
+        NullPointerException.class, () -> json.newNdjsonStreamDecoder((TypeRef<Object>) null, 1));
+    assertThrows(IllegalArgumentException.class, () -> json.newArrayStreamDecoder(Object.class, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> json.newArrayStreamDecoder(Object.class, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void rejectMalformedFraming() {
+    assertArrayFailure("1");
+    assertArrayFailure("[1");
+    assertArrayFailure("[,1]");
+    assertArrayFailure("[1,]");
+    assertArrayFailure("[]x");
+
+    JsonStreamDecoder<Boolean> invalid = json.newArrayStreamDecoder(Boolean.class, 16);
+    assertThrows(ForyJsonException.class, () -> invalid.decodeNext(utf8("[truX]")));
+    assertEquals(json.fromJson("7", Integer.class), Integer.valueOf(7));
+  }
+
+  @Test
+  public void enforceTerminalState() {
+    JsonStreamDecoder<Integer> decoder = json.newArrayStreamDecoder(Integer.class, 16);
+    assertThrows(IllegalStateException.class, decoder::value);
+    ByteBuffer input = utf8("[1]");
+    assertTrue(decoder.decodeNext(input));
+    assertEquals(decoder.value(), Integer.valueOf(1));
+    assertFalse(decoder.finish());
+    assertThrows(IllegalStateException.class, decoder::finish);
+    assertThrows(IllegalStateException.class, () -> decoder.decodeNext(ByteBuffer.allocate(0)));
+
+    JsonStreamDecoder<Integer> invalid = json.newArrayStreamDecoder(Integer.class, 16);
+    assertThrows(NullPointerException.class, () -> invalid.decodeNext(null));
+    assertThrows(IllegalStateException.class, () -> invalid.decodeNext(ByteBuffer.allocate(0)));
+  }
+
+  @Test
+  public void invalidatePreviousValue() {
+    JsonStreamDecoder<Integer> decoder = json.newArrayStreamDecoder(Integer.class, 16);
+    ByteBuffer input = utf8("[1,2]");
+    assertTrue(decoder.decodeNext(input));
+    assertEquals(decoder.value(), Integer.valueOf(1));
+    assertTrue(decoder.decodeNext(input));
+    assertEquals(decoder.value(), Integer.valueOf(2));
+    assertFalse(decoder.decodeNext(input));
+    assertThrows(IllegalStateException.class, decoder::value);
+    assertFalse(decoder.finish());
+  }
+
+  private void assertArrayFailure(String document) {
+    JsonStreamDecoder<Integer> decoder = json.newArrayStreamDecoder(Integer.class, 32);
+    ByteBuffer input = utf8(document);
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          while (decoder.decodeNext(input)) {
+            decoder.value();
+          }
+          decoder.finish();
+        });
+  }
+
+  private static <T> List<T> decode(JsonStreamDecoder<T> decoder, List<ByteBuffer> inputs) {
+    List<T> values = new ArrayList<>();
+    for (ByteBuffer input : inputs) {
+      drain(decoder, input, values);
+    }
+    if (decoder.finish()) {
+      values.add(decoder.value());
+    }
+    return values;
+  }
+
+  private static <T> void drain(JsonStreamDecoder<T> decoder, ByteBuffer input, List<T> values) {
+    while (decoder.decodeNext(input)) {
+      values.add(decoder.value());
+    }
+  }
+
+  private static List<ByteBuffer> buffers(String value, int... ends) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    List<ByteBuffer> buffers = new ArrayList<>();
+    int start = 0;
+    for (int end : ends) {
+      buffers.add(ByteBuffer.wrap(bytes, start, end - start));
+      start = end;
+    }
+    buffers.add(ByteBuffer.wrap(bytes, start, bytes.length - start));
+    return buffers;
+  }
+
+  private static ByteBuffer utf8(String value) {
+    return ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- adds `JsonStreamDecoder<T>` for incremental top-level JSON array and NDJSON decoding from `ByteBuffer` chunks
- adds bounded byte-array range roots to `ForyJson` and enforces the logical range throughout generated UTF-8 readers
- separates scanning from caller-visible buffer consumption, committing one current-buffer value segment at a boundary or chunk end
- allocates staging storage from the first proven required length, grows it only when needed, reuses it within the active stream, and releases it on finish or failure
- supports heap, direct, sliced, read-only, and either-byte-order buffers while preserving one-value backpressure and root cleanup
- documents stream ownership, `ByteBuffer.position()`, and exact per-value limit accounting

## Tests

- `ENABLE_FORY_DEBUG_OUTPUT=1 mvn -pl fory-json -Dtest=ForyJsonByteRangeTest,JsonStreamDecoderTest test` (17 tests)
- `ENABLE_FORY_DEBUG_OUTPUT=1 mvn -pl fory-json test` (931 tests)
- `mvn -pl fory-json spotless:check`
- `mvn -pl fory-json checkstyle:check`
- `prettier --check ../docs/json/getting-started.md fory-json/README.md`
- Azul JDK 8u462 `mvn -pl fory-json clean compile -DskipTests`
- `mvn -pl fory-json package -DskipTests` including sources and Javadoc JARs

Boundary coverage includes every byte split of representative array and NDJSON inputs, delimiters on either side of a buffer boundary, CRLF split across buffers, adjacent NDJSON separators split across buffers, exact-size values, and incomplete values that wait for more input.
