### PR TITLE
feat(xlang): expand field tag IDs to signed int32

### DIFF
--- a/compiler/fory_compiler/generators/dart.py
+++ b/compiler/fory_compiler/generators/dart.py
@@ -1039,7 +1039,7 @@ class DartGenerator(DartServiceGeneratorMixin, BaseGenerator):
         indent: int,
         parent_stack: Optional[List[Message]] = None,
     ) -> List[str]:
-        id_literal = str(field.number) if field.tag_id is not None else "null"
+        id_literal = str(field.number) if field.tag_id is not None else "-1"
         ident_literal = (
             str(field.number)
             if field.tag_id is not None

--- a/compiler/fory_compiler/ir/validator.py
+++ b/compiler/fory_compiler/ir/validator.py
@@ -48,6 +48,7 @@ INVALID_MAP_KEY_KINDS = {
 }
 INVALID_MAP_KEY_MESSAGE = "map keys do not support any, binary, float, decimal, message, union, list, map, or array types"
 OPTIONAL_ANY_MESSAGE = "optional or nullable any is not supported; use any instead"
+MAX_FIELD_TAG_ID = (1 << 29) - 1
 
 
 @dataclass
@@ -227,6 +228,11 @@ class SchemaValidator:
             field_numbers = {}
             field_names = {}
             for f in message.fields:
+                if f.tag_id is not None and not 0 <= f.tag_id <= MAX_FIELD_TAG_ID:
+                    self._error(
+                        f"Field tag ID {f.tag_id} in {full_name} must be in [0, 2^29)",
+                        f.location,
+                    )
                 if f.number in field_numbers:
                     self._error(
                         f"Duplicate field number {f.number} in {full_name}: {f.name} and {field_numbers[f.number].name}",

--- a/compiler/fory_compiler/tests/test_dart_generator.py
+++ b/compiler/fory_compiler/tests/test_dart_generator.py
@@ -80,6 +80,23 @@ def test_dart_generator_emits_annotated_structs_and_generated_part_registration(
     assert "_ScalarForySerializer" not in file.content
 
 
+def test_dart_generator_emits_max_field_tag():
+    file = generate_dart(
+        """
+        package demo;
+
+        message Tagged [id=100] {
+            int32 value = 536870911;
+        }
+        """
+    )
+
+    assert (
+        "@ForyField(type: Int32Type(encoding: Encoding.varint), id: 536870911)"
+        in file.content
+    )
+
+
 def test_dart_generator_keeps_enum_helpers_in_source_and_uses_generated_enum_registration():
     file = generate_dart(
         """

--- a/compiler/fory_compiler/tests/test_generated_code.py
+++ b/compiler/fory_compiler/tests/test_generated_code.py
@@ -697,6 +697,26 @@ def test_generated_registration_uses_single_name_for_dart_python_swift():
     assert "namespace:" not in swift_output
 
 
+def test_dart_union_field_sentinel():
+    schema = parse_proto(
+        """
+        syntax = "proto3";
+        package demo;
+
+        message Envelope {
+            oneof value {
+                string note = 1;
+                uint32 count = 2;
+            }
+        }
+        """
+    )
+
+    dart_output = render_files(generate_files(schema, DartGenerator))
+    assert dart_output.count("\n        id: -1,") == 2
+    assert "\n        id: null," not in dart_output
+
+
 def test_java_default_package_import_registers_dependency(tmp_path):
     common = tmp_path / "common.fdl"
     common.write_text(

--- a/compiler/fory_compiler/tests/test_message_defaults.py
+++ b/compiler/fory_compiler/tests/test_message_defaults.py
@@ -68,3 +68,26 @@ def test_fdl_field_numbers_set_tag_ids():
     assert validator.validate()
     field = schema.messages[0].fields[0]
     assert field.tag_id == field.number
+
+
+def test_field_tag_domain():
+    valid_schema = Parser.from_source(
+        """
+        message Tagged {
+            int32 value = 536870911;
+        }
+        """
+    ).parse()
+    valid = SchemaValidator(valid_schema)
+    assert valid.validate(), valid.errors
+
+    invalid_schema = Parser.from_source(
+        """
+        message Tagged {
+            int32 value = 536870912;
+        }
+        """
+    ).parse()
+    invalid = SchemaValidator(invalid_schema)
+    assert not invalid.validate()
+    assert any("must be in [0, 2^29)" in str(error) for error in invalid.errors)

--- a/cpp/fory/meta/field.h
+++ b/cpp/fory/meta/field.h
@@ -119,7 +119,7 @@ inline constexpr bool has_field_config_v = FieldConfigInfo<T>::has_config;
 template <typename T, size_t Index, typename = void>
 struct GetFieldConfigEntry {
   static constexpr Encoding encoding = Encoding::Default;
-  static constexpr int16_t id = -1;
+  static constexpr int32_t id = -1;
   static constexpr bool nullable = false;
   static constexpr bool ref = false;
   static constexpr int dynamic_value = -1;
@@ -153,7 +153,7 @@ private:
 public:
   static constexpr FieldEntry entry = find_entry<>();
   static constexpr Encoding encoding = entry.meta.encoding_;
-  static constexpr int16_t id = entry.meta.id_;
+  static constexpr int32_t id = entry.meta.id_;
   static constexpr bool nullable = entry.meta.nullable_;
   static constexpr bool ref = entry.meta.ref_;
   static constexpr int dynamic_value = entry.meta.dynamic_;
@@ -176,10 +176,10 @@ template <typename T> struct unwrap_field {
 template <typename T> using unwrap_field_t = typename unwrap_field<T>::type;
 
 template <typename T> struct field_tag_id {
-  static constexpr int16_t value = -1;
+  static constexpr int32_t value = -1;
 };
 template <typename T>
-inline constexpr int16_t field_tag_id_v = field_tag_id<T>::value;
+inline constexpr int32_t field_tag_id_v = field_tag_id<T>::value;
 
 template <typename T> struct field_is_nullable {
   static constexpr bool value = detail::is_optional_v<T>;

--- a/cpp/fory/meta/field_info.h
+++ b/cpp/fory/meta/field_info.h
@@ -193,7 +193,7 @@ struct FieldNodeSpec {
 };
 
 struct FieldMeta {
-  int16_t id_ = -1;
+  int32_t id_ = -1;
   bool has_id_ = false;
   bool nullable_ = false;
   bool ref_ = false;
@@ -203,7 +203,7 @@ struct FieldMeta {
   bool compress_ = true;
   int16_t type_id_override_ = -1;
 
-  constexpr FieldMeta id(int16_t v) const {
+  constexpr FieldMeta id(int32_t v) const {
     auto copy = *this;
     copy.id_ = v;
     copy.has_id_ = true;
@@ -258,7 +258,7 @@ struct FieldMeta {
 };
 
 constexpr FieldMeta F() { return FieldMeta{}; }
-constexpr FieldMeta F(int16_t id) { return FieldMeta{}.id(id); }
+constexpr FieldMeta F(int32_t id) { return FieldMeta{}.id(id); }
 
 namespace T {
 

--- a/cpp/fory/serialization/context.cc
+++ b/cpp/fory/serialization/context.cc
@@ -702,15 +702,15 @@ ReadContext::read_type_meta_owner(const TypeInfo *expected_type_info) {
 
   FORY_TRY(remote_schema_key, check_remote_type_meta_limit(*parsed_meta));
 
-  // Create TypeInfo with field_ids assigned
+  // Create TypeInfo with local compatible dispatch IDs assigned.
   auto cached = std::make_unique<CachedTypeInfo>();
   TypeInfo *type_info = &cached->type_info;
   cached->concrete_owner = local_type_info;
   if (local_type_info) {
-    // Have local type - assign field_ids by comparing schemas
+    // Have local type - assign dispatch IDs by comparing schemas.
     // Note: Extension types don't have type_meta (only structs do)
     if (local_type_info->type_meta) {
-      FORY_RETURN_NOT_OK(TypeMeta::assign_field_ids(
+      FORY_RETURN_NOT_OK(TypeMeta::assign_local_dispatch_ids(
           local_type_info->type_meta.get(), parsed_meta->field_infos));
     }
     type_info->type_id = local_type_info->type_id;

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -1497,23 +1497,29 @@ template <typename T> struct CompileTimeFieldHelpers {
 
   /// Returns the tag ID for the field at Index.
   /// Returns -1 if no tag ID is defined.
-  template <size_t Index> static constexpr int16_t field_tag_id() {
+  template <size_t Index> static constexpr int32_t field_tag_id() {
     if constexpr (FieldCount == 0) {
       return -1;
     } else {
       using RawFieldType = RawFieldTypeFor<Index>;
 
       if constexpr (::fory::detail::has_field_config_v<T>) {
-        constexpr int16_t config_id =
+        constexpr int32_t config_id =
             ::fory::detail::GetFieldConfigEntry<T, Index>::id;
         if constexpr (::fory::detail::GetFieldConfigEntry<T, Index>::has_id) {
           static_assert(config_id >= 0, "Fory field id must be non-negative");
+          static_assert(config_id <=
+                            ::fory::serialization::detail::kMaxFieldTag,
+                        "Fory field id exceeds the wire TAG_ID range");
           return config_id;
         }
       }
       if constexpr (is_fory_field_v<RawFieldType>) {
         static_assert(RawFieldType::tag_id >= 0,
                       "Fory field id must be non-negative");
+        static_assert(RawFieldType::tag_id <=
+                          ::fory::serialization::detail::kMaxFieldTag,
+                      "Fory field id exceeds the wire TAG_ID range");
         return RawFieldType::tag_id;
       }
       // No tag ID defined
@@ -1524,7 +1530,7 @@ template <typename T> struct CompileTimeFieldHelpers {
   }
 
   template <size_t... Indices>
-  static constexpr std::array<int16_t, FieldCount>
+  static constexpr std::array<int32_t, FieldCount>
   make_field_ids(std::index_sequence<Indices...>) {
     if constexpr (FieldCount == 0) {
       return {};
@@ -1891,8 +1897,24 @@ template <typename T> struct CompileTimeFieldHelpers {
   static inline constexpr std::array<bool, FieldCount> nullable_flags =
       make_nullable_flags(std::make_index_sequence<FieldCount>{});
 
-  static inline constexpr std::array<int16_t, FieldCount> field_ids =
+  static inline constexpr std::array<int32_t, FieldCount> field_ids =
       make_field_ids(std::make_index_sequence<FieldCount>{});
+
+  static constexpr bool field_tags_unique() {
+    for (size_t i = 0; i < FieldCount; ++i) {
+      if (field_ids[i] < 0) {
+        continue;
+      }
+      for (size_t j = i + 1; j < FieldCount; ++j) {
+        if (field_ids[i] == field_ids[j]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static_assert(field_tags_unique(), "Fory field ids must be unique");
 
   /// Flags for fields whose types are nullable wrappers (optional/shared_ptr/
   /// unique_ptr/weak_ptr), which require ref/null flags in the wire format.
@@ -1953,9 +1975,9 @@ template <typename T> struct CompileTimeFieldHelpers {
         return names;
       }();
 
-  static constexpr size_t tag_id_length(int16_t value) {
+  static constexpr size_t tag_id_length(uint32_t value) {
     size_t count = 1;
-    int16_t v = value;
+    uint32_t v = value;
     while (v >= 10) {
       v /= 10;
       ++count;
@@ -1964,9 +1986,9 @@ template <typename T> struct CompileTimeFieldHelpers {
   }
 
   static constexpr size_t identifier_length(size_t index) {
-    int16_t id = field_ids[index];
+    int32_t id = field_ids[index];
     if (id >= 0) {
-      return tag_id_length(id);
+      return tag_id_length(static_cast<uint32_t>(id));
     }
     return snake_case_lengths[index];
   }
@@ -2008,8 +2030,8 @@ template <typename T> struct CompileTimeFieldHelpers {
           for (size_t i = 0; i < FieldCount; ++i) {
             size_t length = identifier_lengths[i];
             if (field_ids[i] >= 0) {
-              int16_t value = field_ids[i];
-              int16_t divisor = 1;
+              uint32_t value = static_cast<uint32_t>(field_ids[i]);
+              uint32_t divisor = 1;
               for (size_t j = 1; j < length; ++j) {
                 divisor *= 10;
               }
@@ -3578,7 +3600,7 @@ read_exact_primitive_run(T &obj, ReadContext &ctx,
       constexpr int16_t next_matched_id =
           static_cast<int16_t>(next_sorted_idx * 2);
       if (remote_idx + 1 < remote_fields.size() &&
-          remote_fields[remote_idx + 1].field_id == next_matched_id) {
+          remote_fields[remote_idx + 1].matched_field_id == next_matched_id) {
         ++remote_idx;
         read_exact_primitive_run<T, next_sorted_idx>(obj, ctx, remote_fields,
                                                      remote_idx, offset);
@@ -4439,7 +4461,7 @@ read_struct_fields_impl_fast(T &obj, ReadContext &ctx,
 }
 
 /// Read struct fields with schema evolution (compatible mode)
-/// Reads fields in remote schema order, dispatching by field_id to local fields
+/// Reads fields in remote schema order, dispatching by the matched local ID.
 template <typename T, size_t... Indices>
 FORY_NOINLINE void
 read_struct_fields_compatible(T &obj, ReadContext &ctx,
@@ -4512,7 +4534,7 @@ read_struct_fields_compatible(T &obj, ReadContext &ctx,
   // Iterate through remote fields in their serialization order
   for (size_t remote_idx = 0; remote_idx < remote_fields.size(); ++remote_idx) {
     const auto &remote_field = remote_fields[remote_idx];
-    int16_t field_id = remote_field.field_id;
+    int16_t field_id = remote_field.matched_field_id;
 
     if (field_id == -1) {
       if (use_exact_offset_reads) {
@@ -4956,7 +4978,7 @@ struct Serializer<T, std::enable_if_t<is_fory_serializable_v<T>>> {
         decltype(fory_field_info(std::declval<const T &>()));
     constexpr size_t field_count = FieldDescriptor::Size;
 
-    // remote_type_info is from the stream, with field_ids already assigned
+    // remote_type_info is from the stream, with dispatch IDs already assigned.
     if (!remote_type_info || !remote_type_info->type_meta) {
       ctx.set_error(Error::type_error("Remote type metadata not available"));
       return T{};

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -136,6 +136,16 @@ struct MixedFieldIdentityStruct {
               alpha_value, (count, fory::F(2).varint()));
 };
 
+struct MaximumFieldTagStruct {
+  int32_t value;
+
+  bool operator==(const MaximumFieldTagStruct &other) const {
+    return value == other.value;
+  }
+
+  FORY_STRUCT(MaximumFieldTagStruct, (value, fory::F(536870911)));
+};
+
 struct SignedToUnsignedWriter {
   int32_t value;
 
@@ -734,7 +744,7 @@ inline FieldType make_test_field_type(TypeId type_id,
                    std::move(generics));
 }
 
-inline FieldInfo make_test_field_info(std::string name, int16_t field_id,
+inline FieldInfo make_test_field_info(std::string name, int32_t field_id,
                                       FieldType field_type) {
   FieldInfo info(std::move(name), std::move(field_type));
   info.field_id = field_id;
@@ -929,7 +939,7 @@ TEST(StructComprehensiveTest, UnsignedEncodingFieldMeta) {
         });
     return it == fields.end() ? nullptr : &*it;
   };
-  auto find_field_id = [&](int16_t id) -> const FieldInfo * {
+  auto find_field_id = [&](int32_t id) -> const FieldInfo * {
     auto it =
         std::find_if(fields.begin(), fields.end(), [&](const FieldInfo &field) {
           return field.field_id == id;
@@ -1318,7 +1328,7 @@ TEST(StructComprehensiveTest, FullyTaggedStructsUseNumericTagOrder) {
   EXPECT_EQ(fields[1].field_id, 2);
   EXPECT_EQ(fields[2].field_id, 10);
 
-  std::map<int16_t, const FieldInfo *> fields_by_id;
+  std::map<int32_t, const FieldInfo *> fields_by_id;
   for (const auto &field : fields) {
     fields_by_id.emplace(field.field_id, &field);
   }
@@ -1326,7 +1336,7 @@ TEST(StructComprehensiveTest, FullyTaggedStructsUseNumericTagOrder) {
   ASSERT_NE(fields_by_id.find(2), fields_by_id.end());
   ASSERT_NE(fields_by_id.find(10), fields_by_id.end());
 
-  auto fingerprint_part = [&](int16_t field_id) {
+  auto fingerprint_part = [&](int32_t field_id) {
     const FieldInfo &field = *fields_by_id[field_id];
     return std::to_string(field_id) + "," +
            std::to_string(field.field_type.type_id) + "," +
@@ -1371,6 +1381,35 @@ TEST(StructComprehensiveTest, MixedFieldIdentifiersUseProtocolOrder) {
   EXPECT_EQ(fields[2].field_id, -1);
   EXPECT_EQ(fields[3].field_name, "beta_value");
   EXPECT_EQ(fields[3].field_id, -1);
+}
+
+TEST(StructComprehensiveTest, FieldTagRange) {
+  MaximumFieldTagStruct value{42};
+  auto fory =
+      Fory::builder().xlang(true).compatible(true).track_ref(false).build();
+  ASSERT_TRUE(fory.register_struct<MaximumFieldTagStruct>(631).ok());
+  auto encoded = fory.serialize(value);
+  ASSERT_TRUE(encoded.ok()) << encoded.error().to_string();
+  auto decoded = fory.deserialize<MaximumFieldTagStruct>(encoded.value());
+  ASSERT_TRUE(decoded.ok()) << decoded.error().to_string();
+  EXPECT_EQ(decoded.value(), value);
+
+  TypeMeta meta =
+      fory.type_resolver().clone_struct_meta<MaximumFieldTagStruct>();
+  ASSERT_EQ(meta.field_infos.size(), 1);
+  EXPECT_EQ(meta.field_infos[0].field_id, 536870911);
+
+  FieldInfo invalid("value", make_test_field_type(TypeId::INT32));
+  invalid.field_id = 536870912;
+  EXPECT_FALSE(invalid.to_bytes().ok());
+
+  TypeMeta duplicate;
+  duplicate.type_id = static_cast<uint32_t>(TypeId::COMPATIBLE_STRUCT);
+  duplicate.user_type_id = 632;
+  duplicate.field_infos = {
+      make_test_field_info("first", 7, make_test_field_type(TypeId::INT32)),
+      make_test_field_info("second", 7, make_test_field_type(TypeId::INT32))};
+  EXPECT_FALSE(duplicate.to_bytes().ok());
 }
 
 TEST(StructComprehensiveTest, NonPrimitiveFieldsSortByFieldIdentifier) {
@@ -1434,7 +1473,7 @@ TEST(StructComprehensiveTest, FieldTypeCompatibilitySeparatesAdapters) {
 }
 
 TEST(StructComprehensiveTest,
-     AssignFieldIdsRejectsIncompatibleTaggedNestedTypes) {
+     LocalDispatchRejectsIncompatibleTaggedNestedTypes) {
   TypeMeta local_type;
   local_type.field_infos = {make_test_field_info(
       "items", 7,
@@ -1447,7 +1486,7 @@ TEST(StructComprehensiveTest,
                            {make_test_field_type(TypeId::VAR_UINT32),
                             make_test_field_type(TypeId::VAR_UINT32)}))};
   auto incompatible_result =
-      TypeMeta::assign_field_ids(&local_type, incompatible_remote);
+      TypeMeta::assign_local_dispatch_ids(&local_type, incompatible_remote);
   EXPECT_FALSE(incompatible_result.ok());
 
   std::vector<FieldInfo> nested_scalar_remote = {make_test_field_info(
@@ -1455,7 +1494,7 @@ TEST(StructComprehensiveTest,
       make_test_field_type(TypeId::LIST,
                            {make_test_field_type(TypeId::UINT32)}))};
   auto nested_scalar_result =
-      TypeMeta::assign_field_ids(&local_type, nested_scalar_remote);
+      TypeMeta::assign_local_dispatch_ids(&local_type, nested_scalar_remote);
   EXPECT_FALSE(nested_scalar_result.ok());
 
   TypeMeta scalar_local;
@@ -1463,9 +1502,11 @@ TEST(StructComprehensiveTest,
       "count", 8, make_test_field_type(TypeId::VAR_UINT32))};
   std::vector<FieldInfo> scalar_remote = {
       make_test_field_info("count", 8, make_test_field_type(TypeId::UINT32))};
-  auto scalar_result = TypeMeta::assign_field_ids(&scalar_local, scalar_remote);
+  auto scalar_result =
+      TypeMeta::assign_local_dispatch_ids(&scalar_local, scalar_remote);
   ASSERT_TRUE(scalar_result.ok());
-  EXPECT_EQ(scalar_remote[0].field_id, 1);
+  EXPECT_EQ(scalar_remote[0].field_id, 8);
+  EXPECT_EQ(scalar_remote[0].matched_field_id, 1);
 
   TypeMeta name_mode_local;
   name_mode_local.field_infos = {make_test_field_info(
@@ -1477,15 +1518,19 @@ TEST(StructComprehensiveTest,
       make_test_field_type(TypeId::LIST,
                            {make_test_field_type(TypeId::UINT32)}))};
   ASSERT_TRUE(
-      TypeMeta::assign_field_ids(&name_mode_local, mixed_mode_remote).ok());
-  EXPECT_EQ(mixed_mode_remote[0].field_id, -1);
+      TypeMeta::assign_local_dispatch_ids(&name_mode_local, mixed_mode_remote)
+          .ok());
+  EXPECT_EQ(mixed_mode_remote[0].field_id, 7);
+  EXPECT_EQ(mixed_mode_remote[0].matched_field_id, -1);
 
   std::vector<FieldInfo> name_remote = {make_test_field_info(
       "items", -1,
       make_test_field_type(TypeId::LIST,
                            {make_test_field_type(TypeId::UINT32)}))};
-  ASSERT_TRUE(TypeMeta::assign_field_ids(&local_type, name_remote).ok());
+  ASSERT_TRUE(
+      TypeMeta::assign_local_dispatch_ids(&local_type, name_remote).ok());
   EXPECT_EQ(name_remote[0].field_id, -1);
+  EXPECT_EQ(name_remote[0].matched_field_id, -1);
 
   TypeMeta mixed_local;
   mixed_local.field_infos = {
@@ -1496,17 +1541,22 @@ TEST(StructComprehensiveTest,
       make_test_field_info("alpha", -1, make_test_field_type(TypeId::BINARY)),
       make_test_field_info("tagged", 3, make_test_field_type(TypeId::STRING)),
       make_test_field_info("beta", -1, make_test_field_type(TypeId::VARINT32))};
-  ASSERT_TRUE(TypeMeta::assign_field_ids(&mixed_local, mixed_remote).ok());
-  EXPECT_EQ(mixed_remote[0].field_id, 2);
-  EXPECT_EQ(mixed_remote[1].field_id, 0);
-  EXPECT_EQ(mixed_remote[2].field_id, 4);
+  ASSERT_TRUE(
+      TypeMeta::assign_local_dispatch_ids(&mixed_local, mixed_remote).ok());
+  EXPECT_EQ(mixed_remote[0].field_id, -1);
+  EXPECT_EQ(mixed_remote[0].matched_field_id, 2);
+  EXPECT_EQ(mixed_remote[1].field_id, 3);
+  EXPECT_EQ(mixed_remote[1].matched_field_id, 0);
+  EXPECT_EQ(mixed_remote[2].field_id, -1);
+  EXPECT_EQ(mixed_remote[2].matched_field_id, 4);
 
   std::vector<FieldInfo> untagged_remote_for_tagged_local = {
       make_test_field_info("tagged", -1, make_test_field_type(TypeId::STRING))};
-  ASSERT_TRUE(
-      TypeMeta::assign_field_ids(&mixed_local, untagged_remote_for_tagged_local)
-          .ok());
+  ASSERT_TRUE(TypeMeta::assign_local_dispatch_ids(
+                  &mixed_local, untagged_remote_for_tagged_local)
+                  .ok());
   EXPECT_EQ(untagged_remote_for_tagged_local[0].field_id, -1);
+  EXPECT_EQ(untagged_remote_for_tagged_local[0].matched_field_id, -1);
 }
 
 TEST(StructComprehensiveTest, CompatibleSignedToUnsignedStructRead) {
@@ -1547,7 +1597,7 @@ TEST(StructComprehensiveTest, CompatibleNegativeSignedToUnsignedFails) {
   EXPECT_FALSE(result.ok());
 }
 
-TEST(StructComprehensiveTest, AssignFieldIdsRejectsMatchedIdOverflow) {
+TEST(StructComprehensiveTest, LocalDispatchRejectsMatchedIdOverflow) {
   constexpr size_t max_compatible_matched_field_index =
       (static_cast<size_t>(std::numeric_limits<int16_t>::max()) - 1) / 2;
   const FieldType field_type = make_test_field_type(TypeId::INT32);
@@ -1563,7 +1613,7 @@ TEST(StructComprehensiveTest, AssignFieldIdsRejectsMatchedIdOverflow) {
   std::vector<FieldInfo> remote_fields = {make_test_field_info(
       "field_" + std::to_string(max_compatible_matched_field_index + 1), -1,
       field_type)};
-  auto result = TypeMeta::assign_field_ids(&local_type, remote_fields);
+  auto result = TypeMeta::assign_local_dispatch_ids(&local_type, remote_fields);
 
   ASSERT_FALSE(result.ok());
   EXPECT_NE(result.error().message().find("exceeds max"), std::string::npos);

--- a/cpp/fory/serialization/type_resolver.cc
+++ b/cpp/fory/serialization/type_resolver.cc
@@ -887,8 +887,14 @@ TypeMeta::from_bytes_with_header(Buffer &buffer, int64_t header,
   return meta;
 }
 
-Result<void, Error> TypeMeta::skip_bytes_for_validated_header(Buffer &buffer,
-                                                              int64_t header) {
+// This helper runs on every compatible metadata-cache hit. Keep its entry on a
+// cache-line boundary so growth in unrelated cold metadata codecs cannot change
+// cache-hit throughput through link-layout drift.
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((aligned(64)))
+#endif
+Result<void, Error>
+TypeMeta::skip_bytes_for_validated_header(Buffer &buffer, int64_t header) {
   // Header-cache hits intentionally skip opaque metadata. This path must not
   // allocate or materialize the body from the attacker-declared size.
   Error error;

--- a/cpp/fory/serialization/type_resolver.cc
+++ b/cpp/fory/serialization/type_resolver.cc
@@ -29,6 +29,7 @@
 #include <limits>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace fory {
 namespace serialization {
@@ -160,7 +161,12 @@ Result<std::vector<uint8_t>, Error> FieldInfo::to_bytes() const {
   // write field header:
   // header: | field_name_encoding:2bits | size:4bits | nullability:1bit |
   // track_ref:1bit |
-  const bool use_tag_id = field_id >= 0;
+  if (FORY_PREDICT_FALSE(field_id < detail::kFieldNameIdentity ||
+                         field_id > detail::kMaxFieldTag)) {
+    return Unexpected(
+        Error::invalid("Field tag exceeds the wire TAG_ID range"));
+  }
+  const bool use_tag_id = field_id != detail::kFieldNameIdentity;
   uint8_t encoding_idx = use_tag_id ? 3 : 0; // TAG_ID or UTF8
   std::vector<uint8_t> encoded_name;
   if (!use_tag_id) {
@@ -188,10 +194,13 @@ Result<std::vector<uint8_t>, Error> FieldInfo::to_bytes() const {
     }
     encoded_name = std::move(encoded.bytes);
   }
-  const size_t size_field =
-      use_tag_id ? static_cast<size_t>(field_id) : encoded_name.size() - 1;
-  uint8_t header =
-      (std::min(FIELD_NAME_SIZE_THRESHOLD, size_field) << 2) & 0x3C;
+  const uint32_t tag_id = use_tag_id ? static_cast<uint32_t>(field_id) : 0;
+  const size_t name_size_field = use_tag_id ? 0 : encoded_name.size() - 1;
+  const uint8_t inline_size =
+      use_tag_id ? std::min<uint32_t>(FIELD_NAME_SIZE_THRESHOLD, tag_id)
+                 : static_cast<uint8_t>(std::min<size_t>(
+                       FIELD_NAME_SIZE_THRESHOLD, name_size_field));
+  uint8_t header = (inline_size << 2) & 0x3C;
 
   if (field_type.track_ref) {
     header |= 1; // bit 0 for ref tracking
@@ -203,8 +212,12 @@ Result<std::vector<uint8_t>, Error> FieldInfo::to_bytes() const {
 
   buffer.write_uint8(header);
 
-  if (size_field >= FIELD_NAME_SIZE_THRESHOLD) {
-    buffer.write_var_uint32(size_field - FIELD_NAME_SIZE_THRESHOLD);
+  if (use_tag_id && tag_id >= FIELD_NAME_SIZE_THRESHOLD) {
+    buffer.write_var_uint32(
+        static_cast<uint32_t>(tag_id - FIELD_NAME_SIZE_THRESHOLD));
+  } else if (!use_tag_id && name_size_field >= FIELD_NAME_SIZE_THRESHOLD) {
+    buffer.write_var_uint32(
+        static_cast<uint32_t>(name_size_field - FIELD_NAME_SIZE_THRESHOLD));
   }
 
   // write field type
@@ -236,13 +249,25 @@ Result<FieldInfo, Error> FieldInfo::from_bytes(Buffer &buffer) {
   bool use_tag_id = encoding_idx == 3;
   bool track_ref = (header & 0b01u) != 0;
   bool nullable = (header & 0b10u) != 0;
-  size_t size_field = ((header >> 2) & FIELD_NAME_SIZE_THRESHOLD);
-  if (size_field == FIELD_NAME_SIZE_THRESHOLD) {
+  const uint32_t inline_size = (header >> 2) & FIELD_NAME_SIZE_THRESHOLD;
+  uint32_t tag_id = use_tag_id ? inline_size : 0;
+  size_t name_size_field = use_tag_id ? 0 : inline_size;
+  if (inline_size == FIELD_NAME_SIZE_THRESHOLD) {
     uint32_t extra = buffer.read_var_uint32(error);
     if (FORY_PREDICT_FALSE(!error.ok())) {
       return Unexpected(std::move(error));
     }
-    size_field += extra;
+    if (use_tag_id) {
+      if (FORY_PREDICT_FALSE(extra >
+                             static_cast<uint32_t>(detail::kMaxFieldTag) -
+                                 inline_size)) {
+        return Unexpected(
+            Error::invalid_data("Field tag exceeds the wire TAG_ID range"));
+      }
+      tag_id += extra;
+    } else {
+      name_size_field += extra;
+    }
   }
 
   // Read field type with nullable and track_ref from header
@@ -251,7 +276,7 @@ Result<FieldInfo, Error> FieldInfo::from_bytes(Buffer &buffer) {
 
   if (use_tag_id) {
     FieldInfo info("", std::move(field_type));
-    info.field_id = static_cast<int16_t>(size_field);
+    info.field_id = static_cast<int32_t>(tag_id);
     return info;
   }
 
@@ -262,7 +287,7 @@ Result<FieldInfo, Error> FieldInfo::from_bytes(Buffer &buffer) {
   // We mirror that here using MetaStringDecoder with '$' and '_' as
   // special characters (same as Encoders.FIELD_NAME_DECODER).
 
-  const size_t name_size = size_field + 1;
+  const size_t name_size = name_size_field + 1;
   if (FORY_PREDICT_FALSE(
           name_size >
           static_cast<size_t>(std::numeric_limits<uint32_t>::max()))) {
@@ -636,15 +661,24 @@ parse_type_meta_body(Buffer &body, const TypeMeta *local_type_info,
   }
   std::vector<FieldInfo> field_infos;
   field_infos.reserve(num_fields);
+  std::unordered_set<int32_t> field_tags;
   for (size_t i = 0; i < num_fields; ++i) {
     FORY_TRY(field, FieldInfo::from_bytes(body));
+    if (local_type_info == nullptr && field.field_id >= 0) {
+      if (field_tags.empty()) {
+        field_tags.reserve(num_fields);
+      }
+      if (!field_tags.emplace(field.field_id).second) {
+        return Unexpected(Error::invalid_data("Duplicate field tag"));
+      }
+    }
     field_infos.push_back(std::move(field));
   }
 
   // Remote fields are already in sender data order and must not be re-sorted.
   if (local_type_info != nullptr) {
     FORY_RETURN_IF_ERROR(
-        TypeMeta::assign_field_ids(local_type_info, field_infos));
+        TypeMeta::assign_local_dispatch_ids(local_type_info, field_infos));
   }
   if (FORY_PREDICT_FALSE(body.remaining_size() != 0)) {
     return Unexpected(Error::invalid_data(
@@ -691,6 +725,17 @@ Result<std::vector<uint8_t>, Error> TypeMeta::to_bytes() const {
   if (FORY_PREDICT_FALSE(!is_struct && num_fields != 0)) {
     return Unexpected(
         Error::invalid_data("Non-struct TypeMeta cannot carry field metadata"));
+  }
+  std::unordered_set<int32_t> field_tags;
+  for (const auto &field : field_infos) {
+    if (field.field_id >= 0) {
+      if (field_tags.empty()) {
+        field_tags.reserve(num_fields);
+      }
+      if (!field_tags.emplace(field.field_id).second) {
+        return Unexpected(Error::invalid("Duplicate field tag"));
+      }
+    }
   }
 
   if (is_struct) {
@@ -1271,11 +1316,29 @@ TypeMeta::sort_field_infos(std::vector<FieldInfo> fields) {
 // ============================================================================
 
 Result<void, Error>
-TypeMeta::assign_field_ids(const TypeMeta *local_type,
-                           std::vector<FieldInfo> &remote_fields) {
+TypeMeta::assign_local_dispatch_ids(const TypeMeta *local_type,
+                                    std::vector<FieldInfo> &remote_fields) {
+  if (FORY_PREDICT_FALSE(local_type == nullptr)) {
+    return Unexpected(Error::invalid("Local TypeMeta is required"));
+  }
   const auto &local_fields = local_type->field_infos;
   constexpr size_t max_compatible_matched_field_index =
       (static_cast<size_t>(std::numeric_limits<int16_t>::max()) - 1) / 2;
+  const auto invalid_wire_id = [](int32_t field_id) {
+    return field_id < detail::kFieldNameIdentity ||
+           field_id > detail::kMaxFieldTag;
+  };
+  if (FORY_PREDICT_FALSE(std::any_of(local_fields.begin(), local_fields.end(),
+                                     [&](const FieldInfo &field) {
+                                       return invalid_wire_id(field.field_id);
+                                     }) ||
+                         std::any_of(remote_fields.begin(), remote_fields.end(),
+                                     [&](const FieldInfo &field) {
+                                       return invalid_wire_id(field.field_id);
+                                     }))) {
+    return Unexpected(
+        Error::invalid("Field tag exceeds the wire TAG_ID range"));
+  }
 
   // Primary mapping: field name -> sorted index in local schema
   std::unordered_map<std::string, size_t> local_field_index_map;
@@ -1284,11 +1347,23 @@ TypeMeta::assign_field_ids(const TypeMeta *local_type,
     local_field_index_map.emplace(local_fields[i].field_name, i);
   }
   // Tag ID mapping when field IDs are explicitly configured.
-  std::unordered_map<int16_t, size_t> local_field_id_map;
+  std::unordered_map<int32_t, size_t> local_field_id_map;
   local_field_id_map.reserve(local_fields.size());
   for (size_t i = 0; i < local_fields.size(); ++i) {
-    if (local_fields[i].field_id >= 0) {
-      local_field_id_map.emplace(local_fields[i].field_id, i);
+    if (local_fields[i].field_id >= 0 &&
+        !local_field_id_map.emplace(local_fields[i].field_id, i).second) {
+      return Unexpected(Error::invalid("Duplicate local field tag"));
+    }
+  }
+  std::unordered_set<int32_t> remote_field_ids;
+  for (const auto &remote_field : remote_fields) {
+    if (remote_field.field_id >= 0) {
+      if (remote_field_ids.empty()) {
+        remote_field_ids.reserve(remote_fields.size());
+      }
+      if (!remote_field_ids.emplace(remote_field.field_id).second) {
+        return Unexpected(Error::invalid_data("Duplicate remote field tag"));
+      }
     }
   }
   // Track which local fields have already been matched so that each
@@ -1311,7 +1386,7 @@ TypeMeta::assign_field_ids(const TypeMeta *local_type,
             std::to_string(local_index) + " exceeds max " +
             std::to_string(max_compatible_matched_field_index)));
       }
-      remote_field.field_id = static_cast<int16_t>(local_index * 2);
+      remote_field.matched_field_id = static_cast<int16_t>(local_index * 2);
       used[local_index] = true;
       return true;
     }
@@ -1324,7 +1399,7 @@ TypeMeta::assign_field_ids(const TypeMeta *local_type,
             std::to_string(local_index) + " exceeds max " +
             std::to_string(max_compatible_matched_field_index)));
       }
-      remote_field.field_id = static_cast<int16_t>(local_index * 2 + 1);
+      remote_field.matched_field_id = static_cast<int16_t>(local_index * 2 + 1);
       used[local_index] = true;
       return true;
     }
@@ -1383,7 +1458,7 @@ TypeMeta::assign_field_ids(const TypeMeta *local_type,
 
     if (!matched) {
       // No suitable local field found -> mark as skipped.
-      remote_field.field_id = -1;
+      remote_field.matched_field_id = -1;
     }
   }
   return Result<void, Error>();

--- a/cpp/fory/serialization/type_resolver.h
+++ b/cpp/fory/serialization/type_resolver.h
@@ -193,18 +193,19 @@ bool field_types_compatible_top_level(const FieldType &local,
 // FieldInfo - Field metadata (name, type, id)
 // ============================================================================
 
-/// Field information including name, type, and assigned field ID
+/// Field information including wire identity, type, and compatible dispatch.
 class FieldInfo {
 public:
-  int16_t field_id;       // Tag ID if configured; -1 means no ID
-  std::string field_name; // Field name
-  FieldType field_type;   // Field type information
+  int32_t field_id;         // Wire tag ID; -1 means name-based identity
+  int16_t matched_field_id; // Local compatible dispatch; -1 means unmatched
+  std::string field_name;   // Field name
+  FieldType field_type;     // Field type information
 
-  FieldInfo() : field_id(-1) {}
+  FieldInfo() : field_id(-1), matched_field_id(-1) {}
 
   FieldInfo(std::string name, FieldType type)
-      : field_id(-1), field_name(std::move(name)), field_type(std::move(type)) {
-  }
+      : field_id(-1), matched_field_id(-1), field_name(std::move(name)),
+        field_type(std::move(type)) {}
 
   /// write field info to buffer (for serialization)
   Result<std::vector<uint8_t>, Error> to_bytes() const;
@@ -275,11 +276,10 @@ public:
   /// get sorted field infos (sorted according to xlang spec)
   static std::vector<FieldInfo> sort_field_infos(std::vector<FieldInfo> fields);
 
-  /// Assign field IDs by comparing with local type
-  /// This is the key function for schema evolution!
+  /// Assign local compatible-reader dispatch IDs without changing wire tags.
   static Result<void, Error>
-  assign_field_ids(const TypeMeta *local_type,
-                   std::vector<FieldInfo> &remote_fields);
+  assign_local_dispatch_ids(const TypeMeta *local_type,
+                            std::vector<FieldInfo> &remote_fields);
 
   const std::vector<FieldInfo> &get_field_infos() const { return field_infos; }
   int64_t get_hash() const { return hash; }
@@ -331,6 +331,9 @@ private:
 // ============================================================================
 
 namespace detail {
+
+inline constexpr int32_t kFieldNameIdentity = -1;
+inline constexpr int32_t kMaxFieldTag = (1 << 29) - 1;
 
 inline uint32_t to_type_id(TypeId id) { return static_cast<uint32_t>(id); }
 
@@ -1075,12 +1078,14 @@ constexpr bool compute_track_ref() {
 }
 
 template <typename ActualFieldType, typename T, size_t Index>
-constexpr int16_t compute_field_id() {
+constexpr int32_t compute_field_id() {
   if constexpr (::fory::detail::has_field_config_v<T>) {
-    constexpr int16_t config_id =
+    constexpr int32_t config_id =
         ::fory::detail::GetFieldConfigEntry<T, Index>::id;
     if constexpr (::fory::detail::GetFieldConfigEntry<T, Index>::has_id) {
       static_assert(config_id >= 0, "Fory field id must be non-negative");
+      static_assert(config_id <= kMaxFieldTag,
+                    "Fory field id exceeds the wire TAG_ID range");
       return config_id;
     }
   }
@@ -1187,7 +1192,7 @@ template <typename T, size_t Index> struct FieldInfoBuilder {
     constexpr bool is_nullable =
         compute_is_nullable<ActualFieldType, T, Index, UnwrappedFieldType>();
     constexpr bool track_ref = compute_track_ref<ActualFieldType, T, Index>();
-    constexpr int16_t field_id = compute_field_id<ActualFieldType, T, Index>();
+    constexpr int32_t field_id = compute_field_id<ActualFieldType, T, Index>();
 
     constexpr FieldNodeSpec spec =
         ::fory::detail::GetFieldConfigEntry<T, Index>::spec;
@@ -1233,7 +1238,7 @@ template <typename T, size_t Index> struct FieldInfoBuilder {
     constexpr bool is_nullable =
         compute_is_nullable<ActualFieldType, T, Index, UnwrappedFieldType>();
     constexpr bool track_ref = compute_track_ref<ActualFieldType, T, Index>();
-    constexpr int16_t field_id = compute_field_id<ActualFieldType, T, Index>();
+    constexpr int32_t field_id = compute_field_id<ActualFieldType, T, Index>();
 
     constexpr FieldNodeSpec spec =
         ::fory::detail::GetFieldConfigEntry<T, Index>::spec;

--- a/cpp/fory/serialization/xlang_test_main.cc
+++ b/cpp/fory/serialization/xlang_test_main.cc
@@ -133,7 +133,8 @@ struct SimpleStruct {
            f4 == other.f4 && f5 == other.f5 && f6 == other.f6 &&
            f7 == other.f7 && f8 == other.f8 && last == other.last;
   }
-  FORY_STRUCT(SimpleStruct, f1, f2, f3, f4, f5, f6, f7, f8, last);
+  FORY_STRUCT(SimpleStruct, f1, (f2, fory::F(15)), f3, f4, f5, f6,
+              (f7, fory::F(65551)), f8, (last, fory::F(536870911)));
 };
 
 struct EvolvingOverrideStruct {

--- a/csharp/src/Fory.Generator/ForyModelGenerator.Analysis.cs
+++ b/csharp/src/Fory.Generator/ForyModelGenerator.Analysis.cs
@@ -1396,11 +1396,11 @@ public sealed partial class ForyModelGenerator
         List<Diagnostic> diagnostics,
         SchemaTypeModel? schemaTypeOverride,
         bool parseFieldAttribute,
-        short? fieldIdOverride = null,
+        int fieldIdOverride = -1,
         ITypeSymbol? schemaDescriptorTypeOverride = null)
     {
         (bool isOptional, ITypeSymbol unwrappedType) = UnwrapNullable(memberType);
-        short? fieldId = fieldIdOverride;
+        int fieldId = fieldIdOverride;
         SchemaTypeModel? schemaType = schemaTypeOverride;
         ITypeSymbol? schemaDescriptorType = schemaDescriptorTypeOverride;
         bool invalidSchemaType = false;
@@ -1410,7 +1410,7 @@ public sealed partial class ForyModelGenerator
             if (fieldAttribute is not null)
             {
                 if (fieldAttribute.ConstructorArguments.Length == 1 &&
-                    TryGetFieldId(fieldAttribute.ConstructorArguments[0], memberSymbol, diagnostics, out short ctorFieldId))
+                    TryGetFieldId(fieldAttribute.ConstructorArguments[0], memberSymbol, diagnostics, out int ctorFieldId))
                 {
                     fieldId = ctorFieldId;
                 }
@@ -1419,7 +1419,7 @@ public sealed partial class ForyModelGenerator
                 {
                     if (string.Equals(namedArg.Key, "Id", StringComparison.Ordinal))
                     {
-                        if (TryGetFieldId(namedArg.Value, memberSymbol, diagnostics, out short parsedFieldId))
+                        if (TryGetFieldId(namedArg.Value, memberSymbol, diagnostics, out int parsedFieldId))
                         {
                             fieldId = parsedFieldId;
                         }
@@ -1897,7 +1897,7 @@ public sealed partial class ForyModelGenerator
         TypedConstant value,
         ISymbol memberSymbol,
         List<Diagnostic> diagnostics,
-        out short fieldId)
+        out int fieldId)
     {
         fieldId = default;
         object? raw = value.Value;
@@ -1931,7 +1931,7 @@ public sealed partial class ForyModelGenerator
                 numeric = v;
                 break;
             case ulong v:
-                if (v > (ulong)short.MaxValue)
+                if (v > MaxFieldId)
                 {
                     diagnostics.Add(Diagnostic.Create(
                         InvalidFieldId,
@@ -1946,7 +1946,7 @@ public sealed partial class ForyModelGenerator
                 return false;
         }
 
-        if (numeric < 0 || numeric > short.MaxValue)
+        if (numeric < 0 || numeric > MaxFieldId)
         {
             diagnostics.Add(Diagnostic.Create(
                 InvalidFieldId,
@@ -1955,7 +1955,7 @@ public sealed partial class ForyModelGenerator
             return false;
         }
 
-        fieldId = (short)numeric;
+        fieldId = (int)numeric;
         return true;
     }
 
@@ -1982,8 +1982,8 @@ public sealed partial class ForyModelGenerator
 
                 return 0;
             })
-            .ThenBy(m => m.FieldId.HasValue ? 0 : 1)
-            .ThenBy(m => m.FieldId.GetValueOrDefault())
+            .ThenBy(m => m.FieldId >= 0 ? 0 : 1)
+            .ThenBy(m => m.FieldId)
             .ThenBy(m => m.FieldIdentifier, StringComparer.Ordinal)
             .ToImmutableArray();
     }

--- a/csharp/src/Fory.Generator/ForyModelGenerator.Emission.cs
+++ b/csharp/src/Fory.Generator/ForyModelGenerator.Emission.cs
@@ -2769,8 +2769,8 @@ public sealed partial class ForyModelGenerator
         }
 
         IEnumerable<MemberModel> ordered = members
-            .OrderBy(m => m.FieldId.HasValue ? 0 : 1)
-            .ThenBy(m => m.FieldId.GetValueOrDefault())
+            .OrderBy(m => m.FieldId >= 0 ? 0 : 1)
+            .ThenBy(m => m.FieldId)
             .ThenBy(m => m.FieldIdentifier, StringComparer.Ordinal);
 
         StringBuilder sb = new();
@@ -2793,8 +2793,8 @@ public sealed partial class ForyModelGenerator
 
     private static string BuildSchemaFieldIdentifier(MemberModel member)
     {
-        return member.FieldId.HasValue
-            ? member.FieldId.Value.ToString(CultureInfo.InvariantCulture)
+        return member.FieldId >= 0
+            ? member.FieldId.ToString(CultureInfo.InvariantCulture)
             : member.FieldIdentifier;
     }
 
@@ -2899,9 +2899,9 @@ public sealed partial class ForyModelGenerator
         return $"new global::Apache.Fory.TypeMetaFieldType({model.TypeIdExpr}, {BoolLiteral(model.Nullable)}, {localTrackRefExpr})";
     }
 
-    private static string BuildTypeMetaFieldIdExpression(short? fieldId)
+    private static string BuildTypeMetaFieldIdExpression(int fieldId)
     {
-        return fieldId.HasValue ? $"(short){fieldId.Value}" : "null";
+        return fieldId.ToString(CultureInfo.InvariantCulture);
     }
 
     private static string BuildWriteRefModeExpression(MemberModel member)

--- a/csharp/src/Fory.Generator/ForyModelGenerator.Hierarchy.cs
+++ b/csharp/src/Fory.Generator/ForyModelGenerator.Hierarchy.cs
@@ -592,7 +592,7 @@ public sealed partial class ForyModelGenerator
             .GetMembers(expectedAccessorName)
             .OfType<IMethodSymbol>()
             .ToImmutableArray();
-        if (fieldIdValue is < -1 or > short.MaxValue ||
+        if (fieldIdValue is < -1 or > MaxFieldId ||
             readCandidates.Length != 1 ||
             !SymbolEqualityComparer.Default.Equals(
                 readCandidates[0],
@@ -667,7 +667,7 @@ public sealed partial class ForyModelGenerator
             diagnostics,
             schemaType,
             parseFieldAttribute: false,
-            fieldIdValue < 0 ? null : (short)fieldIdValue,
+            fieldIdValue,
             schemaDescriptorType);
         if (parsed is null || diagnostics.Count != diagnosticCount)
         {
@@ -809,25 +809,25 @@ public sealed partial class ForyModelGenerator
         IEnumerable<MemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        Dictionary<short, MemberModel> fieldIds = [];
+        Dictionary<int, MemberModel> fieldIds = [];
         Dictionary<string, MemberModel> fieldNames = new(StringComparer.Ordinal);
         foreach (MemberModel member in members)
         {
-            if (member.FieldId.HasValue)
+            if (member.FieldId >= 0)
             {
-                if (fieldIds.TryGetValue(member.FieldId.Value, out MemberModel? previous))
+                if (fieldIds.TryGetValue(member.FieldId, out MemberModel? previous))
                 {
                     diagnostics.Add(Diagnostic.Create(
                         DuplicateStructuralField,
                         target.DeclarationLocation,
                         target.TargetTypeName,
-                        member.FieldId.Value.ToString(CultureInfo.InvariantCulture),
+                        member.FieldId.ToString(CultureInfo.InvariantCulture),
                         MemberDisplay(previous),
                         MemberDisplay(member)));
                 }
                 else
                 {
-                    fieldIds.Add(member.FieldId.Value, member);
+                    fieldIds.Add(member.FieldId, member);
                 }
             }
             else if (fieldNames.TryGetValue(member.FieldIdentifier, out MemberModel? previous))
@@ -891,9 +891,9 @@ public sealed partial class ForyModelGenerator
             member.DeclaringType.ToDisplayString(FullNameFormat);
         sb.Append(
             $"    [global::Apache.Fory.ForyGeneratedWireMember({member.DeclarationOrdinal}, typeof({declaringTypeName}), \"{EscapeString(member.Name)}\", \"{EscapeString(member.TargetMemberName)}\"");
-        if (member.FieldId.HasValue)
+        if (member.FieldId >= 0)
         {
-            sb.Append($", FieldId = {member.FieldId.Value}");
+            sb.Append($", FieldId = {member.FieldId}");
         }
 
         if (member.SchemaDescriptorType is not null)

--- a/csharp/src/Fory.Generator/ForyModelGenerator.Models.cs
+++ b/csharp/src/Fory.Generator/ForyModelGenerator.Models.cs
@@ -451,7 +451,7 @@ public sealed partial class ForyModelGenerator
             string typeName,
             bool isNullable,
             bool isNullableValueType,
-            short? fieldId,
+            int fieldId,
             TypeClassification classification,
             int group,
             bool isCollection,
@@ -512,7 +512,7 @@ public sealed partial class ForyModelGenerator
         public string TypeName { get; }
         public bool IsNullable { get; }
         public bool IsNullableValueType { get; }
-        public short? FieldId { get; }
+        public int FieldId { get; }
         public TypeClassification Classification { get; }
         public int Group { get; }
         public bool IsCollection { get; }

--- a/csharp/src/Fory.Generator/ForyModelGenerator.cs
+++ b/csharp/src/Fory.Generator/ForyModelGenerator.cs
@@ -26,6 +26,7 @@ namespace Apache.Fory.Generator;
 [Generator(LanguageNames.CSharp)]
 public sealed partial class ForyModelGenerator : IIncrementalGenerator
 {
+    private const int MaxFieldId = (1 << 29) - 1;
     private const uint UInt8ArrayTypeId = 48;
 
     private static readonly SymbolDisplayFormat FullNameFormat =
@@ -59,7 +60,7 @@ public sealed partial class ForyModelGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor InvalidFieldId = new(
         id: "FORY004",
         title: "Invalid Fory field id",
-        messageFormat: "Member '{0}' uses an invalid [ForyField] id; field ids must be non-negative and no greater than short.MaxValue",
+        messageFormat: "Member '{0}' uses an invalid [ForyField] id; field ids must be in the range 0 through 536870911",
         category: "Fory",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/csharp/src/Fory/Attributes.cs
+++ b/csharp/src/Fory/Attributes.cs
@@ -119,33 +119,24 @@ public sealed class ForyUnknownCaseAttribute : Attribute
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 public sealed class ForyFieldAttribute : Attribute
 {
-    private short id = -1;
+    private int id = -1;
 
     public ForyFieldAttribute()
     {
     }
 
-    public ForyFieldAttribute(short id)
+    public ForyFieldAttribute(int id)
     {
         ValidateId(id);
         this.id = id;
     }
 
-    public ForyFieldAttribute(int id)
-    {
-        if (id is < 0 or > short.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(id));
-        }
-
-        this.id = (short)id;
-    }
-
     /// <summary>
-    /// Optional stable field tag id used for compatible metadata dispatch.
-    /// Use a non-negative value to emit numeric field ids instead of field names.
+    /// Stable field tag id used for compatible metadata dispatch.
+    /// Use a value from <c>0</c> through <c>536870911</c> to emit a numeric field id
+    /// instead of a field name.
     /// </summary>
-    public short Id
+    public int Id
     {
         get => id;
         set
@@ -186,9 +177,9 @@ public sealed class ForyFieldAttribute : Attribute
     /// </remarks>
     public string? TargetMemberName { get; set; }
 
-    private static void ValidateId(short id)
+    private static void ValidateId(int id)
     {
-        if (id < 0)
+        if (id is < 0 or > TypeMetaConstants.MaxFieldId)
         {
             throw new ArgumentOutOfRangeException(nameof(id));
         }

--- a/csharp/src/Fory/TypeMeta.cs
+++ b/csharp/src/Fory/TypeMeta.cs
@@ -35,6 +35,7 @@ internal static class TypeMetaConstants
     public const ulong TypeMetaSizeMask = 0xFF;
     public const ulong TypeMetaHashSeed = 47;
     public const uint NoUserTypeId = uint.MaxValue;
+    public const int MaxFieldId = (1 << 29) - 1;
 }
 
 public static class TypeMetaEncodings
@@ -269,15 +270,23 @@ public sealed class TypeMetaFieldType : IEquatable<TypeMetaFieldType>
 
 public sealed class TypeMetaFieldInfo : IEquatable<TypeMetaFieldInfo>
 {
-    public TypeMetaFieldInfo(short? fieldId, string fieldName, TypeMetaFieldType fieldType)
+    public TypeMetaFieldInfo(int fieldId, string fieldName, TypeMetaFieldType fieldType)
     {
+        if (fieldId is < -1 or > TypeMetaConstants.MaxFieldId)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fieldId));
+        }
+
         FieldId = fieldId;
         FieldName = fieldName;
         FieldType = fieldType;
         AssignedFieldId = -1;
     }
 
-    public short? FieldId { get; }
+    /// <summary>
+    /// Stable field tag, or <c>-1</c> when the field is identified by name.
+    /// </summary>
+    public int FieldId { get; }
 
     public string FieldName { get; }
 
@@ -300,14 +309,9 @@ public sealed class TypeMetaFieldInfo : IEquatable<TypeMetaFieldInfo>
             header |= 0b10;
         }
 
-        if (FieldId.HasValue)
+        if (FieldId >= 0)
         {
-            short fieldId = FieldId.Value;
-            if (fieldId < 0)
-            {
-                throw new EncodingException("negative field id is invalid");
-            }
-
+            int fieldId = FieldId;
             int size = fieldId;
             header |= 0b11 << 6;
             if (size >= TypeMetaConstants.FieldNameSizeThreshold)
@@ -357,12 +361,29 @@ public sealed class TypeMetaFieldInfo : IEquatable<TypeMetaFieldInfo>
         byte header = reader.ReadUInt8();
         int encodingFlags = (header >> 6) & 0b11;
         int size = (header >> 2) & 0b1111;
+        int fieldId = encodingFlags == 3 ? size : -1;
         if (size == TypeMetaConstants.FieldNameSizeThreshold)
         {
-            size += (int)reader.ReadVarUInt32();
+            uint extension = reader.ReadVarUInt32();
+            if (encodingFlags == 3)
+            {
+                if (extension > (uint)(TypeMetaConstants.MaxFieldId - TypeMetaConstants.FieldNameSizeThreshold))
+                {
+                    throw new InvalidDataException("field id exceeds the protocol range");
+                }
+
+                fieldId += (int)extension;
+            }
+            else
+            {
+                size = checked(size + (int)extension);
+            }
         }
 
-        size += 1;
+        if (encodingFlags != 3)
+        {
+            size = checked(size + 1);
+        }
 
         bool nullable = (header & 0b10) != 0;
         bool trackRef = (header & 0b1) != 0;
@@ -370,7 +391,6 @@ public sealed class TypeMetaFieldInfo : IEquatable<TypeMetaFieldInfo>
 
         if (encodingFlags == 3)
         {
-            short fieldId = unchecked((short)(size - 1));
             return new TypeMetaFieldInfo(fieldId, $"$tag{fieldId}", fieldType);
         }
 
@@ -383,7 +403,7 @@ public sealed class TypeMetaFieldInfo : IEquatable<TypeMetaFieldInfo>
         string name = MetaStringDecoder.FieldName.Decode(
             nameBytes,
             TypeMetaEncodings.FieldNameMetaStringEncodings[encodingFlags]).Value;
-        return new TypeMetaFieldInfo(null, name, fieldType);
+        return new TypeMetaFieldInfo(-1, name, fieldType);
     }
 
     public bool Equals(TypeMetaFieldInfo? other)
@@ -444,6 +464,21 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
             if (!userTypeId.HasValue || userTypeId.Value == TypeMetaConstants.NoUserTypeId)
             {
                 throw new EncodingException("user type id is required in register-by-id mode");
+            }
+        }
+
+        HashSet<int>? fieldIds = null;
+        foreach (TypeMetaFieldInfo field in fields)
+        {
+            if (field.FieldId < 0)
+            {
+                continue;
+            }
+
+            fieldIds ??= [];
+            if (!fieldIds.Add(field.FieldId))
+            {
+                throw new EncodingException($"duplicate field id {field.FieldId}");
             }
         }
 
@@ -767,13 +802,13 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
         ArgumentNullException.ThrowIfNull(localFieldInfos);
 
         Dictionary<string, (int Index, TypeMetaFieldInfo Field)> localByName = new(localFieldInfos.Count, StringComparer.Ordinal);
-        Dictionary<short, (int Index, TypeMetaFieldInfo Field)> localById = new(localFieldInfos.Count);
+        Dictionary<int, (int Index, TypeMetaFieldInfo Field)> localById = new(localFieldInfos.Count);
         for (int i = 0; i < localFieldInfos.Count; i++)
         {
             TypeMetaFieldInfo localField = localFieldInfos[i];
-            if (localField.FieldId.HasValue && localField.FieldId.Value >= 0)
+            if (localField.FieldId >= 0)
             {
-                short fieldId = localField.FieldId.Value;
+                int fieldId = localField.FieldId;
                 if (!localById.TryAdd(fieldId, (i, localField)))
                 {
                     throw new InvalidDataException(
@@ -786,15 +821,15 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
             }
         }
 
-        HashSet<short>? remoteFieldIds = null;
+        HashSet<int>? remoteFieldIds = null;
         HashSet<int> usedLocalFields = [];
         for (int i = 0; i < remoteTypeMeta.Fields.Count; i++)
         {
             TypeMetaFieldInfo remoteField = remoteTypeMeta.Fields[i];
             remoteField.CompatibleScalarRead = null;
-            if (remoteField.FieldId.HasValue && remoteField.FieldId.Value >= 0)
+            if (remoteField.FieldId >= 0)
             {
-                short fieldId = remoteField.FieldId.Value;
+                int fieldId = remoteField.FieldId;
                 remoteFieldIds ??= [];
                 if (!remoteFieldIds.Add(fieldId))
                 {
@@ -806,14 +841,13 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
             int localIndex = -1;
             TypeMetaFieldInfo? localMatch = null;
 
-            if (remoteField.FieldId.HasValue &&
-                remoteField.FieldId.Value >= 0 &&
-                localById.TryGetValue(remoteField.FieldId.Value, out (int Index, TypeMetaFieldInfo Field) byId))
+            if (remoteField.FieldId >= 0 &&
+                localById.TryGetValue(remoteField.FieldId, out (int Index, TypeMetaFieldInfo Field) byId))
             {
                 localIndex = byId.Index;
                 localMatch = byId.Field;
             }
-            else if (!remoteField.FieldId.HasValue)
+            else if (remoteField.FieldId < 0)
             {
                 if (localByName.TryGetValue(remoteField.FieldName, out (int Index, TypeMetaFieldInfo Field) byName))
                 {

--- a/csharp/src/Fory/TypeMeta.cs
+++ b/csharp/src/Fory/TypeMeta.cs
@@ -467,8 +467,9 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
             }
         }
 
+        IReadOnlyList<TypeMetaFieldInfo> ownedFields = Array.AsReadOnly(fields.ToArray());
         HashSet<int>? fieldIds = null;
-        foreach (TypeMetaFieldInfo field in fields)
+        foreach (TypeMetaFieldInfo field in ownedFields)
         {
             if (field.FieldId < 0)
             {
@@ -487,10 +488,10 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
         NamespaceName = namespaceName;
         TypeName = typeName;
         RegisterByName = registerByName;
-        Fields = fields;
+        Fields = ownedFields;
         Compressed = compressed;
         HeaderHash = headerHash;
-        ReadDataAlwaysAdvances = fields.Any(static field => field.FieldType.FieldReadAlwaysAdvances);
+        ReadDataAlwaysAdvances = ownedFields.Any(static field => field.FieldType.FieldReadAlwaysAdvances);
     }
 
     public uint? TypeId { get; }
@@ -821,22 +822,11 @@ public sealed class TypeMeta : IEquatable<TypeMeta>
             }
         }
 
-        HashSet<int>? remoteFieldIds = null;
         HashSet<int> usedLocalFields = [];
         for (int i = 0; i < remoteTypeMeta.Fields.Count; i++)
         {
             TypeMetaFieldInfo remoteField = remoteTypeMeta.Fields[i];
             remoteField.CompatibleScalarRead = null;
-            if (remoteField.FieldId >= 0)
-            {
-                int fieldId = remoteField.FieldId;
-                remoteFieldIds ??= [];
-                if (!remoteFieldIds.Add(fieldId))
-                {
-                    throw new InvalidDataException(
-                        $"duplicate remote field id {fieldId} in compatible type metadata");
-                }
-            }
 
             int localIndex = -1;
             TypeMetaFieldInfo? localMatch = null;

--- a/csharp/src/Fory/TypeResolver.cs
+++ b/csharp/src/Fory/TypeResolver.cs
@@ -694,7 +694,7 @@ public sealed class TypeResolver
                     for (int fieldIdx = 0; fieldIdx < fields.Count; fieldIdx++)
                     {
                         TypeMetaFieldInfo field = fields[fieldIdx];
-                        hash = MixUInt32(hash, field.FieldId.HasValue ? (uint)field.FieldId.Value + 1u : 0u);
+                        hash = MixUInt32(hash, field.FieldId >= 0 ? (uint)field.FieldId + 1u : 0u);
                         hash = MixString(hash, field.FieldName);
                         hash = MixFieldType(hash, field.FieldType);
                     }

--- a/csharp/tests/Fory.Tests/ClassInheritanceTests.cs
+++ b/csharp/tests/Fory.Tests/ClassInheritanceTests.cs
@@ -275,13 +275,13 @@ public sealed class ClassInheritanceTests
     [Fact]
     public void WireAndStorageModelsAreFlattened()
     {
-        short?[] fieldIds = new TypeResolver()
+        int[] fieldIds = new TypeResolver()
             .GetTypeInfo<InheritedLeaf>()
             .TypeMetaFields(false)
             .Select(field => field.FieldId)
             .ToArray();
         Assert.Equal(
-            new short?[] { 1, 3, 5, 7, 8, 2, 4, 6 },
+            new[] { 1, 3, 5, 7, 8, 2, 4, 6 },
             fieldIds);
 
         Assert.Equal(28, ProviderShallowBytes(typeof(InheritedRoot)));

--- a/csharp/tests/Fory.Tests/ForyGeneratorTests.cs
+++ b/csharp/tests/Fory.Tests/ForyGeneratorTests.cs
@@ -123,6 +123,56 @@ public sealed class ForyGeneratorTests
     }
 
     [Fact]
+    public void LargeForyFieldIdReportsDiagnostic()
+    {
+        const string source = """
+            using Apache.Fory;
+
+            namespace GeneratedDiagnostics;
+
+            [ForyStruct]
+            public sealed class InvalidFieldId
+            {
+                [ForyField(536_870_912)]
+                public int Value { get; set; }
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(source);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ForyModelGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation output, out ImmutableArray<Diagnostic> diagnostics);
+
+        ImmutableArray<Diagnostic> generatorDiagnostics = driver.GetRunResult().Diagnostics;
+        Assert.Contains(generatorDiagnostics.Concat(diagnostics), diagnostic => diagnostic.Id == "FORY004");
+        Assert.DoesNotContain(output.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Id != "FORY004");
+    }
+
+    [Fact]
+    public void MaximumForyFieldIdCompiles()
+    {
+        const string source = """
+            using Apache.Fory;
+
+            namespace GeneratedDiagnostics;
+
+            [ForyStruct]
+            public sealed class TaggedField
+            {
+                [ForyField(536_870_911)]
+                public int Value { get; set; }
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(source);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ForyModelGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation output, out ImmutableArray<Diagnostic> diagnostics);
+
+        Assert.DoesNotContain(
+            diagnostics.Concat(output.GetDiagnostics()),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
     public void UnionRequiresRealCaseBeyondUnknown()
     {
         const string source = """
@@ -968,15 +1018,15 @@ public sealed class ForyGeneratorTests
             leafGenerated,
             StringComparison.Ordinal);
         Assert.Contains(
-            "TypeMetaFieldInfo((short)4,",
+            "TypeMetaFieldInfo(4,",
             leafGenerated,
             StringComparison.Ordinal);
         Assert.Contains(
-            "TypeMetaFieldInfo((short)6,",
+            "TypeMetaFieldInfo(6,",
             leafGenerated,
             StringComparison.Ordinal);
         Assert.Contains(
-            "TypeMetaFieldInfo((short)8,",
+            "TypeMetaFieldInfo(8,",
             leafGenerated,
             StringComparison.Ordinal);
         Assert.DoesNotContain(

--- a/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
+++ b/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
@@ -1357,7 +1357,7 @@ public sealed class ForyRuntimeTests
         resolver.GetTypeInfo<NestedSchemaByName>();
         TypeMetaFieldInfo field = Assert.Single(resolver.GetTypeInfo<NestedSchemaByName>().TypeMetaFields(false));
 
-        Assert.Null(field.FieldId);
+        Assert.Equal(-1, field.FieldId);
         Assert.Equal("values", field.FieldName);
         Assert.Equal((uint)TypeId.Map, field.FieldType.TypeId);
         Assert.Equal((uint)TypeId.UInt32, field.FieldType.Generics[0].TypeId);
@@ -1374,10 +1374,39 @@ public sealed class ForyRuntimeTests
         resolver.GetTypeInfo<NestedSchemaById>();
         TypeMetaFieldInfo field = Assert.Single(resolver.GetTypeInfo<NestedSchemaById>().TypeMetaFields(false));
 
-        Assert.Equal((short)3, field.FieldId);
+        Assert.Equal(3, field.FieldId);
         Assert.Equal((uint)TypeId.Map, field.FieldType.TypeId);
         Assert.Equal((uint)TypeId.UInt32, field.FieldType.Generics[0].TypeId);
         Assert.Equal((uint)TypeId.TaggedUInt64, field.FieldType.Generics[1].Generics[0].TypeId);
+    }
+
+    [Fact]
+    public void ForyFieldIdRange()
+    {
+        Assert.Equal(536_870_911, new ForyFieldAttribute(536_870_911).Id);
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForyFieldAttribute(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ForyFieldAttribute(536_870_912));
+
+        TypeMeta typeMeta = new(
+            (uint)TypeId.CompatibleStruct,
+            515,
+            MetaString.Empty('.', '_'),
+            MetaString.Empty('$', '_'),
+            registerByName: false,
+            [new TypeMetaFieldInfo(536_870_911, "value", new TypeMetaFieldType((uint)TypeId.VarInt32, false))]);
+        Assert.Equal(536_870_911, Assert.Single(TypeMeta.Decode(typeMeta.Encode()).Fields).FieldId);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TypeMetaFieldInfo(536_870_912, "value", new TypeMetaFieldType((uint)TypeId.VarInt32, false)));
+        Assert.Throws<EncodingException>(() => new TypeMeta(
+            (uint)TypeId.CompatibleStruct,
+            516,
+            MetaString.Empty('.', '_'),
+            MetaString.Empty('$', '_'),
+            registerByName: false,
+            [
+                new TypeMetaFieldInfo(7, "first", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
+                new TypeMetaFieldInfo(7, "second", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
+            ]));
     }
 
     [Fact]
@@ -1576,7 +1605,7 @@ public sealed class ForyRuntimeTests
         List<TypeMetaFieldInfo> localFields =
         [
             new TypeMetaFieldInfo(
-                null,
+                -1,
                 "values",
                 new TypeMetaFieldType(
                     (uint)TypeId.Map,
@@ -1595,7 +1624,7 @@ public sealed class ForyRuntimeTests
             false,
             [
                 new TypeMetaFieldInfo(
-                    null,
+                    -1,
                     "values",
                     new TypeMetaFieldType(
                         (uint)TypeId.Map,
@@ -1622,7 +1651,7 @@ public sealed class ForyRuntimeTests
         List<TypeMetaFieldInfo> localFields =
         [
             new TypeMetaFieldInfo(
-                null,
+                -1,
                 "values",
                 new TypeMetaFieldType(
                     (uint)TypeId.List,
@@ -1639,7 +1668,7 @@ public sealed class ForyRuntimeTests
             false,
             [
                 new TypeMetaFieldInfo(
-                    null,
+                    -1,
                     "values",
                     new TypeMetaFieldType(
                         (uint)TypeId.List,
@@ -1659,7 +1688,7 @@ public sealed class ForyRuntimeTests
             false,
             [
                 new TypeMetaFieldInfo(
-                    null,
+                    -1,
                     "values",
                     new TypeMetaFieldType(
                         (uint)TypeId.List,
@@ -1702,7 +1731,7 @@ public sealed class ForyRuntimeTests
         List<TypeMetaFieldInfo> localNested =
         [
             new TypeMetaFieldInfo(
-                null,
+                -1,
                 "value",
                 new TypeMetaFieldType(
                     (uint)TypeId.List,
@@ -1718,7 +1747,7 @@ public sealed class ForyRuntimeTests
             false,
             [
                 new TypeMetaFieldInfo(
-                    null,
+                    -1,
                     "value",
                     new TypeMetaFieldType(
                         (uint)TypeId.List,
@@ -3159,13 +3188,13 @@ public sealed class ForyRuntimeTests
     {
         List<TypeMetaFieldInfo> localFields =
         [
-            new TypeMetaFieldInfo(null, "int_value", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
+            new TypeMetaFieldInfo(-1, "int_value", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
             new TypeMetaFieldInfo(2, "name", new TypeMetaFieldType((uint)TypeId.String, true)),
         ];
         List<TypeMetaFieldInfo> remoteFields =
         [
             new TypeMetaFieldInfo(2, "$tag2", new TypeMetaFieldType((uint)TypeId.String, true)),
-            new TypeMetaFieldInfo(null, "intValue", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
+            new TypeMetaFieldInfo(-1, "intValue", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
             new TypeMetaFieldInfo(99, "$tag99", new TypeMetaFieldType((uint)TypeId.String, true)),
         ];
         TypeMeta remoteTypeMeta = new(
@@ -3191,7 +3220,7 @@ public sealed class ForyRuntimeTests
         ];
         List<TypeMetaFieldInfo> remoteFields =
         [
-            new TypeMetaFieldInfo(null, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
+            new TypeMetaFieldInfo(-1, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
         ];
         TypeMeta remoteTypeMeta = new(
             (uint)TypeId.CompatibleStruct,
@@ -3210,12 +3239,12 @@ public sealed class ForyRuntimeTests
     {
         List<TypeMetaFieldInfo> localFields =
         [
-            new TypeMetaFieldInfo(null, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
+            new TypeMetaFieldInfo(-1, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
         ];
         List<TypeMetaFieldInfo> remoteFields =
         [
-            new TypeMetaFieldInfo(null, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
-            new TypeMetaFieldInfo(null, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
+            new TypeMetaFieldInfo(-1, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
+            new TypeMetaFieldInfo(-1, "value", new TypeMetaFieldType((uint)TypeId.String, false)),
         ];
         TypeMeta remoteTypeMeta = new(
             (uint)TypeId.CompatibleStruct,
@@ -3335,7 +3364,6 @@ public sealed class ForyRuntimeTests
         List<TypeMetaFieldInfo> remoteFields =
         [
             new TypeMetaFieldInfo(9, "$tag9a", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
-            new TypeMetaFieldInfo(9, "$tag9b", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
         ];
         TypeMeta remoteTypeMeta = new(
             (uint)TypeId.CompatibleStruct,
@@ -3344,6 +3372,8 @@ public sealed class ForyRuntimeTests
             MetaString.Empty('$', '_'),
             registerByName: false,
             remoteFields);
+        remoteFields.Add(
+            new TypeMetaFieldInfo(9, "$tag9b", new TypeMetaFieldType((uint)TypeId.VarInt32, false)));
 
         InvalidDataException exception = Assert.Throws<InvalidDataException>(
             () => TypeMeta.AssignFieldIds(remoteTypeMeta, localFields));

--- a/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
+++ b/csharp/tests/Fory.Tests/ForyRuntimeTests.cs
@@ -3355,12 +3355,8 @@ public sealed class ForyRuntimeTests
     }
 
     [Fact]
-    public void TypeMetaAssignFieldIdsThrowsOnDuplicateRemoteFieldId()
+    public void TypeMetaOwnsFields()
     {
-        List<TypeMetaFieldInfo> localFields =
-        [
-            new TypeMetaFieldInfo(9, "value", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
-        ];
         List<TypeMetaFieldInfo> remoteFields =
         [
             new TypeMetaFieldInfo(9, "$tag9a", new TypeMetaFieldType((uint)TypeId.VarInt32, false)),
@@ -3372,12 +3368,13 @@ public sealed class ForyRuntimeTests
             MetaString.Empty('$', '_'),
             registerByName: false,
             remoteFields);
+        byte[] encoded = remoteTypeMeta.Encode();
+
         remoteFields.Add(
             new TypeMetaFieldInfo(9, "$tag9b", new TypeMetaFieldType((uint)TypeId.VarInt32, false)));
 
-        InvalidDataException exception = Assert.Throws<InvalidDataException>(
-            () => TypeMeta.AssignFieldIds(remoteTypeMeta, localFields));
-        Assert.Contains("duplicate remote field id 9", exception.Message, StringComparison.Ordinal);
+        Assert.Single(remoteTypeMeta.Fields);
+        Assert.Equal(encoded, remoteTypeMeta.Encode());
     }
 
     private static byte[] RewriteCompatibleTypeMetaTypeId(byte[] payload, uint embeddedTypeId)

--- a/csharp/tests/Fory.Tests/RuntimeEdgeCaseTests.cs
+++ b/csharp/tests/Fory.Tests/RuntimeEdgeCaseTests.cs
@@ -1334,7 +1334,7 @@ public sealed class RuntimeEdgeCaseTests
         TypeMetaFieldInfo[] fields = new TypeMetaFieldInfo[fieldNames.Length];
         for (int i = 0; i < fieldNames.Length; i++)
         {
-            fields[i] = new TypeMetaFieldInfo(null, fieldNames[i], new TypeMetaFieldType((uint)TypeId.Int32, nullable: false));
+            fields[i] = new TypeMetaFieldInfo(-1, fieldNames[i], new TypeMetaFieldType((uint)TypeId.Int32, nullable: false));
         }
 
         return new TypeMeta(
@@ -1376,7 +1376,7 @@ public sealed class RuntimeEdgeCaseTests
             MetaString.Empty('.', '_'),
             MetaString.Empty('$', '_'),
             registerByName: false,
-            [new TypeMetaFieldInfo(null, fieldName, fieldType)]);
+            [new TypeMetaFieldInfo(-1, fieldName, fieldType)]);
     }
 
     private static TypeMetaFieldType MapType()

--- a/csharp/tests/Fory.Tests/UnbackedContainerBudgetTests.cs
+++ b/csharp/tests/Fory.Tests/UnbackedContainerBudgetTests.cs
@@ -303,7 +303,7 @@ public sealed class UnbackedContainerBudgetTests
         TypeMetaFieldInfo[] fields = new TypeMetaFieldInfo[fieldTypes.Length];
         for (int i = 0; i < fieldTypes.Length; i++)
         {
-            fields[i] = new TypeMetaFieldInfo((short)i, $"field{i}", fieldTypes[i]);
+            fields[i] = new TypeMetaFieldInfo(i, $"field{i}", fieldTypes[i]);
         }
 
         return new TypeMeta(

--- a/csharp/tests/Fory.XlangPeer/Program.cs
+++ b/csharp/tests/Fory.XlangPeer/Program.cs
@@ -1269,13 +1269,16 @@ public sealed class Item
 public sealed class SimpleStruct
 {
     public Dictionary<int, double> F1 { get; set; } = [];
+    [ForyField(15)]
     public int F2 { get; set; }
     public Item F3 { get; set; } = new();
     public string F4 { get; set; } = string.Empty;
     public Color F5 { get; set; }
     public List<string> F6 { get; set; } = [];
+    [ForyField(65551)]
     public int F7 { get; set; }
     public int F8 { get; set; }
+    [ForyField(536870911)]
     public int Last { get; set; }
 }
 

--- a/dart/packages/fory-test/lib/entity/xlang_test_custom.dart
+++ b/dart/packages/fory-test/lib/entity/xlang_test_custom.dart
@@ -107,7 +107,7 @@ _refOverrideContainerForyFieldInfo = <GeneratedFieldInfo>[
   GeneratedFieldInfo(
     name: 'listField',
     identifier: 'list_field',
-    id: null,
+    id: -1,
     fieldType: GeneratedFieldType(
       type: List,
       typeId: TypeIds.list,
@@ -120,7 +120,7 @@ _refOverrideContainerForyFieldInfo = <GeneratedFieldInfo>[
   GeneratedFieldInfo(
     name: 'mapField',
     identifier: 'map_field',
-    id: null,
+    id: -1,
     fieldType: GeneratedFieldType(
       type: Map,
       typeId: TypeIds.map,
@@ -143,7 +143,7 @@ _refOverrideContainerForyFieldInfo = <GeneratedFieldInfo>[
   GeneratedFieldInfo(
     name: 'setField',
     identifier: 'set_field',
-    id: null,
+    id: -1,
     fieldType: GeneratedFieldType(
       type: Set,
       typeId: TypeIds.set,

--- a/dart/packages/fory-test/lib/entity/xlang_test_models.dart
+++ b/dart/packages/fory-test/lib/entity/xlang_test_models.dart
@@ -62,20 +62,20 @@ class SimpleStruct {
   @MapField(key: Int32Type())
   Map<int?, double?> f1 = <int?, double?>{};
 
-  @ForyField(type: Int32Type())
+  @ForyField(id: 15, type: Int32Type())
   int f2 = 0;
   Item f3 = Item();
   String f4 = '';
   Color f5 = Color.green;
   List<String?> f6 = <String?>[];
 
-  @ForyField(type: Int32Type())
+  @ForyField(id: 65551, type: Int32Type())
   int f7 = 0;
 
   @ForyField(type: Int32Type())
   int f8 = 0;
 
-  @ForyField(type: Int32Type())
+  @ForyField(id: 536870911, type: Int32Type())
   int last = 0;
 }
 

--- a/dart/packages/fory/lib/src/annotation/fory_field.dart
+++ b/dart/packages/fory/lib/src/annotation/fory_field.dart
@@ -35,7 +35,10 @@ final class ForyField {
   final bool ignore;
 
   /// The stable numeric field identity used for schema evolution.
-  final int? id;
+  ///
+  /// Values must be in the range `0 <= id < 2^29`. The default `-1` means
+  /// that the field uses its name as its wire identity.
+  final int id;
 
   /// An optional override for the field's inferred nullability.
   final bool? nullable;
@@ -52,14 +55,14 @@ final class ForyField {
   /// Creates field-level serialization metadata.
   const ForyField({
     this.ignore = false,
-    this.id,
+    this.id = -1,
     this.nullable,
     this.ref = false,
     this.dynamic,
     this.type,
   }) : assert(
          !ignore ||
-             (id == null &&
+             (id == -1 &&
                  nullable == null &&
                  !ref &&
                  dynamic == null &&
@@ -69,14 +72,14 @@ final class ForyField {
 }
 
 final class ListField {
-  final int? id;
+  final int id;
   final bool? nullable;
   final bool ref;
   final bool? dynamic;
   final TypeSpec? element;
 
   const ListField({
-    this.id,
+    this.id = -1,
     this.nullable,
     this.ref = false,
     this.dynamic,
@@ -85,14 +88,14 @@ final class ListField {
 }
 
 final class ArrayField {
-  final int? id;
+  final int id;
   final bool? nullable;
   final bool ref;
   final bool? dynamic;
   final TypeSpec element;
 
   const ArrayField({
-    this.id,
+    this.id = -1,
     this.nullable,
     this.ref = false,
     this.dynamic,
@@ -101,14 +104,14 @@ final class ArrayField {
 }
 
 final class SetField {
-  final int? id;
+  final int id;
   final bool? nullable;
   final bool ref;
   final bool? dynamic;
   final TypeSpec? element;
 
   const SetField({
-    this.id,
+    this.id = -1,
     this.nullable,
     this.ref = false,
     this.dynamic,
@@ -117,7 +120,7 @@ final class SetField {
 }
 
 final class MapField {
-  final int? id;
+  final int id;
   final bool? nullable;
   final bool ref;
   final bool? dynamic;
@@ -125,7 +128,7 @@ final class MapField {
   final TypeSpec? value;
 
   const MapField({
-    this.id,
+    this.id = -1,
     this.nullable,
     this.ref = false,
     this.dynamic,

--- a/dart/packages/fory/lib/src/codegen/fory_generator.dart
+++ b/dart/packages/fory/lib/src/codegen/fory_generator.dart
@@ -52,6 +52,7 @@ class DebugGeneratedFieldTypeSpec {
 }
 
 final class ForyGenerator extends Generator {
+  static const int _maxFieldId = (1 << 29) - 1;
   static const int _referenceBytes = 4;
   // Conservative lower bound for a retained generated Dart struct object itself. Field reference
   // slots are added separately; this is not a Fory wire header or a Dart VM layout probe.
@@ -1850,7 +1851,7 @@ final class ForyGenerator extends Generator {
     final names = <String, _GeneratedFieldSpec>{};
     for (final field in fields) {
       final id = field.id;
-      if (id != null) {
+      if (id >= 0) {
         final previous = ids[id];
         if (previous != null) {
           throw InvalidGenerationSourceError(
@@ -1950,11 +1951,18 @@ final class ForyGenerator extends Generator {
     final idValue = reader?.peek('id');
     final nullableValue = reader?.peek('nullable');
     final dynamicValue = reader?.peek('dynamic');
-    final rawFieldId =
-        idValue == null || idValue.isNull ? null : idValue.intValue;
-    if (rawFieldId != null && rawFieldId < 0) {
+    final rawFieldId = idValue == null || idValue.isNull
+        ? -1
+        : idValue.intValue;
+    if (rawFieldId < -1) {
       throw InvalidGenerationSourceError(
         'Fory field id must be non-negative.',
+        element: annotationField,
+      );
+    }
+    if (rawFieldId > _maxFieldId) {
+      throw InvalidGenerationSourceError(
+        'Fory field id must not exceed $_maxFieldId.',
         element: annotationField,
       );
     }
@@ -1973,7 +1981,7 @@ final class ForyGenerator extends Generator {
       type: effectiveType,
       displayType: _typeCodeString(effectiveType),
       wireName:
-          rawFieldId == null ? _toSnakeCase(annotationField.displayName) : null,
+          rawFieldId < 0 ? _toSnakeCase(annotationField.displayName) : null,
       id: rawFieldId,
       writable: writable,
       codegenName: codegenName,
@@ -3216,7 +3224,7 @@ final class ForyGenerator extends Generator {
   }
 
   String _fieldInfoLiteral(_GeneratedFieldSpec field) {
-    final identifier = field.id?.toString() ?? field.wireName!;
+    final identifier = field.id >= 0 ? field.id.toString() : field.wireName!;
     return '''
   GeneratedFieldInfo(
     name: '${field.name}',
@@ -4705,16 +4713,16 @@ GeneratedFieldType(
   ) {
     final leftId = left.id;
     final rightId = right.id;
-    if (leftId != null && leftId >= 0 && rightId != null && rightId >= 0) {
+    if (leftId >= 0 && rightId >= 0) {
       final idCompare = leftId.compareTo(rightId);
       if (idCompare != 0) {
         return idCompare;
       }
     }
-    if (leftId != null && leftId >= 0 && (rightId == null || rightId < 0)) {
+    if (leftId >= 0 && rightId < 0) {
       return -1;
     }
-    if ((leftId == null || leftId < 0) && rightId != null && rightId >= 0) {
+    if (leftId < 0 && rightId >= 0) {
       return 1;
     }
     final keyCompare = left.wireName!.compareTo(right.wireName!);
@@ -5917,7 +5925,7 @@ final class _GeneratedFieldSpec {
   final DartType type;
   final String displayType;
   final String? wireName;
-  final int? id;
+  final int id;
   final bool writable;
   final String codegenName;
   final FieldElement declaration;

--- a/dart/packages/fory/lib/src/codegen/generated_support.dart
+++ b/dart/packages/fory/lib/src/codegen/generated_support.dart
@@ -88,7 +88,7 @@ final class GeneratedFieldType {
 final class GeneratedFieldInfo {
   final String name;
   final String identifier;
-  final int? id;
+  final int id;
   final GeneratedFieldType fieldType;
 
   const GeneratedFieldInfo({

--- a/dart/packages/fory/lib/src/meta/field_info.dart
+++ b/dart/packages/fory/lib/src/meta/field_info.dart
@@ -32,8 +32,8 @@ final class FieldInfo {
   /// untagged fields, so the two identity domains remain distinct.
   final String identifier;
 
-  /// The numeric wire tag for a tagged field.
-  final int? id;
+  /// The numeric wire tag, or `-1` when [identifier] is a field name.
+  final int id;
 
   final FieldType fieldType;
 

--- a/dart/packages/fory/lib/src/resolver/type_resolver.dart
+++ b/dart/packages/fory/lib/src/resolver/type_resolver.dart
@@ -315,13 +315,10 @@ String? _fieldIdentityError(List<FieldInfo> fields) {
   final fieldsByName = <String, FieldInfo>{};
   for (final field in fields) {
     final id = field.id;
-    if (id < -1) {
-      return 'Field id $id is invalid.';
+    if (id < -1 || id > TypeResolver._maxFieldId) {
+      return 'Field id is outside the protocol range.';
     }
     if (id >= 0) {
-      if (id > TypeResolver._maxFieldId) {
-        return 'Field id $id exceeds ${TypeResolver._maxFieldId}.';
-      }
       if (field.identifier != id.toString()) {
         return 'Tagged field ${field.name} has textual identifier '
             '${field.identifier}, which must match field id $id.';

--- a/dart/packages/fory/lib/src/resolver/type_resolver.dart
+++ b/dart/packages/fory/lib/src/resolver/type_resolver.dart
@@ -315,9 +315,12 @@ String? _fieldIdentityError(List<FieldInfo> fields) {
   final fieldsByName = <String, FieldInfo>{};
   for (final field in fields) {
     final id = field.id;
-    if (id != null) {
-      if (id < 0) {
-        return 'Field id $id must be non-negative.';
+    if (id < -1) {
+      return 'Field id $id is invalid.';
+    }
+    if (id >= 0) {
+      if (id > TypeResolver._maxFieldId) {
+        return 'Field id $id exceeds ${TypeResolver._maxFieldId}.';
       }
       if (field.identifier != id.toString()) {
         return 'Tagged field ${field.name} has textual identifier '
@@ -355,6 +358,7 @@ List<FieldInfo> _validateLocalFieldInfos(List<FieldInfo> fields) {
 }
 
 final class TypeResolver {
+  static const int _maxFieldId = (1 << 29) - 1;
   static const int _minRemoteTypeMetaLimit = 8192;
   static const int _maxRemoteTypeMetaKeys = 8192;
 
@@ -1176,9 +1180,9 @@ final class TypeResolver {
 
   void _writeTypeDefField(Buffer target, FieldInfo field) {
     final fieldType = field.fieldType;
-    final usesTag = field.id != null;
+    final usesTag = field.id >= 0;
     final encodedName = usesTag ? null : fieldNameMetaString(field.identifier);
-    var size = usesTag ? field.id! : encodedName!.bytes.length - 1;
+    var size = usesTag ? field.id : encodedName!.bytes.length - 1;
     var header = fieldType.ref ? 1 : 0;
     if (fieldType.nullable) {
       header |= 1 << 1;
@@ -1562,7 +1566,10 @@ final class TypeResolver {
     }
     size += 1;
     final isTag = encoding == 3;
-    final tagId = isTag ? size - 1 : null;
+    final tagId = isTag ? size - 1 : -1;
+    if (tagId > _maxFieldId) {
+      throw StateError('Field id exceeds the protocol range.');
+    }
     final fieldType = _readTypeDefFieldType(
       source,
       typeId: source.readUint8(),

--- a/dart/packages/fory/lib/src/serializer/serialization_field_info.dart
+++ b/dart/packages/fory/lib/src/serializer/serialization_field_info.dart
@@ -42,7 +42,7 @@ final class SerializationFieldInfo {
 
   String get identifier => field.identifier;
 
-  int? get id => field.id;
+  int get id => field.id;
 
   FieldType get fieldType => field.fieldType;
 

--- a/dart/packages/fory/lib/src/serializer/struct_serializer.dart
+++ b/dart/packages/fory/lib/src/serializer/struct_serializer.dart
@@ -182,7 +182,7 @@ final class StructSerializer extends Serializer<Object?> {
       final remoteField = remoteTypeDef.fields[remoteIndex];
       final remoteId = remoteField.id;
       final localField =
-          remoteId == null
+          remoteId < 0
               ? localFieldsByName[remoteField.identifier]
               : localFieldsById[remoteId];
       if (localField == null) {
@@ -270,7 +270,7 @@ final class StructSerializer extends Serializer<Object?> {
     final fieldsByName = <String, SerializationFieldInfo>{};
     for (final field in _localFields) {
       final id = field.id;
-      if (id == null) {
+      if (id < 0) {
         fieldsByName[field.identifier] = field;
       } else {
         fieldsById[id] = field;

--- a/dart/packages/fory/lib/src/util/hash_util.dart
+++ b/dart/packages/fory/lib/src/util/hash_util.dart
@@ -203,11 +203,8 @@ String schemaFingerprint(TypeDef typeDef) {
     ..sort((left, right) {
       final leftId = left.id;
       final rightId = right.id;
-      if ((leftId != null && leftId < 0) || (rightId != null && rightId < 0)) {
-        throw ArgumentError('Field id must be non-negative.');
-      }
-      final leftHasId = leftId != null;
-      final rightHasId = rightId != null;
+      final leftHasId = leftId >= 0;
+      final rightHasId = rightId >= 0;
       if (leftHasId && rightHasId) {
         final result = leftId.compareTo(rightId);
         return result == 0

--- a/dart/packages/fory/test/struct_inheritance_generator_test.dart
+++ b/dart/packages/fory/test/struct_inheritance_generator_test.dart
@@ -593,6 +593,36 @@ class IdChild extends IdBase {
       );
     });
 
+    test('accepts the largest field id', () async {
+      await _expectGenerationOutput(
+        source: '''
+@ForyStruct()
+class LargestFieldId {
+  LargestFieldId();
+
+  @ForyField(id: 0x1fffffff)
+  int value = 0;
+}
+''',
+        output: anything,
+      );
+    });
+
+    test('rejects field ids outside the protocol range', () async {
+      await _expectGenerationError(
+        source: '''
+@ForyStruct()
+class OversizedFieldId {
+  OversizedFieldId();
+
+  @ForyField(id: 0x20000000)
+  int value = 0;
+}
+''',
+        message: 'Fory field id must not exceed 536870911.',
+      );
+    });
+
     test('rejects duplicate canonical names across hierarchy layers', () async {
       await _expectGenerationError(
         source: '''

--- a/dart/packages/fory/test/xlang_protocol_test.dart
+++ b/dart/packages/fory/test/xlang_protocol_test.dart
@@ -151,7 +151,7 @@ const _lateExtFieldType = GeneratedFieldType(
 GeneratedFieldInfo _generatedField(String name) => GeneratedFieldInfo(
   name: name,
   identifier: name,
-  id: null,
+  id: -1,
   fieldType: _intFieldType,
 );
 
@@ -165,7 +165,7 @@ GeneratedFieldInfo _taggedField(int id) => GeneratedFieldInfo(
 GeneratedFieldInfo _generatedMapField(String name) => GeneratedFieldInfo(
   name: name,
   identifier: name,
-  id: null,
+  id: -1,
   fieldType: _mapFieldType,
 );
 
@@ -184,7 +184,7 @@ GeneratedFieldInfo _generatedNestedListField(String name, int depth) {
   return GeneratedFieldInfo(
     name: name,
     identifier: name,
-    id: null,
+    id: -1,
     fieldType: fieldType,
   );
 }
@@ -218,7 +218,7 @@ void _rememberLateHolder() {
     const GeneratedFieldInfo(
       name: 'value',
       identifier: 'value',
-      id: null,
+      id: -1,
       fieldType: _lateExtFieldType,
     ),
   ]);
@@ -567,6 +567,14 @@ Uint8List _duplicateNamedTypeDef(Uint8List validBytes) {
     validBytes,
     (body) => _replaceUniqueBytes(body, second.bytes, first.bytes),
   );
+}
+
+List<int> _taggedInt32FieldBytes(int id) {
+  final buffer = Buffer();
+  buffer.writeByte((3 << 6) | (typeDefBigFieldNameThreshold << 2));
+  buffer.writeVarUint32Small7(id - typeDefBigFieldNameThreshold);
+  buffer.writeByte(TypeIds.int32);
+  return buffer.toBytes();
 }
 
 void main() {
@@ -1271,6 +1279,37 @@ void main() {
         throwsA(isA<StateError>()),
       );
       _readTypeMeta(reader, valid);
+    });
+
+    test('rejects field ids outside domain', () {
+      const name = 'example.FieldIdDomain';
+      const maxFieldId = (1 << 29) - 1;
+      final reader = TypeResolver(Config());
+      _rememberSchema(_SchemaLocal, <GeneratedFieldInfo>[
+        _taggedField(maxFieldId),
+      ]);
+      reader.registerGenerated(
+        _SchemaLocal,
+        namespace: 'example',
+        typeName: 'FieldIdDomain',
+      );
+      final valid = _typeMetaBytes(_SchemaRemoteA, name, <GeneratedFieldInfo>[
+        _taggedField(maxFieldId),
+      ]);
+      _readTypeMeta(reader, valid);
+
+      final malformed = _rewriteTypeDefBody(
+        valid,
+        (body) => _replaceUniqueBytes(
+          body,
+          _taggedInt32FieldBytes(maxFieldId),
+          _taggedInt32FieldBytes(maxFieldId + 1),
+        ),
+      );
+      expect(
+        () => _readTypeMeta(reader, malformed),
+        throwsA(isA<StateError>()),
+      );
     });
 
     test('rejects duplicate remote field names before caching', () {

--- a/docs/specification/java_serialization_spec.md
+++ b/docs/specification/java_serialization_spec.md
@@ -448,7 +448,8 @@ For name encodings, bits `4..6` store `encoded_length - 1` when it is less than
 
 For tag ID encoding, bits `4..6` store the numeric field ID when it is less than
 `7`. If the value is `7`, read an extra `varuint32` and add it to `7`. Field IDs
-must be non-negative. Duplicate field IDs in one TypeDef are invalid.
+must satisfy `0 <= tag_id < 2^29`; the largest legal value is `536870911`.
+Duplicate field IDs in one TypeDef are invalid.
 
 ### Field Type
 

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -849,8 +849,9 @@ Field header layout:
   `LOWER_UPPER_DIGIT_SPECIAL`, or `TAG_ID`)
 - Bits 2-5: size
   - For name encoding: `size = (name_bytes_length - 1)`
-  - For tag ID: `size = tag_id`
-  - If `size == 0b1111`, read `varuint32(size - 15)` and add it
+  - For tag ID: `size = min(tag_id, 15)`
+  - If a tag ID has `size == 0b1111`, write `varuint32(tag_id - 15)` after the
+    header; decoding adds that extension to `15`
 - Bit 1: nullable flag
 - Bit 0: reference tracking flag
 

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -865,6 +865,11 @@ Field type info:
 Field names:
 
 - If `TAG_ID` encoding is used, no name bytes are written.
+- Tag IDs are signed-32-bit protocol values in the range
+  `0 <= tag_id < 2^29` (`0` through `536870911`). The upper bound leaves the
+  complete protocol domain representable by every implementation's signed
+  32-bit field-ID type; the extended form still writes `tag_id - 15` with the
+  existing `varuint32` encoding.
 - Otherwise, write the encoded field name bytes as a meta string.
 - For xlang, field names are converted to `snake_case` before encoding for
   cross-language compatibility.
@@ -1718,10 +1723,11 @@ For every field, compute a stable identifier used for ordering:
 - If a non-negative tag ID is configured (e.g., `@ForyField(id=...)`), use the tag ID.
 - Otherwise, use the field name converted to `snake_case`.
 
-Configured tag IDs must be non-negative. A negative configured tag ID is invalid; languages may
-use a negative value only as a default or internal sentinel for "no tag ID configured", which falls
-back to the `snake_case` field name and is not a tag ID. Tag IDs must be unique within a type;
-duplicate tag IDs are invalid.
+Configured tag IDs must satisfy `0 <= tag_id < 2^29`. A negative configured tag ID is invalid;
+languages may use a negative value only as a default or internal sentinel for "no tag ID
+configured", which falls back to the `snake_case` field name and is not a tag ID. Values greater
+than or equal to `2^29` are invalid. Tag IDs must be unique within a type; duplicate tag IDs are
+invalid.
 
 Field identifiers compare as follows:
 

--- a/docs/specification/xlang_serialization_spec.md
+++ b/docs/specification/xlang_serialization_spec.md
@@ -848,7 +848,10 @@ Field header layout:
 - Bits 6-7: field name encoding (`UTF8`, `ALL_TO_LOWER_SPECIAL`,
   `LOWER_UPPER_DIGIT_SPECIAL`, or `TAG_ID`)
 - Bits 2-5: size
-  - For name encoding: `size = (name_bytes_length - 1)`
+  - For name encoding, let `logical_size = name_bytes_length - 1` and store
+    `size = min(logical_size, 15)`. If `logical_size >= 15`, write
+    `varuint32(logical_size - 15)` after the header; decoding adds that
+    extension to `15`, then adds `1` to obtain `name_bytes_length`.
   - For tag ID: `size = min(tag_id, 15)`
   - If a tag ID has `size == 0b1111`, write `varuint32(tag_id - 15)` after the
     header; decoding adds that extension to `15`

--- a/go/fory/field_info.go
+++ b/go/fory/field_info.go
@@ -271,7 +271,7 @@ func GroupFields(fields []FieldInfo) FieldGroup {
 	return g
 }
 
-func getFieldTagID(field *FieldInfo) int {
+func getFieldTagID(field *FieldInfo) int32 {
 	if field.Meta != nil {
 		if field.Meta.Spec != nil && field.Meta.Spec.TagID >= 0 {
 			return field.Meta.Spec.TagID
@@ -570,7 +570,7 @@ func isStructFieldType(spec *TypeSpec) bool {
 // FieldFingerprintInfo contains the information needed to compute a field's fingerprint.
 type FieldFingerprintInfo struct {
 	// FieldID is the tag ID if configured (>= 0), or -1 to use field name
-	FieldID int
+	FieldID int32
 	// FieldName is the snake_case field name (used when FieldID < 0)
 	FieldName string
 	// TypeSpec is the effective nested field type specification when available.
@@ -610,7 +610,7 @@ func ComputeStructFingerprint(fields []FieldFingerprintInfo) string {
 	type fieldWithKey struct {
 		field      FieldFingerprintInfo
 		sortKey    string
-		fieldID    int
+		fieldID    int32
 		hasFieldID bool
 	}
 	fieldsWithKeys := make([]fieldWithKey, 0, len(fields))
@@ -729,13 +729,13 @@ type triple struct {
 	serializer Serializer
 	name       string
 	nullable   bool
-	tagID      int // -1 = use field name, >=0 = use tag ID for sorting
+	tagID      int32 // -1 = use field name, >=0 = use tag ID for sorting
 }
 
 // getSortKeyText returns the text key used when fields do not both use numeric tag IDs.
 func (t triple) getSortKeyText() string {
 	if t.tagID >= 0 {
-		return strconv.Itoa(t.tagID)
+		return strconv.FormatInt(int64(t.tagID), 10)
 	}
 	return SnakeCase(t.name)
 }
@@ -761,7 +761,7 @@ func lessTripleSortKey(a, b triple) bool {
 func getFieldSortKeyText(f *FieldInfo) string {
 	tagID := getFieldTagID(f)
 	if tagID >= 0 {
-		return strconv.Itoa(tagID)
+		return strconv.FormatInt(int64(tagID), 10)
 	}
 	return f.Meta.Name
 }
@@ -796,7 +796,7 @@ func sortFields(
 	serializers []Serializer,
 	typeIds []TypeId,
 	nullables []bool,
-	tagIDs []int,
+	tagIDs []int32,
 ) ([]Serializer, []string) {
 	var (
 		typeTriples []triple

--- a/go/fory/field_spec.go
+++ b/go/fory/field_spec.go
@@ -38,7 +38,7 @@ const (
 type FieldSpec struct {
 	Name        string
 	GoType      reflect.Type
-	TagID       int
+	TagID       int32
 	Ignore      bool
 	HasTag      bool
 	RawTag      string
@@ -392,7 +392,7 @@ func (t *TypeSpec) goTypeForResolver(resolver *TypeResolver) (reflect.Type, erro
 type parsedFieldTag struct {
 	hasTag      bool
 	rawTag      string
-	tagID       int
+	tagID       int32
 	idSet       bool
 	nullable    bool
 	nullableSet bool
@@ -489,15 +489,18 @@ func parseFieldTag(field reflect.StructField) (parsedFieldTag, error) {
 			if !hasValue {
 				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag on field %s: id requires a value", field.Name)
 			}
-			id, err := strconv.Atoi(value)
+			id, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
 				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag id=%q on field %s", value, field.Name)
 			}
 			if id < 0 {
 				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag id=%d on field %s: id must be non-negative", id, field.Name)
 			}
+			if id > int64(maxTypeDefTagID) {
+				return parsedFieldTag{}, InvalidTagErrorf("invalid fory tag id=%d on field %s: id exceeds TypeDef range", id, field.Name)
+			}
 			parsed.idSet = true
-			parsed.tagID = id
+			parsed.tagID = int32(id)
 		case "nullable":
 			var boolVal bool
 			if hasValue {

--- a/go/fory/struct_init.go
+++ b/go/fory/struct_init.go
@@ -116,7 +116,7 @@ func (s *structSerializer) initFields(typeResolver *TypeResolver) error {
 	var serializers []Serializer
 	var typeIds []TypeId
 	var nullables []bool
-	var tagIDs []int
+	var tagIDs []int32
 
 	for i := 0; i < type_.NumField(); i++ {
 		field := type_.Field(i)
@@ -340,7 +340,7 @@ func (s *structSerializer) initFieldsFromTypeDef(typeResolver *TypeResolver) err
 	localNullableByIndex := make(map[int]bool)
 	localTrackRefByIndex := make(map[int]bool)
 	localSpecByIndex := make(map[int]*TypeSpec)
-	fieldTagIDToBinding := make(map[int]localFieldBinding)
+	fieldTagIDToBinding := make(map[int32]localFieldBinding)
 	for i := 0; i < type_.NumField(); i++ {
 		field := type_.Field(i)
 		if field.PkgPath != "" {

--- a/go/fory/tag.go
+++ b/go/fory/tag.go
@@ -24,7 +24,8 @@ import (
 
 const (
 	// TagIDUseFieldName indicates field name should be used instead of tag ID.
-	TagIDUseFieldName = -1
+	TagIDUseFieldName int32 = -1
+	maxTypeDefTagID   int32 = 1<<29 - 1
 )
 
 func parseBoolStrict(s string) (bool, bool) {
@@ -49,7 +50,7 @@ func validateForyTags(t reflect.Type) error {
 		return nil
 	}
 
-	tagIDs := make(map[int]string)
+	tagIDs := make(map[int32]string)
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		parsed, err := parseFieldTag(field)
@@ -62,6 +63,9 @@ func validateForyTags(t reflect.Type) error {
 		if parsed.idSet {
 			if parsed.tagID < 0 {
 				return InvalidTagErrorf("invalid fory tag id=%d on field %s: id must be non-negative", parsed.tagID, field.Name)
+			}
+			if parsed.tagID > maxTypeDefTagID {
+				return InvalidTagErrorf("invalid fory tag id=%d on field %s: id exceeds TypeDef range", parsed.tagID, field.Name)
 			}
 			if existing, ok := tagIDs[parsed.tagID]; ok {
 				return InvalidTagErrorf("duplicate fory tag id=%d on fields %s and %s", parsed.tagID, existing, field.Name)

--- a/go/fory/tag_test.go
+++ b/go/fory/tag_test.go
@@ -43,14 +43,14 @@ func TestParseFieldSpecBasic(t *testing.T) {
 	typ := reflect.TypeOf(Example{})
 
 	idSpec := mustParseFieldSpec(t, typ.Field(0))
-	require.Equal(t, 0, idSpec.TagID)
+	require.Equal(t, int32(0), idSpec.TagID)
 	require.False(t, idSpec.NullableSet)
 	require.False(t, idSpec.RefSet)
 	require.EqualValues(t, VARINT32, idSpec.Type.TypeId())
 	require.False(t, idSpec.Type.Nullable)
 
 	versionSpec := mustParseFieldSpec(t, typ.Field(1))
-	require.Equal(t, 1, versionSpec.TagID)
+	require.Equal(t, int32(1), versionSpec.TagID)
 	require.True(t, versionSpec.NullableSet)
 	require.True(t, versionSpec.Nullable)
 	require.True(t, versionSpec.RefSet)
@@ -218,7 +218,7 @@ func TestSortFieldsOrdersNonPrimitivesByFieldIdentifier(t *testing.T) {
 	serializers := make([]Serializer, len(fieldNames))
 	typeIDs := []TypeId{STRING, MAP, NAMED_STRUCT, LIST, VARINT32}
 	nullables := []bool{false, false, false, false, false}
-	tagIDs := []int{20, 10, TagIDUseFieldName, TagIDUseFieldName, 30}
+	tagIDs := []int32{20, 10, TagIDUseFieldName, TagIDUseFieldName, 30}
 
 	_, sortedNames := sortFields(nil, fieldNames, serializers, typeIDs, nullables, tagIDs)
 

--- a/go/fory/tests/xlang/xlang_test_main.go
+++ b/go/fory/tests/xlang/xlang_test_main.go
@@ -290,14 +290,14 @@ type Item1 struct {
 
 type SimpleStruct struct {
 	F1   map[int32]float64
-	F2   int32
+	F2   int32 `fory:"id=15"`
 	F3   Item
 	F4   string
 	F5   Color
 	F6   []string
-	F7   int32
+	F7   int32 `fory:"id=65551"`
 	F8   int32
-	Last int32
+	Last int32 `fory:"id=536870911"`
 }
 
 type EvolvingOverrideStruct struct {

--- a/go/fory/type_def.go
+++ b/go/fory/type_def.go
@@ -451,7 +451,7 @@ type FieldDef struct {
 	nullable     bool
 	trackRef     bool
 	typeSpec     *TypeSpec
-	tagID        int // -1 = use field name, >=0 = use tag ID
+	tagID        int32 // -1 = use field name, >=0 = use tag ID
 }
 
 // String returns a string representation of FieldDef for debugging
@@ -532,7 +532,7 @@ func buildFieldDefs(fory *Fory, value reflect.Value) ([]FieldDef, error) {
 		fieldNames := make([]string, len(fieldDefs))
 		typeIds := make([]TypeId, len(fieldDefs))
 		nullables := make([]bool, len(fieldDefs))
-		tagIDs := make([]int, len(fieldDefs))
+		tagIDs := make([]int32, len(fieldDefs))
 		for i, entry := range entries {
 			serializers[i] = entry.serializer
 			fieldNames[i] = entry.fieldDef.name
@@ -941,6 +941,9 @@ func writeFieldDefs(typeResolver *TypeResolver, buffer *ByteBuffer, fieldDefs []
 
 // writeFieldDef writes a single field's definition
 func writeFieldDef(typeResolver *TypeResolver, buffer *ByteBuffer, field FieldDef) error {
+	if field.tagID < TagIDUseFieldName || field.tagID > maxTypeDefTagID {
+		return fmt.Errorf("field tag ID %d is outside the TypeDef range", field.tagID)
+	}
 	// WriteData field header
 	// 2 bits field name encoding + 4 bits size + nullability flag + ref tracking flag
 	offset := buffer.writerIndex
@@ -960,7 +963,7 @@ func writeFieldDef(typeResolver *TypeResolver, buffer *ByteBuffer, field FieldDe
 		header |= FieldNameEncodingTagID << 6
 		// For tag ID, we encode the tag ID value in the size bits (4 bits)
 		// If tagID < 15, encode directly in header; otherwise use varint
-		if field.tagID < FieldNameSizeThreshold {
+		if field.tagID < int32(FieldNameSizeThreshold) {
 			header |= uint8(field.tagID&0x0F) << 2
 		} else {
 			header |= 0x0F << 2 // Max value, actual tag ID will follow
@@ -968,8 +971,8 @@ func writeFieldDef(typeResolver *TypeResolver, buffer *ByteBuffer, field FieldDe
 		buffer.PutUint8(offset, header)
 
 		// Write extra varint for large tag IDs
-		if field.tagID >= FieldNameSizeThreshold {
-			buffer.WriteVarUint32(uint32(field.tagID - FieldNameSizeThreshold))
+		if field.tagID >= int32(FieldNameSizeThreshold) {
+			buffer.WriteVarUint32(uint32(field.tagID - int32(FieldNameSizeThreshold)))
 		}
 
 		// Write field type
@@ -1258,10 +1261,20 @@ func decodeTypeDef(fory *Fory, buffer *ByteBuffer, header int64) (*TypeDef, erro
 
 	// ReadData fields information
 	fieldInfos := make([]FieldDef, fieldCount)
+	var fieldTagIDs map[int32]struct{}
 	for i := 0; i < fieldCount; i++ {
 		fieldInfo, err := readFieldDef(fory.typeResolver, metaBuffer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read field def %d: %w", i, err)
+		}
+		if fieldInfo.tagID >= 0 {
+			if fieldTagIDs == nil {
+				fieldTagIDs = make(map[int32]struct{})
+			}
+			if _, exists := fieldTagIDs[fieldInfo.tagID]; exists {
+				return nil, fmt.Errorf("duplicate TypeDef field tag ID %d", fieldInfo.tagID)
+			}
+			fieldTagIDs[fieldInfo.tagID] = struct{}{}
 		}
 		fieldInfos[i] = fieldInfo
 	}
@@ -1394,16 +1407,16 @@ func readFieldDef(typeResolver *TypeResolver, buffer *ByteBuffer) (FieldDef, err
 	// Check if using TAG_ID encoding
 	if nameEncodingFlag == FieldNameEncodingTagID {
 		// Read tag ID
-		tagID := sizeBits
+		tagID := int32(sizeBits)
 		if sizeBits == 0x0F {
 			extra := buffer.ReadVarUint32(&bufErr)
 			if bufErr.HasError() {
 				return FieldDef{}, bufErr.TakeError()
 			}
-			if uint64(extra) > uint64(MaxInt-FieldNameSizeThreshold) {
+			if extra > uint32(maxTypeDefTagID-int32(FieldNameSizeThreshold)) {
 				return FieldDef{}, fmt.Errorf("invalid TypeDef field tag ID")
 			}
-			tagID = FieldNameSizeThreshold + int(extra)
+			tagID = int32(FieldNameSizeThreshold) + int32(extra)
 		}
 
 		// Read field type

--- a/go/fory/type_def_test.go
+++ b/go/fory/type_def_test.go
@@ -506,7 +506,7 @@ func TestTypeDefExtendedFieldCountHeaderDoesNotSetRegisterByName(t *testing.T) {
 	for i := range fields {
 		fields[i] = FieldDef{
 			typeSpec: NewSimpleTypeSpec(INT32),
-			tagID:    i + 1,
+			tagID:    int32(i + 1),
 		}
 	}
 	typeDef := NewTypeDef(uint32(STRUCT), 700, nil, nil, false, false, fields)
@@ -516,6 +516,29 @@ func TestTypeDefExtendedFieldCountHeaderDoesNotSetRegisterByName(t *testing.T) {
 	header := buffer.Bytes()[0]
 	require.Equal(t, byte(StructTypeDefFlag|SmallNumFieldsThreshold), header)
 	require.Zero(t, header&RegisterByNameFlag)
+}
+
+func TestTypeDefFieldTagDomain(t *testing.T) {
+	field := FieldDef{typeSpec: NewSimpleTypeSpec(INT32), tagID: maxTypeDefTagID}
+	buffer := NewByteBuffer(nil)
+	require.NoError(t, writeFieldDef(nil, buffer, field))
+	buffer.SetReaderIndex(0)
+	decoded, err := readFieldDef(nil, buffer)
+	require.NoError(t, err)
+	require.Equal(t, maxTypeDefTagID, decoded.tagID)
+
+	field.tagID = TagIDUseFieldName - 1
+	require.Error(t, writeFieldDef(nil, NewByteBuffer(nil), field))
+	field.tagID = maxTypeDefTagID + 1
+	require.Error(t, writeFieldDef(nil, NewByteBuffer(nil), field))
+
+	buffer = NewByteBuffer(nil)
+	require.NoError(t, buffer.WriteByte(byte(FieldNameEncodingTagID<<6|0x0F<<2)))
+	buffer.WriteVarUint32(uint32(maxTypeDefTagID+1) - FieldNameSizeThreshold)
+	NewSimpleTypeSpec(INT32).write(buffer)
+	buffer.SetReaderIndex(0)
+	_, err = readFieldDef(nil, buffer)
+	require.Error(t, err)
 }
 
 func TestTypeDefRejectsMetadataHashMismatch(t *testing.T) {

--- a/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
+++ b/java/fory-annotation-processor/src/main/java/org/apache/fory/annotation/processing/ForyStructProcessor.java
@@ -60,6 +60,7 @@ import javax.tools.StandardLocation;
 
 public final class ForyStructProcessor extends AbstractProcessor {
   private static final int REFERENCE_BYTES = 4;
+  private static final int MAX_FORY_FIELD_ID = (1 << 29) - 1;
   // Source classes are not loadable as Class<?> during annotation processing; generated struct
   // estimates add compile-time field widths to the shared JVM object-base component.
   private static final int JVM_OBJECT_BASE_BYTES = REFERENCE_BYTES + REFERENCE_BYTES;
@@ -321,6 +322,10 @@ public final class ForyStructProcessor extends AbstractProcessor {
       String binaryName, Map<Integer, VariableElement> fieldIds, VariableElement field) {
     ForyFieldMeta foryField = foryField(field);
     if (foryField.hasForyField && foryField.id >= 0) {
+      if (foryField.id > MAX_FORY_FIELD_ID) {
+        throw new InvalidStructException(
+            "@ForyField id must be smaller than 2^29 in " + binaryName, field);
+      }
       VariableElement previousField = fieldIds.put(foryField.id, field);
       if (previousField != null) {
         throw new InvalidStructException(
@@ -1191,9 +1196,9 @@ public final class ForyStructProcessor extends AbstractProcessor {
         dynamic = String.valueOf(value);
       }
     }
-    if (id < -1) {
+    if (id < -1 || id > MAX_FORY_FIELD_ID) {
       throw new InvalidStructException(
-          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID", field);
+          "@ForyField id must be -1 (no tag ID) or in [0, 2^29)", field);
     }
     return new ForyFieldMeta(true, id, dynamic);
   }

--- a/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
+++ b/java/fory-annotation-processor/src/test/java/org/apache/fory/annotation/processing/ForyStructProcessorTest.java
@@ -349,9 +349,25 @@ public class ForyStructProcessorTest {
                 + "}\n");
     Assert.assertFalse(result.success);
     Assert.assertTrue(
-        result
-            .diagnostics()
-            .contains("@ForyField id must be -1 (no tag ID) or a non-negative tag ID"),
+        result.diagnostics().contains("@ForyField id must be -1 (no tag ID) or in [0, 2^29)"),
+        result.diagnostics());
+  }
+
+  @Test
+  public void testOversizedFieldIdFails() throws Exception {
+    CompilationResult result =
+        compile(
+            "test.OversizedIdStruct",
+            "package test;\n"
+                + "import org.apache.fory.annotation.ForyField;\n"
+                + "import org.apache.fory.annotation.ForyStruct;\n"
+                + "@ForyStruct public class OversizedIdStruct {\n"
+                + "  @ForyField(id = 536870912) public int value;\n"
+                + "  public OversizedIdStruct() {}\n"
+                + "}\n");
+    Assert.assertFalse(result.success);
+    Assert.assertTrue(
+        result.diagnostics().contains("@ForyField id must be -1 (no tag ID) or in [0, 2^29)"),
         result.diagnostics());
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
+++ b/java/fory-core/src/main/java/org/apache/fory/annotation/ForyField.java
@@ -28,6 +28,9 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 public @interface ForyField {
 
+  /** Largest field tag ID accepted by the cross-language protocol. */
+  int MAX_ID = (1 << 29) - 1;
+
   /** Controls polymorphism behavior for struct fields in cross-language serialization. */
   enum Dynamic {
     /**
@@ -57,8 +60,8 @@ public @interface ForyField {
    *       encoding
    * </ul>
    *
-   * <p>Configured tag IDs are values {@code >= 0}; they must be unique within the class and stable
-   * across versions. Values below {@code -1} are invalid.
+   * <p>Configured tag IDs are in {@code [0, 2^29)}; they must be unique within the class and stable
+   * across versions. Values below {@code -1} or above {@link #MAX_ID} are invalid.
    */
   int id() default -1;
 

--- a/java/fory-core/src/main/java/org/apache/fory/meta/FieldInfo.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/FieldInfo.java
@@ -47,13 +47,16 @@ public final class FieldInfo implements Serializable {
   final FieldTypes.FieldType fieldType;
 
   /** Field ID for schema evolution, -1 means no field ID (use field name). */
-  final short fieldId;
+  final int fieldId;
 
   public FieldInfo(String definedClass, String fieldName, FieldTypes.FieldType fieldType) {
-    this(definedClass, fieldName, fieldType, (short) -1);
+    this(definedClass, fieldName, fieldType, -1);
   }
 
-  FieldInfo(String definedClass, String fieldName, FieldTypes.FieldType fieldType, short fieldId) {
+  FieldInfo(String definedClass, String fieldName, FieldTypes.FieldType fieldType, int fieldId) {
+    if (fieldId < -1 || fieldId > ForyField.MAX_ID) {
+      throw new IllegalArgumentException("Field tag ID out of range: " + fieldId);
+    }
     this.definedClass = definedClass;
     this.fieldName = fieldName;
     this.fieldType = fieldType;
@@ -76,7 +79,7 @@ public final class FieldInfo implements Serializable {
   }
 
   /** Returns annotated field-id for the field. */
-  public short getFieldId() {
+  public int getFieldId() {
     return fieldId;
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefDecoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefDecoder.java
@@ -28,7 +28,10 @@ import static org.apache.fory.meta.TypeDef.COMPRESS_META_FLAG;
 import static org.apache.fory.meta.TypeDef.META_SIZE_MASKS;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.apache.fory.annotation.ForyField;
 import org.apache.fory.collection.Tuple2;
 import org.apache.fory.exception.DeserializationException;
 import org.apache.fory.memory.MemoryBuffer;
@@ -324,32 +327,47 @@ class NativeTypeDefDecoder {
   private static List<FieldInfo> readFieldsInfo(
       MemoryBuffer buffer, ClassResolver resolver, String className, int numFields) {
     List<FieldInfo> fieldInfos = new ArrayList<>();
+    Set<Integer> tagIds = null;
     for (int i = 0; i < numFields; i++) {
       int header = buffer.readByte() & 0xff;
       //  `3 bits size + 2 bits field name encoding + nullability flag + ref tracking flag`
       int encodingFlags = (header >>> 2) & 0b11;
       boolean useTagID = encodingFlags == 3;
-      int size = header >>> 4;
-      if (size == 7) {
+      int inlineSize = header >>> 4;
+      long size = inlineSize;
+      int tagId = useTagID ? inlineSize : -1;
+      if (inlineSize == 7) {
         int extendedSize = buffer.readVarUInt32Small7();
-        if (extendedSize < 0 || extendedSize > Integer.MAX_VALUE - size - 1) {
+        if (useTagID) {
+          if (Integer.compareUnsigned(extendedSize, ForyField.MAX_ID - inlineSize) > 0) {
+            throw new DeserializationException("TypeDef field tag ID out of range");
+          }
+          tagId += extendedSize;
+        } else {
+          size += Integer.toUnsignedLong(extendedSize);
+        }
+      }
+      if (!useTagID) {
+        size += 1;
+        if (size > Integer.MAX_VALUE) {
           throw new DeserializationException("Invalid TypeDef field name size");
         }
-        size += extendedSize;
       }
-      size += 1;
 
       // Read field name or tag ID
       String fieldName;
-      short tagId = -1;
       if (useTagID) {
-        // When useTagID is true, size contains the tag ID
-        tagId = (short) (size - 1);
+        if (tagIds == null) {
+          tagIds = new HashSet<>();
+        }
+        if (!tagIds.add(tagId)) {
+          throw new DeserializationException("Duplicate TypeDef field tag ID " + tagId);
+        }
         // Use placeholder field name since tag ID is used for identification
         fieldName = "$tag" + tagId;
       } else {
         Encoding encoding = fieldNameEncodings[encodingFlags];
-        fieldName = Encoders.FIELD_NAME_DECODER.decode(buffer.readBytes(size), encoding);
+        fieldName = Encoders.FIELD_NAME_DECODER.decode(buffer.readBytes((int) size), encoding);
       }
 
       boolean nullable = (header & 0b010) != 0;

--- a/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/NativeTypeDefEncoder.java
@@ -113,8 +113,7 @@ public class NativeTypeDefEncoder {
           }
           // Create FieldInfo with tag ID for optimized serialization
           fieldInfo =
-              new FieldInfo(
-                  descriptor.getDeclaringClass(), descriptor.getName(), fieldType, (short) tagId);
+              new FieldInfo(descriptor.getDeclaringClass(), descriptor.getName(), fieldType, tagId);
         } else {
           // Negative is the annotation default sentinel for no configured tag ID; use field name.
           fieldInfo =

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDef.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDef.java
@@ -413,7 +413,7 @@ public class TypeDef implements Serializable {
       TypeResolver resolver, Class<?> cls, Collection<Descriptor> fieldDescriptors) {
     boolean isXlang = resolver.isCrossLanguage();
     Map<String, Descriptor> descriptorsMap = new HashMap<>();
-    Map<Short, Descriptor> fieldIdToDescriptorMap = new HashMap<>();
+    Map<Integer, Descriptor> fieldIdToDescriptorMap = new HashMap<>();
     Map<String, Descriptor> xlangNameDescriptors = null;
 
     if (isXlang) {
@@ -437,7 +437,7 @@ public class TypeDef implements Serializable {
       }
       if (descriptor.hasForyFieldId()) {
         int fieldId = descriptor.getForyFieldId();
-        if (fieldIdToDescriptorMap.containsKey((short) fieldId)) {
+        if (fieldIdToDescriptorMap.containsKey(fieldId)) {
           throw new IllegalArgumentException(
               "Duplicate field id "
                   + fieldId
@@ -446,15 +446,15 @@ public class TypeDef implements Serializable {
                   + " in class "
                   + cls.getName());
         }
-        fieldIdToDescriptorMap.put((short) fieldId, descriptor);
+        fieldIdToDescriptorMap.put(fieldId, descriptor);
       }
     }
     List<Descriptor> descriptors = new ArrayList<>(fieldsInfo.size());
     Collection<Descriptor> remoteDescriptors = null;
     Map<String, Descriptor> remoteDescriptorsMap = null;
-    Map<Short, Descriptor> remoteFieldIdToDescriptorMap = null;
+    Map<Integer, Descriptor> remoteFieldIdToDescriptorMap = null;
     Map<String, Map<String, Descriptor>> remoteDefinedClassDescriptors = new HashMap<>();
-    Map<String, Map<Short, Descriptor>> remoteDefinedClassFieldIds = new HashMap<>();
+    Map<String, Map<Integer, Descriptor>> remoteDefinedClassFieldIds = new HashMap<>();
     for (FieldInfo fieldInfo : fieldsInfo) {
       Descriptor descriptor;
       if (fieldInfo.hasFieldId()) {
@@ -495,7 +495,7 @@ public class TypeDef implements Serializable {
           String definedClass = fieldInfo.getDefinedClass();
           Map<String, Descriptor> definedClassDescriptors =
               remoteDefinedClassDescriptors.get(definedClass);
-          Map<Short, Descriptor> definedClassFieldIds =
+          Map<Integer, Descriptor> definedClassFieldIds =
               remoteDefinedClassFieldIds.get(definedClass);
           if (definedClassDescriptors == null) {
             Collection<Descriptor> descriptorsForDefinedClass =
@@ -539,11 +539,11 @@ public class TypeDef implements Serializable {
   private static void populateDescriptorMaps(
       Collection<Descriptor> descriptors,
       Map<String, Descriptor> descriptorsMap,
-      Map<Short, Descriptor> fieldIdToDescriptorMap) {
+      Map<Integer, Descriptor> fieldIdToDescriptorMap) {
     for (Descriptor descriptor : descriptors) {
       descriptorsMap.put(descriptor.getDeclaringClass() + "." + descriptor.getName(), descriptor);
       if (descriptor.hasForyFieldId()) {
-        fieldIdToDescriptorMap.put((short) descriptor.getForyFieldId(), descriptor);
+        fieldIdToDescriptorMap.put(descriptor.getForyFieldId(), descriptor);
       }
     }
   }

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefDecoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefDecoder.java
@@ -33,7 +33,10 @@ import static org.apache.fory.meta.TypeDefEncoder.SMALL_NUM_FIELDS_THRESHOLD;
 import static org.apache.fory.meta.TypeDefEncoder.STRUCT_FLAG;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.apache.fory.annotation.ForyField;
 import org.apache.fory.collection.Tuple2;
 import org.apache.fory.exception.DeserializationException;
 import org.apache.fory.logging.Logger;
@@ -215,20 +218,32 @@ class TypeDefDecoder {
   private static List<FieldInfo> readFieldsInfo(
       MemoryBuffer buffer, XtypeResolver resolver, String className, int numFields) {
     List<FieldInfo> fieldInfos = new ArrayList<>();
+    Set<Integer> tagIds = null;
     for (int i = 0; i < numFields; i++) {
       // header: 2 bits field name encoding + 4 bits size + nullability flag + ref tracking flag
       byte header = buffer.readByte();
       int encodingFlags = (header >>> 6) & 0b11;
       boolean useTagID = encodingFlags == 3;
-      int fieldNameSize = (header >>> 2) & 0b1111;
-      if (fieldNameSize == FIELD_NAME_SIZE_THRESHOLD) {
+      int inlineSize = (header >>> 2) & 0b1111;
+      long fieldNameSize = inlineSize;
+      int tagId = useTagID ? inlineSize : -1;
+      if (inlineSize == FIELD_NAME_SIZE_THRESHOLD) {
         int extendedSize = buffer.readVarUInt32Small7();
-        if (extendedSize < 0 || extendedSize > Integer.MAX_VALUE - fieldNameSize - 1) {
+        if (useTagID) {
+          if (Integer.compareUnsigned(extendedSize, ForyField.MAX_ID - inlineSize) > 0) {
+            throw new DeserializationException("TypeDef field tag ID out of range");
+          }
+          tagId += extendedSize;
+        } else {
+          fieldNameSize += Integer.toUnsignedLong(extendedSize);
+        }
+      }
+      if (!useTagID) {
+        fieldNameSize += 1;
+        if (fieldNameSize > Integer.MAX_VALUE) {
           throw new DeserializationException("Invalid TypeDef field name size");
         }
-        fieldNameSize += extendedSize;
       }
-      fieldNameSize += 1;
       boolean nullable = (header & 0b10) != 0;
       boolean trackingRef = (header & 0b1) != 0;
       int typeId = buffer.readUInt8();
@@ -237,15 +252,19 @@ class TypeDefDecoder {
 
       // read field name or tag ID
       if (useTagID) {
-        // When useTagID is true, fieldNameSize actually contains the tag ID
-        short tagId = (short) (fieldNameSize - 1);
+        if (tagIds == null) {
+          tagIds = new HashSet<>();
+        }
+        if (!tagIds.add(tagId)) {
+          throw new DeserializationException("Duplicate TypeDef field tag ID " + tagId);
+        }
         // Use a placeholder field name since tag ID is used for identification
         String fieldName = "$tag" + tagId; // TODO we could use id as String as field name
         fieldInfos.add(new FieldInfo(className, fieldName, fieldType, tagId));
       } else {
         Encoding encoding = fieldNameEncodings[encodingFlags];
         String wireFieldName =
-            Encoders.FIELD_NAME_DECODER.decode(buffer.readBytes(fieldNameSize), encoding);
+            Encoders.FIELD_NAME_DECODER.decode(buffer.readBytes((int) fieldNameSize), encoding);
         // Convert snake_case field names back to camelCase for Java field matching
         String fieldName = StringUtils.lowerUnderscoreToLowerCamelCase(wireFieldName);
         fieldInfos.add(new FieldInfo(className, fieldName, fieldType));

--- a/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/meta/TypeDefEncoder.java
@@ -153,8 +153,7 @@ class TypeDefEncoder {
                             + " in class "
                             + type.getName());
                   }
-                  return new FieldInfo(
-                      type.getName(), descriptor.getName(), fieldType, (short) tagId);
+                  return new FieldInfo(type.getName(), descriptor.getName(), fieldType, tagId);
                 }
                 // Negative is the annotation default sentinel for no configured tag ID; fall
                 // through to create regular FieldInfo. User-facing tag IDs must be non-negative.

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/StaticGeneratedStructSerializer.java
@@ -628,12 +628,12 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
       Descriptor descriptor = remoteDescriptors.get(i);
       putRemoteFieldInfo(remoteFieldInfosByKey, fieldInfo, descriptor);
     }
-    Map<Short, Integer> fieldIds = new HashMap<>();
+    Map<Integer, Integer> fieldIds = new HashMap<>();
     Map<String, Integer> fields = new HashMap<>();
     for (int i = 0; i < localDescriptors.size(); i++) {
       Descriptor descriptor = localDescriptors.get(i);
       if (descriptor.hasForyFieldId()) {
-        fieldIds.put((short) descriptor.getForyFieldId(), i);
+        fieldIds.put(descriptor.getForyFieldId(), i);
       }
       fields.put(fieldKey(descriptor), i);
     }
@@ -674,7 +674,7 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
       List<RemoteFieldInfo> remoteFields,
       SerializationFieldInfo[] remoteFieldInfosInWireOrder,
       Map<String, FieldInfo> remoteFieldInfosByKey,
-      Map<Short, Integer> fieldIds,
+      Map<Integer, Integer> fieldIds,
       Map<String, Integer> fields,
       List<Descriptor> localDescriptors,
       SerializationFieldInfo[] localFieldsById) {
@@ -732,7 +732,7 @@ public abstract class StaticGeneratedStructSerializer<T> extends AbstractObjectS
   }
 
   private int matchField(
-      FieldInfo fieldInfo, Map<Short, Integer> fieldIds, Map<String, Integer> fields) {
+      FieldInfo fieldInfo, Map<Integer, Integer> fieldIds, Map<String, Integer> fields) {
     Integer localId;
     if (fieldInfo.hasFieldId()) {
       localId = fieldIds.get(fieldInfo.getFieldId());

--- a/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/Descriptor.java
@@ -394,9 +394,9 @@ public class Descriptor {
     this.writeMethod = null;
     this.foryField = null;
     this.hasForyField = hasForyField;
-    if (hasForyField && foryFieldId < -1) {
+    if (hasForyField && (foryFieldId < -1 || foryFieldId > ForyField.MAX_ID)) {
       throw new IllegalArgumentException(
-          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + name);
+          "@ForyField id must be -1 (no tag ID) or in [0, 2^29) for field " + name);
     }
     this.foryFieldId = hasForyField ? foryFieldId : -1;
     this.dynamic = hasForyField ? Objects.requireNonNull(dynamic) : ForyField.Dynamic.AUTO;
@@ -477,9 +477,9 @@ public class Descriptor {
             ? builder.foryField
             : (this.field == null ? null : this.field.getAnnotation(ForyField.class));
     if (builder.hasForyField) {
-      if (builder.foryFieldId < -1) {
+      if (builder.foryFieldId < -1 || builder.foryFieldId > ForyField.MAX_ID) {
         throw new IllegalArgumentException(
-            "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + name);
+            "@ForyField id must be -1 (no tag ID) or in [0, 2^29) for field " + name);
       }
       this.hasForyField = true;
       this.foryFieldId = builder.foryFieldId;
@@ -511,9 +511,9 @@ public class Descriptor {
       return -1;
     }
     int id = foryField.id();
-    if (id < -1) {
+    if (id < -1 || id > ForyField.MAX_ID) {
       throw new IllegalArgumentException(
-          "@ForyField id must be -1 (no tag ID) or a non-negative tag ID for field " + fieldName);
+          "@ForyField id must be -1 (no tag ID) or in [0, 2^29) for field " + fieldName);
     }
     return id;
   }

--- a/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
+++ b/java/fory-core/src/main/java/org/apache/fory/type/DescriptorBuilder.java
@@ -133,9 +133,8 @@ public class DescriptorBuilder {
     this.hasForyField = foryField != null;
     if (hasForyField) {
       this.foryFieldId = foryField.id();
-      if (foryFieldId < -1) {
-        throw new IllegalArgumentException(
-            "@ForyField id must be -1 (no tag ID) or a non-negative tag ID");
+      if (foryFieldId < -1 || foryFieldId > ForyField.MAX_ID) {
+        throw new IllegalArgumentException("@ForyField id must be -1 (no tag ID) or in [0, 2^29)");
       }
       this.dynamic = foryField.dynamic();
     } else {

--- a/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/annotation/ForyFieldTagIdTest.java
@@ -22,6 +22,7 @@ package org.apache.fory.annotation;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Field;
@@ -55,6 +56,11 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     public String invalidField;
   }
 
+  public static class InvalidTagClass {
+    @ForyField(id = 1 << 29)
+    public String value;
+  }
+
   @Test(dataProvider = "languageAndCodegen")
   public void testFieldInfoCreationWithTagIds(boolean xlang, boolean codegen, boolean registered) {
     Fory fory =
@@ -84,16 +90,12 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     // Verify field with id=0 has tag
     assertTrue(field0.hasFieldId(), "Field with id=0 should have tag in xlang=" + xlang);
     assertEquals(
-        field0.getFieldId(),
-        (short) 0,
-        "Field with id=0 should have tag value 0 in xlang=" + xlang);
+        field0.getFieldId(), 0, "Field with id=0 should have tag value 0 in xlang=" + xlang);
 
     // Verify field with id=5 has tag
     assertTrue(field5.hasFieldId(), "Field with id=5 should have tag in xlang=" + xlang);
     assertEquals(
-        field5.getFieldId(),
-        (short) 5,
-        "Field with id=5 should have tag value 5 in xlang=" + xlang);
+        field5.getFieldId(), 5, "Field with id=5 should have tag value 5 in xlang=" + xlang);
 
     // Verify field with annotation but no ID does NOT have tag
     assertFalse(
@@ -186,6 +188,14 @@ public class ForyFieldTagIdTest extends ForyTestBase {
     org.testng.Assert.assertThrows(
         IllegalArgumentException.class,
         () -> TypeDef.buildTypeDef(fory.getTypeResolver(), NegativeTagIdClass.class));
+  }
+
+  @Test
+  public void rejectsTagOutsideProtocolDomain() {
+    Fory fory = Fory.builder().requireClassRegistration(false).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDef.buildTypeDef(fory.getTypeResolver(), InvalidTagClass.class));
   }
 
   /** Helper method to find a FieldInfo by field name */

--- a/java/fory-core/src/test/java/org/apache/fory/meta/NativeTypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/NativeTypeDefEncoderTest.java
@@ -765,6 +765,23 @@ public class NativeTypeDefEncoderTest {
     private int fieldC;
   }
 
+  public static class ClassWithLargeTagIds {
+    @ForyField(id = 15)
+    private String field15;
+
+    @ForyField(id = 32768)
+    private String field32768;
+
+    @ForyField(id = 65535)
+    private String field65535;
+
+    @ForyField(id = 65551)
+    private String field65551;
+
+    @ForyField(id = ForyField.MAX_ID)
+    private String fieldMax;
+  }
+
   @Data
   public static class ClassWithMixedFields {
     @ForyField(id = 15)
@@ -800,6 +817,20 @@ public class NativeTypeDefEncoderTest {
     for (FieldInfo fieldInfo : fieldsInfo) {
       Assert.assertTrue(fieldInfo.hasFieldId());
     }
+  }
+
+  @Test
+  public void testLargeTagIdsRoundTrip() {
+    Fory fory = Fory.builder().withXlang(false).withMetaShare(true).withCompatible(true).build();
+
+    TypeDef typeDef = TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithLargeTagIds.class);
+    TypeDef decoded =
+        TypeDef.readTypeDef(
+            fory.getTypeResolver(), MemoryBuffer.fromByteArray(typeDef.getEncoded()));
+
+    Assert.assertEquals(
+        decoded.getFieldsInfo().stream().map(FieldInfo::getFieldId).toArray(),
+        new Object[] {15, 32768, 65535, 65551, ForyField.MAX_ID});
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/TypeDefEncoderTest.java
@@ -231,11 +231,20 @@ public class TypeDefEncoderTest {
   // Test data: Class with large tag IDs
   @Data
   public static class ClassWithLargeTagIds {
-    @ForyField(id = 32000)
+    @ForyField(id = 15)
     private String field1;
 
-    @ForyField(id = 32767) // Max short value
-    private int field2;
+    @ForyField(id = 32768)
+    private String field2;
+
+    @ForyField(id = 65535)
+    private String field3;
+
+    @ForyField(id = 65551)
+    private String field4;
+
+    @ForyField(id = ForyField.MAX_ID)
+    private String field5;
   }
 
   public static class NestedUnionMapField {
@@ -382,15 +391,15 @@ public class TypeDefEncoderTest {
 
     // Verify all fields have the correct tag IDs
     Assert.assertTrue(fieldInfos.get(0).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(0).getFieldId(), (short) 100);
+    Assert.assertEquals(fieldInfos.get(0).getFieldId(), 100);
     Assert.assertEquals(fieldInfos.get(0).getFieldName(), "field1");
 
     Assert.assertTrue(fieldInfos.get(1).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(1).getFieldId(), (short) 200);
+    Assert.assertEquals(fieldInfos.get(1).getFieldId(), 200);
     Assert.assertEquals(fieldInfos.get(1).getFieldName(), "field2");
 
     Assert.assertTrue(fieldInfos.get(2).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(2).getFieldId(), (short) 300);
+    Assert.assertEquals(fieldInfos.get(2).getFieldId(), 300);
     Assert.assertEquals(fieldInfos.get(2).getFieldName(), "field3");
   }
 
@@ -414,7 +423,7 @@ public class TypeDefEncoderTest {
 
     // annotatedField1 should have tag 50
     Assert.assertTrue(fieldInfos.get(0).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(0).getFieldId(), (short) 50);
+    Assert.assertEquals(fieldInfos.get(0).getFieldId(), 50);
     Assert.assertEquals(fieldInfos.get(0).getFieldName(), "annotatedField1");
 
     // noAnnotation should not have a tag (uses field name)
@@ -427,7 +436,7 @@ public class TypeDefEncoderTest {
 
     // annotatedField2 should have tag 60
     Assert.assertTrue(fieldInfos.get(3).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(3).getFieldId(), (short) 60);
+    Assert.assertEquals(fieldInfos.get(3).getFieldId(), 60);
     Assert.assertEquals(fieldInfos.get(3).getFieldName(), "annotatedField2");
   }
 
@@ -473,7 +482,7 @@ public class TypeDefEncoderTest {
 
     Assert.assertEquals(fieldInfos.size(), 1);
     Assert.assertTrue(fieldInfos.get(0).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(0).getFieldId(), (short) 42);
+    Assert.assertEquals(fieldInfos.get(0).getFieldId(), 42);
     Assert.assertEquals(fieldInfos.get(0).getFieldName(), "field");
   }
 
@@ -532,18 +541,59 @@ public class TypeDefEncoderTest {
     List<Field> fields =
         Arrays.asList(
             getField(ClassWithLargeTagIds.class, "field1"),
-            getField(ClassWithLargeTagIds.class, "field2"));
+            getField(ClassWithLargeTagIds.class, "field2"),
+            getField(ClassWithLargeTagIds.class, "field3"),
+            getField(ClassWithLargeTagIds.class, "field4"),
+            getField(ClassWithLargeTagIds.class, "field5"));
 
     List<FieldInfo> fieldInfos =
         TypeDefEncoder.buildFieldsInfo(resolver, ClassWithLargeTagIds.class, fields);
 
-    Assert.assertEquals(fieldInfos.size(), 2);
+    Assert.assertEquals(fieldInfos.size(), 5);
 
     Assert.assertTrue(fieldInfos.get(0).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(0).getFieldId(), (short) 32000);
+    Assert.assertEquals(fieldInfos.get(0).getFieldId(), 15);
 
     Assert.assertTrue(fieldInfos.get(1).hasFieldId());
-    Assert.assertEquals(fieldInfos.get(1).getFieldId(), (short) 32767);
+    Assert.assertEquals(fieldInfos.get(1).getFieldId(), 32768);
+    Assert.assertEquals(fieldInfos.get(2).getFieldId(), 65535);
+    Assert.assertEquals(fieldInfos.get(3).getFieldId(), 65551);
+    Assert.assertEquals(fieldInfos.get(4).getFieldId(), ForyField.MAX_ID);
+  }
+
+  @Test
+  public void testLargeTagIdsRoundTripAndMatch() {
+    Fory fory = Fory.builder().withXlang(true).withCompatible(true).withMetaShare(true).build();
+    fory.register(ClassWithLargeTagIds.class, 6004);
+
+    TypeDef local = TypeDef.buildTypeDef(fory.getTypeResolver(), ClassWithLargeTagIds.class);
+    TypeDef decoded =
+        TypeDef.readTypeDef(fory.getTypeResolver(), MemoryBuffer.fromByteArray(local.getEncoded()));
+
+    Assert.assertEquals(
+        decoded.getFieldsInfo().stream().map(FieldInfo::getFieldId).collect(Collectors.toList()),
+        Arrays.asList(15, 32768, 65535, 65551, ForyField.MAX_ID));
+    Map<Integer, String> matchedFields =
+        decoded.getDescriptors(fory.getTypeResolver(), ClassWithLargeTagIds.class).stream()
+            .collect(Collectors.toMap(Descriptor::getForyFieldId, Descriptor::getName));
+    Assert.assertEquals(matchedFields.get(15), "field1");
+    Assert.assertEquals(matchedFields.get(65551), "field4");
+
+    MemoryBuffer body = MemoryBuffer.newHeapBuffer(32);
+    body.writeByte(TypeDefEncoder.STRUCT_FLAG | TypeDefEncoder.COMPATIBLE_FLAG | 1);
+    body.writeVarUInt32(6004);
+    FieldTypes.FieldType fieldType = local.getFieldsInfo().get(0).getFieldType();
+    int header = (3 << 6) | (TypeDefEncoder.FIELD_NAME_SIZE_THRESHOLD << 2);
+    header |= fieldType.nullable() ? 0b10 : 0;
+    header |= fieldType.trackingRef() ? 1 : 0;
+    body.writeByte(header);
+    body.writeVarUInt32(ForyField.MAX_ID + 1 - TypeDefEncoder.FIELD_NAME_SIZE_THRESHOLD);
+    fieldType.writeCrossLanguage(body, false);
+    Assert.assertThrows(
+        RuntimeException.class,
+        () ->
+            TypeDef.readTypeDef(
+                fory.getTypeResolver(), NativeTypeDefEncoder.prependHeader(body, false)));
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/xlang/XlangTestBase.java
+++ b/java/fory-core/src/test/java/org/apache/fory/xlang/XlangTestBase.java
@@ -636,13 +636,21 @@ public abstract class XlangTestBase extends ForyTestBase {
   @ForyStruct
   static class SimpleStruct {
     HashMap<Integer, Double> f1;
+
+    @ForyField(id = 15)
     int f2;
+
     Item f3;
     String f4;
     Color f5;
     List<String> f6;
+
+    @ForyField(id = 65551)
     int f7;
+
     int f8; // Changed from Integer to int to match Rust
+
+    @ForyField(id = 536870911)
     int last; // Changed from Integer to int to match Rust
   }
 

--- a/javascript/packages/core/lib/context.ts
+++ b/javascript/packages/core/lib/context.ts
@@ -1644,8 +1644,8 @@ export class ReadContext {
       const localFieldTypeInfo = localProps?.[fieldInfo.getFieldName()];
       let fieldTypeInfo = this.fieldInfoToTypeInfo(fieldInfo, localFieldTypeInfo)
         .setNullable(fieldInfo.nullable)
-        .setTrackingRef(fieldInfo.trackingRef)
-        .setId(fieldInfo.fieldId);
+        .setTrackingRef(fieldInfo.trackingRef);
+      fieldTypeInfo.id = fieldInfo.fieldId;
       if (localFieldTypeInfo === undefined) {
         fieldTypeInfo = markCompatibleSkipRead(fieldTypeInfo);
       }

--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -20,7 +20,7 @@
 import { BinaryWriter } from "../writer";
 import { BinaryReader } from "../reader";
 import { Encoding, MetaStringDecoder, MetaStringEncoder } from "./MetaString";
-import { TypeInfo } from "../typeInfo";
+import { checkFieldId, TypeInfo } from "../typeInfo";
 import { TypeId } from "../type";
 import { x64hash128 } from "../murmurHash3";
 import { fromString } from "../platformBuffer";
@@ -150,7 +150,6 @@ export interface InnerFieldInfo {
   trackingRef?: boolean;
   nullable?: boolean;
   options?: InnerFieldInfoOptions;
-  fieldId?: number;
 }
 export class FieldInfo {
   constructor(
@@ -160,7 +159,7 @@ export class FieldInfo {
     public trackingRef = false,
     public nullable = false,
     public options: InnerFieldInfoOptions = {},
-    public fieldId?: number,
+    public fieldId = -1,
   ) {}
 
   getFieldName() {
@@ -176,7 +175,7 @@ export class FieldInfo {
   }
 
   hasFieldId() {
-    return typeof this.fieldId === "number" && this.fieldId >= 0;
+    return this.fieldId >= 0;
   }
 
   getFieldId() {
@@ -409,11 +408,9 @@ export class TypeMeta {
           fieldTypeId = TypeId.UNION;
         }
         const { trackingRef, nullable, id, userTypeId, options } = typeInfo;
-        if (typeof id === "number" && id < 0) {
-          throw new Error(`Field id for ${fieldName} must be non-negative`);
-        }
-        const fieldId = typeof id === "number" ? id : undefined;
-        if (fieldId !== undefined) {
+        const fieldId = id;
+        if (fieldId !== -1) {
+          checkFieldId(fieldId);
           if (usedFieldIds.has(fieldId)) {
             throw new Error(`Duplicate field id ${fieldId}`);
           }
@@ -542,7 +539,7 @@ export class TypeMeta {
     for (let i = 0; i < numFields; i++) {
       const fieldInfo = this.readFieldInfo(bodyReader);
       if (fieldInfo.hasFieldId()) {
-        const fieldId = fieldInfo.getFieldId()!;
+        const fieldId = fieldInfo.getFieldId();
         if (fieldIds?.has(fieldId)) {
           throw new Error(`Duplicate field id ${fieldId}`);
         }
@@ -636,9 +633,10 @@ export class TypeMeta {
     const { typeId, userTypeId, options } = this.readTypeId(reader);
 
     let fieldName: string;
-    let fieldId: number | undefined;
+    let fieldId = -1;
     if (encodingFlags === 3) {
       fieldId = size;
+      checkFieldId(fieldId);
       fieldName = `$tag${fieldId}`;
     } else {
       // Read field name
@@ -756,10 +754,8 @@ export class TypeMeta {
     const localNameById = new Map<number, string>();
     const localNameByNormalized = new Map<string, string>();
     for (const [fieldName, typeInfo] of Object.entries(localProps)) {
-      if (typeof typeInfo.id === "number") {
-        if (typeInfo.id < 0) {
-          throw new Error(`Field id for ${fieldName} must be non-negative`);
-        }
+      if (typeInfo.id !== -1) {
+        checkFieldId(typeInfo.id);
         localNameById.set(typeInfo.id, fieldName);
       }
       const normalized = TypeMeta.toSnakeCase(fieldName);
@@ -771,7 +767,7 @@ export class TypeMeta {
     return this.fields.map((fieldInfo) => {
       let resolvedName = fieldInfo.getFieldName();
       if (fieldInfo.hasFieldId()) {
-        const localName = localNameById.get(fieldInfo.getFieldId()!);
+        const localName = localNameById.get(fieldInfo.getFieldId());
         if (localName) {
           resolvedName = localName;
         }
@@ -896,6 +892,7 @@ export class TypeMeta {
   }
 
   private writeFieldsInfo(writer: BinaryWriter, fields: FieldInfo[]) {
+    let fieldIds: Set<number> | undefined;
     for (const fieldInfo of fields) {
       // header: 2 bits field name encoding + 4 bits size + nullability flag + ref tracking flag
       let header = fieldInfo.trackingRef ? 1 : 0;
@@ -905,7 +902,15 @@ export class TypeMeta {
       let encoded: Uint8Array | null = null;
 
       if (fieldInfo.hasFieldId()) {
-        size = fieldInfo.getFieldId()!;
+        size = fieldInfo.getFieldId();
+        checkFieldId(size);
+        if (fieldIds?.has(size)) {
+          throw new Error(`Duplicate field id ${size}`);
+        }
+        if (fieldIds === undefined) {
+          fieldIds = new Set();
+        }
+        fieldIds.add(size);
         encodingFlags = 3; // TAG_ID encoding
       } else {
         // Convert camelCase to snake_case for xlang compatibility
@@ -1075,8 +1080,8 @@ export class TypeMeta {
     return result.join("");
   }
 
-  static getFieldSortKey(i: { fieldName: string; fieldId?: number }) {
-    if (i.fieldId !== undefined && i.fieldId !== null && i.fieldId >= 0) {
+  static getFieldSortKey(i: { fieldName: string; fieldId: number }) {
+    if (i.fieldId >= 0) {
       return `${i.fieldId}`;
     }
     return TypeMeta.toSnakeCase(i.fieldName);
@@ -1090,23 +1095,16 @@ export class TypeMeta {
   }
 
   static compareFieldSortKey(
-    a: { fieldName: string; fieldId?: number },
-    b: { fieldName: string; fieldId?: number },
+    a: { fieldName: string; fieldId: number },
+    b: { fieldName: string; fieldId: number },
   ) {
-    if (
-      a.fieldId !== undefined &&
-      a.fieldId !== null &&
-      a.fieldId >= 0 &&
-      b.fieldId !== undefined &&
-      b.fieldId !== null &&
-      b.fieldId >= 0
-    ) {
+    if (a.fieldId >= 0 && b.fieldId >= 0) {
       return a.fieldId - b.fieldId;
     }
-    if (a.fieldId !== undefined && a.fieldId !== null && a.fieldId >= 0) {
+    if (a.fieldId >= 0) {
       return -1;
     }
-    if (b.fieldId !== undefined && b.fieldId !== null && b.fieldId >= 0) {
+    if (b.fieldId >= 0) {
       return 1;
     }
     return TypeMeta.compareOrdinal(TypeMeta.getFieldSortKey(a), TypeMeta.getFieldSortKey(b));
@@ -1117,7 +1115,7 @@ export class TypeMeta {
       fieldName: string;
       nullable?: boolean;
       typeId: number;
-      fieldId?: number;
+      fieldId: number;
     },
   >(typeInfos: Array<T>): Array<T> {
     const primitiveFields: Array<T> = [];

--- a/javascript/packages/core/lib/typeInfo.ts
+++ b/javascript/packages/core/lib/typeInfo.ts
@@ -24,6 +24,19 @@ import { Float16Array } from "./types/float16";
 import { Decimal } from "./types/decimal";
 
 const targetFields = new WeakMap<new () => any, { [key: string]: TypeInfo }>();
+export const MAX_FIELD_ID = (1 << 29) - 1;
+
+export function checkFieldId(fieldId: number) {
+  if (Number.isFinite(fieldId) && fieldId < 0) {
+    throw new Error("field id must be non-negative");
+  }
+  if (!Number.isFinite(fieldId) || !Number.isInteger(fieldId)) {
+    throw new Error("field id must be a finite integer");
+  }
+  if (fieldId > MAX_FIELD_ID) {
+    throw new Error(`field id must not exceed ${MAX_FIELD_ID}`);
+  }
+}
 
 const addField = (target: new () => any, key: string, des: TypeInfo) => {
   if (!targetFields.has(target)) {
@@ -97,11 +110,9 @@ export class TypeInfo<T = unknown> extends ExtensibleFunction {
     this.trackingRef = v;
     return this;
   }
-  id?: number;
-  setId(v: number | undefined) {
-    if (typeof v === "number" && v < 0) {
-      throw new Error("field id must be non-negative");
-    }
+  id = -1;
+  setId(v: number) {
+    checkFieldId(v);
     this.id = v;
     return this;
   }

--- a/javascript/test/crossLanguage.test.ts
+++ b/javascript/test/crossLanguage.test.ts
@@ -328,14 +328,14 @@ describe("bool", () => {
     // Define SimpleStruct class with field type registration
     @Type.struct(103, {
       f1: Type.map(Type.int32(), Type.float64()),
-      f2: Type.int32(),
+      f2: Type.int32().setId(15),
       f3: Type.struct(102),
       f4: Type.string(),
       f5: Type.enum(101, Color),
       f6: Type.list(Type.string()),
-      f7: Type.int32(),
+      f7: Type.int32().setId(65551),
       f8: Type.int32(),
-      last: Type.int32(),
+      last: Type.int32().setId(536870911),
     })
     class SimpleStruct {
       f2: number = 0;
@@ -396,14 +396,14 @@ describe("bool", () => {
       { namespace: "demo", typeName: "simple_struct" },
       {
         f1: Type.map(Type.int32(), Type.float64()),
-        f2: Type.int32(),
+        f2: Type.int32().setId(15),
         f3: Type.struct({ namespace: "demo", typeName: "item" }),
         f4: Type.string(),
         f5: Type.enum({ namespace: "demo", typeName: "color" }, Color),
         f6: Type.list(Type.string()),
-        f7: Type.int32(),
+        f7: Type.int32().setId(65551),
         f8: Type.int32(),
-        last: Type.int32(),
+        last: Type.int32().setId(536870911),
       },
     )
     class SimpleStruct {

--- a/javascript/test/typemeta.test.ts
+++ b/javascript/test/typemeta.test.ts
@@ -31,6 +31,7 @@ import { localTypeMetaSymbol, TypeMeta } from "../packages/core/lib/meta/TypeMet
 import { x64hash128 } from "../packages/core/lib/murmurHash3";
 import { BinaryReader } from "../packages/core/lib/reader";
 import { RefFlags, TypeId } from "../packages/core/lib/type";
+import { MAX_FIELD_ID } from "../packages/core/lib/typeInfo";
 import { BinaryWriter } from "../packages/core/lib/writer";
 import { describe, expect, test } from "@jest/globals";
 
@@ -200,6 +201,32 @@ describe("typemeta", () => {
     expect(() => Type.string().setId(-1)).toThrow("field id must be non-negative");
   });
 
+  test("bounds field ids to the signed int32 protocol domain", () => {
+    const maxTypeInfo = Type.struct(7014, {
+      value: Type.string().setId(MAX_FIELD_ID),
+    });
+    const maxBytes = TypeMeta.fromTypeInfo(maxTypeInfo).toBytes();
+    const maxReader = new BinaryReader({});
+    maxReader.reset(maxBytes);
+    expect(TypeMeta.fromBytes(maxReader).getFieldInfo()[0].fieldId).toBe(MAX_FIELD_ID);
+
+    const validTag = new BinaryWriter({});
+    validTag.writeVarUint32Small7(MAX_FIELD_ID - 15);
+    const invalidTag = new BinaryWriter({});
+    invalidTag.writeVarUint32Small7(MAX_FIELD_ID + 1 - 15);
+    const invalidBody = replaceFirstBytes(maxBytes.subarray(8), validTag.dump(), invalidTag.dump());
+    const invalidMeta = new BinaryWriter({});
+    invalidMeta.writeUint64((TypeMeta as any).buildHeader(invalidBody, false).header);
+    invalidMeta.buffer(invalidBody);
+    const invalidReader = new BinaryReader({});
+    invalidReader.reset(invalidMeta.dump());
+    expect(() => TypeMeta.fromBytes(invalidReader)).toThrow();
+
+    expect(() => Type.string().setId(MAX_FIELD_ID + 1)).toThrow();
+    expect(() => Type.string().setId(1.5)).toThrow();
+    expect(() => Type.string().setId(Number.NaN)).toThrow();
+  });
+
   test("orders name-based identifiers with ordinal comparison", () => {
     const typeMeta = TypeMeta.fromTypeInfo(
       Type.struct(7011, {
@@ -343,16 +370,22 @@ describe("typemeta", () => {
     const writer = writerFory.register(writerType);
     const reader = readerFory.register(readerType);
     const validTypeMeta = TypeMeta.fromTypeInfo(writerType, (writerFory as any).typeResolver);
-    const duplicateTypeMeta = TypeMeta.fromTypeInfo(writerType, (writerFory as any).typeResolver);
-    duplicateTypeMeta.getFieldInfo()[1].fieldId = 1;
-    const duplicateBytes = duplicateTypeMeta.toBytes();
+    const validTypeMetaBytes = validTypeMeta.toBytes();
+    const duplicateBody = Uint8Array.from(validTypeMetaBytes.subarray(8));
+    const secondFieldHeader = duplicateBody.lastIndexOf(0b1100_1000);
+    expect(secondFieldHeader).toBeGreaterThanOrEqual(0);
+    duplicateBody[secondFieldHeader] = 0b1100_0100;
+    const duplicateWriter = new BinaryWriter({});
+    duplicateWriter.writeUint64((TypeMeta as any).buildHeader(duplicateBody, false).header);
+    duplicateWriter.buffer(duplicateBody);
+    const duplicateBytes = duplicateWriter.dump();
     const parseReader = new BinaryReader({});
     parseReader.reset(duplicateBytes);
     expect(() => TypeMeta.fromBytes(parseReader)).toThrow("Duplicate field id 1");
 
     const value = { first: 1, second: 2 };
     const valid = writer.serialize(value);
-    const malformed = replaceFirstBytes(valid, validTypeMeta.toBytes(), duplicateBytes);
+    const malformed = replaceFirstBytes(valid, validTypeMetaBytes, duplicateBytes);
     const readContext = (readerFory as any).readContext;
 
     expect(() => reader.deserialize(malformed)).toThrow("Duplicate field id 1");

--- a/kotlin/fory-kotlin-ksp/src/main/kotlin/org/apache/fory/kotlin/ksp/ForyKotlinSymbolProcessor.kt
+++ b/kotlin/fory-kotlin-ksp/src/main/kotlin/org/apache/fory/kotlin/ksp/ForyKotlinSymbolProcessor.kt
@@ -43,6 +43,7 @@ import java.util.Locale
 import org.apache.fory.codegen.GeneratedClassNames
 
 private const val MAX_DEFAULT_FIELDS = 12
+private const val MAX_FIELD_ID = (1 shl 29) - 1
 
 private data class ParsedStructFields(
   val construction: KotlinStructConstruction,
@@ -54,6 +55,13 @@ internal fun fieldLimitError(defaultFieldCount: Int): String? =
     "Kotlin KSP xlang serializers currently support at most $MAX_DEFAULT_FIELDS defaulted constructor fields because Kotlin source generation must call constructors with omitted default arguments"
   } else {
     null
+  }
+
+internal fun fieldIdError(id: Int, requireFieldId: Boolean): String? =
+  when {
+    id < -1 || (requireFieldId && id < 0) -> "@ForyField id must be a non-negative value"
+    id > MAX_FIELD_ID -> "@ForyField id must not exceed $MAX_FIELD_ID"
+    else -> null
   }
 
 internal fun structKindError(
@@ -402,8 +410,9 @@ internal class ForyKotlinSymbolProcessor(private val environment: SymbolProcesso
       return null
     }
     val fieldMeta = resolveForyField(property, parameter) ?: return null
-    if (fieldMeta.id < -1 || (requireForyId && fieldMeta.id < 0)) {
-      logger.error("@ForyField id must be a non-negative value", property)
+    val fieldIdDiagnostic = fieldIdError(fieldMeta.id, requireForyId)
+    if (fieldIdDiagnostic != null) {
+      logger.error(fieldIdDiagnostic, property)
       return null
     }
     if (fieldMeta.id >= 0 && !foryIds.add(fieldMeta.id)) {

--- a/kotlin/fory-kotlin-ksp/src/test/kotlin/org/apache/fory/kotlin/ksp/ProcessorValidationTest.kt
+++ b/kotlin/fory-kotlin-ksp/src/test/kotlin/org/apache/fory/kotlin/ksp/ProcessorValidationTest.kt
@@ -25,6 +25,7 @@ import org.apache.fory.codegen.GeneratedClassNames
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertNotEquals
+import org.testng.Assert.assertNotNull
 import org.testng.Assert.assertNull
 import org.testng.Assert.assertTrue
 import org.testng.annotations.Test
@@ -76,6 +77,15 @@ class ProcessorValidationTest {
       fieldLimitError(13),
       "Kotlin KSP xlang serializers currently support at most 12 defaulted constructor fields because Kotlin source generation must call constructors with omitted default arguments",
     )
+  }
+
+  @Test
+  fun validatesFieldIds() {
+    assertNull(fieldIdError(-1, requireFieldId = false))
+    assertNull(fieldIdError(0, requireFieldId = true))
+    assertNull(fieldIdError(536_870_911, requireFieldId = true))
+    assertNotNull(fieldIdError(-1, requireFieldId = true))
+    assertNotNull(fieldIdError(536_870_912, requireFieldId = true))
   }
 
   @Test

--- a/python/pyfory/field.py
+++ b/python/pyfory/field.py
@@ -42,6 +42,7 @@ from typing import Any, Callable, Dict, Mapping, Optional
 FORY_FIELD_METADATA_KEY = "__fory__"
 FORY_OBJECT_METADATA_KEY = "__fory_object__"
 _FIELD_ID_UNSET = object()
+MAX_FIELD_ID = (1 << 29) - 1
 
 
 @dataclasses.dataclass(frozen=True)
@@ -180,6 +181,8 @@ def field(
         raise TypeError(f"id must be an int, got {type(id).__name__}")
     elif id < 0:
         raise ValueError(f"id must be non-negative, got {id}")
+    elif id > MAX_FIELD_ID:
+        raise ValueError(f"id must not exceed {MAX_FIELD_ID}, got {id}")
 
     # Build Fory metadata
     fory_meta = ForyFieldMeta(
@@ -252,6 +255,8 @@ def validate_field_metas(
     # Check tag ID uniqueness
     tag_ids_seen: Dict[int, str] = {}
     for field_name, meta in field_metas.items():
+        if meta.id < -1 or meta.id > MAX_FIELD_ID:
+            raise ValueError(f"Tag ID {meta.id} in class {cls.__name__} must be -1 or in [0, {MAX_FIELD_ID}]")
         if meta.id >= 0:
             if meta.id in tag_ids_seen:
                 raise ValueError(

--- a/python/pyfory/meta/typedef.py
+++ b/python/pyfory/meta/typedef.py
@@ -27,6 +27,7 @@ from pyfory.type_util import get_homogeneous_tuple_elem_type, infer_field
 from pyfory.meta.metastring import Encoding
 from pyfory.type_util import infer_field_types
 from pyfory.lib.mmh3 import hash_buffer
+from pyfory.field import MAX_FIELD_ID
 
 
 # Constants from the specification
@@ -355,6 +356,8 @@ def _snake_to_camel(s: str) -> str:
 
 class FieldInfo:
     def __init__(self, name: str, field_type: "FieldType", defined_class: str, tag_id: int = -1):
+        if tag_id < -1 or tag_id > MAX_FIELD_ID:
+            raise ValueError(f"tag_id must be -1 or in [0, {MAX_FIELD_ID}], got {tag_id}")
         self.name = name
         self.field_type = field_type
         self.defined_class = defined_class

--- a/python/pyfory/meta/typedef_decoder.py
+++ b/python/pyfory/meta/typedef_decoder.py
@@ -240,8 +240,15 @@ def read_meta_string(buffer: Buffer, decoder: MetaStringDecoder, encodings: List
 def read_fields_info(buffer: Buffer, resolver, defined_class: str, num_fields: int) -> List[FieldInfo]:
     """Read field information from the buffer."""
     field_infos = []
+    tag_ids = None
     for _ in range(num_fields):
         field_info = read_field_info(buffer, resolver, defined_class)
+        if field_info.tag_id >= 0:
+            if tag_ids is None:
+                tag_ids = set()
+            if field_info.tag_id in tag_ids:
+                raise ValueError(f"Duplicate TypeDef field tag ID {field_info.tag_id}")
+            tag_ids.add(field_info.tag_id)
         field_infos.append(field_info)
     return field_infos
 

--- a/python/pyfory/meta/typedef_encoder.py
+++ b/python/pyfory/meta/typedef_encoder.py
@@ -39,6 +39,7 @@ from pyfory.meta.typedef import (
 )
 from pyfory.meta.metastring import MetaStringEncoder
 from pyfory._fory import NO_USER_TYPE_ID
+from pyfory.field import MAX_FIELD_ID
 from pyfory.types import TypeId
 
 from pyfory.serialization import Buffer
@@ -224,6 +225,8 @@ def write_field_info(buffer: Buffer, field_info: FieldInfo):
     if field_info.uses_tag_id():
         # TAG_ID encoding (encoding = 0b11 at bits 6-7)
         tag_id = field_info.tag_id
+        if tag_id > MAX_FIELD_ID:
+            raise ValueError(f"tag_id must not exceed {MAX_FIELD_ID}, got {tag_id}")
         header |= FIELD_NAME_ENCODING_TAG_ID << 6  # encoding at bits 6-7
 
         if tag_id >= TAG_ID_SIZE_THRESHOLD:

--- a/python/pyfory/tests/test_field_meta.py
+++ b/python/pyfory/tests/test_field_meta.py
@@ -27,6 +27,7 @@ import pyfory
 from pyfory import Fory, Float64, Int32
 from pyfory.field import (
     ForyFieldMeta,
+    MAX_FIELD_ID,
     extract_field_meta,
 )
 
@@ -95,6 +96,12 @@ class TestFieldFunction:
         for f in fields(TestClass):
             meta = extract_field_meta(f)
             assert meta.uses_tag_id()
+
+    def test_field_tag_id_domain(self):
+        max_field = pyfory.field(MAX_FIELD_ID)
+        assert extract_field_meta(max_field).id == MAX_FIELD_ID
+        with pytest.raises(ValueError):
+            pyfory.field(MAX_FIELD_ID + 1)
 
     def test_nullable_field(self):
         """Test nullable field."""

--- a/python/pyfory/tests/test_typedef_encoding.py
+++ b/python/pyfory/tests/test_typedef_encoding.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 import pyfory
+from pyfory.field import MAX_FIELD_ID
 from pyfory.meta import typedef as typedef_module
 from pyfory.meta import typedef_decoder
 from pyfory.serialization import Buffer, ENABLE_FORY_CYTHON_SERIALIZATION
@@ -56,6 +57,8 @@ from pyfory.meta.typedef_encoder import (
     FIELD_NAME_ENCODER,
     encode_typedef,
     prepend_header,
+    write_namespace,
+    write_typename,
 )
 from pyfory.meta.typedef_decoder import decode_typedef
 from pyfory.serializer import PyArraySerializer
@@ -395,6 +398,39 @@ def test_decode_typedef_rejects_hash_consistent_malformed_body():
 
     with pytest.raises(Exception):
         decode_typedef(Buffer(encoded), fory.type_resolver)
+
+
+def test_remote_tag_identity_domain():
+    int_type = FieldType(TypeId.INT32, True, False, False)
+
+    def encoded_tag_fields(tag_ids):
+        body = Buffer.allocate(128)
+        body.write_uint8(STRUCT_TYPEDEF_FLAG | REGISTER_BY_NAME_FLAG | typedef_module.COMPATIBLE_TYPEDEF_FLAG | len(tag_ids))
+        write_namespace(body, "example")
+        write_typename(body, "TaggedRemote")
+        for tag_id in tag_ids:
+            body.write_uint8((typedef_module.FIELD_NAME_ENCODING_TAG_ID << 6) | (min(tag_id, typedef_module.TAG_ID_SIZE_THRESHOLD) << 2))
+            if tag_id >= typedef_module.TAG_ID_SIZE_THRESHOLD:
+                body.write_var_uint32(tag_id - typedef_module.TAG_ID_SIZE_THRESHOLD)
+            int_type.write(body, False)
+        return prepend_header(body.to_bytes(0, body.get_writer_index()), False)
+
+    decoded = decode_typedef(
+        Buffer(encoded_tag_fields([0, 15, MAX_FIELD_ID])),
+        Fory(xlang=True, compatible=True).type_resolver,
+    )
+    assert [field.tag_id for field in decoded.fields] == [0, 15, MAX_FIELD_ID]
+
+    with pytest.raises(ValueError):
+        decode_typedef(
+            Buffer(encoded_tag_fields([MAX_FIELD_ID + 1])),
+            Fory(xlang=True, compatible=True).type_resolver,
+        )
+    with pytest.raises(ValueError, match="Duplicate TypeDef field tag ID"):
+        decode_typedef(
+            Buffer(encoded_tag_fields([7, 7])),
+            Fory(xlang=True, compatible=True).type_resolver,
+        )
 
 
 def test_namespace_encoding():

--- a/python/pyfory/tests/xlang_test_main.py
+++ b/python/pyfory/tests/xlang_test_main.py
@@ -104,14 +104,14 @@ class Item:
 @dataclass
 class SimpleStruct:
     f1: Dict[pyfory.Int32, pyfory.Float64] = None
-    f2: pyfory.Int32 = 0
+    f2: pyfory.Int32 = pyfory.field(15, default=0)
     f3: Item = None
     f4: str = ""
     f5: Color = None
     f6: List[str] = None
-    f7: pyfory.Int32 = 0
+    f7: pyfory.Int32 = pyfory.field(65551, default=0)
     f8: pyfory.Int32 = 0
-    last: pyfory.Int32 = 0
+    last: pyfory.Int32 = pyfory.field(536870911, default=0)
 
 
 @pyfory.dataclass

--- a/rust/fory-core/src/meta/mod.rs
+++ b/rust/fory-core/src/meta/mod.rs
@@ -22,9 +22,9 @@ pub use meta_string::{
     Encoding, MetaString, MetaStringDecoder, MetaStringEncoder, FIELD_NAME_DECODER,
     FIELD_NAME_ENCODER, NAMESPACE_DECODER, NAMESPACE_ENCODER, TYPE_NAME_DECODER, TYPE_NAME_ENCODER,
 };
-#[doc(hidden)]
-pub use type_meta::assign_remote_field_ids;
 pub(crate) use type_meta::compatible_scalar_field_pair;
+#[doc(hidden)]
+pub use type_meta::match_remote_fields;
 pub use type_meta::{
     compute_field_hash, compute_struct_hash, sort_fields, FieldInfo, FieldType, TypeMeta,
     NAMESPACE_ENCODINGS, TYPE_NAME_ENCODINGS,

--- a/rust/fory-core/src/meta/type_meta.rs
+++ b/rust/fory-core/src/meta/type_meta.rs
@@ -85,13 +85,12 @@ fn compatible_scalar_type_id(type_id: u32) -> bool {
 }
 use std::clone::Clone;
 use std::cmp::min;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 const SMALL_NUM_FIELDS_THRESHOLD: usize = 0b11111;
 const DEFAULT_MAX_TYPE_FIELDS: usize = 512;
 const DEFAULT_MAX_TYPE_META_BYTES: usize = 4096;
-const MAX_COMPATIBLE_MATCHED_FIELD_INDEX: usize = (i16::MAX as usize - 1) / 2;
 const REGISTER_BY_NAME_FLAG: u8 = 0b0010_0000;
 const COMPATIBLE_TYPEDEF_FLAG: u8 = 0b0100_0000;
 const STRUCT_TYPEDEF_FLAG: u8 = 0b1000_0000;
@@ -99,7 +98,8 @@ const FIELD_NAME_SIZE_THRESHOLD: usize = 0b1111;
 /// Marker value in encoding bits to indicate field ID mode (instead of field name)
 const FIELD_ID_ENCODING_MARKER: u8 = 0b11;
 /// Threshold for field ID that fits in 4-bit size field
-const SMALL_FIELD_ID_THRESHOLD: i16 = 0b1111;
+const SMALL_FIELD_ID_THRESHOLD: i32 = 0b1111;
+const MAX_FIELD_ID: i32 = (1 << 29) - 1;
 
 const BIG_NAME_THRESHOLD: usize = 0b111111;
 
@@ -426,7 +426,11 @@ impl FieldType {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FieldInfo {
-    pub field_id: i16,
+    /// Protocol field tag, or `-1` when the field is identified by name.
+    pub field_id: i32,
+    /// Local compatible-reader dispatch ID, or `-1` when no local field matched.
+    #[doc(hidden)]
+    pub matched_field_id: i32,
     pub field_name: String,
     pub field_type: FieldType,
 }
@@ -434,15 +438,17 @@ pub struct FieldInfo {
 impl FieldInfo {
     pub fn new(field_name: &str, field_type: FieldType) -> FieldInfo {
         FieldInfo {
-            field_id: -1i16,
+            field_id: -1,
+            matched_field_id: -1,
             field_name: field_name.to_string(),
             field_type,
         }
     }
 
-    pub fn new_with_id(field_id: i16, field_name: &str, field_type: FieldType) -> FieldInfo {
+    pub fn new_with_id(field_id: i32, field_name: &str, field_type: FieldType) -> FieldInfo {
         FieldInfo {
             field_id,
+            matched_field_id: -1,
             field_name: field_name.to_string(),
             field_type,
         }
@@ -468,18 +474,22 @@ impl FieldInfo {
         // Check if this is field ID mode (encoding bits == 0b11)
         if encoding_bits == FIELD_ID_ENCODING_MARKER {
             // Field ID mode: | 0b11:2bits | field_id_low:4bits | nullable:1bit | track_ref:1bit |
-            let mut field_id = ((header >> 2) & FIELD_NAME_SIZE_THRESHOLD as u8) as i16;
-            if field_id == SMALL_FIELD_ID_THRESHOLD {
-                field_id = field_id
-                    .checked_add(reader.read_var_u32()? as i16)
-                    .ok_or_else(|| Error::invalid_data("field_id overflow"))?;
+            let mut field_id = u32::from((header >> 2) & FIELD_NAME_SIZE_THRESHOLD as u8);
+            if field_id == SMALL_FIELD_ID_THRESHOLD as u32 {
+                let extension = reader.read_var_u32()?;
+                if extension > MAX_FIELD_ID as u32 - field_id {
+                    return Err(Error::invalid_data("field ID exceeds maximum"));
+                }
+                field_id += extension;
             }
+            let field_id = field_id as i32;
 
             let mut field_type = FieldType::from_bytes(reader, false, Option::from(nullable))?;
             field_type.track_ref = track_ref;
 
             Ok(FieldInfo {
                 field_id,
+                matched_field_id: -1,
                 field_name: String::new(), // No field name when using ID encoding
                 field_type,
             })
@@ -499,7 +509,8 @@ impl FieldInfo {
 
             let field_name = FIELD_NAME_DECODER.decode(field_name_bytes, encoding)?;
             Ok(FieldInfo {
-                field_id: -1i16,
+                field_id: -1,
+                matched_field_id: -1,
                 field_name: field_name.original,
                 field_type,
             })
@@ -507,18 +518,25 @@ impl FieldInfo {
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        if self.field_id < -1 {
+            return Err(Error::invalid_data(format!(
+                "field ID {} must be -1 or non-negative",
+                self.field_id
+            )));
+        }
         let mut buffer = vec![];
         let mut writer = Writer::from_buffer(&mut buffer);
         let nullable = self.field_type.nullable;
         let track_ref = self.field_type.track_ref;
 
-        // Use field ID encoding if:
-        // 1. field_id >= 0 (user-set or matched from local type), OR
-        // 2. field_name is empty (ID-encoded field that couldn't be matched - use ID even if -1)
-        if self.field_id >= 0 || self.field_name.is_empty() {
+        if self.field_id >= 0 {
             // Field ID mode: | 0b11:2bits | field_id_low:4bits | nullable:1bit | track_ref:1bit |
-            // Use max(0, field_id) to handle unmatched fields that have field_id = -1
-            let field_id = std::cmp::max(0, self.field_id);
+            let field_id = self.field_id;
+            if field_id > MAX_FIELD_ID {
+                return Err(Error::invalid_data(format!(
+                    "field ID {field_id} exceeds maximum {MAX_FIELD_ID}"
+                )));
+            }
             let mut header: u8 = (min(SMALL_FIELD_ID_THRESHOLD, field_id) as u8) << 2;
             if track_ref {
                 header |= 1;
@@ -535,6 +553,11 @@ impl FieldInfo {
             self.field_type.to_bytes(&mut writer, false, nullable)?;
             // No field name written in ID mode
         } else {
+            if self.field_name.is_empty() {
+                return Err(Error::invalid_data(
+                    "name-identified field must have a non-empty name",
+                ));
+            }
             // Field name mode (original behavior)
             // field_bytes: | header | type_info | field_name |
             // header: | field_name_encoding:2bits | size:4bits | nullability:1bit | track_ref:1bit |
@@ -710,7 +733,7 @@ fn compute_schema_hash(field_infos: &[FieldInfo]) -> i64 {
 }
 
 #[inline(always)]
-pub fn compute_field_hash(hash: u32, id: i16) -> u32 {
+pub fn compute_field_hash(hash: u32, id: i32) -> u32 {
     let mut next_hash = (hash as u64) * 31 + (id as u64);
     while next_hash >= MAX_HASH32 {
         next_hash /= 7;
@@ -719,7 +742,7 @@ pub fn compute_field_hash(hash: u32, id: i16) -> u32 {
 }
 
 #[inline(always)]
-pub fn compute_struct_hash(field_ids: impl IntoIterator<Item = i16>) -> u32 {
+pub fn compute_struct_hash(field_ids: impl IntoIterator<Item = i32>) -> u32 {
     field_ids.into_iter().fold(17u32, compute_field_hash)
 }
 
@@ -830,7 +853,7 @@ impl PartialEq for FieldType {
 }
 
 #[doc(hidden)]
-pub fn assign_remote_field_ids(
+pub fn match_remote_fields(
     local_field_infos: &[FieldInfo],
     field_infos: &mut [FieldInfo],
 ) -> Result<(), Error> {
@@ -843,7 +866,7 @@ pub fn assign_remote_field_ids(
         .map(|(i, f)| (f.field_name.clone(), (i, f)))
         .collect();
 
-    let field_index_by_id: HashMap<i16, (usize, &FieldInfo)> = local_field_infos
+    let field_index_by_id: HashMap<i32, (usize, &FieldInfo)> = local_field_infos
         .iter()
         .enumerate()
         .filter(|(_, f)| f.field_id >= 0)
@@ -890,22 +913,16 @@ pub fn assign_remote_field_ids(
                 if field.field_name.is_empty() {
                     field.field_name = local_info.field_name.clone();
                 }
-                if sorted_index > MAX_COMPATIBLE_MATCHED_FIELD_INDEX {
-                    return Err(Error::type_error(format!(
-                        "Cannot assign compatible matched id for local field {}: local field index {} exceeds max {}",
-                        local_info.field_name, sorted_index, MAX_COMPATIBLE_MATCHED_FIELD_INDEX
-                    )));
-                }
-                field.field_id = if exact_field {
-                    (sorted_index * 2) as i16
+                field.matched_field_id = if exact_field {
+                    (sorted_index * 2) as i32
                 } else {
-                    (sorted_index * 2 + 1) as i16
+                    (sorted_index * 2 + 1) as i32
                 };
                 used_local_fields[sorted_index] = true;
                 if crate::util::ENABLE_FORY_DEBUG_OUTPUT {
                     eprintln!(
                         "[fory-debug]   matched field: name={}, assigned_field_id={}, remote_type={:?}, local_type={:?}",
-                        field.field_name, field.field_id, field.field_type, local_info.field_type
+                        field.field_name, field.matched_field_id, field.field_type, local_info.field_type
                     );
                 }
             }
@@ -916,7 +933,7 @@ pub fn assign_remote_field_ids(
                         field.field_name
                     );
                 }
-                field.field_id = -1;
+                field.matched_field_id = -1;
             }
         }
     }
@@ -951,6 +968,18 @@ impl TypeMeta {
         register_by_name: bool,
         field_infos: Vec<FieldInfo>,
     ) -> Result<TypeMeta, Error> {
+        let mut field_ids = HashSet::new();
+        for field in &field_infos {
+            if field.field_id < -1 || field.field_id > MAX_FIELD_ID {
+                return Err(Error::invalid_data(format!(
+                    "field ID {} must be -1 or within [0, {MAX_FIELD_ID}]",
+                    field.field_id
+                )));
+            }
+            if field.field_id >= 0 && !field_ids.insert(field.field_id) {
+                return Err(Error::invalid_data("duplicate field ID"));
+            }
+        }
         let schema_hash = compute_schema_hash(&field_infos);
         let mut meta = TypeMeta {
             hash: 0,
@@ -1219,7 +1248,7 @@ impl TypeMeta {
                         "TypeMeta kind does not match registered type metadata",
                     ));
                 }
-                Self::assign_field_ids(&type_info_current, &mut sorted_field_infos)?;
+                Self::match_fields(&type_info_current, &mut sorted_field_infos)?;
             }
         } else if user_type_id != NO_USER_TYPE_ID {
             if let Some(type_info_current) = type_resolver.get_user_type_info_by_id(user_type_id) {
@@ -1228,10 +1257,10 @@ impl TypeMeta {
                         "TypeMeta kind does not match registered type metadata",
                     ));
                 }
-                Self::assign_field_ids(&type_info_current, &mut sorted_field_infos)?;
+                Self::match_fields(&type_info_current, &mut sorted_field_infos)?;
             }
         } else if let Some(type_info_current) = type_resolver.get_type_info_by_id(type_id) {
-            Self::assign_field_ids(&type_info_current, &mut sorted_field_infos)?;
+            Self::match_fields(&type_info_current, &mut sorted_field_infos)?;
         }
         // if no type found, keep all fields id as -1 to be skipped.
         TypeMeta::new(
@@ -1244,13 +1273,13 @@ impl TypeMeta {
         )
     }
 
-    fn assign_field_ids(
+    fn match_fields(
         type_info_current: &TypeInfo,
         field_infos: &mut [FieldInfo],
     ) -> Result<(), Error> {
         if crate::util::ENABLE_FORY_DEBUG_OUTPUT {
             eprintln!(
-                "[fory-debug] assign_field_ids called for type: {:?}",
+                "[fory-debug] match_fields called for type: {:?}",
                 type_info_current.get_type_name()
             );
             for f in field_infos.iter() {
@@ -1271,7 +1300,7 @@ impl TypeMeta {
             }
         }
 
-        assign_remote_field_ids(local_field_infos, field_infos)
+        match_remote_fields(local_field_infos, field_infos)
     }
 
     #[allow(dead_code)]
@@ -1408,26 +1437,37 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unrepresentable_matched_field_id() {
+    fn preserves_field_id_domain() {
         let field_type = FieldType::new(crate::type_id::INT32, false, vec![]);
-        let mut local_fields = Vec::with_capacity(MAX_COMPATIBLE_MATCHED_FIELD_INDEX + 2);
-        for index in 0..=MAX_COMPATIBLE_MATCHED_FIELD_INDEX + 1 {
-            local_fields.push(FieldInfo::new(
-                &format!("field_{}", index),
-                field_type.clone(),
-            ));
+        for field_id in [65_551, MAX_FIELD_ID] {
+            let field = FieldInfo::new_with_id(field_id, "value", field_type.clone());
+            let bytes = field.to_bytes().unwrap();
+            let mut reader = Reader::new(&bytes);
+            let decoded = FieldInfo::from_bytes(&mut reader).unwrap();
+            assert_eq!(decoded.field_id, field_id);
         }
-        let mut remote_fields = [FieldInfo::new(
-            &format!("field_{}", MAX_COMPATIBLE_MATCHED_FIELD_INDEX + 1),
-            field_type,
-        )];
 
-        let message = assign_remote_field_ids(&local_fields, &mut remote_fields)
-            .err()
-            .map(|error| error.to_string())
-            .unwrap_or_default();
-
-        assert!(message.contains("exceeds max"));
+        assert!(FieldInfo::new_with_id(-2, "value", field_type.clone())
+            .to_bytes()
+            .is_err());
+        assert!(FieldInfo::new("", field_type.clone()).to_bytes().is_err());
+        assert!(
+            FieldInfo::new_with_id(MAX_FIELD_ID + 1, "value", field_type.clone())
+                .to_bytes()
+                .is_err()
+        );
+        assert!(TypeMeta::new(
+            crate::type_id::STRUCT,
+            1,
+            MetaString::get_empty().clone(),
+            MetaString::get_empty().clone(),
+            false,
+            vec![
+                FieldInfo::new_with_id(7, "first", field_type.clone()),
+                FieldInfo::new_with_id(7, "second", field_type),
+            ],
+        )
+        .is_err());
     }
 
     #[test]
@@ -1437,9 +1477,10 @@ mod tests {
         let local_fields = [FieldInfo::new("value", local_type)];
         let mut remote_fields = [FieldInfo::new("value", remote_type)];
 
-        assign_remote_field_ids(&local_fields, &mut remote_fields).unwrap();
+        match_remote_fields(&local_fields, &mut remote_fields).unwrap();
 
-        assert_eq!(remote_fields[0].field_id, 1);
+        assert_eq!(remote_fields[0].field_id, -1);
+        assert_eq!(remote_fields[0].matched_field_id, 1);
     }
 
     #[test]
@@ -1452,23 +1493,25 @@ mod tests {
             FieldType::new(crate::type_id::LIST, false, vec![int_type]),
         )];
 
-        assign_remote_field_ids(&local_fields, &mut remote_fields).unwrap();
-        assert_eq!(remote_fields[0].field_id, 1);
+        match_remote_fields(&local_fields, &mut remote_fields).unwrap();
+        assert_eq!(remote_fields[0].field_id, -1);
+        assert_eq!(remote_fields[0].matched_field_id, 1);
 
         let nullable_int = FieldType::new(crate::type_id::INT32, true, vec![]);
         let mut nullable_remote = [FieldInfo::new(
             "values",
             FieldType::new(crate::type_id::LIST, false, vec![nullable_int]),
         )];
-        assign_remote_field_ids(&local_fields, &mut nullable_remote).unwrap();
-        assert_eq!(nullable_remote[0].field_id, 1);
+        match_remote_fields(&local_fields, &mut nullable_remote).unwrap();
+        assert_eq!(nullable_remote[0].field_id, -1);
+        assert_eq!(nullable_remote[0].matched_field_id, 1);
 
         let tracked_int = FieldType::new_with_ref(crate::type_id::INT32, false, true, vec![]);
         let mut tracked_remote = [FieldInfo::new(
             "values",
             FieldType::new(crate::type_id::LIST, false, vec![tracked_int]),
         )];
-        assert!(assign_remote_field_ids(&local_fields, &mut tracked_remote).is_err());
+        assert!(match_remote_fields(&local_fields, &mut tracked_remote).is_err());
 
         let nullable_array_local = [FieldInfo::new(
             "values",
@@ -1482,7 +1525,7 @@ mod tests {
                 vec![FieldType::new(crate::type_id::INT32, false, vec![])],
             ),
         )];
-        assert!(assign_remote_field_ids(&nullable_array_local, &mut remote_list).is_err());
+        assert!(match_remote_fields(&nullable_array_local, &mut remote_list).is_err());
     }
 
     #[test]
@@ -1507,9 +1550,10 @@ mod tests {
         let local_fields = [FieldInfo::new_with_id(0, "values", local_map)];
         let mut remote_fields = [FieldInfo::new_with_id(0, "", remote_map)];
 
-        assign_remote_field_ids(&local_fields, &mut remote_fields).unwrap();
+        match_remote_fields(&local_fields, &mut remote_fields).unwrap();
 
-        assert_eq!(remote_fields[0].field_id, 1);
+        assert_eq!(remote_fields[0].field_id, 0);
+        assert_eq!(remote_fields[0].matched_field_id, 1);
     }
 
     #[test]
@@ -1523,9 +1567,10 @@ mod tests {
         let local_fields = [FieldInfo::new("values", local_list)];
         let mut remote_fields = [FieldInfo::new("values", remote_list)];
 
-        assign_remote_field_ids(&local_fields, &mut remote_fields).unwrap();
+        match_remote_fields(&local_fields, &mut remote_fields).unwrap();
 
-        assert_eq!(remote_fields[0].field_id, 1);
+        assert_eq!(remote_fields[0].field_id, -1);
+        assert_eq!(remote_fields[0].matched_field_id, 1);
     }
 
     #[test]
@@ -1534,9 +1579,10 @@ mod tests {
         let local_fields = [FieldInfo::new_with_id(1, "value", field_type.clone())];
         let mut remote_fields = [FieldInfo::new("value", field_type)];
 
-        assign_remote_field_ids(&local_fields, &mut remote_fields).unwrap();
+        match_remote_fields(&local_fields, &mut remote_fields).unwrap();
 
         assert_eq!(remote_fields[0].field_id, -1);
+        assert_eq!(remote_fields[0].matched_field_id, -1);
     }
 
     #[test]
@@ -1548,7 +1594,7 @@ mod tests {
             FieldInfo::new("value", field_type),
         ];
 
-        let message = assign_remote_field_ids(&local_fields, &mut remote_fields)
+        let message = match_remote_fields(&local_fields, &mut remote_fields)
             .err()
             .map(|error| error.to_string())
             .unwrap_or_default();

--- a/rust/fory-derive/src/object/field_codec.rs
+++ b/rust/fory-derive/src/object/field_codec.rs
@@ -41,7 +41,7 @@ pub(crate) struct ResolvedField<'a> {
     pub private_ident: syn::Ident,
     pub codec_ty: TokenStream,
     pub value_ty: &'a Type,
-    pub field_id: i16,
+    pub field_id: i32,
     pub has_selected_provider: bool,
     pub read_always_advances: TokenStream,
 }
@@ -271,7 +271,7 @@ pub(crate) fn build_bindings<'a>(
                 }));
             }
             let field_id = if meta.uses_tag_id() {
-                meta.effective_id() as i16
+                meta.effective_id()
             } else {
                 -1
             };
@@ -929,7 +929,7 @@ fn codec_for_child(ty: &Type, meta: &ForyFieldMeta) -> syn::Result<CodecSelectio
 
 fn transparent_child_meta(meta: &ForyFieldMeta) -> ForyFieldMeta {
     let mut child = meta.clone();
-    child.id = None;
+    child.id = -1;
     child.nullable = None;
     child.r#ref = None;
     child.skip = false;

--- a/rust/fory-derive/src/object/field_meta.rs
+++ b/rust/fory-derive/src/object/field_meta.rs
@@ -35,11 +35,13 @@ use std::collections::HashMap;
 use syn::spanned::Spanned;
 use syn::{Field, GenericArgument, PathArguments, Type};
 
+const MAX_FIELD_ID: i32 = (1 << 29) - 1;
+
 /// Represents parsed `#[fory(...)]` field attributes
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ForyFieldMeta {
-    /// Field tag ID: None = use field name, Some(>=0) = use tag ID
-    pub id: Option<i32>,
+    /// Field tag ID: -1 = use field name, non-negative = use tag ID.
+    pub id: i32,
     /// Whether the field can be null (None = use type-based default)
     pub nullable: Option<bool>,
     /// Whether to enable reference tracking (None = use type-based default)
@@ -60,6 +62,24 @@ pub struct ForyFieldMeta {
     pub tuple: Option<ForyTupleMeta>,
     /// Serializer selected for this exact value node.
     pub with: Option<Type>,
+}
+
+impl Default for ForyFieldMeta {
+    fn default() -> Self {
+        Self {
+            id: -1,
+            nullable: None,
+            r#ref: None,
+            skip: false,
+            encoding: None,
+            list: None,
+            array: false,
+            bytes: false,
+            map: None,
+            tuple: None,
+            with: None,
+        }
+    }
 }
 
 impl std::fmt::Debug for ForyFieldMeta {
@@ -163,14 +183,14 @@ impl ForyFieldMeta {
         ))
     }
 
-    /// Returns effective field ID or -1 for field name encoding
+    /// Returns the field ID or -1 for field name encoding.
     pub fn effective_id(&self) -> i32 {
-        self.id.unwrap_or(-1)
+        self.id
     }
 
     /// Returns true if this field should use tag ID encoding
     pub fn uses_tag_id(&self) -> bool {
-        self.id.is_some_and(|id| id >= 0)
+        self.id >= 0
     }
 
     pub fn element_meta(&self) -> ForyFieldMeta {
@@ -235,14 +255,20 @@ fn parse_meta_item(
             ));
         }
         let lit: syn::LitInt = nested.value()?.parse()?;
-        let id: i32 = lit.base10_parse()?;
+        let id: i128 = lit.base10_parse()?;
         if id < 0 {
             return Err(syn::Error::new(lit.span(), "id must be non-negative"));
         }
-        if meta.id.is_some() {
+        if id > i128::from(MAX_FIELD_ID) {
+            return Err(syn::Error::new(
+                lit.span(),
+                format!("id must not exceed {MAX_FIELD_ID}"),
+            ));
+        }
+        if meta.id >= 0 {
             return Err(syn::Error::new(nested.path.span(), "duplicate id config"));
         }
-        meta.id = Some(id);
+        meta.id = id as i32;
     } else if nested.path.is_ident("nullable") {
         let value = parse_bool_or_flag(&nested)?;
         if meta.nullable.is_some() {
@@ -556,20 +582,19 @@ pub fn validate_field_metas(fields_with_meta: &[(&Field, ForyFieldMeta)]) -> syn
             continue;
         }
 
-        if let Some(id) = meta.id {
-            if id >= 0 {
-                if let Some(existing) = id_to_field.get(&id) {
-                    let field_name = field.ident.as_ref().unwrap();
-                    return Err(syn::Error::new(
-                        field_name.span(),
-                        format!(
-                            "duplicate fory field id={} on fields '{}' and '{}'",
-                            id, existing, field_name
-                        ),
-                    ));
-                }
-                id_to_field.insert(id, field.ident.as_ref().unwrap());
+        let id = meta.id;
+        if id >= 0 {
+            if let Some(existing) = id_to_field.get(&id) {
+                let field_name = field.ident.as_ref().unwrap();
+                return Err(syn::Error::new(
+                    field_name.span(),
+                    format!(
+                        "duplicate fory field id={} on fields '{}' and '{}'",
+                        id, existing, field_name
+                    ),
+                ));
             }
+            id_to_field.insert(id, field.ident.as_ref().unwrap());
         }
     }
 
@@ -704,7 +729,7 @@ mod tests {
             name: String
         };
         let meta = parse_field_meta(&field).unwrap();
-        assert_eq!(meta.id, Some(0));
+        assert_eq!(meta.id, 0);
         assert_eq!(meta.nullable, None);
         assert_eq!(meta.r#ref, None);
         assert!(!meta.skip);
@@ -721,13 +746,22 @@ mod tests {
     }
 
     #[test]
+    fn rejects_tag_above_wire_domain() {
+        let field: Field = parse_quote! {
+            #[fory(id = 536870912)]
+            name: String
+        };
+        assert!(parse_field_meta(&field).is_err());
+    }
+
+    #[test]
     fn test_parse_full_attributes() {
         let field: Field = parse_quote! {
             #[fory(id = 1, nullable = true, ref = false)]
             data: Vec<u8>
         };
         let meta = parse_field_meta(&field).unwrap();
-        assert_eq!(meta.id, Some(1));
+        assert_eq!(meta.id, 1);
         assert_eq!(meta.nullable, Some(true));
         assert_eq!(meta.r#ref, Some(false));
     }
@@ -759,7 +793,7 @@ mod tests {
             data: String
         };
         let meta = parse_field_meta(&field).unwrap();
-        assert_eq!(meta.id, Some(2));
+        assert_eq!(meta.id, 2);
         assert_eq!(meta.nullable, Some(true));
         assert_eq!(meta.r#ref, Some(true));
     }
@@ -885,7 +919,7 @@ mod tests {
     fn test_explicit_attribute_overrides_default() {
         // Explicit nullable=true overrides default
         let meta = ForyFieldMeta {
-            id: Some(0),
+            id: 0,
             nullable: Some(true),
             r#ref: None,
             skip: false,
@@ -901,7 +935,7 @@ mod tests {
 
         // Explicit ref=false overrides default
         let meta = ForyFieldMeta {
-            id: Some(0),
+            id: 0,
             nullable: None,
             r#ref: Some(false),
             skip: false,

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -368,8 +368,8 @@ pub(crate) fn gen_read_compatible_target(
         })
         .enumerate()
         .flat_map(|(sorted_idx, binding)| {
-            let direct_field_id = (sorted_idx * 2) as i16;
-            let compatible_field_id = (sorted_idx * 2 + 1) as i16;
+            let direct_field_id = (sorted_idx * 2) as i32;
+            let compatible_field_id = (sorted_idx * 2 + 1) as i32;
             let field_index = sorted_idx;
             let direct_body = binding.read_compatible_direct();
             let compatible_body = binding.read_compatible_conversion();
@@ -483,7 +483,7 @@ pub(crate) fn gen_read_compatible_target(
                 // local variant, the remote synthetic variant TypeMeta could not be classified by
                 // name during parsing, so the selected local variant owns the field remap here.
                 remapped_fields = remote_meta.get_field_infos().clone();
-                fory_core::meta::assign_remote_field_ids(local_fields, &mut remapped_fields)?;
+                fory_core::meta::match_remote_fields(local_fields, &mut remapped_fields)?;
                 &remapped_fields
             };
             let local_fields_ptr = local_fields.as_ptr();
@@ -527,7 +527,7 @@ pub(crate) fn gen_read_compatible_target(
         #schema_setup
         #(#declare_ts)*
         for _field in fields.iter() {
-            match _field.field_id {
+            match _field.matched_field_id {
                 #(#match_arms)*
                 #skip_arm
                 #invalid_arm

--- a/rust/fory-derive/src/object/read.rs
+++ b/rust/fory-derive/src/object/read.rs
@@ -474,9 +474,9 @@ pub(crate) fn gen_read_compatible_target(
                     == local_variant_type_meta.get_type_name().original.as_str()
             {
                 // Same-name variant TypeMeta is resolved by the synthetic variant TypeInfo during
-                // parsing, so its field ids are already doubled matched dispatch ids. Running
-                // schema matching here again would treat those internal ids as explicit wire ids
-                // and skip every field.
+                // parsing, so matched_field_id already contains local dispatch while field_id
+                // still preserves wire identity. Reuse that owner result instead of rebuilding the
+                // same matching maps and compatibility decisions here.
                 remote_meta.get_field_infos()
             } else {
                 // Compatible enums match variants by tag first. If that tag now names a different

--- a/rust/fory-derive/src/object/util.rs
+++ b/rust/fory-derive/src/object/util.rs
@@ -168,32 +168,29 @@ fn is_forward_field_internal(ty: &Type, struct_name: &str) -> bool {
 
 #[derive(Clone)]
 struct FieldSortKey {
-    id: Option<i32>,
+    id: i32,
     text: String,
 }
 
 impl FieldSortKey {
     fn id(id: i32) -> Self {
         Self {
-            id: Some(id),
+            id,
             text: id.to_string(),
         }
     }
 
     fn name(name: String) -> Self {
-        Self {
-            id: None,
-            text: name,
-        }
+        Self { id: -1, text: name }
     }
 }
 
 fn compare_field_sort_key(a: &FieldSortKey, b: &FieldSortKey) -> std::cmp::Ordering {
-    match (a.id, b.id) {
-        (Some(id_a), Some(id_b)) => id_a.cmp(&id_b),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        _ => a.text.cmp(&b.text),
+    match (a.id >= 0, b.id >= 0) {
+        (true, true) => a.id.cmp(&b.id),
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        (false, false) => a.text.cmp(&b.text),
     }
 }
 

--- a/rust/tests/tests/test_cross_language.rs
+++ b/rust/tests/tests/test_cross_language.rs
@@ -57,6 +57,7 @@ struct Item {
 struct SimpleStruct {
     // field_order != sorted_order
     f1: HashMap<i32, f64>,
+    #[fory(id = 15)]
     f2: i32,
     f3: Item,
     // Use String (not Option<String>) to match Java's non-nullable String field
@@ -64,8 +65,10 @@ struct SimpleStruct {
     f5: Color,
     // Use Vec<String> to match Java's List<String> with non-nullable elements
     f6: Vec<String>,
+    #[fory(id = 65551)]
     f7: i32,
     f8: i32,
+    #[fory(id = 536870911)]
     last: i32,
 }
 

--- a/rust/tests/tests/test_enum_compatible.rs
+++ b/rust/tests/tests/test_enum_compatible.rs
@@ -742,3 +742,58 @@ fn test_struct_with_enum_field_evolution() {
     assert_eq!(msg_v2.payload, "error");
     assert_eq!(msg_v2.priority, 1);
 }
+
+#[test]
+fn wide_variant_remap() {
+    #[derive(ForyUnion, Debug, PartialEq)]
+    enum WideEnumV1 {
+        #[fory(id = 0, default)]
+        Empty,
+        #[fory(id = 7)]
+        Original {
+            #[fory(id = 536870911)]
+            max: String,
+            #[fory(id = 31)]
+            small: bool,
+            #[fory(id = 65551)]
+            high: i64,
+        },
+    }
+
+    #[derive(ForyUnion, Debug, PartialEq)]
+    enum WideEnumV2 {
+        #[fory(id = 0, default)]
+        Empty,
+        #[fory(id = 7)]
+        Renamed {
+            #[fory(id = 65551)]
+            renamed_high: i64,
+            #[fory(id = 536870911)]
+            renamed_max: String,
+            #[fory(id = 31)]
+            renamed_small: bool,
+        },
+    }
+
+    let mut writer = Fory::builder().xlang(false).compatible(true).build();
+    writer.register::<WideEnumV1>(8000).unwrap();
+    let bytes = writer
+        .serialize(&WideEnumV1::Original {
+            max: "maximum".to_string(),
+            small: true,
+            high: 65_551,
+        })
+        .unwrap();
+
+    let mut reader = Fory::builder().xlang(false).compatible(true).build();
+    reader.register::<WideEnumV2>(8000).unwrap();
+    let decoded = reader.deserialize::<WideEnumV2>(&bytes).unwrap();
+    assert_eq!(
+        decoded,
+        WideEnumV2::Renamed {
+            renamed_high: 65_551,
+            renamed_max: "maximum".to_string(),
+            renamed_small: true,
+        }
+    );
+}

--- a/scala/fory-scala/src/main/scala-3/org/apache/fory/scala/internal/ForySerializerMacros.scala
+++ b/scala/fory-scala/src/main/scala-3/org/apache/fory/scala/internal/ForySerializerMacros.scala
@@ -191,11 +191,19 @@ object ForySerializerMacros {
       val refTracking = refAnnotation(field).orElse(topLevelTypeRefTracking(sourceType))
       val constructorOwned = constructorFieldSet.contains(field)
       val privateField = field.flags.is(Flags.Private)
+      val fieldId = annotationIntArg[ForyField](field, "id").getOrElse(-1)
+      if fieldId < -1 || fieldId > ForyField.MAX_ID then {
+        val message = s"@ForyField id must be in [-1, ${ForyField.MAX_ID}], got $fieldId"
+        field.pos match {
+          case Some(position) => report.errorAndAbort(message, position)
+          case None => report.errorAndAbort(message)
+        }
+      }
       FieldMeta(
         field,
         field.name,
         index,
-        annotationIntArg[ForyField](field, "id").getOrElse(-1),
+        fieldId,
         sourceType,
         wireType,
         option,

--- a/scala/fory-scala/src/test/scala-3/org/apache/fory/serializer/scala/ForySerializerDerivationTest.scala
+++ b/scala/fory-scala/src/test/scala-3/org/apache/fory/serializer/scala/ForySerializerDerivationTest.scala
@@ -590,6 +590,26 @@ import org.apache.fory.scala.ForyScala
       errors.exists(_.message.contains("at least one non-Unknown case")) shouldBe true
     }
 
+    "validate field tag range" in {
+      typeCheckErrors("""
+        import org.apache.fory.annotation.{ForyField, ForyStruct}
+        import org.apache.fory.scala.ForySerializer
+
+        @ForyStruct
+        final case class MaxFieldTag(@ForyField(id = 536870911) value: Int)
+            derives ForySerializer
+      """) shouldBe empty
+
+      typeCheckErrors("""
+        import org.apache.fory.annotation.{ForyField, ForyStruct}
+        import org.apache.fory.scala.ForySerializer
+
+        @ForyStruct
+        final case class InvalidFieldTag(@ForyField(id = 536870912) value: Int)
+            derives ForySerializer
+      """) should not be empty
+    }
+
     "serialize derived union unknown cases with original ids" in {
       val fory = xlangFory()
       val unknown = SearchTarget.Unknown(new UnknownCase(99, SearchUser("Future")))

--- a/scala/fory-scala/src/test/scala-3/org/apache/fory/serializer/scala/ScalaXlangPeer.scala
+++ b/scala/fory-scala/src/test/scala-3/org/apache/fory/serializer/scala/ScalaXlangPeer.scala
@@ -84,14 +84,14 @@ final case class Item(name: String) derives ForySerializer
 @ForyStruct
 final case class SimpleStruct(
     f1: util.HashMap[Integer, java.lang.Double],
-    f2: Int,
+    @ForyField(id = 15) f2: Int,
     f3: Item,
     f4: String,
     f5: Color,
     f6: util.List[String],
-    f7: Int,
+    @ForyField(id = 65551) f7: Int,
     f8: Int,
-    last: Int)
+    @ForyField(id = 536870911) last: Int)
     derives ForySerializer
 
 @ForyStruct(evolution = Evolution.ENABLED)

--- a/swift/Sources/Fory/MacroDeclarations.swift
+++ b/swift/Sources/Fory/MacroDeclarations.swift
@@ -248,7 +248,7 @@ public struct ForyFieldType: Sendable {
 /// Configures a generated field, selects its exact serializer, or declares
 /// budget-only storage for an external structural serializer.
 public macro ForyField(
-    id: Int? = nil,
+    id: Int32 = -1,
     ignore: Bool = false,
     encoding: ForyFieldEncoding? = nil,
     type: ForyFieldType? = nil,

--- a/swift/Sources/Fory/TypeMeta.swift
+++ b/swift/Sources/Fory/TypeMeta.swift
@@ -31,6 +31,7 @@ private let typeMetaNumHashBits: UInt64 = 52
 private let typeMetaHashSeed: UInt64 = 47
 private let noUserTypeID: UInt32 = UInt32.max
 private let typeMetaMaxDepth = 20
+private let maxTaggedFieldID: Int32 = (1 << 29) - 1
 
 @inline(__always)
 internal func typeMetaHashFromHeader(_ header: UInt64) -> UInt64 {
@@ -206,19 +207,32 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
     }
 
     public struct FieldInfo: Equatable, Sendable {
-        public var fieldID: Int16?
+        /// The protocol tag ID, or `-1` when the field is identified by name.
+        public var fieldID: Int32
         public var fieldName: String
         public var fieldType: FieldType
+        /// Local compatible-reader dispatch ordinal. This is not part of wire field identity.
+        public internal(set) var matchedFieldID: Int16
 
-        public init(fieldID: Int16?, fieldName: String, fieldType: FieldType) {
+        public init(fieldID: Int32, fieldName: String, fieldType: FieldType) {
             self.fieldID = fieldID
             self.fieldName = fieldName
             self.fieldType = fieldType
+            self.matchedFieldID = -1
+        }
+
+        private init(fieldName: String, fieldType: FieldType) {
+            self.fieldID = -1
+            self.fieldName = fieldName
+            self.fieldType = fieldType
+            self.matchedFieldID = -1
         }
 
         @inline(never)
-        private static func invalidTaggedFieldID(_ fieldID: Int) -> ForyError {
-            ForyError.invalidData("tagged field id \(fieldID) exceeds Int16 range")
+        private static func invalidTaggedFieldID(_ fieldID: Int32) -> ForyError {
+            ForyError.encodingError(
+                "tagged field id \(fieldID) exceeds protocol maximum \(maxTaggedFieldID)"
+            )
         }
 
         fileprivate func write(_ buffer: ByteBuffer) throws {
@@ -230,18 +244,20 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
                 header |= 0b10
             }
 
-            if let fieldID {
-                if fieldID < 0 {
-                    throw ForyError.encodingError("negative field id is invalid")
+            guard fieldID >= -1 else {
+                throw ForyError.encodingError("field id must be -1 or non-negative")
+            }
+            if fieldID >= 0 {
+                guard fieldID <= maxTaggedFieldID else {
+                    throw Self.invalidTaggedFieldID(fieldID)
                 }
-                let size = Int(fieldID)
                 header |= UInt8(0b11 << 6)
-                if size >= fieldNameSizeThreshold {
+                if fieldID >= Int32(fieldNameSizeThreshold) {
                     header |= 0b0011_1100
                     buffer.writeUInt8(header)
-                    buffer.writeVarUInt32(UInt32(size - fieldNameSizeThreshold))
+                    buffer.writeVarUInt32(UInt32(fieldID - Int32(fieldNameSizeThreshold)))
                 } else {
-                    header |= UInt8(size << 2)
+                    header |= UInt8(fieldID << 2)
                     buffer.writeUInt8(header)
                 }
                 fieldType.write(buffer, writeFlags: false)
@@ -273,11 +289,20 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         fileprivate static func read(_ buffer: ByteBuffer) throws -> FieldInfo {
             let header = try buffer.readUInt8()
             let encodingFlags = Int((header >> 6) & 0b11)
-            var size = Int((header >> 2) & 0b1111)
-            if size == fieldNameSizeThreshold {
-                size += Int(try buffer.readVarUInt32())
+            let inlineSize = Int32((header >> 2) & 0b1111)
+            var nameSize = Int(inlineSize)
+            var fieldID: Int32 = encodingFlags == 3 ? inlineSize : -1
+            if inlineSize == Int32(fieldNameSizeThreshold) {
+                let extensionSize = try buffer.readVarUInt32()
+                if encodingFlags == 3 {
+                    guard extensionSize <= UInt32(maxTaggedFieldID - inlineSize) else {
+                        throw ForyError.invalidData("tagged field id exceeds protocol maximum")
+                    }
+                    fieldID += Int32(extensionSize)
+                } else {
+                    nameSize += Int(extensionSize)
+                }
             }
-            size += 1
 
             let nullable = (header & 0b10) != 0
             let trackRef = (header & 0b1) != 0
@@ -289,11 +314,6 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
             )
 
             if encodingFlags == 3 {
-                let rawFieldID = size - 1
-                if _slowPath(rawFieldID > Int(Int16.max)) {
-                    throw invalidTaggedFieldID(rawFieldID)
-                }
-                let fieldID = Int16(rawFieldID)
                 return FieldInfo(
                     fieldID: fieldID,
                     fieldName: "$tag\(fieldID)",
@@ -304,12 +324,18 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
             guard encodingFlags < fieldNameMetaStringEncodings.count else {
                 throw ForyError.invalidData("invalid field name encoding id")
             }
-            let nameBytes = try buffer.readBytes(count: size)
+            let nameBytes = try buffer.readBytes(count: nameSize + 1)
             let name = try MetaStringDecoder.fieldName
                 .decode(bytes: nameBytes, encoding: fieldNameMetaStringEncodings[encodingFlags])
                 .value
 
-            return FieldInfo(fieldID: nil, fieldName: name, fieldType: fieldType)
+            return FieldInfo(fieldName: name, fieldType: fieldType)
+        }
+
+        public static func == (lhs: FieldInfo, rhs: FieldInfo) -> Bool {
+            lhs.fieldID == rhs.fieldID
+                && lhs.fieldName == rhs.fieldName
+                && lhs.fieldType == rhs.fieldType
         }
     }
 
@@ -323,13 +349,6 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
     /// The protocol-defined 52-bit schema identity. Equal values identify the same schema,
     /// so readers do not need to compare the field array again.
     public let headerHash: UInt64
-
-    internal var readDataAlwaysAdvances: Bool {
-        for field in fields where field.fieldType.readDataAlwaysAdvances {
-            return true
-        }
-        return false
-    }
 
     public init(
         typeID: UInt32?,
@@ -353,6 +372,7 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
                 throw ForyError.encodingError("user type id is required in register-by-id mode")
             }
         }
+        try Self.validateFieldTags(fields)
 
         self.typeID = typeID
         self.userTypeID = userTypeID
@@ -362,13 +382,6 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         self.fields = fields
         self.compressed = compressed
         self.headerHash = headerHash
-    }
-
-    public static func == (lhs: TypeMeta, rhs: TypeMeta) -> Bool {
-        lhs.typeID == rhs.typeID && lhs.userTypeID == rhs.userTypeID && lhs.namespace == rhs.namespace
-            && lhs.typeName == rhs.typeName && lhs.registerByName == rhs.registerByName
-            && lhs.fields == rhs.fields && lhs.compressed == rhs.compressed
-            && lhs.headerHash == rhs.headerHash
     }
 
     public func encode() throws -> [UInt8] {
@@ -566,21 +579,6 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         return Array(buffer.storage.prefix(buffer.count))
     }
 
-    private static func hashMask() -> UInt64 {
-        UInt64.max << (64 - typeMetaNumHashBits)
-    }
-
-    private static func typeMetaHeaderHash(_ body: [UInt8], headerLowBits: UInt64) -> UInt64 {
-        var hashInput = body
-        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits))
-        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits >> 8))
-        let bodyHash = MurmurHash3.x64_128(hashInput, seed: typeMetaHashSeed).0
-        let shifted = bodyHash << (64 - typeMetaNumHashBits)
-        let signed = Int64(bitPattern: shifted)
-        let absSigned = signed == Int64.min ? signed : Swift.abs(signed)
-        return UInt64(bitPattern: absSigned) & hashMask()
-    }
-
     private static func isStructTypeMetaKind(_ typeID: TypeId) -> Bool {
         switch typeID {
         case .structType, .compatibleStruct, .namedStruct, .namedCompatibleStruct:
@@ -699,8 +697,8 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         guard !localFields.isEmpty else {
             var resolvedFields = fields
             var changed = false
-            for index in resolvedFields.indices where resolvedFields[index].fieldID != -1 {
-                resolvedFields[index].fieldID = -1
+            for index in resolvedFields.indices where resolvedFields[index].matchedFieldID != -1 {
+                resolvedFields[index].matchedFieldID = -1
                 changed = true
             }
             guard changed else {
@@ -719,13 +717,13 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         }
 
         var fieldIndexByName: [String: (Int, FieldInfo)] = [:]
-        var fieldIndexByID: [Int16: (Int, FieldInfo)] = [:]
+        var fieldIndexByID: [Int32: (Int, FieldInfo)] = [:]
         fieldIndexByName.reserveCapacity(localFields.count)
         fieldIndexByID.reserveCapacity(localFields.count)
 
         for (index, localField) in localFields.enumerated() {
-            if let fieldID = localField.fieldID, fieldID >= 0 {
-                fieldIndexByID[fieldID] = (index, localField)
+            if localField.fieldID >= 0 {
+                fieldIndexByID[localField.fieldID] = (index, localField)
             } else {
                 fieldIndexByName[toSnakeCase(localField.fieldName)] = (index, localField)
             }
@@ -739,8 +737,8 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
             let field = resolvedFields[index]
 
             var localMatch: (Int, FieldInfo)?
-            if let fieldID = field.fieldID, fieldID >= 0 {
-                if let candidate = fieldIndexByID[fieldID] {
+            if field.fieldID >= 0 {
+                if let candidate = fieldIndexByID[field.fieldID] {
                     guard Self.isCompatibleFieldType(field.fieldType, candidate.1.fieldType) else {
                         throw ForyError.invalidData(
                             "compatible field \(field.fieldName) cannot be read as local field \(candidate.1.fieldName)"
@@ -750,7 +748,7 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
                 }
             }
 
-            if localMatch == nil && field.fieldID == nil {
+            if localMatch == nil && field.fieldID == -1 {
                 if let candidate = fieldIndexByName[toSnakeCase(field.fieldName)] {
                     guard Self.isCompatibleFieldType(field.fieldType, candidate.1.fieldType) else {
                         throw ForyError.invalidData(
@@ -763,7 +761,7 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
 
             // Only anonymous legacy fields may fall back by exact type. Named or
             // tagged remote-only fields must stay unmatched so the reader skips them.
-            if localMatch == nil && field.fieldID == nil && field.fieldName.isEmpty {
+            if localMatch == nil && field.fieldID == -1 && field.fieldName.isEmpty {
                 for localIndex in localFields.indices where !usedLocalFields[localIndex] {
                     if Self.isCompatibleFieldType(
                         field.fieldType,
@@ -778,8 +776,8 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
             }
 
             guard let (sortedIndex, _) = localMatch else {
-                if field.fieldID != -1 {
-                    resolvedFields[index].fieldID = -1
+                if field.matchedFieldID != -1 {
+                    resolvedFields[index].matchedFieldID = -1
                     changed = true
                 }
                 continue
@@ -798,8 +796,8 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
             let localField = localFields[sortedIndex]
             let exactField = field.fieldType == localField.fieldType
             let resolvedFieldID = Int16(sortedIndex * 2 + (exactField ? 0 : 1))
-            if field.fieldID != resolvedFieldID {
-                resolvedFields[index].fieldID = resolvedFieldID
+            if field.matchedFieldID != resolvedFieldID {
+                resolvedFields[index].matchedFieldID = resolvedFieldID
                 changed = true
             }
             usedLocalFields[sortedIndex] = true
@@ -1046,6 +1044,49 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         default:
             return typeID
         }
+    }
+}
+
+extension TypeMeta {
+    internal var readDataAlwaysAdvances: Bool {
+        for field in fields where field.fieldType.readDataAlwaysAdvances {
+            return true
+        }
+        return false
+    }
+
+    public static func == (lhs: TypeMeta, rhs: TypeMeta) -> Bool {
+        lhs.typeID == rhs.typeID && lhs.userTypeID == rhs.userTypeID && lhs.namespace == rhs.namespace
+            && lhs.typeName == rhs.typeName && lhs.registerByName == rhs.registerByName
+            && lhs.fields == rhs.fields && lhs.compressed == rhs.compressed
+            && lhs.headerHash == rhs.headerHash
+    }
+
+    private static func validateFieldTags(_ fields: [FieldInfo]) throws {
+        var fieldIDs = Set<Int32>()
+        for field in fields {
+            guard field.fieldID >= -1, field.fieldID <= maxTaggedFieldID else {
+                throw ForyError.invalidData("invalid compatible field tag \(field.fieldID)")
+            }
+            if field.fieldID >= 0, !fieldIDs.insert(field.fieldID).inserted {
+                throw ForyError.invalidData("duplicate compatible field tag \(field.fieldID)")
+            }
+        }
+    }
+
+    private static func hashMask() -> UInt64 {
+        UInt64.max << (64 - typeMetaNumHashBits)
+    }
+
+    private static func typeMetaHeaderHash(_ body: [UInt8], headerLowBits: UInt64) -> UInt64 {
+        var hashInput = body
+        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits))
+        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits >> 8))
+        let bodyHash = MurmurHash3.x64_128(hashInput, seed: typeMetaHashSeed).0
+        let shifted = bodyHash << (64 - typeMetaNumHashBits)
+        let signed = Int64(bitPattern: shifted)
+        let absSigned = signed == Int64.min ? signed : Swift.abs(signed)
+        return UInt64(bitPattern: absSigned) & hashMask()
     }
 }
 

--- a/swift/Sources/Fory/TypeMeta.swift
+++ b/swift/Sources/Fory/TypeMeta.swift
@@ -350,6 +350,13 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
     /// so readers do not need to compare the field array again.
     public let headerHash: UInt64
 
+    internal var readDataAlwaysAdvances: Bool {
+        for field in fields where field.fieldType.readDataAlwaysAdvances {
+            return true
+        }
+        return false
+    }
+
     public init(
         typeID: UInt32?,
         userTypeID: UInt32?,
@@ -382,6 +389,13 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         self.fields = fields
         self.compressed = compressed
         self.headerHash = headerHash
+    }
+
+    public static func == (lhs: TypeMeta, rhs: TypeMeta) -> Bool {
+        lhs.typeID == rhs.typeID && lhs.userTypeID == rhs.userTypeID && lhs.namespace == rhs.namespace
+            && lhs.typeName == rhs.typeName && lhs.registerByName == rhs.registerByName
+            && lhs.fields == rhs.fields && lhs.compressed == rhs.compressed
+            && lhs.headerHash == rhs.headerHash
     }
 
     public func encode() throws -> [UInt8] {
@@ -577,6 +591,21 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
         }
 
         return Array(buffer.storage.prefix(buffer.count))
+    }
+
+    private static func hashMask() -> UInt64 {
+        UInt64.max << (64 - typeMetaNumHashBits)
+    }
+
+    private static func typeMetaHeaderHash(_ body: [UInt8], headerLowBits: UInt64) -> UInt64 {
+        var hashInput = body
+        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits))
+        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits >> 8))
+        let bodyHash = MurmurHash3.x64_128(hashInput, seed: typeMetaHashSeed).0
+        let shifted = bodyHash << (64 - typeMetaNumHashBits)
+        let signed = Int64(bitPattern: shifted)
+        let absSigned = signed == Int64.min ? signed : Swift.abs(signed)
+        return UInt64(bitPattern: absSigned) & hashMask()
     }
 
     private static func isStructTypeMetaKind(_ typeID: TypeId) -> Bool {
@@ -1048,20 +1077,6 @@ public final class TypeMeta: Equatable, @unchecked Sendable {
 }
 
 extension TypeMeta {
-    internal var readDataAlwaysAdvances: Bool {
-        for field in fields where field.fieldType.readDataAlwaysAdvances {
-            return true
-        }
-        return false
-    }
-
-    public static func == (lhs: TypeMeta, rhs: TypeMeta) -> Bool {
-        lhs.typeID == rhs.typeID && lhs.userTypeID == rhs.userTypeID && lhs.namespace == rhs.namespace
-            && lhs.typeName == rhs.typeName && lhs.registerByName == rhs.registerByName
-            && lhs.fields == rhs.fields && lhs.compressed == rhs.compressed
-            && lhs.headerHash == rhs.headerHash
-    }
-
     private static func validateFieldTags(_ fields: [FieldInfo]) throws {
         var fieldIDs = Set<Int32>()
         for field in fields {
@@ -1072,21 +1087,6 @@ extension TypeMeta {
                 throw ForyError.invalidData("duplicate compatible field tag \(field.fieldID)")
             }
         }
-    }
-
-    private static func hashMask() -> UInt64 {
-        UInt64.max << (64 - typeMetaNumHashBits)
-    }
-
-    private static func typeMetaHeaderHash(_ body: [UInt8], headerLowBits: UInt64) -> UInt64 {
-        var hashInput = body
-        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits))
-        hashInput.append(UInt8(truncatingIfNeeded: headerLowBits >> 8))
-        let bodyHash = MurmurHash3.x64_128(hashInput, seed: typeMetaHashSeed).0
-        let shifted = bodyHash << (64 - typeMetaNumHashBits)
-        let signed = Int64(bitPattern: shifted)
-        let absSigned = signed == Int64.min ? signed : Swift.abs(signed)
-        return UInt64(bitPattern: absSigned) & hashMask()
     }
 }
 

--- a/swift/Sources/ForyMacro/ForyObjectMacro.swift
+++ b/swift/Sources/ForyMacro/ForyObjectMacro.swift
@@ -367,7 +367,7 @@ struct ParsedField {
 
     let isOptional: Bool
     let isCollection: Bool
-    let fieldID: Int?
+    let fieldID: Int32
     let schemaIdentifier: String
     let fieldIdentifier: String
 
@@ -435,7 +435,7 @@ private indirect enum FieldTypeHint {
 
 private struct ParsedForyFieldConfiguration {
     let encoding: FieldEncoding?
-    let id: Int?
+    let id: Int32
     let ignore: Bool?
     let typeHint: FieldTypeHint?
     let serializerType: String?
@@ -1008,7 +1008,7 @@ private func parseFields(
             )
         }
         if isIgnored,
-            fieldConfig?.id != nil || fieldConfig?.encoding != nil || fieldTypeHint != nil
+            (fieldConfig?.id ?? -1) >= 0 || fieldConfig?.encoding != nil || fieldTypeHint != nil
         {
             throw MacroExpansionErrorMessage(
                 "@ForyField(ignore: true) cannot be combined with wire or nested field options"
@@ -1081,10 +1081,10 @@ private func parseFields(
                 classification.isCollection || classification.isMap
                 ? try codecTypeExpression(typeText: concreteType, hint: nil)
                 : nil
-            let fieldID = fieldConfig?.id
+            let fieldID = fieldConfig?.id ?? -1
             let baseIdentifier = toSnakeCase(name)
-            let schemaIdentifier = fieldID.map(String.init) ?? baseIdentifier
-            let fieldIdentifier = fieldID.map { "$tag\($0)" } ?? baseIdentifier
+            let schemaIdentifier = fieldID >= 0 ? String(fieldID) : baseIdentifier
+            let fieldIdentifier = fieldID >= 0 ? "$tag\(fieldID)" : baseIdentifier
             let group: Int
             if classification.isPrimitive {
                 group = isOptional ? 2 : 1
@@ -1115,9 +1115,10 @@ private func parseFields(
         }
     }
 
-    var seenFieldIDs: [Int: String] = [:]
+    var seenFieldIDs: [Int32: String] = [:]
     for field in fields {
-        guard let fieldID = field.fieldID else {
+        let fieldID = field.fieldID
+        guard fieldID >= 0 else {
             continue
         }
         if let existing = seenFieldIDs[fieldID], existing != field.name {
@@ -1140,7 +1141,7 @@ private func parseForyFieldConfiguration(
     supportsEncoding: Bool
 ) throws -> ParsedForyFieldConfiguration? {
     var parsedEncoding: FieldEncoding?
-    var parsedID: Int?
+    var parsedID: Int32 = -1
     var parsedIgnore: Bool?
     var parsedTypeHint: FieldTypeHint?
     var parsedSerializerType: String?
@@ -1180,7 +1181,7 @@ private func parseForyFieldConfiguration(
 
             if label == "id" {
                 let idValue = try parseFieldIDExpression(arg.expression)
-                if let existing = parsedID, existing != idValue {
+                if parsedID >= 0 && parsedID != idValue {
                     throw MacroExpansionErrorMessage("conflicting @ForyField id values on the same declaration")
                 }
                 parsedID = idValue
@@ -1238,7 +1239,7 @@ private func parseForyFieldConfiguration(
     }
 
     if parsedEncoding == nil,
-        parsedID == nil,
+        parsedID < 0,
         parsedIgnore == nil,
         parsedTypeHint == nil,
         parsedSerializerType == nil
@@ -1280,7 +1281,7 @@ private func parseForyCaseConfiguration(
         for arg in argList {
             let label = arg.label?.text
             if label == nil || label == "id" {
-                let idValue = try parseFieldIDExpression(arg.expression)
+                let idValue = try parseCaseIDExpression(arg.expression)
                 if let existing = parsedID, existing != idValue {
                     throw MacroExpansionErrorMessage("conflicting @ForyCase id values on the same declaration")
                 }
@@ -1645,16 +1646,30 @@ private func parseMapFieldTypeHint(args: LabeledExprListSyntax) throws -> FieldT
     return .map(key: key, value: value)
 }
 
-private func parseFieldIDExpression(_ expr: ExprSyntax) throws -> Int {
+private func parseFieldIDExpression(_ expr: ExprSyntax) throws -> Int32 {
     let raw = trimType(expr.trimmedDescription)
-    guard let value = Int(raw) else {
+    guard let value = Int32(raw) else {
         throw MacroExpansionErrorMessage("@ForyField id must be an integer literal")
     }
     if value < 0 {
         throw MacroExpansionErrorMessage("@ForyField id must be non-negative")
     }
+    if value >= 1 << 29 {
+        throw MacroExpansionErrorMessage("@ForyField id must be < 2^29")
+    }
+    return value
+}
+
+private func parseCaseIDExpression(_ expr: ExprSyntax) throws -> Int {
+    let raw = trimType(expr.trimmedDescription)
+    guard let value = Int(raw) else {
+        throw MacroExpansionErrorMessage("@ForyCase id must be an integer literal")
+    }
+    if value < 0 {
+        throw MacroExpansionErrorMessage("@ForyCase id must be non-negative")
+    }
     if value > Int(Int16.max) {
-        throw MacroExpansionErrorMessage("@ForyField id must be <= \(Int16.max)")
+        throw MacroExpansionErrorMessage("@ForyCase id must be <= \(Int16.max)")
     }
     return value
 }
@@ -2434,13 +2449,13 @@ private func containsDynamicAny(typeText: String) -> Bool {
 }
 
 private func compareFieldIdentifier(_ lhs: ParsedField, _ rhs: ParsedField) -> Bool? {
-    if let lhsID = lhs.fieldID, let rhsID = rhs.fieldID, lhsID != rhsID {
-        return lhsID < rhsID
+    if lhs.fieldID >= 0 && rhs.fieldID >= 0 && lhs.fieldID != rhs.fieldID {
+        return lhs.fieldID < rhs.fieldID
     }
-    if lhs.fieldID != nil && rhs.fieldID == nil {
+    if lhs.fieldID >= 0 && rhs.fieldID < 0 {
         return true
     }
-    if lhs.fieldID == nil && rhs.fieldID != nil {
+    if lhs.fieldID < 0 && rhs.fieldID >= 0 {
         return false
     }
     if lhs.fieldIdentifier != rhs.fieldIdentifier {
@@ -2450,20 +2465,20 @@ private func compareFieldIdentifier(_ lhs: ParsedField, _ rhs: ParsedField) -> B
 }
 
 private func compareTaggedFieldIdentifier(_ lhs: ParsedField, _ rhs: ParsedField) -> Bool? {
-    switch (lhs.fieldID, rhs.fieldID) {
-    case let (lhsID?, rhsID?):
-        if lhsID != rhsID {
-            return lhsID < rhsID
+    switch (lhs.fieldID >= 0, rhs.fieldID >= 0) {
+    case (true, true):
+        if lhs.fieldID != rhs.fieldID {
+            return lhs.fieldID < rhs.fieldID
         }
         if lhs.fieldIdentifier != rhs.fieldIdentifier {
             return lhs.fieldIdentifier < rhs.fieldIdentifier
         }
         return nil
-    case (_?, nil):
+    case (true, false):
         return true
-    case (nil, _?):
+    case (false, true):
         return false
-    case (nil, nil):
+    case (false, false):
         return nil
     }
 }
@@ -2552,7 +2567,7 @@ private func compatibleTypeMetaFieldsExpr(
 ) -> String {
     let fieldInfos = sortedFields.map { field in
         let fieldTypeExpr = compatibleTypeMetaFieldExpression(field, trackRefExpression: trackRefExpression)
-        return "TypeMeta.FieldInfo(fieldID: \(compatibleFieldIDExpr(field)), fieldName: \"\(field.name)\", fieldType: \(fieldTypeExpr))"
+        return "TypeMeta.FieldInfo(fieldID: \(field.fieldID), fieldName: \"\(field.name)\", fieldType: \(fieldTypeExpr))"
     }
     guard !fieldInfos.isEmpty else {
         return "[]"
@@ -2563,19 +2578,12 @@ private func compatibleTypeMetaFieldsExpr(
 private func resolvedTypeMetaFieldsBody(sortedFields: [ParsedField]) -> String {
     let fieldInfos = sortedFields.map { field in
         let fieldTypeExpr = resolvedTypeMetaFieldExpr(field)
-        return "TypeMeta.FieldInfo(fieldID: \(compatibleFieldIDExpr(field)), fieldName: \"\(field.name)\", fieldType: \(fieldTypeExpr))"
+        return "TypeMeta.FieldInfo(fieldID: \(field.fieldID), fieldName: \"\(field.name)\", fieldType: \(fieldTypeExpr))"
     }
     guard !fieldInfos.isEmpty else {
         return "return []"
     }
     return "return [\n            \(fieldInfos.joined(separator: ",\n            "))\n        ]"
-}
-
-private func compatibleFieldIDExpr(_ field: ParsedField) -> String {
-    if let fieldID = field.fieldID {
-        return "\(fieldID)"
-    }
-    return "nil"
 }
 
 private func buildSchemaFingerprint(fields: [ParsedField], trackRefExpression: String) throws -> String {

--- a/swift/Sources/ForyMacro/ForyObjectMacroReadGeneration.swift
+++ b/swift/Sources/ForyMacro/ForyObjectMacroReadGeneration.swift
@@ -357,12 +357,12 @@ private func buildClassReadCompatibleDataDecl(
                 return value
             }
             \(localFieldsBinding)for remoteField in typeMeta.fields {
-                switch Int(remoteField.fieldID ?? -1) {
+                switch Int(remoteField.matchedFieldID) {
             \(compatibleCases)
                 case -1:
                     try context.skipFieldValue(remoteField.fieldType)
                 default:
-                    throw ForyError.invalidData("invalid compatible matched id \\(remoteField.fieldID ?? -2)")
+                    throw ForyError.invalidData("invalid compatible matched id \\(remoteField.matchedFieldID)")
                 }
             }
             return value
@@ -473,12 +473,12 @@ private func buildStructChangedFallbackDecl(
               \(bufferBinding)
               \(defaults)
               \(localFieldsBinding)for remoteField in typeMeta.fields {
-                  switch Int(remoteField.fieldID ?? -1) {
+                  switch Int(remoteField.matchedFieldID) {
                   \(cases)
                   case -1:
                       try context.skipFieldValue(remoteField.fieldType)
                   default:
-                      throw ForyError.invalidData("invalid compatible matched id \\(remoteField.fieldID ?? -2)")
+                      throw ForyError.invalidData("invalid compatible matched id \\(remoteField.matchedFieldID)")
                   }
               }
               return Target(

--- a/swift/Tests/ForyTests/CollectionSerializerTests.swift
+++ b/swift/Tests/ForyTests/CollectionSerializerTests.swift
@@ -810,7 +810,7 @@ func generatedReadProgress() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "value",
                 fieldType: TypeMeta.FieldType(
                     typeID: TypeId.int32.rawValue,

--- a/swift/Tests/ForyTests/CompatibilityTests.swift
+++ b/swift/Tests/ForyTests/CompatibilityTests.swift
@@ -759,7 +759,8 @@ func scalarTrackRefMismatchIsRejected() throws {
     }
 
     let resolvedBothTracking = try remoteTracking.assigningFieldIDs(from: localTracking)
-    #expect(resolvedBothTracking.fields[0].fieldID == 0)
+    #expect(resolvedBothTracking.fields[0].fieldID == 1)
+    #expect(resolvedBothTracking.fields[0].matchedFieldID == 0)
 
     let localNullableTracking = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -789,7 +790,8 @@ func scalarTrackRefMismatchIsRejected() throws {
         ])
     let resolvedBothNullableTracking = try remoteNullableTracking.assigningFieldIDs(
         from: localNullableTracking)
-    #expect(resolvedBothNullableTracking.fields[0].fieldID == 0)
+    #expect(resolvedBothNullableTracking.fields[0].fieldID == 1)
+    #expect(resolvedBothNullableTracking.fields[0].matchedFieldID == 0)
     try expectInvalidData {
         _ = try remoteNullableTracking.assigningFieldIDs(from: localTracking)
     }
@@ -810,8 +812,8 @@ func namedRemoteOnlyFieldIsSkipped() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "username", fieldType: stringType),
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "id", fieldType: intType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "username", fieldType: stringType),
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "id", fieldType: intType)
         ])
     let remote = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -820,13 +822,15 @@ func namedRemoteOnlyFieldIsSkipped() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "email", fieldType: stringType),
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "id", fieldType: intType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "email", fieldType: stringType),
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "id", fieldType: intType)
         ])
 
     let resolved = try remote.assigningFieldIDs(from: local)
     #expect(resolved.fields[0].fieldID == -1)
-    #expect(resolved.fields[1].fieldID == 2)
+    #expect(resolved.fields[0].matchedFieldID == -1)
+    #expect(resolved.fields[1].fieldID == -1)
+    #expect(resolved.fields[1].matchedFieldID == 2)
 }
 
 @Test
@@ -853,8 +857,10 @@ func remoteOnlyFieldsSkipWhenLocalSchemaIsEmpty() throws {
         ])
 
     let resolved = try remote.assigningFieldIDs(from: local)
-    #expect(resolved.fields[0].fieldID == -1)
-    #expect(resolved.fields[1].fieldID == -1)
+    #expect(resolved.fields[0].fieldID == 1)
+    #expect(resolved.fields[0].matchedFieldID == -1)
+    #expect(resolved.fields[1].fieldID == 2)
+    #expect(resolved.fields[1].matchedFieldID == -1)
 }
 
 @Test
@@ -877,7 +883,7 @@ func nameRemoteFieldDoesNotMatchTaggedLocalField() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "value", fieldType: stringType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "value", fieldType: stringType)
         ])
 
     let resolved = try remote.assigningFieldIDs(from: local)
@@ -895,7 +901,7 @@ func duplicateRemoteNameBindingFails() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "value", fieldType: stringType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "value", fieldType: stringType)
         ])
     let remote = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -904,8 +910,8 @@ func duplicateRemoteNameBindingFails() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "value", fieldType: stringType),
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "value", fieldType: stringType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "value", fieldType: stringType),
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "value", fieldType: stringType)
         ])
 
     #expect(throws: ForyError.invalidData("compatible field value duplicates local field value")) {
@@ -919,7 +925,7 @@ func matchedFieldIdOverflowFails() throws {
     let fieldType = TypeMeta.FieldType(typeID: TypeId.bool.rawValue, nullable: false)
     let overflowIndex = Int(Int16.max) / 2 + 1
     let localFields = (0...overflowIndex).map {
-        TypeMeta.FieldInfo(fieldID: nil, fieldName: "f\($0)", fieldType: fieldType)
+        TypeMeta.FieldInfo(fieldID: -1, fieldName: "f\($0)", fieldType: fieldType)
     }
     let local = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -936,7 +942,7 @@ func matchedFieldIdOverflowFails() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "f\(overflowIndex)",
                 fieldType: fieldType)
         ])
@@ -959,7 +965,7 @@ func matchedByteFamilyClassification() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "payload", fieldType: binaryType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "payload", fieldType: binaryType)
         ])
     let remoteUInt8Array = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -968,7 +974,7 @@ func matchedByteFamilyClassification() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "payload", fieldType: uint8ArrayType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "payload", fieldType: uint8ArrayType)
         ])
     let remoteInt8Array = try TypeMeta(
         typeID: TypeId.compatibleStruct.rawValue,
@@ -977,11 +983,12 @@ func matchedByteFamilyClassification() throws {
         typeName: empty,
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "payload", fieldType: int8ArrayType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "payload", fieldType: int8ArrayType)
         ])
 
     let resolved = try remoteUInt8Array.assigningFieldIDs(from: local)
-    #expect(resolved.fields[0].fieldID == 1)
+    #expect(resolved.fields[0].fieldID == -1)
+    #expect(resolved.fields[0].matchedFieldID == 1)
     try expectInvalidData {
         _ = try remoteInt8Array.assigningFieldIDs(from: local)
     }
@@ -998,7 +1005,7 @@ func matchedNestedScalarShapeAcceptsNullableDrift() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "values",
                 fieldType: TypeMeta.FieldType(
                     typeID: TypeId.list.rawValue,
@@ -1013,7 +1020,7 @@ func matchedNestedScalarShapeAcceptsNullableDrift() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "values",
                 fieldType: TypeMeta.FieldType(
                     typeID: TypeId.list.rawValue,
@@ -1022,7 +1029,8 @@ func matchedNestedScalarShapeAcceptsNullableDrift() throws {
         ])
 
     let resolved = try remote.assigningFieldIDs(from: local)
-    #expect(resolved.fields[0].fieldID == 1)
+    #expect(resolved.fields[0].fieldID == -1)
+    #expect(resolved.fields[0].matchedFieldID == 1)
 }
 
 @Test
@@ -1036,7 +1044,7 @@ func matchedNestedScalarShapeRejectsRefDrift() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "values",
                 fieldType: TypeMeta.FieldType(
                     typeID: TypeId.list.rawValue,
@@ -1051,7 +1059,7 @@ func matchedNestedScalarShapeRejectsRefDrift() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "values",
                 fieldType: TypeMeta.FieldType(
                     typeID: TypeId.list.rawValue,

--- a/swift/Tests/ForyTests/DecoderStateTests.swift
+++ b/swift/Tests/ForyTests/DecoderStateTests.swift
@@ -154,7 +154,7 @@ func remoteSchemaLogicalKeyLimitPersists() throws {
         if let fieldName {
             fields = [
                 TypeMeta.FieldInfo(
-                    fieldID: nil,
+                    fieldID: -1,
                     fieldName: fieldName,
                     fieldType: TypeMeta.FieldType(
                         typeID: TypeId.int32.rawValue,

--- a/swift/Tests/ForyTests/ForySwiftTests.swift
+++ b/swift/Tests/ForyTests/ForySwiftTests.swift
@@ -96,6 +96,12 @@ struct FieldIdConfigured: Equatable {
 }
 
 @ForyStruct
+struct MaximumFieldId: Equatable {
+    @ForyField(id: 536870911)
+    var value: Int32
+}
+
+@ForyStruct
 struct FieldIdSource: Equatable {
     @ForyField(id: 1)
     var value: Int32
@@ -550,8 +556,8 @@ func typeMetaFieldLimitRejectsLargeStruct() throws {
         typeName: .empty(specialChar1: "$", specialChar2: "_"),
         registerByName: false,
         fields: [
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "first", fieldType: fieldType),
-            TypeMeta.FieldInfo(fieldID: nil, fieldName: "second", fieldType: fieldType)
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "first", fieldType: fieldType),
+            TypeMeta.FieldInfo(fieldID: -1, fieldName: "second", fieldType: fieldType)
         ]
     )
     let encoded = try meta.encode()
@@ -571,7 +577,7 @@ func typeMetaBodyLimitRejectsLargeMetadata() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "value",
                 fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false))
         ]
@@ -584,23 +590,48 @@ func typeMetaBodyLimitRejectsLargeMetadata() throws {
 }
 
 @Test
-func typeMetaRejectsLargeTaggedFieldID() {
+func typeMetaFieldTagDomain() throws {
+    let fieldType = TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
+    let meta = try TypeMeta(
+        typeID: TypeId.compatibleStruct.rawValue,
+        userTypeID: 1,
+        namespace: .empty(specialChar1: ".", specialChar2: "_"),
+        typeName: .empty(specialChar1: "$", specialChar2: "_"),
+        registerByName: false,
+        fields: [
+            TypeMeta.FieldInfo(fieldID: 536_870_911, fieldName: "maximum", fieldType: fieldType)
+        ]
+    )
+    let decoded = try TypeMeta.decode(meta.encode())
+    #expect(decoded.fields.map(\.fieldID) == [536_870_911])
+
     let body = ByteBuffer()
     body.writeUInt8(0b1000_0001)
     body.writeVarUInt32(1)
     body.writeUInt8(0b1111_1100)
-    body.writeVarUInt32(UInt32(Int(Int16.max) + 1 - 0b1111))
+    body.writeVarUInt32(536_870_912 - 0b1111)
     body.writeUInt8(UInt8(TypeId.int32.rawValue))
 
     let encoded = ByteBuffer()
     encoded.writeUInt64(UInt64(body.count))
     encoded.writeBytes(body.storage)
 
-    #expect(
-        throws: ForyError.invalidData(
-            "tagged field id \(Int(Int16.max) + 1) exceeds Int16 range")
-    ) {
+    #expect(throws: (any Error).self) {
         _ = try TypeMeta.decode(encoded)
+    }
+
+    #expect(throws: (any Error).self) {
+        _ = try TypeMeta(
+            typeID: TypeId.compatibleStruct.rawValue,
+            userTypeID: 1,
+            namespace: .empty(specialChar1: ".", specialChar2: "_"),
+            typeName: .empty(specialChar1: "$", specialChar2: "_"),
+            registerByName: false,
+            fields: [
+                TypeMeta.FieldInfo(fieldID: 7, fieldName: "first", fieldType: fieldType),
+                TypeMeta.FieldInfo(fieldID: 7, fieldName: "second", fieldType: fieldType)
+            ]
+        )
     }
 }
 
@@ -621,7 +652,7 @@ func schemaLimitTracksStructTypesSeparately() throws {
             registerByName: false,
             fields: [
                 TypeMeta.FieldInfo(
-                    fieldID: nil,
+                    fieldID: -1,
                     fieldName: fieldName,
                     fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
                 )
@@ -772,7 +803,7 @@ func failedSchemaDoesNotConsumeLimit() throws {
             registerByName: false,
             fields: [
                 TypeMeta.FieldInfo(
-                    fieldID: nil,
+                    fieldID: -1,
                     fieldName: fieldName,
                     fieldType: fieldType
                 )
@@ -871,7 +902,7 @@ func cachedMetaChecksConcreteOwner() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "remoteId",
                 fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
             )
@@ -921,7 +952,7 @@ func failedStaticMetaDoesNotCount() throws {
             registerByName: false,
             fields: [
                 TypeMeta.FieldInfo(
-                    fieldID: nil,
+                    fieldID: -1,
                     fieldName: fieldName,
                     fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
                 )
@@ -1467,7 +1498,7 @@ func macroNonPrimitiveFieldsSortByFieldIdentifier() throws {
         fields.map(\.fieldName) == [
             "intValue", "mapValue", "stringValue", "addressValue", "binaryValue"
         ])
-    #expect(fields.map(\.fieldID) == [nil, 10, 20, nil, nil])
+    #expect(fields.map(\.fieldID) == [-1, 10, 20, -1, -1])
 }
 
 @Test
@@ -1541,17 +1572,20 @@ func macroFieldIDsPopulateCompatibleTypeMeta() {
     let fields = FieldIdConfigured.foryFieldsInfo(trackRef: false)
     #expect(fields.count == 2)
 
-    var byID: [Int16: TypeMeta.FieldInfo] = [:]
-    for field in fields {
-        if let id = field.fieldID {
-            byID[id] = field
-        }
+    var byID: [Int32: TypeMeta.FieldInfo] = [:]
+    for field in fields where field.fieldID >= 0 {
+        byID[field.fieldID] = field
     }
 
     #expect(byID[2]?.fieldName == "stableID")
     #expect(byID[2]?.fieldType.typeID == TypeId.varint32.rawValue)
     #expect(byID[5]?.fieldName == "fixedValue")
     #expect(byID[5]?.fieldType.typeID == TypeId.int32.rawValue)
+}
+
+@Test
+func macroAcceptsMaximumFieldID() {
+    #expect(MaximumFieldId.foryFieldsInfo(trackRef: false).map(\.fieldID) == [536_870_911])
 }
 
 @Test
@@ -1762,12 +1796,12 @@ func typeMetaRoundTripByName() throws {
 
     let fields: [TypeMeta.FieldInfo] = [
         .init(
-            fieldID: nil,
+            fieldID: -1,
             fieldName: "createdAt",
             fieldType: .init(typeID: TypeId.varint64.rawValue, nullable: false)
         ),
         .init(
-            fieldID: nil,
+            fieldID: -1,
             fieldName: "tags",
             fieldType: .init(
                 typeID: TypeId.list.rawValue,
@@ -1776,7 +1810,7 @@ func typeMetaRoundTripByName() throws {
             )
         ),
         .init(
-            fieldID: nil,
+            fieldID: -1,
             fieldName: "attributes",
             fieldType: .init(
                 typeID: TypeId.map.rawValue,

--- a/swift/Tests/ForyTests/MacroDiagnosticTests.swift
+++ b/swift/Tests/ForyTests/MacroDiagnosticTests.swift
@@ -158,6 +158,26 @@ func duplicateFieldIDsAreRejected() {
 }
 
 @Test
+func rejectsFieldIDOutsideDomain() {
+    assertForyDiagnostic(
+        """
+        @ForyStruct
+        struct BadID {
+            @ForyField(id: 536870912)
+            var value: Int32 = 0
+        }
+        """,
+        expandedSource:
+            """
+            struct BadID {
+                var value: Int32 = 0
+            }
+            """,
+        message: "@ForyField id must be < 2^29"
+    )
+}
+
+@Test
 func unionPayloadHintsMustMatchPayloadType() {
     assertForyDiagnostic(
         """

--- a/swift/Tests/ForyTests/TypeMetaDepthTests.swift
+++ b/swift/Tests/ForyTests/TypeMetaDepthTests.swift
@@ -138,7 +138,7 @@ func cachedMetaUsesHeaderHash() throws {
         registerByName: false,
         fields: [
             TypeMeta.FieldInfo(
-                fieldID: nil,
+                fieldID: -1,
                 fieldName: "remoteId",
                 fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
             )
@@ -235,7 +235,7 @@ func genericMetaUsesResolvedHash() throws {
 
     func field(_ name: String) -> TypeMeta.FieldInfo {
         TypeMeta.FieldInfo(
-            fieldID: nil,
+            fieldID: -1,
             fieldName: name,
             fieldType: TypeMeta.FieldType(typeID: TypeId.int32.rawValue, nullable: false)
         )
@@ -361,7 +361,7 @@ private func constructedTypeMeta(depth: Int) throws -> TypeMeta {
         namespace: .empty(specialChar1: ".", specialChar2: "_"),
         typeName: .empty(specialChar1: "$", specialChar2: "_"),
         registerByName: false,
-        fields: [TypeMeta.FieldInfo(fieldID: nil, fieldName: "value", fieldType: fieldType)]
+        fields: [TypeMeta.FieldInfo(fieldID: -1, fieldName: "value", fieldType: fieldType)]
     )
 }
 

--- a/swift/Tests/ForyXlangTests/main.swift
+++ b/swift/Tests/ForyXlangTests/main.swift
@@ -46,13 +46,16 @@ private struct SimpleStruct {
     // schema marks map keys/values and list elements nullable even when the
     // sample payload contains only non-null values.
     var f1: [Int32?: Double?] = [:]
+    @ForyField(id: 15)
     var f2: Int32 = 0
     var f3: Item = Item()
     var f4: String = ""
     var f5: PeerColor = .green
     var f6: [String?] = []
+    @ForyField(id: 65551)
     var f7: Int32 = 0
     var f8: Int32 = 0
+    @ForyField(id: 536870911)
     var last: Int32 = 0
 }
 


### PR DESCRIPTION
## Why?

Field tags are stable protocol identities, but the supported numeric range and carrier width were
inconsistent across runtimes. Some implementations narrowed IDs before metadata encoding or
compatible matching even though the existing compact field header already supports an extended
identifier.

This change defines one cross-language range and representation so schemas can use larger stable
field IDs without runtime-specific limits or wire-identity drift.

## What does this PR do?

- Defines the field-tag domain as `0 <= tag_id < 2^29`.
- Uses signed 32-bit field-tag carriers across supported runtimes and keeps `-1` as the no-tag/name
  sentinel.
- Preserves existing wire bytes while extending the existing compact/extended tag encoding to the
  full range.
- Validates range and uniqueness at annotation, compiler, registration, metadata construction, and
  metadata decoding boundaries owned by each runtime.
- Keeps protocol field identity separate from compatible-reader local dispatch identity.
- Documents the range, stability, uniqueness, and extended encoding rules in the protocol and
  runtime schema guides.
- Adds causal boundary coverage for inline tag `15`, extended tag `65551`, and maximum tag
  `536870911` in exact-schema and compatible modes.

## Related issues

None.

## Does this PR introduce any user-facing change?

- [x] Does this PR introduce any public API change?
- [x] Does this PR introduce any binary protocol compatibility change?

Field tags now accept values from `0` through `536870911`. Existing valid field tags and their wire
bytes remain unchanged. APIs that previously used narrower numeric carriers now use signed 32-bit
carriers; `-1` continues to mean that field-name identity is used.

## Test

- Focused annotation, compiler, registration, metadata encode/decode, compatibility, and generated
  serializer tests passed for all changed runtimes.
- Java-driven exact-schema and compatible field-tag cases passed against C++, C#, Dart, Go,
  JavaScript, Python, Rust, Scala, and Swift in both Java codegen modes.
- Kotlin's KSP-generated maximum-tag serializer, descriptor, and round trip passed.
- Dart IDL regeneration, compilation, and Java/Dart semantic round trips passed.

## Benchmark

Paired latency deltas compare this branch with frozen `apache/main` at
`26b6b6cefca63aaab0195523ce817d8b3da2845b`. Negative values are improvements.

| Runtime/path                | Serialize | Deserialize |
| --------------------------- | --------: | ----------: |
| C++                         |   +0.070% |     +0.858% |
| Java runtime codegen        |   -0.014% |     -2.383% |
| Java static generated       |   +0.779% |     -0.457% |
| Rust                        |   -3.740% |     -0.281% |
| Go                          |   -0.424% |     +0.504% |
| Python Cython               |   -2.151% |     +0.184% |
| Python pure                 |   -1.185% |     -1.648% |
| JavaScript                  |   -0.416% |     -0.075% |
| C# final production boundary |   -0.813% |     -1.094% |
| Dart                        |   -0.365% |     +0.351% |
| Swift                       |   -3.315% |     +0.255% |

Kotlin and Scala production changes are compile-time validation changes and use the measured Java
static-generated runtime path. Every paired median is below the `+1.0%` regression ceiling.
