### PR TITLE
fix(ci): forward Nexus credentials to SBT

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -309,6 +309,16 @@ def _publish_kotlin(mode="release"):
 
 
 def _publish_scala(mode="release"):
+    # GitHub Actions exposes Maven's NEXUS_* variables, while SBT consumes
+    # SONATYPE_* directly. Forward only present values so local SBT credentials
+    # continue to work without requiring publication environment variables.
+    for nexus_name, sonatype_name in (
+        ("NEXUS_USERNAME", "SONATYPE_USERNAME"),
+        ("NEXUS_PASSWORD", "SONATYPE_PASSWORD"),
+    ):
+        value = os.environ.get(nexus_name)
+        if value:
+            os.environ.setdefault(sonatype_name, value)
     commands = SCALA_RELEASE_COMMANDS if mode == "release" else SCALA_SNAPSHOT_COMMANDS
     for command in commands:
         _run_release_cmd(command, "scala")


### PR DESCRIPTION
## Why?

The Scala snapshot workflow provides Nexus credentials, while SBT reads Sonatype credential environment variables. As a result, Scala snapshot publishing fails with HTTP 401.

## What does this PR do?

Forward the configured Nexus credentials to the Sonatype variables used by SBT, while preserving explicitly configured Sonatype values and local SBT credentials.

## Verification

- Verified Nexus-to-Sonatype credential forwarding
- Verified explicit Sonatype credentials are preserved
- Verified publishing without environment credentials still supports local SBT configuration
- Ran `git diff --check`