### PR TITLE
ci: use configured credentials for JVM publishing

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -86,7 +86,6 @@ SCALA_SNAPSHOT_COMMANDS = (
     "sbt 'project fory-json-scala' +publish",
 )
 JVM_PUBLICATION_MODES = ("release", "snapshot")
-JVM_PUBLICATION_CREDENTIALS = ("NEXUS_USERNAME", "NEXUS_PASSWORD")
 KOTLIN_PUBLIC_ARTIFACTS = (
     "fory-kotlin",
     "fory-kotlin-ksp",
@@ -272,13 +271,8 @@ def _jvm_release_langs(languages):
 def _require_publication_authority(mode):
     if mode not in JVM_PUBLICATION_MODES:
         raise ValueError(f"Unsupported JVM publication mode: {mode}")
-    missing = [name for name in JVM_PUBLICATION_CREDENTIALS if not os.environ.get(name)]
-    if missing:
-        raise RuntimeError(f"JVM {mode} publication requires: {', '.join(missing)}")
     if mode == "release" and not _has_gpg_secret_key():
         raise RuntimeError("JVM release publication requires a GPG secret key")
-    os.environ["SONATYPE_USERNAME"] = os.environ["NEXUS_USERNAME"]
-    os.environ["SONATYPE_PASSWORD"] = os.environ["NEXUS_PASSWORD"]
 
 
 def _has_gpg_secret_key():


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

