### PR TITLE
perf(json): add ordered field read fast path

### DIFF
--- a/java/fory-json/src/main/java/org/apache/fory/json/codec/ObjectCodec.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/codec/ObjectCodec.java
@@ -54,6 +54,7 @@ import org.apache.fory.json.resolver.JsonTypeInfo;
 import org.apache.fory.json.resolver.JsonTypeResolver;
 import org.apache.fory.json.writer.StringJsonWriter;
 import org.apache.fory.json.writer.Utf8JsonWriter;
+import org.apache.fory.memory.NativeByteOrder;
 import org.apache.fory.platform.AndroidSupport;
 import org.apache.fory.platform.GraalvmSupport;
 import org.apache.fory.platform.internal._JDKAccess;
@@ -533,9 +534,19 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
       reader.exitDepth();
       return object;
     }
+    int expectedIndex = 0;
     do {
-      JsonFieldInfo field = reader.readField(readTable);
-      reader.expect(':');
+      JsonFieldInfo field;
+      if (expectedIndex < readFields.length
+          && tryReadLatin1Field(reader, readFields[expectedIndex])) {
+        field = readFields[expectedIndex++];
+      } else {
+        field = reader.readField(readTable);
+        reader.expect(':');
+        if (field != null) {
+          expectedIndex = field.readIndex() + 1;
+        }
+      }
       if (field == null) {
         reader.skipValue();
       } else {
@@ -579,9 +590,19 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
       reader.exitDepth();
       return object;
     }
+    int expectedIndex = 0;
     do {
-      JsonFieldInfo field = reader.readField(readTable);
-      reader.expect(':');
+      JsonFieldInfo field;
+      if (expectedIndex < readFields.length
+          && tryReadUtf16Field(reader, readFields[expectedIndex])) {
+        field = readFields[expectedIndex++];
+      } else {
+        field = reader.readField(readTable);
+        reader.expect(':');
+        if (field != null) {
+          expectedIndex = field.readIndex() + 1;
+        }
+      }
       if (field == null) {
         reader.skipValue();
       } else {
@@ -625,9 +646,19 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
       reader.exitDepth();
       return object;
     }
+    int expectedIndex = 0;
     do {
-      JsonFieldInfo field = reader.readField(readTable);
-      reader.expect(':');
+      JsonFieldInfo field;
+      if (expectedIndex < readFields.length
+          && tryReadUtf8Field(reader, readFields[expectedIndex])) {
+        field = readFields[expectedIndex++];
+      } else {
+        field = reader.readField(readTable);
+        reader.expect(':');
+        if (field != null) {
+          expectedIndex = field.readIndex() + 1;
+        }
+      }
       if (field == null) {
         reader.skipValue();
       } else {
@@ -984,11 +1015,20 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Latin1ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.latin1Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int match = table.match(hash);
-        reader.expect(':');
+        int match;
+        if (expectedIndex < readFields.length
+            && tryReadLatin1Field(reader, readFields[expectedIndex])) {
+          match = expectedIndex++;
+        } else {
+          match = table.match(reader.readFieldNameHash());
+          reader.expect(':');
+          if (match >= 0) {
+            expectedIndex = match + 1;
+          }
+        }
         if (match >= 0) {
           readFields[match].readLatin1(reader, object);
         } else if (match == JsonFieldTable.SKIP) {
@@ -1030,11 +1070,20 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Utf16ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.utf16Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int match = table.match(hash);
-        reader.expect(':');
+        int match;
+        if (expectedIndex < readFields.length
+            && tryReadUtf16Field(reader, readFields[expectedIndex])) {
+          match = expectedIndex++;
+        } else {
+          match = table.match(reader.readFieldNameHash());
+          reader.expect(':');
+          if (match >= 0) {
+            expectedIndex = match + 1;
+          }
+        }
         if (match >= 0) {
           readFields[match].readUtf16(reader, object);
         } else if (match == JsonFieldTable.SKIP) {
@@ -1076,11 +1125,20 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Utf8ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.utf8Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int match = table.match(hash);
-        reader.expect(':');
+        int match;
+        if (expectedIndex < readFields.length
+            && tryReadUtf8Field(reader, readFields[expectedIndex])) {
+          match = expectedIndex++;
+        } else {
+          match = table.match(reader.readFieldNameHash());
+          reader.expect(':');
+          if (match >= 0) {
+            expectedIndex = match + 1;
+          }
+        }
         if (match >= 0) {
           readFields[match].readUtf8(reader, object);
         } else if (match == JsonFieldTable.SKIP) {
@@ -1121,11 +1179,21 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Latin1ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.latin1Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int index = creatorInfo.index(hash);
-        reader.expect(':');
+        int index;
+        long hash = 0;
+        if (expectedIndex < fields.length && tryReadLatin1Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          hash = reader.readFieldNameHash();
+          index = creatorInfo.index(hash);
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index >= 0) {
           JsonCreatorFieldInfo field = fields[index];
           arguments[field.argumentIndex()] = field.readLatin1(reader);
@@ -1159,11 +1227,21 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Utf16ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.utf16Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int index = creatorInfo.index(hash);
-        reader.expect(':');
+        int index;
+        long hash = 0;
+        if (expectedIndex < fields.length && tryReadUtf16Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          hash = reader.readFieldNameHash();
+          index = creatorInfo.index(hash);
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index >= 0) {
           JsonCreatorFieldInfo field = fields[index];
           arguments[field.argumentIndex()] = field.readUtf16(reader);
@@ -1197,11 +1275,21 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     Utf8ReaderCodec<Object> anyReader = anyInfo.valueTypeInfo.utf8Reader();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
         int start = reader.position();
-        long hash = reader.readFieldNameHash();
-        int index = creatorInfo.index(hash);
-        reader.expect(':');
+        int index;
+        long hash = 0;
+        if (expectedIndex < fields.length && tryReadUtf8Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          hash = reader.readFieldNameHash();
+          index = creatorInfo.index(hash);
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index >= 0) {
           JsonCreatorFieldInfo field = fields[index];
           arguments[field.argumentIndex()] = field.readUtf8(reader);
@@ -1233,9 +1321,18 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     JsonCreatorFieldInfo[] fields = creatorInfo.fields();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
-        int index = creatorInfo.index(reader.readFieldNameHash());
-        reader.expect(':');
+        int index;
+        if (expectedIndex < fields.length && tryReadLatin1Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          index = creatorInfo.index(reader.readFieldNameHash());
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index < 0) {
           reader.skipValue();
         } else {
@@ -1253,9 +1350,18 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     JsonCreatorFieldInfo[] fields = creatorInfo.fields();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
-        int index = creatorInfo.index(reader.readFieldNameHash());
-        reader.expect(':');
+        int index;
+        if (expectedIndex < fields.length && tryReadUtf16Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          index = creatorInfo.index(reader.readFieldNameHash());
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index < 0) {
           reader.skipValue();
         } else {
@@ -1273,9 +1379,18 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
     JsonCreatorFieldInfo[] fields = creatorInfo.fields();
     reader.expect('{');
     if (!reader.consume('}')) {
+      int expectedIndex = 0;
       do {
-        int index = creatorInfo.index(reader.readFieldNameHash());
-        reader.expect(':');
+        int index;
+        if (expectedIndex < fields.length && tryReadUtf8Field(reader, fields[expectedIndex])) {
+          index = expectedIndex++;
+        } else {
+          index = creatorInfo.index(reader.readFieldNameHash());
+          reader.expect(':');
+          if (index >= 0) {
+            expectedIndex = index + 1;
+          }
+        }
         if (index < 0) {
           reader.skipValue();
         } else {
@@ -1286,6 +1401,107 @@ public class ObjectCodec<T> implements CompositeJsonCodec<T> {
       reader.expect('}');
     }
     return arguments;
+  }
+
+  // Exact ordered probes consume the complete field-name token only on a match. A miss must leave
+  // the cursor unchanged so the existing hash path remains the sole owner of escaped, unknown,
+  // duplicate, and arbitrary-order field semantics.
+  private static boolean tryReadLatin1Field(Latin1JsonReader reader, JsonFieldInfo field) {
+    int length = field.stringNamePrefix().length;
+    if (length != field.name().length() + 3
+        || field.utf8NamePrefix().length != length
+        || length > Long.BYTES * 2) {
+      return false;
+    }
+    if (length <= Long.BYTES) {
+      long mask = length == Long.BYTES ? -1L : (1L << (length << 3)) - 1L;
+      return reader.tryReadNextFieldNameToken0(field.utf8NamePrefixWord0(), mask, length);
+    }
+    int suffixLength = length - Long.BYTES;
+    long suffixMask = suffixLength == Long.BYTES ? -1L : (1L << (suffixLength << 3)) - 1L;
+    return reader.tryReadNextFieldNameToken8(
+        field.utf8NamePrefixWord0(), field.utf8NamePrefixWord1(), suffixMask, length);
+  }
+
+  private static boolean tryReadLatin1Field(Latin1JsonReader reader, JsonCreatorFieldInfo field) {
+    String name = field.name();
+    int length = name.length();
+    if (length == 0 || length > Long.BYTES) {
+      return false;
+    }
+    long mask = length == Long.BYTES ? -1L : (1L << (length << 3)) - 1L;
+    return reader.tryReadNextFieldNameColon(field.nameHash(), mask, length);
+  }
+
+  private static boolean tryReadUtf16Field(Utf16JsonReader reader, JsonFieldInfo field) {
+    int length = field.stringNamePrefix().length;
+    if (length != field.name().length() + 3
+        || field.utf8NamePrefix().length != length
+        || length > 12) {
+      return false;
+    }
+    long firstWord = utf16TokenWord(field.utf8NamePrefixWord0());
+    long secondWord = utf16TokenWord(field.utf8NamePrefixWord0() >>> 32);
+    if (length <= Long.BYTES) {
+      int secondLength = Math.max(0, length - 4);
+      return reader.tryReadNextFieldNameUtf16Token2(
+          firstWord,
+          utf16TokenMask(Math.min(length, 4)),
+          secondLength == 0 ? 0 : secondWord,
+          secondLength == 0 ? 0 : utf16TokenMask(secondLength),
+          length);
+    }
+    return reader.tryReadNextFieldNameUtf16Token3(
+        firstWord, secondWord, utf16TokenWord(field.utf8NamePrefixWord1()), length);
+  }
+
+  private static boolean tryReadUtf16Field(Utf16JsonReader reader, JsonCreatorFieldInfo field) {
+    String name = field.name();
+    int length = name.length();
+    if (length == 0 || length > Long.BYTES) {
+      return false;
+    }
+    long mask = length == Long.BYTES ? -1L : (1L << (length << 3)) - 1L;
+    return reader.tryReadNextFieldNameColon(field.nameHash(), mask, length);
+  }
+
+  private static long utf16TokenWord(long value) {
+    value &= 0xFFFF_FFFFL;
+    value = (value | (value << 16)) & 0x0000_FFFF_0000_FFFFL;
+    value = (value | (value << 8)) & 0x00FF_00FF_00FF_00FFL;
+    return NativeByteOrder.IS_LITTLE_ENDIAN ? value : value << 8;
+  }
+
+  private static long utf16TokenMask(int length) {
+    return length == 4 ? -1L : (1L << (length << 4)) - 1L;
+  }
+
+  private static boolean tryReadUtf8Field(Utf8JsonReader reader, JsonFieldInfo field) {
+    int length = field.utf8NamePrefix().length;
+    if (length == 0 || length > Long.BYTES * 2) {
+      return false;
+    }
+    if (length <= Long.BYTES) {
+      long mask = length == Long.BYTES ? -1L : (1L << (length << 3)) - 1L;
+      return reader.tryReadNextFieldNameToken0(field.utf8NamePrefixWord0(), mask, length);
+    }
+    int suffixLength = length - Long.BYTES;
+    long suffixMask = suffixLength == Long.BYTES ? -1L : (1L << (suffixLength << 3)) - 1L;
+    return reader.tryReadNextFieldNameToken8(
+        field.utf8NamePrefixWord0(), field.utf8NamePrefixWord1(), suffixMask, length);
+  }
+
+  private static boolean tryReadUtf8Field(Utf8JsonReader reader, JsonCreatorFieldInfo field) {
+    return tryReadUtf8Field(reader, field.name(), field.nameHash());
+  }
+
+  private static boolean tryReadUtf8Field(Utf8JsonReader reader, String name, long hash) {
+    int length = name.length();
+    if (length == 0 || length > Long.BYTES) {
+      return false;
+    }
+    long mask = length == Long.BYTES ? -1L : (1L << (length << 3)) - 1L;
+    return reader.tryReadNextFieldNameColon(hash, mask, length);
   }
 
   @SuppressWarnings("unchecked")

--- a/java/fory-json/src/main/java/org/apache/fory/json/meta/JsonFieldInfo.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/meta/JsonFieldInfo.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import org.apache.fory.annotation.Internal;
 import org.apache.fory.json.ForyJsonException;
 import org.apache.fory.json.annotation.JsonCodec;
 import org.apache.fory.json.annotation.JsonFormat;
@@ -1006,6 +1007,16 @@ public final class JsonFieldInfo {
 
   public byte[] utf8CommaNamePrefix() {
     return utf8CommaNamePrefix;
+  }
+
+  @Internal
+  public long utf8NamePrefixWord0() {
+    return utf8NamePrefixWord0;
+  }
+
+  @Internal
+  public long utf8NamePrefixWord1() {
+    return utf8NamePrefixWord1;
   }
 
   public byte[] utf8EnumValue(Enum<?> value) {

--- a/java/fory-json/src/test/java/org/apache/fory/json/JsonObjectTest.java
+++ b/java/fory-json/src/test/java/org/apache/fory/json/JsonObjectTest.java
@@ -197,6 +197,15 @@ public class JsonObjectTest extends ForyJsonTestModels {
     assertEquals(utf8.active, true);
     assertEquals(utf8.id, 7);
     assertEquals(utf8.name, "fory");
+
+    PublicFields fallbacks =
+        json.fromJson(
+            "{\"active\":true,\"unknown\":0,\"\\u0069d\":8,\"name\":\"first\",\"id\":9}"
+                .getBytes(StandardCharsets.UTF_8),
+            PublicFields.class);
+    assertEquals(fallbacks.active, true);
+    assertEquals(fallbacks.id, 9);
+    assertEquals(fallbacks.name, "first");
     assertGeneratedWhenSupported(json, PublicFields.class);
   }
 


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

