### PR TITLE
feat(json): expose stream value limit errors

### DIFF
--- a/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamDecoder.java
@@ -486,8 +486,8 @@ public final class JsonStreamDecoder<T> {
     valueBytes = EMPTY_BYTES;
   }
 
-  private ForyJsonException valueTooLarge() {
-    return new ForyJsonException("JSON stream value exceeds maxValueBytes " + maxValueBytes);
+  private JsonStreamValueLimitException valueTooLarge() {
+    return new JsonStreamValueLimitException(maxValueBytes);
   }
 
   private static ForyJsonException framingError(String message) {

--- a/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamValueLimitException.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/JsonStreamValueLimitException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fory.json;
+
+/** Indicates that one incremental JSON stream value exceeded its configured byte limit. */
+public final class JsonStreamValueLimitException extends ForyJsonException {
+  private final int maxValueBytes;
+
+  JsonStreamValueLimitException(int maxValueBytes) {
+    super("JSON stream value exceeds maxValueBytes " + maxValueBytes);
+    this.maxValueBytes = maxValueBytes;
+  }
+
+  /** Returns the configured maximum UTF-8 bytes for one stream value. */
+  public int getMaxValueBytes() {
+    return maxValueBytes;
+  }
+}

--- a/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/JsonStreamDecoderTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -198,7 +199,9 @@ public class JsonStreamDecoderTest {
 
     JsonStreamDecoder<Integer> oversized = json.newArrayStreamDecoder(Integer.class, 2);
     ByteBuffer input = utf8("[123]");
-    assertThrows(ForyJsonException.class, () -> oversized.decodeNext(input));
+    JsonStreamValueLimitException error =
+        expectThrows(JsonStreamValueLimitException.class, () -> oversized.decodeNext(input));
+    assertEquals(error.getMaxValueBytes(), 2);
     assertTrue(input.position() > 0);
     assertThrows(IllegalStateException.class, () -> oversized.decodeNext(input));
 


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

