### PR TITLE
fix(ci): increase Android Gradle memory

### DIFF
--- a/integration_tests/android_tests/gradle.properties
+++ b/integration_tests/android_tests/gradle.properties
@@ -16,3 +16,4 @@
 # under the License.
 
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Why?

The Android API 36 instrumented-test job failed twice while Gradle ran the
release-minified task graph. The daemon inherited Gradle's 512 MiB heap and
384 MiB metaspace defaults and terminated with a heap OOM in
`lintVitalAnalyzeRelease`. A preceding successful run also reported exhausting
the configured metaspace, so the job was already operating at the limit.

## What does this PR do?

Configure the Android integration-test project's Gradle daemon with a 2 GiB
heap and 1 GiB metaspace. The setting applies consistently to the documented
local commands and both Android CI API levels without changing the task graph,
release minification, lint, or instrumentation coverage.

## Related issues

- Fixes the failure in https://github.com/apache/fory/actions/runs/32837053667/job/97782748986

## Does this PR introduce any user-facing change?

No.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

N/A. This only changes the Gradle daemon memory available to the Android
integration-test fixture.
