### PR TITLE
test(java): shorten inherited tag test name

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/meta/NativeTypeDefEncoderTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/NativeTypeDefEncoderTest.java
@@ -519,7 +519,7 @@ public class NativeTypeDefEncoderTest {
   }
 
   @Test
-  public void testDecodeRejectsInheritedDuplicateTag() {
+  public void testRejectsInheritedDuplicateTag() {
     Fory fory =
         Fory.builder()
             .withXlang(false)


### PR DESCRIPTION
## Why?

PR #3984 added an inherited duplicate-tag regression test whose method name exceeds the repository maximum of 35 characters.

## What does this PR do?

- Renames the test method from `testDecodeRejectsInheritedDuplicateTag` to `testRejectsInheritedDuplicateTag`.
- Leaves the annotation, test body, coverage, and production code unchanged.

## Related issues

Follow-up to #3984.

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Test

- `NativeTypeDefEncoderTest#testRejectsInheritedDuplicateTag` passed.

## Benchmark

Test-only rename; no production or benchmark path changes.