### PR TITLE
fix: harden low-level codec boundaries

### DIFF
--- a/.agents/languages/cpp.md
+++ b/.agents/languages/cpp.md
@@ -13,6 +13,12 @@ Load this file when changing `cpp/`, Cython build plumbing, or C++ xlang behavio
 - When invoking a method that returns `Result`, use `FORY_TRY` unless you are in control-flow logic that cannot use it cleanly.
 - Wrap error checks with `FORY_PREDICT_FALSE` for branch prediction.
 - Continue on trivial errors; return early only for critical errors such as buffer overflow.
+- `ReadContext` and related codec owners intentionally accumulate non-critical
+  errors and inspect them at established serializer or root safepoints. Bounds-safe
+  work may continue after an error is recorded. Do not add eager per-field checks,
+  cursor rollback, or tests that pin the first detection point unless deferral can
+  cause out-of-bounds access, undefined behavior, resource amplification, state
+  pollution, or success past the required safepoint.
 - Put private methods last in class definitions, immediately before private fields.
 - Do not redesign alias-based or low-level public type shapes to add convenience methods unless the user explicitly asks for that API change.
 - For cross-language feature ports, match protocol behavior but use idiomatic C++ ownership and layering instead of mirroring Java structure literally.

--- a/.agents/languages/go.md
+++ b/.agents/languages/go.md
@@ -7,6 +7,12 @@ Load this file when changing `go/fory/` or Go xlang behavior.
 - Run Go commands from within `go/fory/`.
 - Changes under `go/` must pass formatting and tests.
 - The Go implementation focuses on fast serializers.
+- Go codec paths may intentionally record an error and continue bounds-safe work
+  until an established serializer or root safepoint checks it. Do not add eager
+  per-field or per-element error branches, cursor rollback, or tests that pin the
+  first detection point unless deferral can cause a panic, out-of-bounds access,
+  disproportionate work or allocation, persistent state pollution, or success
+  past the required safepoint.
 - Root deserialization graph memory budget state belongs to `ReadContext`.
   `WithMaxGraphMemoryBytes` uses a fixed `128 MiB` default; positive explicit
   values override it, and explicit non-positive values are invalid at config creation.

--- a/.agents/languages/java.md
+++ b/.agents/languages/java.md
@@ -159,6 +159,22 @@ Load this file when changing anything under `java/` or when Java drives a cross-
 - In `MemoryBuffer` and `MemoryOps` hot paths, duplicate small straight-line copy/read/write logic
   when that keeps control flow direct. Do not add private helper indirection to hot paths just to
   reduce local code duplication; keep helpers for slow, cold, or error paths.
+- Add a Java `MemoryBuffer` check only when its absence can cause a JVM or native crash, OOM, or
+  attacker-controlled memory amplification. Delayed, masked, less precise, or differently typed
+  failures do not justify a check, and neither does an incorrect decoded result without one of
+  those crash or memory consequences. Do not duplicate an array, `ByteBuffer`, VarHandle, stream,
+  or other existing bounds owner merely to move or normalize an error.
+- The JDK 25 `MemoryBuffer` overlay is intentionally unchecked at its logical buffer boundary.
+  Indexed array accesses, absolute `ByteBuffer` accesses, and VarHandle accesses own bounds
+  enforcement and already provide a controlled failure; its exact exception type, message, and
+  detection point are not contracts. Do not copy the JDK 8-24 Unsafe-path range checks into this
+  overlay. Keep an explicit check only before allocation, capacity growth, or another side effect
+  when it is required to prevent a crash, OOM, or attacker-controlled memory amplification that the
+  access owner cannot contain.
+- `MemoryAllocator.grow` owns the postcondition that a successful return has supplied at least the
+  requested capacity. `MemoryBuffer` must not recheck that postcondition after calling `grow` or
+  `ensure`; an allocator that returns without satisfying it violates the allocator contract and
+  must be fixed in the allocator implementation rather than burdening every buffer hot path.
 - In JDK 25 Fory JSON C2-sensitive code, preserve measured, naturally large hot-method boundaries.
   A method that exceeds HotSpot's 325-byte hot-inline limit through real representation, scalar,
   array, collection, or generated-schema work is an independent subtree owner. Generated group

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,20 @@ This is the entry point for AI guidance in Apache Fory. Read this file first, th
   hot-path branches, helper APIs, allocations, or generated-code expansion
   solely to make an error earlier, more specific, or more uniform, and do not
   write tests that force such error normalization.
+- Non-strict, non-precise, delayed, masked, differently typed, or differently layered controlled
+  errors are not security findings. Security remediation must not add checks solely to normalize,
+  sharpen, advance, or otherwise make such errors deterministic. Security tests must not require a
+  particular error type, message, layer, offset, or detection point unless an explicit public
+  contract makes that precision part of the policy boundary.
+- Runtimes with an established lazy-error accumulator, including C++ and Go,
+  may keep executing bounds-safe codec work after recording an error and inspect
+  it at an existing serializer or root-operation safepoint. Deferred inspection
+  is an intentional hot-path design, not by itself a correctness or security
+  defect. Do not add per-field or per-element error branches, cursor rollback,
+  or tests that require immediate propagation solely because an earlier check is
+  possible. Treat the behavior as a defect only when the deferred path has a
+  concrete consequence listed below or an established safepoint can return
+  success instead of a controlled root error.
 - Never add a reader-side check solely to produce a more precise malformed-input
   error. Retain or add a check only when the unchecked path has a concrete
   consequence such as a crash, panic, undefined behavior, out-of-bounds access,
@@ -55,6 +69,15 @@ This is the entry point for AI guidance in Apache Fory. Read this file first, th
   helper when the language supports it. A bounds-safe downstream operation that
   already raises a controlled root error is sufficient; do not duplicate it for
   error precision.
+- Buffer and memory-buffer checks require a stricter consequence test. Security remediation may add
+  a check only when its absence can cause a process crash or panic, undefined memory access, OOM, or
+  attacker-controlled memory amplification. Delayed, masked, less precise, or differently typed
+  errors are not sufficient reasons. Neither is an incorrect decoded result when the unchecked
+  path cannot cause one of those crash or memory consequences. A downstream bounds owner that
+  already fails in a controlled way is sufficient; do not duplicate its check in a hotter wrapper.
+  Apply this admission rule prospectively: do not remove an already completed and validated check
+  solely by reclassifying it when it has no demonstrated performance cost. Preserve that check as
+  a correctness fix unless an explicit task requires the behavioral rollback.
 - Before reporting or fixing a robustness finding, prove that the current path
   causes at least one concrete consequence: crash, panic, undefined behavior,
   or out-of-bounds access; disproportionate allocation, CPU work, or stream
@@ -65,6 +88,16 @@ This is the entry point for AI guidance in Apache Fory. Read this file first, th
   malformed or noncanonical flag, enum value, marker, length form, or reserved
   value is accepted, rejected late, decoded differently, or produces a less
   precise error.
+- Keep security remediation scope frozen. Do not fix a standalone non-security
+  correctness, interoperability, API, or lifecycle issue merely because it is
+  discovered during security work. Include an adjacent non-security change only
+  when omitting it would leave the security fix incomplete or force the same
+  owner into an ugly, duplicated, or knowingly unsound design; otherwise record
+  the issue separately and leave production code unchanged. This rule prevents
+  new scope; it does not authorize rolling back a non-security fix that is
+  already implemented and validated. Preserve such fixes. If one may affect
+  performance, inspect and measure the affected path first, then optimize it on
+  evidence instead of removing it by classification.
 - Arbitrary-precision binary Decimal codecs accept only scales in
   `[-10_000, 10_000]` and an absolute unscaled magnitude of at most `10_000`
   binary bytes. The Java standalone `BigInteger` serializer uses the same

--- a/cpp/fory/serialization/collection_serializer.h
+++ b/cpp/fory/serialization/collection_serializer.h
@@ -54,6 +54,23 @@ namespace detail {
 /// Commit that proven range directly so public random-access safety checks do
 /// not expand every generated vector-field write.
 struct PrimitiveVectorWriter {
+  FORY_ALWAYS_INLINE static bool reserve(WriteContext &ctx,
+                                         uint64_t body_size) {
+    Buffer &buffer = ctx.buffer();
+    const uint64_t required_size =
+        static_cast<uint64_t>(buffer.writer_index()) + 8 + body_size;
+    if (FORY_PREDICT_FALSE(required_size >=
+                           std::numeric_limits<uint32_t>::max())) {
+      ctx.set_error(
+          Error::invalid("Vector write exceeds uint32_t buffer range"));
+      return false;
+    }
+    // The uint32 encoder may make an eight-byte physical store for a five-byte
+    // value. Reserve that physical extent together with the complete body.
+    buffer.grow(static_cast<uint32_t>(8 + body_size));
+    return true;
+  }
+
   FORY_ALWAYS_INLINE static uint32_t put_size(Buffer &buffer, uint32_t offset,
                                               uint32_t size) {
     return buffer.put_var_uint32_unchecked(offset, size);
@@ -1002,14 +1019,10 @@ struct Serializer<
   static inline void write_data(const std::vector<T, Alloc> &vec,
                                 WriteContext &ctx) {
     uint64_t total_bytes = static_cast<uint64_t>(vec.size()) * sizeof(T);
-    if (total_bytes > std::numeric_limits<uint32_t>::max()) {
-      ctx.set_error(Error::invalid("Vector byte size exceeds uint32_t range"));
+    if (!detail::PrimitiveVectorWriter::reserve(ctx, total_bytes)) {
       return;
     }
     Buffer &buffer = ctx.buffer();
-    // bulk write may write 8 bytes for varint32
-    size_t max_size = 8 + total_bytes;
-    buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
     writer_index += detail::PrimitiveVectorWriter::put_size(
         buffer, writer_index, static_cast<uint32_t>(total_bytes));
@@ -1119,13 +1132,10 @@ template <typename Alloc> struct Serializer<std::vector<float16_t, Alloc>> {
                                 WriteContext &ctx) {
     uint64_t total_bytes =
         static_cast<uint64_t>(vec.size()) * sizeof(float16_t);
-    if (total_bytes > std::numeric_limits<uint32_t>::max()) {
-      ctx.set_error(Error::invalid("Vector byte size exceeds uint32_t range"));
+    if (!detail::PrimitiveVectorWriter::reserve(ctx, total_bytes)) {
       return;
     }
     Buffer &buffer = ctx.buffer();
-    size_t max_size = 8 + total_bytes;
-    buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
     writer_index += detail::PrimitiveVectorWriter::put_size(
         buffer, writer_index, static_cast<uint32_t>(total_bytes));
@@ -1227,13 +1237,10 @@ template <typename Alloc> struct Serializer<std::vector<bfloat16_t, Alloc>> {
                                 WriteContext &ctx) {
     uint64_t total_bytes =
         static_cast<uint64_t>(vec.size()) * sizeof(bfloat16_t);
-    if (total_bytes > std::numeric_limits<uint32_t>::max()) {
-      ctx.set_error(Error::invalid("Vector byte size exceeds uint32_t range"));
+    if (!detail::PrimitiveVectorWriter::reserve(ctx, total_bytes)) {
       return;
     }
     Buffer &buffer = ctx.buffer();
-    size_t max_size = 8 + total_bytes;
-    buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
     writer_index += detail::PrimitiveVectorWriter::put_size(
         buffer, writer_index, static_cast<uint32_t>(total_bytes));
@@ -1523,10 +1530,11 @@ template <typename Alloc> struct Serializer<std::vector<bool, Alloc>> {
 
   static inline void write_data(const std::vector<bool, Alloc> &vec,
                                 WriteContext &ctx) {
+    if (!detail::PrimitiveVectorWriter::reserve(
+            ctx, static_cast<uint64_t>(vec.size()))) {
+      return;
+    }
     Buffer &buffer = ctx.buffer();
-    // bulk write may write 8 bytes for varint32
-    size_t max_size = 8 + vec.size();
-    buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
     writer_index += detail::PrimitiveVectorWriter::put_size(
         buffer, writer_index, static_cast<uint32_t>(vec.size()));

--- a/cpp/fory/serialization/collection_serializer.h
+++ b/cpp/fory/serialization/collection_serializer.h
@@ -48,6 +48,24 @@ constexpr uint8_t COLL_HAS_NULL = 0b0010;
 constexpr uint8_t COLL_DECL_ELEMENT_TYPE = 0b0100;
 constexpr uint8_t COLL_IS_SAME_TYPE = 0b1000;
 
+namespace detail {
+
+/// Primitive vectors reserve their header and complete body before writing.
+/// Commit that proven range directly so public random-access safety checks do
+/// not expand every generated vector-field write.
+struct PrimitiveVectorWriter {
+  FORY_ALWAYS_INLINE static uint32_t put_size(Buffer &buffer, uint32_t offset,
+                                              uint32_t size) {
+    return buffer.put_var_uint32_unchecked(offset, size);
+  }
+
+  FORY_ALWAYS_INLINE static void commit(Buffer &buffer, uint32_t offset) {
+    buffer.writer_index_ = offset;
+  }
+};
+
+} // namespace detail
+
 // ============================================================================
 // Collection Header
 // ============================================================================
@@ -993,13 +1011,14 @@ struct Serializer<
     size_t max_size = 8 + total_bytes;
     buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
-    writer_index +=
-        buffer.put_var_uint32(writer_index, static_cast<uint32_t>(total_bytes));
+    writer_index += detail::PrimitiveVectorWriter::put_size(
+        buffer, writer_index, static_cast<uint32_t>(total_bytes));
     if (total_bytes > 0) {
       buffer.unsafe_put(writer_index, vec.data(),
                         static_cast<uint32_t>(total_bytes));
     }
-    buffer.writer_index(writer_index + static_cast<uint32_t>(total_bytes));
+    detail::PrimitiveVectorWriter::commit(
+        buffer, writer_index + static_cast<uint32_t>(total_bytes));
   }
 
   static inline void write_data_generic(const std::vector<T, Alloc> &vec,
@@ -1108,13 +1127,14 @@ template <typename Alloc> struct Serializer<std::vector<float16_t, Alloc>> {
     size_t max_size = 8 + total_bytes;
     buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
-    writer_index +=
-        buffer.put_var_uint32(writer_index, static_cast<uint32_t>(total_bytes));
+    writer_index += detail::PrimitiveVectorWriter::put_size(
+        buffer, writer_index, static_cast<uint32_t>(total_bytes));
     if (total_bytes > 0) {
       buffer.unsafe_put(writer_index, vec.data(),
                         static_cast<uint32_t>(total_bytes));
     }
-    buffer.writer_index(writer_index + static_cast<uint32_t>(total_bytes));
+    detail::PrimitiveVectorWriter::commit(
+        buffer, writer_index + static_cast<uint32_t>(total_bytes));
   }
 
   static inline void
@@ -1215,13 +1235,14 @@ template <typename Alloc> struct Serializer<std::vector<bfloat16_t, Alloc>> {
     size_t max_size = 8 + total_bytes;
     buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
-    writer_index +=
-        buffer.put_var_uint32(writer_index, static_cast<uint32_t>(total_bytes));
+    writer_index += detail::PrimitiveVectorWriter::put_size(
+        buffer, writer_index, static_cast<uint32_t>(total_bytes));
     if (total_bytes > 0) {
       buffer.unsafe_put(writer_index, vec.data(),
                         static_cast<uint32_t>(total_bytes));
     }
-    buffer.writer_index(writer_index + static_cast<uint32_t>(total_bytes));
+    detail::PrimitiveVectorWriter::commit(
+        buffer, writer_index + static_cast<uint32_t>(total_bytes));
   }
 
   static inline void
@@ -1507,13 +1528,14 @@ template <typename Alloc> struct Serializer<std::vector<bool, Alloc>> {
     size_t max_size = 8 + vec.size();
     buffer.grow(static_cast<uint32_t>(max_size));
     uint32_t writer_index = buffer.writer_index();
-    writer_index +=
-        buffer.put_var_uint32(writer_index, static_cast<uint32_t>(vec.size()));
+    writer_index += detail::PrimitiveVectorWriter::put_size(
+        buffer, writer_index, static_cast<uint32_t>(vec.size()));
     for (size_t i = 0; i < vec.size(); ++i) {
       buffer.unsafe_put_byte(writer_index + i,
                              static_cast<uint8_t>(vec[i] ? 1 : 0));
     }
-    buffer.writer_index(writer_index + vec.size());
+    detail::PrimitiveVectorWriter::commit(
+        buffer, writer_index + static_cast<uint32_t>(vec.size()));
   }
 
   static inline void write_data_generic(const std::vector<bool, Alloc> &vec,

--- a/cpp/fory/serialization/serialization_test.cc
+++ b/cpp/fory/serialization/serialization_test.cc
@@ -428,6 +428,17 @@ TEST(SerializationTest, BoolVectorReadsCheckBodyBeforeAllocation) {
   EXPECT_TRUE(read_ctx.has_error());
 }
 
+TEST(SerializationTest, PrimitiveVectorWriteChecksCompleteRange) {
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+  WriteContext write_ctx(fory.config(), fory.type_resolver().clone());
+
+  EXPECT_FALSE(detail::PrimitiveVectorWriter::reserve(
+      write_ctx, std::numeric_limits<uint32_t>::max()));
+  EXPECT_TRUE(write_ctx.has_error());
+  EXPECT_EQ(write_ctx.buffer().writer_index(), 0U);
+}
+
 TEST(SerializationTest, FixedPrimitiveArrayRejectsWrongByteSize) {
   auto fory =
       Fory::builder().xlang(true).compatible(false).track_ref(false).build();

--- a/cpp/fory/serialization/serialization_test.cc
+++ b/cpp/fory/serialization/serialization_test.cc
@@ -736,6 +736,105 @@ TEST(SerializationTest, DurationUsesSecondsAndNanosecondsPayload) {
   }
 }
 
+TEST(SerializationTest, DurationCarrierBounds) {
+  struct TestCase {
+    int64_t seconds;
+    int32_t nanos;
+    int64_t expected;
+  };
+  const std::vector<TestCase> valid = {
+      {-9'223'372'037, 145'224'192, std::numeric_limits<int64_t>::min()},
+      {9'223'372'036, 854'775'807, std::numeric_limits<int64_t>::max()},
+      {9'223'372'037, -200'000'000, 9'223'372'036'800'000'000},
+  };
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+
+  for (const TestCase &test_case : valid) {
+    Buffer buffer;
+    buffer.write_var_int64(test_case.seconds);
+    buffer.write_int32(test_case.nanos);
+    ReadContext read_ctx(fory.config(), fory.type_resolver().clone());
+    read_ctx.attach(buffer);
+    Duration value = Serializer<Duration>::read_data(read_ctx);
+    ASSERT_FALSE(read_ctx.has_error()) << read_ctx.error().to_string();
+    EXPECT_EQ(value.count(), test_case.expected);
+  }
+
+  for (const auto &parts :
+       {std::pair<int64_t, int32_t>{-9'223'372'037, 145'224'191},
+        std::pair<int64_t, int32_t>{9'223'372'036, 854'775'808}}) {
+    Buffer buffer;
+    buffer.write_var_int64(parts.first);
+    buffer.write_int32(parts.second);
+    ReadContext read_ctx(fory.config(), fory.type_resolver().clone());
+    read_ctx.attach(buffer);
+    Serializer<Duration>::read_data(read_ctx);
+    EXPECT_TRUE(read_ctx.has_error());
+  }
+}
+
+TEST(SerializationTest, TimestampCarrierBounds) {
+  struct TestCase {
+    int64_t seconds;
+    uint32_t nanos;
+    int64_t expected;
+  };
+  const std::vector<TestCase> valid = {
+      {-9'223'372'037, 145'224'192, std::numeric_limits<int64_t>::min()},
+      {9'223'372'036, 854'775'807, std::numeric_limits<int64_t>::max()},
+      {-9'223'372'038, 4'294'967'295, -9'223'372'033'705'032'705},
+  };
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+
+  for (const TestCase &test_case : valid) {
+    Buffer buffer;
+    buffer.write_int64(test_case.seconds);
+    buffer.write_uint32(test_case.nanos);
+    ReadContext read_ctx(fory.config(), fory.type_resolver().clone());
+    read_ctx.attach(buffer);
+    Timestamp value = Serializer<Timestamp>::read_data(read_ctx);
+    ASSERT_FALSE(read_ctx.has_error()) << read_ctx.error().to_string();
+    EXPECT_EQ(value.time_since_epoch().count(), test_case.expected);
+  }
+
+  for (const auto &parts :
+       {std::pair<int64_t, uint32_t>{-9'223'372'037, 145'224'191},
+        std::pair<int64_t, uint32_t>{9'223'372'036, 854'775'808}}) {
+    Buffer buffer;
+    buffer.write_int64(parts.first);
+    buffer.write_uint32(parts.second);
+    ReadContext read_ctx(fory.config(), fory.type_resolver().clone());
+    read_ctx.attach(buffer);
+    Serializer<Timestamp>::read_data(read_ctx);
+    EXPECT_TRUE(read_ctx.has_error());
+  }
+}
+
+TEST(SerializationTest, ChronoTemporalBounds) {
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+
+  Buffer duration_buffer;
+  duration_buffer.write_var_int64(9'223'372'036);
+  duration_buffer.write_int32(854'775'808);
+  ReadContext duration_ctx(fory.config(), fory.type_resolver().clone());
+  duration_ctx.attach(duration_buffer);
+  Serializer<std::chrono::nanoseconds>::read_data(duration_ctx);
+  EXPECT_TRUE(duration_ctx.has_error());
+
+  using ChronoTimestamp = std::chrono::time_point<std::chrono::system_clock,
+                                                  std::chrono::nanoseconds>;
+  Buffer timestamp_buffer;
+  timestamp_buffer.write_int64(-9'223'372'037);
+  timestamp_buffer.write_uint32(145'224'191);
+  ReadContext timestamp_ctx(fory.config(), fory.type_resolver().clone());
+  timestamp_ctx.attach(timestamp_buffer);
+  Serializer<ChronoTimestamp>::read_data(timestamp_ctx);
+  EXPECT_TRUE(timestamp_ctx.has_error());
+}
+
 TEST(SerializationTest, DurationSkipConsumesSecondsAndNanosecondsPayload) {
   auto fory =
       Fory::builder().xlang(true).compatible(false).track_ref(false).build();

--- a/cpp/fory/serialization/stream_test.cc
+++ b/cpp/fory/serialization/stream_test.cc
@@ -155,6 +155,25 @@ private:
   OneByteOutputStreamBuf buf_;
 };
 
+class CountingOutputStream final : public OutputStream {
+public:
+  Result<void, Error> write_to_stream(const uint8_t *src,
+                                      uint32_t length) override {
+    ++write_calls_;
+    data_.insert(data_.end(), src, src + length);
+    return Result<void, Error>();
+  }
+
+  Result<void, Error> flush_stream() override { return Result<void, Error>(); }
+
+  const std::vector<uint8_t> &data() const { return data_; }
+  uint32_t write_calls() const { return write_calls_; }
+
+private:
+  std::vector<uint8_t> data_;
+  uint32_t write_calls_ = 0;
+};
+
 static inline void register_stream_types(Fory &fory) {
   uint32_t type_id = 1;
   fory.register_struct<StreamPoint>(type_id++);
@@ -358,6 +377,21 @@ TEST(StreamSerializationTest, SerializeToOutputStreamRoundTrip) {
   auto roundtrip = fory.deserialize<StreamEnvelope>(bytes);
   ASSERT_TRUE(roundtrip.ok()) << roundtrip.error().to_string();
   EXPECT_EQ(roundtrip.value(), original);
+}
+
+TEST(StreamSerializationTest, LargeStringsFlushIncrementally) {
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+  std::vector<std::string> original{std::string(5000, 'a'),
+                                    std::string(5000, 'b')};
+  auto expected = fory.serialize(original);
+  ASSERT_TRUE(expected.ok()) << expected.error().to_string();
+
+  CountingOutputStream writer;
+  auto streamed = fory.serialize(writer, original);
+  ASSERT_TRUE(streamed.ok()) << streamed.error().to_string();
+  EXPECT_GE(writer.write_calls(), 2U);
+  EXPECT_EQ(writer.data(), expected.value());
 }
 
 TEST(StreamSerializationTest, SerializeToOStreamOverloadParity) {

--- a/cpp/fory/serialization/string_serializer.h
+++ b/cpp/fory/serialization/string_serializer.h
@@ -47,21 +47,43 @@ enum class StringEncoding : uint8_t {
 
 namespace detail {
 
+struct StringFieldWriter {
+  FORY_ALWAYS_INLINE static uint32_t put_size(Buffer &buffer, uint32_t offset,
+                                              uint64_t size) {
+    return buffer.put_var_uint64_unchecked(offset, size);
+  }
+
+  FORY_ALWAYS_INLINE static void commit(Buffer &buffer, uint32_t offset) {
+    buffer.writer_index_ = offset;
+    if (FORY_PREDICT_FALSE(buffer.output_stream_ != nullptr && offset > 4096)) {
+      buffer.output_stream_->try_flush();
+    }
+  }
+};
+
 /// write string data with UTF-8 encoding
 inline void write_string_data(const char *data, size_t size,
                               WriteContext &ctx) {
   // Always use UTF-8 encoding for cross-language compatibility.
   // Per xlang spec: write size shifted left by 2 bits, with encoding
   // (UTF8) in the lower 2 bits. Use varuint36small encoding.
-  uint64_t length = static_cast<uint64_t>(size);
-  uint64_t size_with_encoding =
-      (length << 2) | static_cast<uint64_t>(StringEncoding::UTF8);
-  ctx.write_var_uint36_small(size_with_encoding);
-
-  // write string bytes
-  if (size > 0) {
-    ctx.write_bytes(data, size);
+  if (FORY_PREDICT_FALSE(size >
+                         std::numeric_limits<uint32_t>::max() - size_t{9})) {
+    ctx.set_error(Error::invalid("String byte size exceeds uint32_t range"));
+    return;
   }
+  const uint64_t length = static_cast<uint64_t>(size);
+  const uint64_t size_with_encoding =
+      (length << 2) | static_cast<uint64_t>(StringEncoding::UTF8);
+  Buffer &buffer = ctx.buffer();
+  buffer.grow(static_cast<uint32_t>(size + 9));
+  uint32_t writer_index = buffer.writer_index();
+  writer_index +=
+      StringFieldWriter::put_size(buffer, writer_index, size_with_encoding);
+  if (size > 0) {
+    buffer.unsafe_put(writer_index, data, static_cast<uint32_t>(size));
+  }
+  StringFieldWriter::commit(buffer, writer_index + static_cast<uint32_t>(size));
 }
 
 /// write UTF-16 string data, converting to UTF-8 or using native encoding
@@ -129,7 +151,12 @@ inline std::string read_string_data(ReadContext &ctx) {
   // Handle different encodings
   switch (encoding) {
   case StringEncoding::LATIN1: {
-    std::string result = latin1_to_utf8(data, length_u32);
+    auto converted = ::fory::detail::latin1_to_utf8_checked(data, length_u32);
+    if (FORY_PREDICT_FALSE(!converted.ok())) {
+      ctx.set_error(std::move(converted).error());
+      return std::string();
+    }
+    std::string result = std::move(converted).value();
     buffer.unsafe_increase_reader_index(length_u32);
     return result;
   }

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -78,6 +78,35 @@ struct SerializationMeta<T,
 
 namespace detail {
 
+/// Generated struct writers reserve the complete primitive-field extent once.
+/// Repeating public offset and cursor checks for each field only expands the
+/// generated hot path; this owner may bypass them after that reservation.
+struct StructFieldWriter {
+  FORY_ALWAYS_INLINE static uint32_t
+  put_var_uint32(Buffer &buffer, uint32_t offset, uint32_t value) {
+    return buffer.put_var_uint32_unchecked(offset, value);
+  }
+
+  FORY_ALWAYS_INLINE static uint32_t
+  put_var_uint64(Buffer &buffer, uint32_t offset, uint64_t value) {
+    return buffer.put_var_uint64_unchecked(offset, value);
+  }
+
+  FORY_ALWAYS_INLINE static uint32_t
+  put_tagged_uint64(Buffer &buffer, uint32_t offset, uint64_t value) {
+    return buffer.put_tagged_uint64_unchecked(offset, value);
+  }
+
+  FORY_ALWAYS_INLINE static uint32_t
+  put_tagged_int64(Buffer &buffer, uint32_t offset, int64_t value) {
+    return buffer.put_tagged_int64_unchecked(offset, value);
+  }
+
+  FORY_ALWAYS_INLINE static void commit(Buffer &buffer, uint32_t offset) {
+    buffer.writer_index_ = offset;
+  }
+};
+
 /// Helper to check if a TypeId represents a primitive type.
 /// Per xlang spec, primitive types are: bool, int8-64, var_int32/64,
 /// sli_int64, float8/16/bfloat16/32/64. For native mode (xlang=false), also
@@ -173,20 +202,22 @@ FORY_ALWAYS_INLINE uint32_t put_primitive_at(T value, Buffer &buffer,
     int32_t val = static_cast<int32_t>(value);
     uint32_t zigzag =
         (static_cast<uint32_t>(val) << 1) ^ static_cast<uint32_t>(val >> 31);
-    return buffer.put_var_uint32(offset, zigzag);
+    return StructFieldWriter::put_var_uint32(buffer, offset, zigzag);
   } else if constexpr (std::is_same_v<T, uint32_t> ||
                        std::is_same_v<T, unsigned int>) {
-    return buffer.put_var_uint32(offset, static_cast<uint32_t>(value));
+    return StructFieldWriter::put_var_uint32(buffer, offset,
+                                             static_cast<uint32_t>(value));
   } else if constexpr (std::is_same_v<T, int64_t> ||
                        std::is_same_v<T, long long>) {
     // varint64 with zigzag encoding
     int64_t val = static_cast<int64_t>(value);
     uint64_t zigzag =
         (static_cast<uint64_t>(val) << 1) ^ static_cast<uint64_t>(val >> 63);
-    return buffer.put_var_uint64(offset, zigzag);
+    return StructFieldWriter::put_var_uint64(buffer, offset, zigzag);
   } else if constexpr (std::is_same_v<T, uint64_t> ||
                        std::is_same_v<T, unsigned long long>) {
-    return buffer.put_var_uint64(offset, static_cast<uint64_t>(value));
+    return StructFieldWriter::put_var_uint64(buffer, offset,
+                                             static_cast<uint64_t>(value));
   } else if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, int>) {
     buffer.unsafe_put<int32_t>(offset, static_cast<int32_t>(value));
     return 4;
@@ -270,23 +301,25 @@ FORY_ALWAYS_INLINE uint32_t put_varint_at(T value, Buffer &buffer,
     int32_t val = static_cast<int32_t>(value);
     uint32_t zigzag =
         (static_cast<uint32_t>(val) << 1) ^ static_cast<uint32_t>(val >> 31);
-    return buffer.put_var_uint32(offset, zigzag);
+    return StructFieldWriter::put_var_uint32(buffer, offset, zigzag);
   } else if constexpr (std::is_same_v<T, int64_t> ||
                        std::is_same_v<T, long long>) {
     // varint64 with zigzag encoding
     int64_t val = static_cast<int64_t>(value);
     uint64_t zigzag =
         (static_cast<uint64_t>(val) << 1) ^ static_cast<uint64_t>(val >> 63);
-    return buffer.put_var_uint64(offset, zigzag);
+    return StructFieldWriter::put_var_uint64(buffer, offset, zigzag);
   } else if constexpr (std::is_same_v<T, uint32_t> ||
                        std::is_same_v<T, unsigned int>) {
     // Unsigned 32-bit varint (no zigzag)
-    return buffer.put_var_uint32(offset, static_cast<uint32_t>(value));
+    return StructFieldWriter::put_var_uint32(buffer, offset,
+                                             static_cast<uint32_t>(value));
   } else if constexpr (std::is_same_v<T, uint64_t> ||
                        std::is_same_v<T, unsigned long long>) {
     // Unsigned 64-bit varint (no zigzag) - used for VAR_UINT64 and
     // TAGGED_UINT64
-    return buffer.put_var_uint64(offset, static_cast<uint64_t>(value));
+    return StructFieldWriter::put_var_uint64(buffer, offset,
+                                             static_cast<uint64_t>(value));
   } else {
     static_assert(sizeof(T) == 0, "Unsupported varint type");
     return 0;
@@ -428,7 +461,8 @@ FORY_ALWAYS_INLINE uint32_t write_configurable_int_at(FieldType value,
       return 8;
     }
     if constexpr (enc == Encoding::Tagged) {
-      return buffer.put_tagged_int64(offset, static_cast<int64_t>(value));
+      return StructFieldWriter::put_tagged_int64(buffer, offset,
+                                                 static_cast<int64_t>(value));
     }
     return put_varint_at<FieldType>(value, buffer, offset);
   } else {
@@ -442,7 +476,8 @@ FORY_ALWAYS_INLINE uint32_t write_configurable_int_at(FieldType value,
     }
     if constexpr (enc == Encoding::Tagged) {
       if constexpr (is_configurable_int64_v<FieldType>) {
-        return buffer.put_tagged_uint64(offset, static_cast<uint64_t>(value));
+        return StructFieldWriter::put_tagged_uint64(
+            buffer, offset, static_cast<uint64_t>(value));
       }
       return put_varint_at<FieldType>(value, buffer, offset);
     }
@@ -2533,7 +2568,8 @@ write_fixed_primitive_fields(const T &obj, Buffer &buffer,
   (write_single_fixed_field<T, Indices>(obj, buffer, base_offset), ...);
 
   // Update writer_index once with total fixed bytes (compile-time constant)
-  buffer.writer_index(base_offset + Helpers::leading_fixed_size_bytes);
+  StructFieldWriter::commit(buffer,
+                            base_offset + Helpers::leading_fixed_size_bytes);
 }
 
 /// Helper to write a single varint primitive field.
@@ -2646,7 +2682,7 @@ write_primitive_fields_fast(const T &obj, Buffer &buffer,
     uint32_t offset = buffer.writer_index();
     write_varint_primitive_fields<T, fixed_count>(
         obj, buffer, offset, std::make_index_sequence<varint_count>{});
-    buffer.writer_index(offset);
+    StructFieldWriter::commit(buffer, offset);
   }
 
   // Phase 3: write remaining primitives (if any) using dedicated helper
@@ -2656,7 +2692,7 @@ write_primitive_fields_fast(const T &obj, Buffer &buffer,
     write_remaining_primitive_fields<T, fast_count>(
         obj, buffer, offset,
         std::make_index_sequence<total_count - fast_count>{});
-    buffer.writer_index(offset);
+    StructFieldWriter::commit(buffer, offset);
   }
 }
 

--- a/cpp/fory/serialization/struct_serializer.h
+++ b/cpp/fory/serialization/struct_serializer.h
@@ -2472,13 +2472,13 @@ template <typename T> struct CompileTimeFieldHelpers {
           total += 4; // fixed 4 bytes
           break;
         case TypeId::VARINT32:
-          total += 5; // varint max for 32-bit
+          total += 8; // five logical bytes use an eight-byte physical store
           break;
         case TypeId::UINT32:
           total += 4; // fixed 4 bytes
           break;
         case TypeId::VAR_UINT32:
-          total += 5; // varint max for 32-bit
+          total += 8; // five logical bytes use an eight-byte physical store
           break;
         case TypeId::FLOAT32:
           total += 4;

--- a/cpp/fory/serialization/struct_test.cc
+++ b/cpp/fory/serialization/struct_test.cc
@@ -358,6 +358,13 @@ struct StringTestStruct {
   FORY_STRUCT(StringTestStruct, empty, ascii, utf8, long_text);
 };
 
+struct HybridVarintStruct {
+  int32_t value;
+  std::string text;
+
+  FORY_STRUCT(HybridVarintStruct, value, text);
+};
+
 // Nested structs
 struct Point2D {
   int32_t x;
@@ -1033,6 +1040,21 @@ TEST(StructComprehensiveTest, BoundingBoxDoubleNested) {
 
 TEST(StructComprehensiveTest, SceneMultipleNested) {
   test_roundtrip(Scene{{0, 0, 10}, {100, 100, 200}, {{0, 0}, {800, 600}}});
+}
+
+TEST(StructComprehensiveTest, HybridVarintReservesPhysicalStore) {
+  auto fory =
+      Fory::builder().xlang(true).compatible(false).track_ref(false).build();
+  WriteContext write_ctx(fory.config(), fory.type_resolver().clone());
+  std::array<uint8_t, 8> storage{};
+  write_ctx.buffer() = Buffer(storage.data(), 5, false);
+
+  HybridVarintStruct value{std::numeric_limits<int32_t>::min(), "x"};
+  detail::write_struct_fields_impl(value, write_ctx,
+                                   std::make_index_sequence<2>{}, false);
+
+  EXPECT_FALSE(write_ctx.has_error());
+  EXPECT_NE(write_ctx.buffer().data(), storage.data());
 }
 
 TEST(StructComprehensiveTest, VectorStructEmpty) {

--- a/cpp/fory/serialization/temporal_serializers.h
+++ b/cpp/fory/serialization/temporal_serializers.h
@@ -23,9 +23,63 @@
 #include "fory/type/temporal.h"
 #include <chrono>
 #include <limits>
+#include <string>
+#include <utility>
 
 namespace fory {
 namespace serialization {
+
+namespace detail {
+
+constexpr int64_t NANOS_PER_SECOND = 1'000'000'000;
+constexpr int64_t MIN_NANO_SECONDS = -9'223'372'037;
+constexpr int64_t MIN_NANO_REMAINDER = 145'224'192;
+constexpr int64_t MAX_NANO_SECONDS = 9'223'372'036;
+constexpr int64_t MAX_NANO_REMAINDER = 854'775'807;
+
+FORY_NOINLINE inline Unexpected<Error>
+temporal_range_error(const char *type_name) {
+  return Unexpected(Error::invalid_data(std::string(type_name) +
+                                        " exceeds the int64 nanosecond range"));
+}
+
+inline Result<std::chrono::nanoseconds, Error>
+temporal_nanos_from_parts(int64_t seconds, int64_t nanos,
+                          const char *type_name) {
+  int64_t carry = nanos / NANOS_PER_SECOND;
+  int64_t remainder = nanos % NANOS_PER_SECOND;
+  if (remainder < 0) {
+    --carry;
+    remainder += NANOS_PER_SECOND;
+  }
+  if (FORY_PREDICT_FALSE(
+          (carry > 0 &&
+           seconds > std::numeric_limits<int64_t>::max() - carry) ||
+          (carry < 0 &&
+           seconds < std::numeric_limits<int64_t>::min() - carry))) {
+    return temporal_range_error(type_name);
+  }
+  seconds += carry;
+  if (FORY_PREDICT_FALSE(
+          seconds < MIN_NANO_SECONDS || seconds > MAX_NANO_SECONDS ||
+          (seconds == MIN_NANO_SECONDS && remainder < MIN_NANO_REMAINDER) ||
+          (seconds == MAX_NANO_SECONDS && remainder > MAX_NANO_REMAINDER))) {
+    return temporal_range_error(type_name);
+  }
+
+  int64_t total_nanos;
+  if (seconds < 0) {
+    // The minimum int64 value normalizes to -9,223,372,037 seconds,
+    // whose direct nanosecond multiplication already overflows.
+    total_nanos =
+        (seconds + 1) * NANOS_PER_SECOND - (NANOS_PER_SECOND - remainder);
+  } else {
+    total_nanos = seconds * NANOS_PER_SECOND + remainder;
+  }
+  return std::chrono::nanoseconds(total_nanos);
+}
+
+} // namespace detail
 
 // ============================================================================
 // Duration Serializer
@@ -102,8 +156,15 @@ template <> struct Serializer<Duration> {
       return Duration();
     }
     int32_t nanos = ctx.read_int32(ctx.error());
-    return Duration(std::chrono::seconds(seconds) +
-                    std::chrono::nanoseconds(nanos));
+    if (FORY_PREDICT_FALSE(ctx.has_error())) {
+      return Duration();
+    }
+    auto result = detail::temporal_nanos_from_parts(seconds, nanos, "Duration");
+    if (FORY_PREDICT_FALSE(!result.ok())) {
+      ctx.set_error(std::move(result).error());
+      return Duration();
+    }
+    return Duration(std::move(result).value());
   }
 
   static inline Duration read_with_type_info(ReadContext &ctx, RefMode ref_mode,
@@ -193,8 +254,16 @@ template <> struct Serializer<Timestamp> {
       return Timestamp();
     }
     uint32_t nanos = ctx.read_uint32(ctx.error());
-    return Timestamp(std::chrono::seconds(seconds) +
-                     std::chrono::nanoseconds(nanos));
+    if (FORY_PREDICT_FALSE(ctx.has_error())) {
+      return Timestamp();
+    }
+    auto result = detail::temporal_nanos_from_parts(
+        seconds, static_cast<int64_t>(nanos), "Timestamp");
+    if (FORY_PREDICT_FALSE(!result.ok())) {
+      ctx.set_error(std::move(result).error());
+      return Timestamp();
+    }
+    return Timestamp(std::move(result).value());
   }
 
   static inline Timestamp read_with_type_info(ReadContext &ctx,

--- a/cpp/fory/serialization/temporal_serializers.h
+++ b/cpp/fory/serialization/temporal_serializers.h
@@ -156,9 +156,6 @@ template <> struct Serializer<Duration> {
       return Duration();
     }
     int32_t nanos = ctx.read_int32(ctx.error());
-    if (FORY_PREDICT_FALSE(ctx.has_error())) {
-      return Duration();
-    }
     auto result = detail::temporal_nanos_from_parts(seconds, nanos, "Duration");
     if (FORY_PREDICT_FALSE(!result.ok())) {
       ctx.set_error(std::move(result).error());
@@ -254,9 +251,6 @@ template <> struct Serializer<Timestamp> {
       return Timestamp();
     }
     uint32_t nanos = ctx.read_uint32(ctx.error());
-    if (FORY_PREDICT_FALSE(ctx.has_error())) {
-      return Timestamp();
-    }
     auto result = detail::temporal_nanos_from_parts(
         seconds, static_cast<int64_t>(nanos), "Timestamp");
     if (FORY_PREDICT_FALSE(!result.ok())) {

--- a/cpp/fory/util/buffer.cc
+++ b/cpp/fory/util/buffer.cc
@@ -218,4 +218,14 @@ void Buffer::grow_checked(uint64_t required_size, uint32_t min_capacity) {
   grow_to_fit(static_cast<uint32_t>(required_size));
 }
 
+void Buffer::fail_range(uint32_t offset, uint32_t length) const {
+  FORY_CHECK(false) << "Buffer out of bound: " << offset << " + " << length
+                    << " > " << size_;
+}
+
+void Buffer::fail_writer_index(uint64_t target) const {
+  FORY_CHECK(false) << "Buffer overflow writer_index " << writer_index_
+                    << " target writer_index " << target << " size " << size_;
+}
+
 } // namespace fory

--- a/cpp/fory/util/buffer.cc
+++ b/cpp/fory/util/buffer.cc
@@ -100,13 +100,23 @@ Buffer::~Buffer() {
 }
 
 bool Buffer::equals(const Buffer &other, int64_t nbytes) const {
+  if (FORY_PREDICT_FALSE(nbytes < 0)) {
+    return false;
+  }
+  if (nbytes == 0) {
+    return true;
+  }
+  const uint64_t length = static_cast<uint64_t>(nbytes);
   return this == &other ||
-         (size_ >= nbytes && other.size_ >= nbytes &&
+         (size_ >= length && other.size_ >= length &&
           (data_ == other.data_ ||
            !memcmp(data_, other.data_, static_cast<size_t>(nbytes))));
 }
 
 bool Buffer::equals(const Buffer &other) const {
+  if (size_ == 0 && other.size_ == 0) {
+    return true;
+  }
   return this == &other ||
          (size_ == other.size_ &&
           (data_ == other.data_ ||
@@ -115,11 +125,27 @@ bool Buffer::equals(const Buffer &other) const {
 
 void Buffer::copy(const uint32_t start, const uint32_t nbytes,
                   std::shared_ptr<Buffer> &out) const {
-  std::memcpy(out->data(), data_ + start, static_cast<size_t>(nbytes));
+  FORY_CHECK(FORY_PREDICT_TRUE(out != nullptr))
+      << "Cannot copy into a null Buffer";
+  FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(start, nbytes)))
+      << "Buffer out of bound: " << start << " + " << nbytes << " > " << size_;
+  FORY_CHECK(FORY_PREDICT_TRUE(nbytes <= out->size()))
+      << "Buffer out of bound: 0 + " << nbytes << " > " << out->size();
+  if (nbytes == 0) {
+    return;
+  }
+  std::memmove(out->data(), data_ + start, static_cast<size_t>(nbytes));
 }
 
 void Buffer::copy(uint32_t start, uint32_t nbytes, Buffer &out) const {
-  std::memcpy(out.data(), data_ + start, static_cast<size_t>(nbytes));
+  FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(start, nbytes)))
+      << "Buffer out of bound: " << start << " + " << nbytes << " > " << size_;
+  FORY_CHECK(FORY_PREDICT_TRUE(nbytes <= out.size()))
+      << "Buffer out of bound: 0 + " << nbytes << " > " << out.size();
+  if (nbytes == 0) {
+    return;
+  }
+  std::memmove(out.data(), data_ + start, static_cast<size_t>(nbytes));
 }
 
 void Buffer::copy(uint32_t start, uint32_t nbytes, uint8_t *out) const {
@@ -128,15 +154,22 @@ void Buffer::copy(uint32_t start, uint32_t nbytes, uint8_t *out) const {
 
 void Buffer::copy(uint32_t start, uint32_t nbytes, uint8_t *out,
                   uint32_t offset) const {
+  if (nbytes == 0) {
+    return;
+  }
   std::memcpy(out + offset, data_ + start, static_cast<size_t>(nbytes));
 }
 
 void Buffer::copy_from(uint32_t offset, const uint8_t *src, uint32_t src_offset,
                        uint32_t nbytes) {
-  auto new_size = offset + nbytes;
-  if (new_size > size_) {
-    reserve(new_size * 2);
+  if (nbytes == 0) {
+    return;
   }
+  const uint64_t required_size = static_cast<uint64_t>(offset) + nbytes;
+  FORY_CHECK(
+      FORY_PREDICT_TRUE(required_size <= std::numeric_limits<uint32_t>::max()))
+      << "Buffer overflow offset " << offset << " length " << nbytes;
+  grow_to_fit(static_cast<uint32_t>(required_size));
   std::memcpy(data_ + offset, src + src_offset, static_cast<size_t>(nbytes));
 }
 
@@ -176,6 +209,13 @@ Buffer *allocate_buffer(uint32_t size) {
   } else {
     return nullptr;
   }
+}
+
+void Buffer::grow_checked(uint64_t required_size, uint32_t min_capacity) {
+  FORY_CHECK(required_size < std::numeric_limits<uint32_t>::max())
+      << "Buffer overflow writer_index" << writer_index_ << " diff "
+      << min_capacity;
+  grow_to_fit(static_cast<uint32_t>(required_size));
 }
 
 } // namespace fory

--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -185,21 +185,21 @@ public:
   }
 
   FORY_ALWAYS_INLINE void writer_index(uint32_t writer_index) {
-    FORY_CHECK(
-        FORY_PREDICT_TRUE(writer_index < std::numeric_limits<uint32_t>::max() &&
-                          writer_index <= size_))
-        << "Buffer overflow writer_index" << writer_index_
-        << " target writer_index " << writer_index << " size " << size_;
+    if (FORY_PREDICT_FALSE(writer_index >=
+                               std::numeric_limits<uint32_t>::max() ||
+                           writer_index > size_)) {
+      fail_writer_index(writer_index);
+    }
     writer_index_ = writer_index;
   }
 
   FORY_ALWAYS_INLINE void increase_writer_index(uint32_t diff) {
     const uint64_t writer_index = static_cast<uint64_t>(writer_index_) + diff;
-    FORY_CHECK(
-        FORY_PREDICT_TRUE(writer_index < std::numeric_limits<uint32_t>::max() &&
-                          writer_index <= size_))
-        << "Buffer overflow writer_index" << writer_index_ << " diff " << diff
-        << " size " << size_;
+    if (FORY_PREDICT_FALSE(writer_index >=
+                               std::numeric_limits<uint32_t>::max() ||
+                           writer_index > size_)) {
+      fail_writer_index(writer_index);
+    }
     writer_index_ = static_cast<uint32_t>(writer_index);
   }
 
@@ -269,18 +269,19 @@ public:
   }
 
   FORY_ALWAYS_INLINE void put_int24(uint32_t offset, int32_t value) {
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 3)))
-        << "Buffer out of bound: " << offset << " + 3 > " << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 3))) {
+      fail_range(offset, 3);
+    }
     data_[offset] = static_cast<uint8_t>(value);
     data_[offset + 1] = static_cast<uint8_t>(value >> 8);
     data_[offset + 2] = static_cast<uint8_t>(value >> 16);
   }
 
   template <typename T> FORY_ALWAYS_INLINE T get(uint32_t relative_offset) {
-    FORY_CHECK(FORY_PREDICT_TRUE(
-        range_in_bounds(relative_offset, static_cast<uint32_t>(sizeof(T)))))
-        << "Out of range " << relative_offset << " should be less than "
-        << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(
+            relative_offset, static_cast<uint32_t>(sizeof(T))))) {
+      fail_range(relative_offset, static_cast<uint32_t>(sizeof(T)));
+    }
     T value = load_unaligned<T>(data_ + relative_offset);
     return value;
   }
@@ -307,8 +308,9 @@ public:
   }
 
   FORY_ALWAYS_INLINE int32_t get_int24(uint32_t offset) {
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 3)))
-        << "Out of range " << offset << " should be less than " << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 3))) {
+      fail_range(offset, 3);
+    }
     int32_t b0 = data_[offset];
     int32_t b1 = data_[offset + 1];
     int32_t b2 = data_[offset + 2];
@@ -367,9 +369,9 @@ public:
                             : value < 0x4000     ? 2
                             : value < 0x10000000 ? 4
                                                  : 8;
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
-        << "Buffer out of bound: " << offset << " + " << extent << " > "
-        << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, extent))) {
+      fail_range(offset, extent);
+    }
     return put_var_uint32_unchecked(offset, value);
   }
 
@@ -474,9 +476,9 @@ public:
                             : value < 0x10000000           ? 4
                             : value < 0x100000000000000ULL ? 8
                                                            : 9;
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
-        << "Buffer out of bound: " << offset << " + " << extent << " > "
-        << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, extent))) {
+      fail_range(offset, extent);
+    }
     return put_var_uint64_unchecked(offset, value);
   }
 
@@ -581,15 +583,17 @@ public:
   /// - If bit 0 is 1: read 1 byte flag + 8 bytes uint64
   FORY_ALWAYS_INLINE uint64_t get_tagged_uint64(uint32_t offset,
                                                 uint32_t *read_bytes_length) {
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
-        << "Buffer out of bound: " << offset << " + 4 > " << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 4))) {
+      fail_range(offset, 4);
+    }
     uint32_t i = load_unaligned<uint32_t>(data_ + offset);
     if ((i & 0b1) != 0b1) {
       *read_bytes_length = 4;
       return static_cast<uint64_t>(i >> 1);
     } else {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
-          << "Buffer out of bound: " << offset << " + 9 > " << size_;
+      if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 9))) {
+        fail_range(offset, 9);
+      }
       *read_bytes_length = 9;
       return load_unaligned<uint64_t>(data_ + offset + 1);
     }
@@ -601,15 +605,17 @@ public:
   /// - If bit 0 is 1: read 1 byte flag + 8 bytes int64
   FORY_ALWAYS_INLINE int64_t get_tagged_int64(uint32_t offset,
                                               uint32_t *read_bytes_length) {
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
-        << "Buffer out of bound: " << offset << " + 4 > " << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 4))) {
+      fail_range(offset, 4);
+    }
     int32_t i = load_unaligned<int32_t>(data_ + offset);
     if ((i & 0b1) != 0b1) {
       *read_bytes_length = 4;
       return static_cast<int64_t>(i >> 1); // Arithmetic shift for signed
     } else {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
-          << "Buffer out of bound: " << offset << " + 9 > " << size_;
+      if (FORY_PREDICT_FALSE(!range_in_bounds(offset, 9))) {
+        fail_range(offset, 9);
+      }
       *read_bytes_length = 9;
       return load_unaligned<int64_t>(data_ + offset + 1);
     }
@@ -623,9 +629,9 @@ public:
                                                 uint64_t value) {
     constexpr uint64_t MAX_SMALL_VALUE = 0x7fffffff; // INT32_MAX as u64
     const uint32_t extent = value <= MAX_SMALL_VALUE ? 4 : 9;
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
-        << "Buffer out of bound: " << offset << " + " << extent << " > "
-        << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, extent))) {
+      fail_range(offset, extent);
+    }
     return put_tagged_uint64_unchecked(offset, value);
   }
 
@@ -639,9 +645,9 @@ public:
     constexpr int64_t MAX_SMALL_VALUE = 1073741823;  // 2^30 - 1
     const uint32_t extent =
         value >= MIN_SMALL_VALUE && value <= MAX_SMALL_VALUE ? 4 : 9;
-    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
-        << "Buffer out of bound: " << offset << " + " << extent << " > "
-        << size_;
+    if (FORY_PREDICT_FALSE(!range_in_bounds(offset, extent))) {
+      fail_range(offset, extent);
+    }
     return put_tagged_int64_unchecked(offset, value);
   }
 
@@ -1431,6 +1437,10 @@ private:
 
   FORY_NOINLINE void grow_checked(uint64_t required_size,
                                   uint32_t min_capacity);
+
+  FORY_NOINLINE void fail_range(uint32_t offset, uint32_t length) const;
+
+  FORY_NOINLINE void fail_writer_index(uint64_t target) const;
 
   uint8_t *data_;
   uint32_t size_;

--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -40,6 +40,8 @@ namespace fory {
 class StdInputStream;
 class PyInputStream;
 namespace serialization::detail {
+struct PrimitiveVectorWriter;
+struct StructFieldWriter;
 struct StringFieldWriter;
 } // namespace serialization::detail
 
@@ -620,19 +622,11 @@ public:
   FORY_ALWAYS_INLINE uint32_t put_tagged_uint64(uint32_t offset,
                                                 uint64_t value) {
     constexpr uint64_t MAX_SMALL_VALUE = 0x7fffffff; // INT32_MAX as u64
-    if (value <= MAX_SMALL_VALUE) {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
-          << "Buffer out of bound: " << offset << " + 4 > " << size_;
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(value)
-                                                    << 1);
-      return 4;
-    } else {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
-          << "Buffer out of bound: " << offset << " + 9 > " << size_;
-      data_[offset] = 0b1;
-      store_unaligned<uint64_t>(data_ + offset + 1, value);
-      return 9;
-    }
+    const uint32_t extent = value <= MAX_SMALL_VALUE ? 4 : 9;
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
+        << "Buffer out of bound: " << offset << " + " << extent << " > "
+        << size_;
+    return put_tagged_uint64_unchecked(offset, value);
   }
 
   /// write int64_t using tagged encoding at given offset. Returns bytes
@@ -643,20 +637,12 @@ public:
   FORY_ALWAYS_INLINE uint32_t put_tagged_int64(uint32_t offset, int64_t value) {
     constexpr int64_t MIN_SMALL_VALUE = -1073741824; // -2^30
     constexpr int64_t MAX_SMALL_VALUE = 1073741823;  // 2^30 - 1
-    if (value >= MIN_SMALL_VALUE && value <= MAX_SMALL_VALUE) {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
-          << "Buffer out of bound: " << offset << " + 4 > " << size_;
-      const uint32_t encoded =
-          static_cast<uint32_t>(static_cast<int32_t>(value)) << 1;
-      store_unaligned<uint32_t>(data_ + offset, encoded);
-      return 4;
-    } else {
-      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
-          << "Buffer out of bound: " << offset << " + 9 > " << size_;
-      data_[offset] = 0b1;
-      store_unaligned<int64_t>(data_ + offset + 1, value);
-      return 9;
-    }
+    const uint32_t extent =
+        value >= MIN_SMALL_VALUE && value <= MAX_SMALL_VALUE ? 4 : 9;
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
+        << "Buffer out of bound: " << offset << " + " << extent << " > "
+        << size_;
+    return put_tagged_int64_unchecked(offset, value);
   }
 
   /// write uint8_t value to buffer at current writer index.
@@ -1209,6 +1195,8 @@ public:
   std::string hex() const;
 
 private:
+  friend struct serialization::detail::PrimitiveVectorWriter;
+  friend struct serialization::detail::StructFieldWriter;
   friend struct serialization::detail::StringFieldWriter;
   friend class StdInputStream;
   friend class PyInputStream;
@@ -1380,6 +1368,34 @@ private:
     encoded |= 0x8000000000000000ULL;
     store_unaligned<uint64_t>(data_ + offset, encoded);
     data_[offset + 8] = static_cast<uint8_t>(value >> 56);
+    return 9;
+  }
+
+  FORY_ALWAYS_INLINE uint32_t put_tagged_uint64_unchecked(uint32_t offset,
+                                                          uint64_t value) {
+    constexpr uint64_t MAX_SMALL_VALUE = 0x7fffffff;
+    if (value <= MAX_SMALL_VALUE) {
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(value)
+                                                    << 1);
+      return 4;
+    }
+    data_[offset] = 0b1;
+    store_unaligned<uint64_t>(data_ + offset + 1, value);
+    return 9;
+  }
+
+  FORY_ALWAYS_INLINE uint32_t put_tagged_int64_unchecked(uint32_t offset,
+                                                         int64_t value) {
+    constexpr int64_t MIN_SMALL_VALUE = -1073741824;
+    constexpr int64_t MAX_SMALL_VALUE = 1073741823;
+    if (value >= MIN_SMALL_VALUE && value <= MAX_SMALL_VALUE) {
+      const uint32_t encoded =
+          static_cast<uint32_t>(static_cast<int32_t>(value)) << 1;
+      store_unaligned<uint32_t>(data_ + offset, encoded);
+      return 4;
+    }
+    data_[offset] = 0b1;
+    store_unaligned<int64_t>(data_ + offset + 1, value);
     return 9;
   }
 

--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -1123,15 +1123,17 @@ public:
   bool equals(const Buffer &other) const;
 
   FORY_ALWAYS_INLINE void grow(uint32_t min_capacity) {
-    const uint64_t required_size =
-        static_cast<uint64_t>(writer_index_) + min_capacity;
-    if (FORY_PREDICT_TRUE(required_size <= size_ &&
-                          required_size <
-                              std::numeric_limits<uint32_t>::max())) {
+    // writer_index_ is always within size_: public cursor mutation checks it,
+    // and internal writers advance only after proving capacity. Comparing the
+    // requested extent with the remaining capacity keeps the success path to
+    // one primitive branch without allowing uint32 addition to wrap.
+    if (FORY_PREDICT_TRUE(min_capacity <= size_ - writer_index_)) {
       return;
     }
     // Keep overflow reporting and resize arithmetic off scalar write hot paths.
     // The slow owner retains the same checked uint32_t capacity contract.
+    const uint64_t required_size =
+        static_cast<uint64_t>(writer_index_) + min_capacity;
     grow_checked(required_size, min_capacity);
   }
 

--- a/cpp/fory/util/buffer.h
+++ b/cpp/fory/util/buffer.h
@@ -39,6 +39,9 @@ namespace fory {
 
 class StdInputStream;
 class PyInputStream;
+namespace serialization::detail {
+struct StringFieldWriter;
+} // namespace serialization::detail
 
 // A buffer class for storing raw bytes with various methods for reading and
 // writing the bytes.
@@ -180,17 +183,22 @@ public:
   }
 
   FORY_ALWAYS_INLINE void writer_index(uint32_t writer_index) {
-    FORY_CHECK(writer_index < std::numeric_limits<uint32_t>::max())
+    FORY_CHECK(
+        FORY_PREDICT_TRUE(writer_index < std::numeric_limits<uint32_t>::max() &&
+                          writer_index <= size_))
         << "Buffer overflow writer_index" << writer_index_
-        << " target writer_index " << writer_index;
+        << " target writer_index " << writer_index << " size " << size_;
     writer_index_ = writer_index;
   }
 
   FORY_ALWAYS_INLINE void increase_writer_index(uint32_t diff) {
-    uint64_t writer_index = writer_index_ + diff;
-    FORY_CHECK(writer_index < std::numeric_limits<uint32_t>::max())
-        << "Buffer overflow writer_index" << writer_index_ << " diff " << diff;
-    writer_index_ = writer_index;
+    const uint64_t writer_index = static_cast<uint64_t>(writer_index_) + diff;
+    FORY_CHECK(
+        FORY_PREDICT_TRUE(writer_index < std::numeric_limits<uint32_t>::max() &&
+                          writer_index <= size_))
+        << "Buffer overflow writer_index" << writer_index_ << " diff " << diff
+        << " size " << size_;
+    writer_index_ = static_cast<uint32_t>(writer_index);
   }
 
   FORY_ALWAYS_INLINE bool reader_index(uint32_t reader_index, Error &error) {
@@ -259,13 +267,16 @@ public:
   }
 
   FORY_ALWAYS_INLINE void put_int24(uint32_t offset, int32_t value) {
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 3)))
+        << "Buffer out of bound: " << offset << " + 3 > " << size_;
     data_[offset] = static_cast<uint8_t>(value);
     data_[offset + 1] = static_cast<uint8_t>(value >> 8);
     data_[offset + 2] = static_cast<uint8_t>(value >> 16);
   }
 
   template <typename T> FORY_ALWAYS_INLINE T get(uint32_t relative_offset) {
-    FORY_CHECK(relative_offset + sizeof(T) <= size_)
+    FORY_CHECK(FORY_PREDICT_TRUE(
+        range_in_bounds(relative_offset, static_cast<uint32_t>(sizeof(T)))))
         << "Out of range " << relative_offset << " should be less than "
         << size_;
     T value = load_unaligned<T>(data_ + relative_offset);
@@ -294,7 +305,7 @@ public:
   }
 
   FORY_ALWAYS_INLINE int32_t get_int24(uint32_t offset) {
-    FORY_CHECK(offset + 3 <= size_)
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 3)))
         << "Out of range " << offset << " should be less than " << size_;
     int32_t b0 = data_[offset];
     int32_t b1 = data_[offset + 1];
@@ -350,33 +361,14 @@ public:
   /// Returns number of bytes written (1-5).
   /// Uses bit manipulation to build encoded value, then single memory write.
   FORY_ALWAYS_INLINE uint32_t put_var_uint32(uint32_t offset, uint32_t value) {
-    if (value < 0x80) {
-      data_[offset] = static_cast<uint8_t>(value);
-      return 1;
-    }
-    // Build encoded value: place data bits with continuation bits interleaved
-    // byte0: bits 0-6 + continuation at bit 7
-    // byte1: bits 7-13 + continuation at bit 15 (in uint16/32/64)
-    // etc.
-    uint64_t encoded = (value & 0x7F) | 0x80;
-    encoded |= (static_cast<uint64_t>(value & 0x3F80) << 1);
-    if (value < 0x4000) {
-      store_unaligned<uint16_t>(data_ + offset, static_cast<uint16_t>(encoded));
-      return 2;
-    }
-    encoded |= (static_cast<uint64_t>(value & 0x1FC000) << 2) | 0x8000;
-    if (value < 0x200000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      return 3;
-    }
-    encoded |= (static_cast<uint64_t>(value & 0xFE00000) << 3) | 0x800000;
-    if (value < 0x10000000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      return 4;
-    }
-    encoded |= (static_cast<uint64_t>(value >> 28) << 32) | 0x80000000;
-    store_unaligned<uint64_t>(data_ + offset, encoded);
-    return 5;
+    const uint32_t extent = value < 0x80         ? 1
+                            : value < 0x4000     ? 2
+                            : value < 0x10000000 ? 4
+                                                 : 8;
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
+        << "Buffer out of bound: " << offset << " + " << extent << " > "
+        << size_;
+    return put_var_uint32_unchecked(offset, value);
   }
 
   /// get unsigned varint32 from offset using optimized bulk read.
@@ -475,52 +467,15 @@ public:
   /// Returns number of bytes written (1-9).
   /// Uses PVL (Progressive Variable-length Long) encoding per xlang spec.
   FORY_ALWAYS_INLINE uint32_t put_var_uint64(uint32_t offset, uint64_t value) {
-    if (value < 0x80) {
-      data_[offset] = static_cast<uint8_t>(value);
-      return 1;
-    }
-    // Build encoded value with continuation bits interleaved
-    uint64_t encoded = (value & 0x7F) | 0x80;
-    encoded |= ((value & 0x3F80) << 1);
-    if (value < 0x4000) {
-      store_unaligned<uint16_t>(data_ + offset, static_cast<uint16_t>(encoded));
-      return 2;
-    }
-    encoded |= ((value & 0x1FC000) << 2) | 0x8000;
-    if (value < 0x200000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      return 3;
-    }
-    encoded |= ((value & 0xFE00000) << 3) | 0x800000;
-    if (value < 0x10000000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      return 4;
-    }
-    encoded |= ((value & 0x7F0000000ULL) << 4) | 0x80000000;
-    if (value < 0x800000000ULL) {
-      store_unaligned<uint64_t>(data_ + offset, encoded);
-      return 5;
-    }
-    encoded |= ((value & 0x3F800000000ULL) << 5) | 0x8000000000ULL;
-    if (value < 0x40000000000ULL) {
-      store_unaligned<uint64_t>(data_ + offset, encoded);
-      return 6;
-    }
-    encoded |= ((value & 0x1FC0000000000ULL) << 6) | 0x800000000000ULL;
-    if (value < 0x2000000000000ULL) {
-      store_unaligned<uint64_t>(data_ + offset, encoded);
-      return 7;
-    }
-    encoded |= ((value & 0xFE000000000000ULL) << 7) | 0x80000000000000ULL;
-    if (value < 0x100000000000000ULL) {
-      store_unaligned<uint64_t>(data_ + offset, encoded);
-      return 8;
-    }
-    // 9 bytes: write 8 bytes + 1 byte for bits 56-63
-    encoded |= 0x8000000000000000ULL;
-    store_unaligned<uint64_t>(data_ + offset, encoded);
-    data_[offset + 8] = static_cast<uint8_t>(value >> 56);
-    return 9;
+    const uint32_t extent = value < 0x80                   ? 1
+                            : value < 0x4000               ? 2
+                            : value < 0x10000000           ? 4
+                            : value < 0x100000000000000ULL ? 8
+                                                           : 9;
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, extent)))
+        << "Buffer out of bound: " << offset << " + " << extent << " > "
+        << size_;
+    return put_var_uint64_unchecked(offset, value);
   }
 
   /// get unsigned varint64 from offset using optimized bulk read.
@@ -624,11 +579,15 @@ public:
   /// - If bit 0 is 1: read 1 byte flag + 8 bytes uint64
   FORY_ALWAYS_INLINE uint64_t get_tagged_uint64(uint32_t offset,
                                                 uint32_t *read_bytes_length) {
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
+        << "Buffer out of bound: " << offset << " + 4 > " << size_;
     uint32_t i = load_unaligned<uint32_t>(data_ + offset);
     if ((i & 0b1) != 0b1) {
       *read_bytes_length = 4;
       return static_cast<uint64_t>(i >> 1);
     } else {
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
+          << "Buffer out of bound: " << offset << " + 9 > " << size_;
       *read_bytes_length = 9;
       return load_unaligned<uint64_t>(data_ + offset + 1);
     }
@@ -640,11 +599,15 @@ public:
   /// - If bit 0 is 1: read 1 byte flag + 8 bytes int64
   FORY_ALWAYS_INLINE int64_t get_tagged_int64(uint32_t offset,
                                               uint32_t *read_bytes_length) {
+    FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
+        << "Buffer out of bound: " << offset << " + 4 > " << size_;
     int32_t i = load_unaligned<int32_t>(data_ + offset);
     if ((i & 0b1) != 0b1) {
       *read_bytes_length = 4;
       return static_cast<int64_t>(i >> 1); // Arithmetic shift for signed
     } else {
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
+          << "Buffer out of bound: " << offset << " + 9 > " << size_;
       *read_bytes_length = 9;
       return load_unaligned<int64_t>(data_ + offset + 1);
     }
@@ -658,10 +621,14 @@ public:
                                                 uint64_t value) {
     constexpr uint64_t MAX_SMALL_VALUE = 0x7fffffff; // INT32_MAX as u64
     if (value <= MAX_SMALL_VALUE) {
-      store_unaligned<int32_t>(data_ + offset, static_cast<int32_t>(value)
-                                                   << 1);
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
+          << "Buffer out of bound: " << offset << " + 4 > " << size_;
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(value)
+                                                    << 1);
       return 4;
     } else {
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
+          << "Buffer out of bound: " << offset << " + 9 > " << size_;
       data_[offset] = 0b1;
       store_unaligned<uint64_t>(data_ + offset + 1, value);
       return 9;
@@ -677,10 +644,15 @@ public:
     constexpr int64_t MIN_SMALL_VALUE = -1073741824; // -2^30
     constexpr int64_t MAX_SMALL_VALUE = 1073741823;  // 2^30 - 1
     if (value >= MIN_SMALL_VALUE && value <= MAX_SMALL_VALUE) {
-      store_unaligned<int32_t>(data_ + offset, static_cast<int32_t>(value)
-                                                   << 1);
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 4)))
+          << "Buffer out of bound: " << offset << " + 4 > " << size_;
+      const uint32_t encoded =
+          static_cast<uint32_t>(static_cast<int32_t>(value)) << 1;
+      store_unaligned<uint32_t>(data_ + offset, encoded);
       return 4;
     } else {
+      FORY_CHECK(FORY_PREDICT_TRUE(range_in_bounds(offset, 9)))
+          << "Buffer out of bound: " << offset << " + 9 > " << size_;
       data_[offset] = 0b1;
       store_unaligned<int64_t>(data_ + offset + 1, value);
       return 9;
@@ -692,7 +664,7 @@ public:
   FORY_ALWAYS_INLINE void write_uint8(uint8_t value) {
     grow(1);
     unsafe_put_byte(writer_index_, value);
-    increase_writer_index(1);
+    advance_writer_index_unchecked(1);
   }
 
   /// write int8_t value to buffer at current writer index.
@@ -700,7 +672,7 @@ public:
   FORY_ALWAYS_INLINE void write_int8(int8_t value) {
     grow(1);
     unsafe_put_byte(writer_index_, static_cast<uint8_t>(value));
-    increase_writer_index(1);
+    advance_writer_index_unchecked(1);
   }
 
   /// write uint16_t value as fixed 2 bytes to buffer at current writer index.
@@ -708,7 +680,7 @@ public:
   FORY_ALWAYS_INLINE void write_uint16(uint16_t value) {
     grow(2);
     unsafe_put<uint16_t>(writer_index_, value);
-    increase_writer_index(2);
+    advance_writer_index_unchecked(2);
   }
 
   /// write int16_t value as fixed 2 bytes to buffer at current writer index.
@@ -716,7 +688,7 @@ public:
   FORY_ALWAYS_INLINE void write_int16(int16_t value) {
     grow(2);
     unsafe_put<int16_t>(writer_index_, value);
-    increase_writer_index(2);
+    advance_writer_index_unchecked(2);
   }
 
   /// write int24 value as fixed 3 bytes to buffer at current writer index.
@@ -724,7 +696,7 @@ public:
   FORY_ALWAYS_INLINE void write_int24(int32_t value) {
     grow(3);
     put_int24(writer_index_, value);
-    increase_writer_index(3);
+    advance_writer_index_unchecked(3);
   }
 
   /// write int32_t value as fixed 4 bytes to buffer at current writer index.
@@ -732,7 +704,7 @@ public:
   FORY_ALWAYS_INLINE void write_int32(int32_t value) {
     grow(4);
     unsafe_put<int32_t>(writer_index_, value);
-    increase_writer_index(4);
+    advance_writer_index_unchecked(4);
   }
 
   /// write uint32_t value as fixed 4 bytes to buffer at current writer index.
@@ -740,7 +712,7 @@ public:
   FORY_ALWAYS_INLINE void write_uint32(uint32_t value) {
     grow(4);
     unsafe_put<uint32_t>(writer_index_, value);
-    increase_writer_index(4);
+    advance_writer_index_unchecked(4);
   }
 
   /// write int64_t value as fixed 8 bytes to buffer at current writer index.
@@ -748,7 +720,7 @@ public:
   FORY_ALWAYS_INLINE void write_int64(int64_t value) {
     grow(8);
     unsafe_put<int64_t>(writer_index_, value);
-    increase_writer_index(8);
+    advance_writer_index_unchecked(8);
   }
 
   /// write float value as fixed 4 bytes to buffer at current writer index.
@@ -756,7 +728,7 @@ public:
   FORY_ALWAYS_INLINE void write_float(float value) {
     grow(4);
     unsafe_put<float>(writer_index_, value);
-    increase_writer_index(4);
+    advance_writer_index_unchecked(4);
   }
 
   /// write double value as fixed 8 bytes to buffer at current writer index.
@@ -764,7 +736,7 @@ public:
   FORY_ALWAYS_INLINE void write_double(double value) {
     grow(8);
     unsafe_put<double>(writer_index_, value);
-    increase_writer_index(8);
+    advance_writer_index_unchecked(8);
   }
 
   /// Write float16_t as fixed 2 bytes (raw IEEE 754 bits, little-endian).
@@ -772,7 +744,7 @@ public:
   FORY_ALWAYS_INLINE void write_f16(float16_t value) {
     grow(2);
     unsafe_put<uint16_t>(writer_index_, value.to_bits());
-    increase_writer_index(2);
+    advance_writer_index_unchecked(2);
   }
 
   /// Write bfloat16_t as fixed 2 bytes (raw IEEE 754 bits, little-endian).
@@ -780,15 +752,15 @@ public:
   FORY_ALWAYS_INLINE void write_bf16(bfloat16_t value) {
     grow(2);
     unsafe_put<uint16_t>(writer_index_, value.to_bits());
-    increase_writer_index(2);
+    advance_writer_index_unchecked(2);
   }
 
   /// write uint32_t value as varint to buffer at current writer index.
   /// Automatically grows buffer and advances writer index.
   FORY_ALWAYS_INLINE void write_var_uint32(uint32_t value) {
     grow(8); // bulk write may write 8 bytes for varint32
-    uint32_t len = put_var_uint32(writer_index_, value);
-    increase_writer_index(len);
+    uint32_t len = put_var_uint32_unchecked(writer_index_, value);
+    advance_writer_index_unchecked(len);
   }
 
   /// write int32_t value as varint (zigzag encoded) to buffer at current
@@ -803,8 +775,8 @@ public:
   /// Automatically grows buffer and advances writer index.
   FORY_ALWAYS_INLINE void write_var_uint64(uint64_t value) {
     grow(9); // Max 9 bytes for varint64
-    uint32_t len = put_var_uint64(writer_index_, value);
-    increase_writer_index(len);
+    uint32_t len = put_var_uint64_unchecked(writer_index_, value);
+    advance_writer_index_unchecked(len);
   }
 
   /// write int64_t value as varint (zigzag encoded) to buffer at current
@@ -820,37 +792,9 @@ public:
   /// in xlang protocol. Optimized for small values (< 0x80).
   /// Automatically grows buffer and advances writer index.
   FORY_ALWAYS_INLINE void write_var_uint36_small(uint64_t value) {
-    grow(8); // Need 8 bytes for safe bulk write
-    uint32_t offset = writer_index_;
-    if (value < 0x80) {
-      data_[offset] = static_cast<uint8_t>(value);
-      increase_writer_index(1);
-      return;
-    }
-    // Build encoded value with continuation bits interleaved
-    uint64_t encoded = (value & 0x7F) | 0x80;
-    encoded |= ((value & 0x3F80) << 1);
-    if (value < 0x4000) {
-      store_unaligned<uint16_t>(data_ + offset, static_cast<uint16_t>(encoded));
-      increase_writer_index(2);
-      return;
-    }
-    encoded |= ((value & 0x1FC000) << 2) | 0x8000;
-    if (value < 0x200000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      increase_writer_index(3);
-      return;
-    }
-    encoded |= ((value & 0xFE00000) << 3) | 0x800000;
-    if (value < 0x10000000) {
-      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
-      increase_writer_index(4);
-      return;
-    }
-    // 5 bytes: bits 28-35 (up to 36 bits total)
-    encoded |= ((value & 0xFF0000000ULL) << 4) | 0x80000000;
-    store_unaligned<uint64_t>(data_ + offset, encoded);
-    increase_writer_index(5);
+    // The multi-byte form is the standard VarUint64 encoding. Keeping that
+    // operation as the single owner also keeps compatible skip in lockstep.
+    write_var_uint64(value);
   }
 
   /// write raw bytes to buffer at current writer index.
@@ -858,7 +802,7 @@ public:
   FORY_ALWAYS_INLINE void write_bytes(const void *data, uint32_t length) {
     grow(length);
     unsafe_put(writer_index_, data, length);
-    increase_writer_index(length);
+    advance_writer_index_unchecked(length);
     if (FORY_PREDICT_FALSE(output_stream_ != nullptr && writer_index_ > 4096)) {
       output_stream_->try_flush();
     }
@@ -1085,12 +1029,12 @@ public:
     constexpr int64_t HALF_MIN_INT_VALUE = -1073741824; // INT32_MIN / 2
     constexpr int64_t HALF_MAX_INT_VALUE = 1073741823;  // INT32_MAX / 2
     if (value >= HALF_MIN_INT_VALUE && value <= HALF_MAX_INT_VALUE) {
-      write_int32(static_cast<int32_t>(value) << 1);
+      write_uint32(static_cast<uint32_t>(static_cast<int32_t>(value)) << 1);
     } else {
       grow(9);
       data_[writer_index_] = 0b1;
       unsafe_put<int64_t>(writer_index_ + 1, value);
-      increase_writer_index(9);
+      advance_writer_index_unchecked(9);
     }
   }
 
@@ -1121,12 +1065,12 @@ public:
   FORY_ALWAYS_INLINE void write_tagged_uint64(uint64_t value) {
     constexpr uint64_t MAX_SMALL_VALUE = 0x7fffffff; // INT32_MAX as u64
     if (value <= MAX_SMALL_VALUE) {
-      write_int32(static_cast<int32_t>(value) << 1);
+      write_uint32(static_cast<uint32_t>(value) << 1);
     } else {
       grow(9);
       data_[writer_index_] = 0b1;
       unsafe_put<uint64_t>(writer_index_ + 1, value);
-      increase_writer_index(9);
+      advance_writer_index_unchecked(9);
     }
   }
 
@@ -1153,39 +1097,7 @@ public:
 
   /// Read uint64_t value as varuint36small. Sets error on bounds violation.
   FORY_ALWAYS_INLINE uint64_t read_var_uint36_small(Error &error) {
-    if (FORY_PREDICT_FALSE(!ensure_readable(1, error))) {
-      return 0;
-    }
-    uint32_t offset = reader_index_;
-    if (FORY_PREDICT_FALSE(size_ - offset < 8)) {
-      return read_var_uint36_small_slow(error);
-    }
-    // Fast path: need at least 8 bytes for safe bulk read.
-    uint64_t bulk = load_unaligned<uint64_t>(data_ + offset);
-    uint64_t result = bulk & 0x7F;
-    if ((bulk & 0x80) == 0) {
-      reader_index_ = offset + 1;
-      return result;
-    }
-    result |= (bulk >> 1) & 0x3F80;
-    if ((bulk & 0x8000) == 0) {
-      reader_index_ = offset + 2;
-      return result;
-    }
-    result |= (bulk >> 2) & 0x1FC000;
-    if ((bulk & 0x800000) == 0) {
-      reader_index_ = offset + 3;
-      return result;
-    }
-    result |= (bulk >> 3) & 0xFE00000;
-    if ((bulk & 0x80000000) == 0) {
-      reader_index_ = offset + 4;
-      return result;
-    }
-    // 5th byte for bits 28-35 (up to 36 bits)
-    result |= (bulk >> 4) & 0xFF0000000ULL;
-    reader_index_ = offset + 5;
-    return result;
+    return read_var_uint64(error);
   }
 
   /// Read raw bytes from buffer. Sets error on bounds violation.
@@ -1211,16 +1123,16 @@ public:
   bool equals(const Buffer &other) const;
 
   FORY_ALWAYS_INLINE void grow(uint32_t min_capacity) {
-    uint32_t len = writer_index_ + min_capacity;
-    if (len > size_) {
-      // NOTE: over allocate by 1.5 or 2 ?
-      // see: Doubling isn't a great overallocation practice
-      // see
-      // https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md
-      // for discussion.
-      auto new_size = util::round_number_of_bytes_to_nearest_word(len * 2);
-      reserve(new_size);
+    const uint64_t required_size =
+        static_cast<uint64_t>(writer_index_) + min_capacity;
+    if (FORY_PREDICT_TRUE(required_size <= size_ &&
+                          required_size <
+                              std::numeric_limits<uint32_t>::max())) {
+      return;
     }
+    // Keep overflow reporting and resize arithmetic off scalar write hot paths.
+    // The slow owner retains the same checked uint32_t capacity contract.
+    grow_checked(required_size, min_capacity);
   }
 
   /// reserve buffer to new_size
@@ -1295,6 +1207,7 @@ public:
   std::string hex() const;
 
 private:
+  friend struct serialization::detail::StringFieldWriter;
   friend class StdInputStream;
   friend class PyInputStream;
   friend class OutputStream;
@@ -1391,56 +1304,115 @@ private:
     return result;
   }
 
-  FORY_ALWAYS_INLINE uint64_t read_var_uint36_small_slow(Error &error) {
-    uint32_t position = reader_index_;
-    if (FORY_PREDICT_FALSE(!ensure_readable(1, error))) {
-      return 0;
+  FORY_ALWAYS_INLINE uint32_t put_var_uint32_unchecked(uint32_t offset,
+                                                       uint32_t value) {
+    if (value < 0x80) {
+      data_[offset] = static_cast<uint8_t>(value);
+      return 1;
     }
-    uint8_t b = data_[position++];
-    uint64_t result = b & 0x7F;
-    if ((b & 0x80) == 0) {
-      reader_index_ = position;
-      return result;
+    // Bulk stores keep the hot path branch-light. Callers must establish the
+    // physical extent selected below, which may exceed the logical encoding.
+    uint64_t encoded = (value & 0x7F) | 0x80;
+    encoded |= (static_cast<uint64_t>(value & 0x3F80) << 1);
+    if (value < 0x4000) {
+      store_unaligned<uint16_t>(data_ + offset, static_cast<uint16_t>(encoded));
+      return 2;
     }
-
-    if (FORY_PREDICT_FALSE(!ensure_readable(2, error))) {
-      return 0;
+    encoded |= (static_cast<uint64_t>(value & 0x1FC000) << 2) | 0x8000;
+    if (value < 0x200000) {
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
+      return 3;
     }
-    b = data_[position++];
-    result |= static_cast<uint64_t>(b & 0x7F) << 7;
-    if ((b & 0x80) == 0) {
-      reader_index_ = position;
-      return result;
+    encoded |= (static_cast<uint64_t>(value & 0xFE00000) << 3) | 0x800000;
+    if (value < 0x10000000) {
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
+      return 4;
     }
-
-    if (FORY_PREDICT_FALSE(!ensure_readable(3, error))) {
-      return 0;
-    }
-    b = data_[position++];
-    result |= static_cast<uint64_t>(b & 0x7F) << 14;
-    if ((b & 0x80) == 0) {
-      reader_index_ = position;
-      return result;
-    }
-
-    if (FORY_PREDICT_FALSE(!ensure_readable(4, error))) {
-      return 0;
-    }
-    b = data_[position++];
-    result |= static_cast<uint64_t>(b & 0x7F) << 21;
-    if ((b & 0x80) == 0) {
-      reader_index_ = position;
-      return result;
-    }
-
-    if (FORY_PREDICT_FALSE(!ensure_readable(5, error))) {
-      return 0;
-    }
-    b = data_[position++];
-    result |= static_cast<uint64_t>(b) << 28;
-    reader_index_ = position;
-    return result;
+    encoded |= (static_cast<uint64_t>(value >> 28) << 32) | 0x80000000;
+    store_unaligned<uint64_t>(data_ + offset, encoded);
+    return 5;
   }
+
+  FORY_ALWAYS_INLINE uint32_t put_var_uint64_unchecked(uint32_t offset,
+                                                       uint64_t value) {
+    if (value < 0x80) {
+      data_[offset] = static_cast<uint8_t>(value);
+      return 1;
+    }
+    uint64_t encoded = (value & 0x7F) | 0x80;
+    encoded |= ((value & 0x3F80) << 1);
+    if (value < 0x4000) {
+      store_unaligned<uint16_t>(data_ + offset, static_cast<uint16_t>(encoded));
+      return 2;
+    }
+    encoded |= ((value & 0x1FC000) << 2) | 0x8000;
+    if (value < 0x200000) {
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
+      return 3;
+    }
+    encoded |= ((value & 0xFE00000) << 3) | 0x800000;
+    if (value < 0x10000000) {
+      store_unaligned<uint32_t>(data_ + offset, static_cast<uint32_t>(encoded));
+      return 4;
+    }
+    encoded |= ((value & 0x7F0000000ULL) << 4) | 0x80000000;
+    if (value < 0x800000000ULL) {
+      store_unaligned<uint64_t>(data_ + offset, encoded);
+      return 5;
+    }
+    encoded |= ((value & 0x3F800000000ULL) << 5) | 0x8000000000ULL;
+    if (value < 0x40000000000ULL) {
+      store_unaligned<uint64_t>(data_ + offset, encoded);
+      return 6;
+    }
+    encoded |= ((value & 0x1FC0000000000ULL) << 6) | 0x800000000000ULL;
+    if (value < 0x2000000000000ULL) {
+      store_unaligned<uint64_t>(data_ + offset, encoded);
+      return 7;
+    }
+    encoded |= ((value & 0xFE000000000000ULL) << 7) | 0x80000000000000ULL;
+    if (value < 0x100000000000000ULL) {
+      store_unaligned<uint64_t>(data_ + offset, encoded);
+      return 8;
+    }
+    encoded |= 0x8000000000000000ULL;
+    store_unaligned<uint64_t>(data_ + offset, encoded);
+    data_[offset + 8] = static_cast<uint8_t>(value >> 56);
+    return 9;
+  }
+
+  FORY_ALWAYS_INLINE bool range_in_bounds(uint32_t offset,
+                                          uint32_t length) const {
+    return offset <= size_ && length <= size_ - offset;
+  }
+
+  // Auto-growing writers call this only after grow() has proved the complete
+  // physical store extent and the uint32 writer-index range. Rechecking here
+  // would make every scalar write pay twice for the same safety proof.
+  FORY_ALWAYS_INLINE void advance_writer_index_unchecked(uint32_t diff) {
+    writer_index_ += diff;
+  }
+
+  FORY_ALWAYS_INLINE void grow_to_fit(uint32_t required_size) {
+    constexpr uint64_t kMaxBufferSize = std::numeric_limits<uint32_t>::max();
+    if (required_size <= size_) {
+      return;
+    }
+
+    uint64_t new_size = static_cast<uint64_t>(required_size) * 2;
+    if (new_size > kMaxBufferSize) {
+      new_size = kMaxBufferSize;
+    } else {
+      new_size = (new_size + 7) & ~uint64_t{7};
+      if (new_size > kMaxBufferSize) {
+        new_size = kMaxBufferSize;
+      }
+    }
+    reserve(static_cast<uint32_t>(new_size));
+  }
+
+  FORY_NOINLINE void grow_checked(uint64_t required_size,
+                                  uint32_t min_capacity);
 
   uint8_t *data_;
   uint32_t size_;

--- a/cpp/fory/util/buffer_test.cc
+++ b/cpp/fory/util/buffer_test.cc
@@ -239,15 +239,207 @@ TEST(Buffer, TestGetVarUint64Truncated) {
   EXPECT_EQ(buffer.reader_index(), 0U);
 }
 
-TEST(Buffer, TestReadVarUint36SmallTruncated) {
-  std::vector<uint8_t> bytes = {0x80, 0x80, 0x80, 0x80};
-  Buffer buffer(bytes);
+TEST(Buffer, VarUint36SmallUsesVarUint64) {
+  constexpr uint64_t kFirstSixByteValue = uint64_t{1} << 35;
+  constexpr uint64_t kMaxValue = (uint64_t{1} << 36) - 1;
+  const std::vector<uint64_t> values = {0x7f, 0x80, kFirstSixByteValue,
+                                        kMaxValue};
 
+  for (uint64_t value : values) {
+    std::shared_ptr<Buffer> expected;
+    std::shared_ptr<Buffer> actual;
+    ASSERT_TRUE(allocate_buffer(32, &expected));
+    ASSERT_TRUE(allocate_buffer(32, &actual));
+    expected->write_var_uint64(value);
+    actual->write_var_uint36_small(value);
+
+    ASSERT_EQ(actual->writer_index(), expected->writer_index());
+    EXPECT_EQ(
+        std::memcmp(actual->data(), expected->data(), actual->writer_index()),
+        0);
+
+    Error error;
+    EXPECT_EQ(actual->read_var_uint36_small(error), value);
+    ASSERT_TRUE(error.ok()) << error.to_string();
+    EXPECT_EQ(actual->reader_index(), actual->writer_index());
+
+    std::vector<uint8_t> exact(actual->data(),
+                               actual->data() + actual->writer_index());
+    Buffer exact_buffer(exact);
+    EXPECT_EQ(exact_buffer.read_var_uint36_small(error), value);
+    ASSERT_TRUE(error.ok()) << error.to_string();
+    EXPECT_EQ(exact_buffer.reader_index(), exact.size());
+  }
+}
+
+TEST(Buffer, WriterRangeRejectsOverflow) {
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_TRUE(allocate_buffer(8, &buffer));
+
+  buffer->writer_index(8);
+  EXPECT_DEATH(buffer->writer_index(9), "");
+
+  buffer->writer_index(1);
+  EXPECT_DEATH(
+      buffer->increase_writer_index(std::numeric_limits<uint32_t>::max()), "");
+  EXPECT_DEATH(buffer->grow(std::numeric_limits<uint32_t>::max()), "");
+
+  buffer->writer_index(8);
+  buffer->grow(1);
+  buffer->increase_writer_index(1);
+  EXPECT_EQ(buffer->writer_index(), 9U);
+}
+
+TEST(Buffer, OffsetRangeRejectsOverflow) {
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_TRUE(allocate_buffer(8, &buffer));
+  uint32_t bytes_read = 0;
+
+  EXPECT_DEATH(
+      (void)buffer->get<uint64_t>(std::numeric_limits<uint32_t>::max()), "");
+  EXPECT_DEATH(buffer->get_int24(std::numeric_limits<uint32_t>::max()), "");
+  EXPECT_DEATH(buffer->put_int24(std::numeric_limits<uint32_t>::max(), 1), "");
+
+  EXPECT_DEATH(buffer->get_tagged_uint64(std::numeric_limits<uint32_t>::max(),
+                                         &bytes_read),
+               "");
+  buffer->unsafe_put<uint32_t>(0, 1);
+  EXPECT_DEATH(buffer->get_tagged_int64(0, &bytes_read), "");
+  EXPECT_DEATH(
+      buffer->put_tagged_uint64(std::numeric_limits<uint32_t>::max(), 0), "");
+  EXPECT_DEATH(buffer->put_tagged_int64(0, std::numeric_limits<int64_t>::max()),
+               "");
+
+  const uint8_t byte = 1;
+  EXPECT_DEATH(
+      buffer->copy_from(std::numeric_limits<uint32_t>::max(), &byte, 0, 1), "");
+}
+
+TEST(Buffer, RepresentedCopyChecksExtents) {
+  std::shared_ptr<Buffer> source;
+  std::shared_ptr<Buffer> destination;
+  ASSERT_TRUE(allocate_buffer(4, &source));
+  ASSERT_TRUE(allocate_buffer(2, &destination));
+
+  EXPECT_DEATH(source->copy(3, 2, destination), "");
+  EXPECT_DEATH(source->copy(0, 4, destination), "");
+
+  Buffer destination_ref(destination->data(), destination->size(), false);
+  EXPECT_DEATH(source->copy(3, 2, destination_ref), "");
+  EXPECT_DEATH(source->copy(0, 4, destination_ref), "");
+
+  source->unsafe_put<uint16_t>(0, 0x0201);
+  source->copy(0, 2, destination);
+  EXPECT_EQ(destination->get<uint16_t>(0), 0x0201);
+}
+
+TEST(Buffer, RepresentedCopySupportsOverlap) {
+  std::vector<uint8_t> bytes = {1, 2, 3, 4, 5};
+  Buffer source(bytes);
+  auto destination = std::make_shared<Buffer>(bytes.data() + 1, 4, false);
+  source.copy(0, 4, destination);
+  EXPECT_EQ(bytes, (std::vector<uint8_t>{1, 1, 2, 3, 4}));
+
+  bytes = {1, 2, 3, 4, 5};
+  Buffer source_ref(bytes);
+  Buffer destination_ref(bytes.data() + 1, 4, false);
+  source_ref.copy(0, 4, destination_ref);
+  EXPECT_EQ(bytes, (std::vector<uint8_t>{1, 1, 2, 3, 4}));
+}
+
+TEST(Buffer, VarUintPutChecksPhysicalExtent) {
+  std::shared_ptr<Buffer> one_byte;
+  std::shared_ptr<Buffer> two_bytes;
+  std::shared_ptr<Buffer> three_bytes;
+  std::shared_ptr<Buffer> four_bytes;
+  std::shared_ptr<Buffer> seven_bytes;
+  std::shared_ptr<Buffer> eight_bytes;
+  std::shared_ptr<Buffer> nine_bytes;
+  ASSERT_TRUE(allocate_buffer(1, &one_byte));
+  ASSERT_TRUE(allocate_buffer(2, &two_bytes));
+  ASSERT_TRUE(allocate_buffer(3, &three_bytes));
+  ASSERT_TRUE(allocate_buffer(4, &four_bytes));
+  ASSERT_TRUE(allocate_buffer(7, &seven_bytes));
+  ASSERT_TRUE(allocate_buffer(8, &eight_bytes));
+  ASSERT_TRUE(allocate_buffer(9, &nine_bytes));
+
+  EXPECT_EQ(one_byte->put_var_uint32(0, 0x7f), 1U);
+  EXPECT_EQ(two_bytes->put_var_uint64(0, 0x80), 2U);
+  constexpr uint32_t kThreeByteValue = uint32_t{1} << 14;
+  EXPECT_DEATH(three_bytes->put_var_uint32(0, kThreeByteValue), "");
+  EXPECT_EQ(four_bytes->put_var_uint32(0, kThreeByteValue), 3U);
+  constexpr uint64_t kFourByteValue = uint64_t{1} << 21;
+  EXPECT_EQ(four_bytes->put_var_uint64(0, kFourByteValue), 4U);
+
+  constexpr uint32_t kFiveByteValue = uint32_t{1} << 28;
+  EXPECT_DEATH(seven_bytes->put_var_uint32(0, kFiveByteValue), "");
+  EXPECT_EQ(eight_bytes->put_var_uint32(0, kFiveByteValue), 5U);
+  uint32_t bytes_read = 0;
+  EXPECT_EQ(eight_bytes->get_var_uint32(0, &bytes_read), kFiveByteValue);
+  EXPECT_EQ(bytes_read, 5U);
+
+  constexpr uint64_t kNineByteValue = uint64_t{1} << 56;
+  EXPECT_DEATH(eight_bytes->put_var_uint64(0, kNineByteValue), "");
+  EXPECT_EQ(nine_bytes->put_var_uint64(0, kNineByteValue), 9U);
+  EXPECT_EQ(nine_bytes->get_var_uint64(0, &bytes_read), kNineByteValue);
+  EXPECT_EQ(bytes_read, 9U);
+}
+
+TEST(Buffer, NegativeEqualsReturnsFalse) {
+  std::vector<uint8_t> bytes = {1, 2, 3};
+  Buffer first(bytes);
+  Buffer second(bytes);
+
+  EXPECT_FALSE(first.equals(second, -1));
+  EXPECT_FALSE(first.equals(first, -1));
+}
+
+TEST(Buffer, EmptyRangeOperations) {
+  Buffer first;
+  Buffer second;
+  std::vector<uint8_t> byte = {1};
+  Buffer nonempty(byte);
+
+  EXPECT_TRUE(first.equals(second));
+  EXPECT_TRUE(first.equals(second, 0));
+  EXPECT_TRUE(first.equals(nonempty, 0));
+
+  auto shared_out = std::make_shared<Buffer>();
+  first.copy(0, 0, shared_out);
+  first.copy(0, 0, second);
+  first.copy(0, 0, static_cast<uint8_t *>(nullptr));
+  first.copy(0, 0, static_cast<uint8_t *>(nullptr),
+             std::numeric_limits<uint32_t>::max());
+  first.copy_from(std::numeric_limits<uint32_t>::max(), nullptr,
+                  std::numeric_limits<uint32_t>::max(), 0);
+  EXPECT_EQ(first.size(), 0U);
+}
+
+TEST(Buffer, TaggedSmallNegative) {
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_TRUE(allocate_buffer(8, &buffer));
+
+  EXPECT_EQ(buffer->put_tagged_int64(0, -1), 4U);
+  uint32_t bytes_read = 0;
+  EXPECT_EQ(buffer->get_tagged_int64(0, &bytes_read), -1);
+  EXPECT_EQ(bytes_read, 4U);
+
+  constexpr uint64_t kMaxSmallUnsigned = 0x7fffffff;
+  EXPECT_EQ(buffer->put_tagged_uint64(0, kMaxSmallUnsigned), 4U);
+  EXPECT_EQ(buffer->get_tagged_uint64(0, &bytes_read), kMaxSmallUnsigned);
+  EXPECT_EQ(bytes_read, 4U);
+
+  Buffer streaming;
+  streaming.write_tagged_int64(-1);
   Error error;
-  uint64_t decoded = buffer.read_var_uint36_small(error);
-  EXPECT_EQ(decoded, 0ULL);
-  EXPECT_FALSE(error.ok());
-  EXPECT_EQ(buffer.reader_index(), 0U);
+  EXPECT_EQ(streaming.read_tagged_int64(error), -1);
+  ASSERT_TRUE(error.ok()) << error.to_string();
+
+  streaming.writer_index(0);
+  ASSERT_TRUE(streaming.reader_index(0, error));
+  streaming.write_tagged_uint64(kMaxSmallUnsigned);
+  EXPECT_EQ(streaming.read_tagged_uint64(error), kMaxSmallUnsigned);
+  ASSERT_TRUE(error.ok()) << error.to_string();
 }
 
 TEST(Buffer, StreamReadFromOneByteSource) {

--- a/cpp/fory/util/string_util.h
+++ b/cpp/fory/util/string_util.h
@@ -19,10 +19,13 @@
 
 #pragma once
 
+#include "fory/util/error.h"
+#include "fory/util/result.h"
 #include "macros.h"
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -68,6 +71,16 @@ namespace detail {
 bool utf8_to_utf16_checked(const char *utf8, size_t size, bool is_little_endian,
                            std::u16string &utf16);
 
+inline bool latin1_utf8_size(size_t input_size, size_t non_ascii_count,
+                             size_t &output_size) {
+  if (FORY_PREDICT_FALSE(non_ascii_count >
+                         std::numeric_limits<size_t>::max() - input_size)) {
+    return false;
+  }
+  output_size = input_size + non_ascii_count;
+  return true;
+}
+
 } // namespace detail
 
 // inline
@@ -102,7 +115,10 @@ inline void utf16_surrogate_pair_to_utf8(uint16_t high, uint16_t low,
 // Convert Latin1 encoded bytes to UTF-8 string.
 // Latin1 (ISO-8859-1) maps bytes 0-127 to ASCII and bytes 128-255 to
 // Unicode code points U+0080 to U+00FF.
-inline std::string latin1_to_utf8(const uint8_t *data, size_t length) {
+namespace detail {
+
+inline Result<std::string, Error> latin1_to_utf8_checked(const uint8_t *data,
+                                                         size_t length) {
   if (length == 0) {
     return std::string();
   }
@@ -112,11 +128,24 @@ inline std::string latin1_to_utf8(const uint8_t *data, size_t length) {
     return std::string(reinterpret_cast<const char *>(data), length);
   }
 
-  // Calculate exact output size to avoid reallocation
-  // ASCII bytes (< 128) need 1 byte, non-ASCII need 2 bytes in UTF-8
+  // Lengths at most half the size_t range cannot overflow when every byte
+  // expands. This keeps uint32_t wire lengths on 64-bit targets on the direct
+  // accumulation path while larger target-dependent lengths use checked math.
   size_t utf8_len = 0;
-  for (size_t i = 0; i < length; ++i) {
-    utf8_len += (data[i] < 128) ? 1 : 2;
+  if (length <= std::numeric_limits<size_t>::max() / 2) {
+    for (size_t i = 0; i < length; ++i) {
+      utf8_len += (data[i] < 128) ? 1 : 2;
+    }
+  } else {
+    size_t non_ascii_count = 0;
+    for (size_t i = 0; i < length; ++i) {
+      non_ascii_count += data[i] >= 128;
+    }
+    if (FORY_PREDICT_FALSE(
+            !detail::latin1_utf8_size(length, non_ascii_count, utf8_len))) {
+      return Unexpected(
+          Error::invalid_data("Latin1 UTF-8 size exceeds size_t range"));
+    }
   }
 
   std::string result;
@@ -137,6 +166,8 @@ inline std::string latin1_to_utf8(const uint8_t *data, size_t length) {
 
   return result;
 }
+
+} // namespace detail
 
 // Convert UTF-16 code units to UTF-8 string.
 // Handles surrogate pairs for characters outside BMP.

--- a/cpp/fory/util/string_util_test.cc
+++ b/cpp/fory/util/string_util_test.cc
@@ -19,6 +19,7 @@
 
 #include <codecvt>
 #include <iostream>
+#include <limits>
 #include <locale>
 #include <random>
 
@@ -95,6 +96,33 @@ TEST(StringUtilTest, TestisLatin1) {
     EXPECT_TRUE(is_latin1(std::u16string(i, '.') + u"\x80"));  //  in Latin-1
     EXPECT_FALSE(is_latin1(std::u16string(i, '.') +
                            std::u16string({256}))); // Ā (not in Latin-1)
+  }
+}
+
+TEST(StringUtilTest, Latin1SizeBoundary) {
+  constexpr size_t max_size = std::numeric_limits<size_t>::max();
+  const size_t input_size = max_size / 2 + 1;
+  const size_t largest_extra = max_size - input_size;
+  size_t output_size = 0;
+
+  ASSERT_LE(largest_extra, input_size);
+  EXPECT_TRUE(detail::latin1_utf8_size(input_size, largest_extra, output_size));
+  EXPECT_EQ(output_size, max_size);
+
+  output_size = 1;
+  EXPECT_FALSE(
+      detail::latin1_utf8_size(input_size, largest_extra + 1, output_size));
+  EXPECT_EQ(output_size, 1);
+
+  constexpr size_t max_wire_length = std::numeric_limits<uint32_t>::max();
+  if constexpr (sizeof(size_t) == sizeof(uint32_t)) {
+    EXPECT_FALSE(detail::latin1_utf8_size(max_wire_length, max_wire_length,
+                                          output_size));
+  } else {
+    EXPECT_TRUE(detail::latin1_utf8_size(max_wire_length, max_wire_length,
+                                         output_size));
+    EXPECT_EQ(static_cast<uint64_t>(output_size),
+              static_cast<uint64_t>(max_wire_length) * 2);
   }
 }
 

--- a/dart/packages/fory/lib/src/memory/buffer_mixin.dart
+++ b/dart/packages/fory/lib/src/memory/buffer_mixin.dart
@@ -344,6 +344,22 @@ mixin _BufferMixin {
       _throwInvalidVarUint36();
     }
     ensureWritable(6);
+    if (value > 0x7fffffff) {
+      _writeLargeVarUint36(value);
+      return;
+    }
+    var remaining = value;
+    while (remaining >= 0x80) {
+      _bytes[_writerIndex] = (remaining & 0x7f) | 0x80;
+      _writerIndex += 1;
+      remaining >>>= 7;
+    }
+    _bytes[_writerIndex] = remaining;
+    _writerIndex += 1;
+  }
+
+  @pragma('vm:never-inline')
+  void _writeLargeVarUint36(int value) {
     var remaining = value;
     while (remaining >= 0x80) {
       _bytes[_writerIndex] = (remaining % 0x80) | 0x80;

--- a/dart/packages/fory/lib/src/memory/buffer_mixin.dart
+++ b/dart/packages/fory/lib/src/memory/buffer_mixin.dart
@@ -338,16 +338,62 @@ mixin _BufferMixin {
   /// Reads a small unsigned integer written by [writeVarUint32Small14].
   int readVarUint32Small14() => readVarUint32();
 
-  /// Writes a small unsigned integer using the 64-bit varint path.
-  void writeVarUint36Small(int value) => writeVarUint64(Uint64(value));
+  /// Writes an unsigned integer using the protocol's standard varuint format.
+  void writeVarUint36Small(int value) {
+    if (value < 0 || value > 0xfffffffff) {
+      _throwInvalidVarUint36();
+    }
+    ensureWritable(6);
+    var remaining = value;
+    while (remaining >= 0x80) {
+      _bytes[_writerIndex] = (remaining % 0x80) | 0x80;
+      _writerIndex += 1;
+      remaining ~/= 0x80;
+    }
+    _bytes[_writerIndex] = remaining;
+    _writerIndex += 1;
+  }
 
   /// Reads a small unsigned integer written by [writeVarUint36Small].
-  int readVarUint36Small() => readVarUint64().toInt();
+  @pragma('vm:prefer-inline')
+  int readVarUint36Small() {
+    final byte = readUint8();
+    if (byte < 0x80) {
+      return byte;
+    }
+    return _readVarUint36SmallTail(byte & 0x7f);
+  }
+
+  @pragma('vm:never-inline')
+  int _readVarUint36SmallTail(int result) {
+    var value = result;
+    var factor = 0x80;
+    // The multi-byte form is a standard varuint: the fifth byte still has a
+    // continuation bit, and 36-bit values can therefore require six bytes.
+    for (var index = 1; index < 5; index += 1) {
+      final byte = readUint8();
+      value += (byte & 0x7f) * factor;
+      if (byte < 0x80) {
+        return value;
+      }
+      factor *= 0x80;
+    }
+    final sixthByte = readUint8();
+    if (sixthByte > 1) {
+      _throwInvalidVarUint36();
+    }
+    return value + sixthByte * factor;
+  }
 }
 
 @pragma('vm:never-inline')
 Never _throwInvalidVarUint32() {
   throw StateError('Invalid varuint32 encoding.');
+}
+
+@pragma('vm:never-inline')
+Never _throwInvalidVarUint36() {
+  throw StateError('VarUint36Small exceeds 36 bits.');
 }
 
 @internal

--- a/dart/packages/fory/lib/src/serializer/time_serializers.dart
+++ b/dart/packages/fory/lib/src/serializer/time_serializers.dart
@@ -25,6 +25,12 @@ import 'package:fory/src/types/local_date.dart';
 import 'package:fory/src/types/timestamp.dart';
 
 const int _nanosecondsPerSecond = 1000000000;
+final BigInt _minDurationMicroseconds = -(BigInt.one << 63);
+final BigInt _maxDurationMicroseconds = (BigInt.one << 63) - BigInt.one;
+// DateTime supports 100,000,000 days from the epoch; these bounds are
+// microseconds, not the SDK's millisecond representation of that range.
+final BigInt _minDateTimeMicroseconds = BigInt.from(-8640000000000000000);
+final BigInt _maxDateTimeMicroseconds = BigInt.from(8640000000000000000);
 final Expando<_ExactDurationWire> _exactDurationWire =
     Expando<_ExactDurationWire>('fory_exact_duration_wire');
 
@@ -61,6 +67,22 @@ void _validateDateTimeNanoseconds(int nanoseconds) {
   }
 }
 
+int _checkedTemporalInt(
+  BigInt value,
+  String carrier,
+  BigInt minimum,
+  BigInt maximum,
+) {
+  if (value < minimum || value > maximum) {
+    throw StateError('$value is outside the platform $carrier range.');
+  }
+  final converted = value.toInt();
+  if (BigInt.from(converted) != value) {
+    throw StateError('$value is outside the platform $carrier range.');
+  }
+  return converted;
+}
+
 Int64 durationWireSeconds(Duration value) {
   final exact = _exactDurationWire[value];
   if (exact != null && exact.microseconds == value.inMicroseconds) {
@@ -86,8 +108,13 @@ Duration durationFromWire(Int64 seconds, int nanoseconds) {
   }
   final totalNanoseconds =
       seconds.toBigInt() * BigInt.from(_nanosecondsPerSecond) +
-          BigInt.from(nanoseconds);
-  final microseconds = (totalNanoseconds ~/ BigInt.from(1000)).toInt();
+      BigInt.from(nanoseconds);
+  final microseconds = _checkedTemporalInt(
+    totalNanoseconds ~/ BigInt.from(1000),
+    'Duration',
+    _minDurationMicroseconds,
+    _maxDurationMicroseconds,
+  );
   final value = Duration(microseconds: microseconds);
   if (nanoseconds.remainder(1000) != 0) {
     _exactDurationWire[value] = _ExactDurationWire(
@@ -118,8 +145,9 @@ Int64 dateTimeWireSeconds(DateTime value) {
 
 int dateTimeWireNanoseconds(DateTime value) {
   final utcValue = value.toUtc();
-  var micros =
-      utcValue.microsecondsSinceEpoch.remainder(Duration.microsecondsPerSecond);
+  var micros = utcValue.microsecondsSinceEpoch.remainder(
+    Duration.microsecondsPerSecond,
+  );
   if (micros < 0) {
     micros += Duration.microsecondsPerSecond;
   }
@@ -135,9 +163,14 @@ DateTime dateTimeFromWire(Int64 seconds, int nanoseconds) {
   _validateDateTimeNanoseconds(nanoseconds);
   final microseconds =
       seconds.toBigInt() * BigInt.from(Duration.microsecondsPerSecond) +
-          BigInt.from(nanoseconds ~/ 1000);
+      BigInt.from(nanoseconds ~/ 1000);
   return DateTime.fromMicrosecondsSinceEpoch(
-    microseconds.toInt(),
+    _checkedTemporalInt(
+      microseconds,
+      'DateTime',
+      _minDateTimeMicroseconds,
+      _maxDateTimeMicroseconds,
+    ),
     isUtc: true,
   );
 }
@@ -195,7 +228,9 @@ final class TimestampSerializer extends Serializer<Timestamp> {
   @override
   Timestamp read(ReadContext context) {
     return timestampFromWire(
-        context.buffer.readInt64(), context.buffer.readUint32());
+      context.buffer.readInt64(),
+      context.buffer.readUint32(),
+    );
   }
 }
 

--- a/dart/packages/fory/lib/src/types/local_date.dart
+++ b/dart/packages/fory/lib/src/types/local_date.dart
@@ -19,6 +19,9 @@
 
 import 'package:fory/src/types/int64.dart';
 
+const int _minEpochDay = -100000000;
+const int _maxEpochDay = 100000000;
+
 /// Calendar date without time-of-day or time-zone information.
 final class LocalDate implements Comparable<LocalDate> {
   /// Year component.
@@ -35,8 +38,12 @@ final class LocalDate implements Comparable<LocalDate> {
 
   /// Creates a date from the xlang epoch-day representation.
   factory LocalDate.fromEpochDay(Int64 epochDay) {
+    final day = epochDay.toBigInt();
+    if (day < BigInt.from(_minEpochDay) || day > BigInt.from(_maxEpochDay)) {
+      throw StateError('Epoch day $day is outside the Dart DateTime range.');
+    }
     final instant = DateTime.fromMillisecondsSinceEpoch(
-      epochDay.toInt() * Duration.millisecondsPerDay,
+      day.toInt() * Duration.millisecondsPerDay,
       isUtc: true,
     );
     return LocalDate(instant.year, instant.month, instant.day);
@@ -50,9 +57,9 @@ final class LocalDate implements Comparable<LocalDate> {
 
   /// Converts this date to xlang epoch-day form.
   Int64 toEpochDay() => Int64(
-        DateTime.utc(year, month, day).millisecondsSinceEpoch ~/
-            Duration.millisecondsPerDay,
-      );
+    DateTime.utc(year, month, day).millisecondsSinceEpoch ~/
+        Duration.millisecondsPerDay,
+  );
 
   /// Converts this date to a UTC [DateTime] at midnight.
   DateTime toDateTime() => DateTime.utc(year, month, day);

--- a/dart/packages/fory/lib/src/util/string_util.dart
+++ b/dart/packages/fory/lib/src/util/string_util.dart
@@ -106,7 +106,7 @@ String readStringFromBuffer(Buffer buffer, int byteLength, int encoding) {
 
 void _writeLatin1(Buffer buffer, String value) {
   final length = value.length;
-  final header = (length << 2) | stringLatin1Encoding;
+  final header = length * 4 + stringLatin1Encoding;
   final headerLength = _varUint36SmallLength(header);
   buffer.ensureWritable(headerLength + length);
   final bytes = bufferBytes(buffer);
@@ -121,7 +121,7 @@ void _writeLatin1(Buffer buffer, String value) {
 
 void _writeUtf8(Buffer buffer, String value) {
   final maxUtf8Length = value.length * 3;
-  final provisionalHeader = (maxUtf8Length << 2) | stringUtf8Encoding;
+  final provisionalHeader = maxUtf8Length * 4 + stringUtf8Encoding;
   final provisionalHeaderLength = _varUint36SmallLength(provisionalHeader);
   buffer.ensureWritable(provisionalHeaderLength + maxUtf8Length);
   final bytes = bufferBytes(buffer);
@@ -129,7 +129,7 @@ void _writeUtf8(Buffer buffer, String value) {
   final payloadStart = start + provisionalHeaderLength;
   final payloadEnd = _writeUtf8Bytes(bytes, payloadStart, value);
   final utf8Length = payloadEnd - payloadStart;
-  final header = (utf8Length << 2) | stringUtf8Encoding;
+  final header = utf8Length * 4 + stringUtf8Encoding;
   final headerLength = _writeVarUint36Small(bytes, start, header);
   final headerShift = provisionalHeaderLength - headerLength;
   if (headerShift > 0) {
@@ -215,20 +215,29 @@ int _writeVarUint36Small(Uint8List target, int offset, int value) {
   final start = offset;
   var remaining = value;
   while (remaining >= 0x80) {
-    target[offset] = (remaining & 0x7f) | 0x80;
+    target[offset] = (remaining % 0x80) | 0x80;
     offset += 1;
-    remaining >>>= 7;
+    remaining ~/= 0x80;
   }
   target[offset] = remaining;
   return offset - start + 1;
 }
 
 int _varUint36SmallLength(int value) {
-  var length = 1;
-  var remaining = value;
-  while (remaining >= 0x80) {
-    remaining >>>= 7;
-    length += 1;
+  if (value < 0x80) {
+    return 1;
   }
-  return length;
+  if (value < 0x4000) {
+    return 2;
+  }
+  if (value < 0x200000) {
+    return 3;
+  }
+  if (value < 0x10000000) {
+    return 4;
+  }
+  if (value < 0x800000000) {
+    return 5;
+  }
+  return 6;
 }

--- a/dart/packages/fory/lib/src/util/string_util.dart
+++ b/dart/packages/fory/lib/src/util/string_util.dart
@@ -212,6 +212,22 @@ bool _isTrailSurrogate(int codeUnit) =>
     codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
 
 int _writeVarUint36Small(Uint8List target, int offset, int value) {
+  if (value > 0x7fffffff) {
+    return _writeVarUint36Large(target, offset, value);
+  }
+  final start = offset;
+  var remaining = value;
+  while (remaining >= 0x80) {
+    target[offset] = (remaining & 0x7f) | 0x80;
+    offset += 1;
+    remaining >>>= 7;
+  }
+  target[offset] = remaining;
+  return offset - start + 1;
+}
+
+@pragma('vm:never-inline')
+int _writeVarUint36Large(Uint8List target, int offset, int value) {
   final start = offset;
   var remaining = value;
   while (remaining >= 0x80) {

--- a/dart/packages/fory/test/buffer_test.dart
+++ b/dart/packages/fory/test/buffer_test.dart
@@ -416,8 +416,8 @@ void main() {
           _expectInt64IntHelperMatchesWrapper(
             value: value,
             writeInt: (buffer, value) => buffer.writeTaggedInt64FromInt(value),
-            writeWrapper:
-                (buffer, value) => buffer.writeTaggedInt64(Int64(value)),
+            writeWrapper: (buffer, value) =>
+                buffer.writeTaggedInt64(Int64(value)),
             readInt: (buffer) => buffer.readTaggedInt64AsInt(),
           );
         }
@@ -457,17 +457,15 @@ void main() {
         throwsA(isA<StateError>()),
       );
       expect(
-        () =>
-            Buffer.wrap(
-              Uint8List.fromList(varint.toBytes()),
-            ).readVarInt64AsInt(),
+        () => Buffer.wrap(
+          Uint8List.fromList(varint.toBytes()),
+        ).readVarInt64AsInt(),
         throwsA(isA<StateError>()),
       );
       expect(
-        () =>
-            Buffer.wrap(
-              Uint8List.fromList(tagged.toBytes()),
-            ).readTaggedInt64AsInt(),
+        () => Buffer.wrap(
+          Uint8List.fromList(tagged.toBytes()),
+        ).readTaggedInt64AsInt(),
         throwsA(isA<StateError>()),
       );
     });
@@ -518,6 +516,36 @@ void main() {
           read: (buffer) => buffer.readVarUint36Small(),
         );
       }
+    });
+
+    test('uses canonical varuint36 small framing', () {
+      const cases = <({List<int> bytes, int value})>[
+        (bytes: <int>[0xff, 0xff, 0xff, 0x7f], value: 0x0fffffff),
+        (bytes: <int>[0x80, 0x80, 0x80, 0x80, 0x01], value: 0x10000000),
+        (bytes: <int>[0x80, 0x80, 0x80, 0x80, 0x80, 0x01], value: 0x800000000),
+        (bytes: <int>[0xff, 0xff, 0xff, 0xff, 0xff, 0x01], value: 0xfffffffff),
+      ];
+
+      for (final testCase in cases) {
+        final buffer = Buffer();
+        buffer.writeVarUint36Small(testCase.value);
+        expect(buffer.toBytes(), orderedEquals(testCase.bytes));
+
+        final wrapped = Buffer.wrap(Uint8List.fromList(testCase.bytes));
+        expect(wrapped.readVarUint36Small(), equals(testCase.value));
+        expect(wrapped.readableBytes, equals(0));
+      }
+    });
+
+    test('rejects values outside varuint36 small range', () {
+      for (final value in const <int>[-1, 0x1000000000]) {
+        expect(() => Buffer().writeVarUint36Small(value), throwsA(anything));
+      }
+
+      final malformed = Buffer.wrap(
+        Uint8List.fromList(const <int>[0xff, 0xff, 0xff, 0xff, 0xff, 0x02]),
+      );
+      expect(malformed.readVarUint36Small, throwsA(anything));
     });
   });
 }

--- a/dart/packages/fory/test/buffer_test.dart
+++ b/dart/packages/fory/test/buffer_test.dart
@@ -416,8 +416,8 @@ void main() {
           _expectInt64IntHelperMatchesWrapper(
             value: value,
             writeInt: (buffer, value) => buffer.writeTaggedInt64FromInt(value),
-            writeWrapper: (buffer, value) =>
-                buffer.writeTaggedInt64(Int64(value)),
+            writeWrapper:
+                (buffer, value) => buffer.writeTaggedInt64(Int64(value)),
             readInt: (buffer) => buffer.readTaggedInt64AsInt(),
           );
         }
@@ -457,15 +457,17 @@ void main() {
         throwsA(isA<StateError>()),
       );
       expect(
-        () => Buffer.wrap(
-          Uint8List.fromList(varint.toBytes()),
-        ).readVarInt64AsInt(),
+        () =>
+            Buffer.wrap(
+              Uint8List.fromList(varint.toBytes()),
+            ).readVarInt64AsInt(),
         throwsA(isA<StateError>()),
       );
       expect(
-        () => Buffer.wrap(
-          Uint8List.fromList(tagged.toBytes()),
-        ).readTaggedInt64AsInt(),
+        () =>
+            Buffer.wrap(
+              Uint8List.fromList(tagged.toBytes()),
+            ).readTaggedInt64AsInt(),
         throwsA(isA<StateError>()),
       );
     });

--- a/dart/packages/fory/test/string_encoding_test.dart
+++ b/dart/packages/fory/test/string_encoding_test.dart
@@ -31,12 +31,9 @@ void main() {
 
       final header = buffer.readVarUint36Small();
       final encoding = header & 0x03;
-      final byteLength = header >>> 2;
+      final byteLength = header ~/ 4;
       expect(encoding, equals(stringLatin1Encoding));
-      expect(
-        readStringFromBuffer(buffer, byteLength, encoding),
-        equals(value),
-      );
+      expect(readStringFromBuffer(buffer, byteLength, encoding), equals(value));
     });
 
     test('round-trips utf8 strings from the buffer fast path', () {
@@ -47,12 +44,9 @@ void main() {
 
       final header = buffer.readVarUint36Small();
       final encoding = header & 0x03;
-      final byteLength = header >>> 2;
+      final byteLength = header ~/ 4;
       expect(encoding, equals(stringUtf8Encoding));
-      expect(
-        readStringFromBuffer(buffer, byteLength, encoding),
-        equals(value),
-      );
+      expect(readStringFromBuffer(buffer, byteLength, encoding), equals(value));
     });
 
     test('round-trips empty strings', () {
@@ -63,12 +57,9 @@ void main() {
 
       final header = buffer.readVarUint36Small();
       final encoding = header & 0x03;
-      final byteLength = header >>> 2;
+      final byteLength = header ~/ 4;
       expect(byteLength, equals(0));
-      expect(
-        readStringFromBuffer(buffer, byteLength, encoding),
-        equals(value),
-      );
+      expect(readStringFromBuffer(buffer, byteLength, encoding), equals(value));
     });
   });
 }

--- a/dart/packages/fory/test/string_serializer_test.dart
+++ b/dart/packages/fory/test/string_serializer_test.dart
@@ -125,44 +125,62 @@ void main() {
     test('handles payload header boundaries and utf8 header compaction', () {
       final cases =
           <({int byteLength, int encoding, int headerLength, String value})>[
-        (
-          value: _repeat('a', 31),
-          encoding: stringLatin1Encoding,
-          byteLength: 31,
-          headerLength: 1
-        ),
-        (
-          value: _repeat('a', 32),
-          encoding: stringLatin1Encoding,
-          byteLength: 32,
-          headerLength: 2
-        ),
-        (
-          value: _repeat('😀', 7),
-          encoding: stringUtf8Encoding,
-          byteLength: 28,
-          headerLength: 1
-        ),
-        (
-          value: _repeat('😀', 8),
-          encoding: stringUtf8Encoding,
-          byteLength: 32,
-          headerLength: 2
-        ),
-        (
-          value: _repeat('你', 31),
-          encoding: stringUtf8Encoding,
-          byteLength: 93,
-          headerLength: 2
-        ),
-      ];
+            (
+              value: _repeat('a', 31),
+              encoding: stringLatin1Encoding,
+              byteLength: 31,
+              headerLength: 1,
+            ),
+            (
+              value: _repeat('a', 32),
+              encoding: stringLatin1Encoding,
+              byteLength: 32,
+              headerLength: 2,
+            ),
+            (
+              value: _repeat('😀', 7),
+              encoding: stringUtf8Encoding,
+              byteLength: 28,
+              headerLength: 1,
+            ),
+            (
+              value: _repeat('😀', 8),
+              encoding: stringUtf8Encoding,
+              byteLength: 32,
+              headerLength: 2,
+            ),
+            (
+              value: _repeat('你', 31),
+              encoding: stringUtf8Encoding,
+              byteLength: 93,
+              headerLength: 2,
+            ),
+            (
+              value: _repeat('a', 4095),
+              encoding: stringLatin1Encoding,
+              byteLength: 4095,
+              headerLength: 2,
+            ),
+            (
+              value: _repeat('a', 4096),
+              encoding: stringLatin1Encoding,
+              byteLength: 4096,
+              headerLength: 3,
+            ),
+          ];
 
       for (final testCase in cases) {
         final payload = _writeAndReadPayload(testCase.value);
-        expect(payload.encoding, equals(testCase.encoding),
-            reason: testCase.value);
-        expect(payload.byteLength, equals(testCase.byteLength),
-            reason: testCase.value);
+        expect(
+          payload.encoding,
+          equals(testCase.encoding),
+          reason: testCase.value,
+        );
+        expect(
+          payload.byteLength,
+          equals(testCase.byteLength),
+          reason: testCase.value,
+        );
         expect(
           payload.bytes.length - payload.byteLength,
           equals(testCase.headerLength),
@@ -208,14 +226,15 @@ void main() {
         (input: _repeat('😀', 64), expected: _repeat('😀', 64)),
         (
           input: '${_repeat('x', 500)}${_repeat('你', 500)}',
-          expected: '${_repeat('x', 500)}${_repeat('你', 500)}'
+          expected: '${_repeat('x', 500)}${_repeat('你', 500)}',
         ),
         (input: 'x\uD800y', expected: 'x\uFFFDy'),
       ];
 
       for (final testCase in cases) {
-        final roundTrip =
-            fory.deserialize<String>(fory.serialize(testCase.input));
+        final roundTrip = fory.deserialize<String>(
+          fory.serialize(testCase.input),
+        );
         expect(roundTrip, equals(testCase.expected));
       }
     });
@@ -261,9 +280,9 @@ void main() {
         _repeat('你', 64),
       ];
 
-      final roundTrip = fory.deserialize<Object?>(
-        fory.serialize(values, trackRef: true),
-      ) as List<Object?>;
+      final roundTrip =
+          fory.deserialize<Object?>(fory.serialize(values, trackRef: true))
+              as List<Object?>;
 
       expect(roundTrip, orderedEquals(expected));
     });
@@ -290,9 +309,7 @@ void main() {
 }
 
 ({Uint8List bytes, int encoding, int byteLength, String decoded})
-    _writeAndReadPayload(
-  String value,
-) {
+_writeAndReadPayload(String value) {
   final buffer = Buffer();
   writeString(buffer, value);
   return _readPayload(buffer.toBytes());
@@ -304,7 +321,7 @@ void main() {
   final buffer = Buffer.wrap(Uint8List.fromList(bytes));
   final header = buffer.readVarUint36Small();
   final encoding = header & 0x03;
-  final byteLength = header >>> 2;
+  final byteLength = header ~/ 4;
   final decoded = readStringFromBuffer(buffer, byteLength, encoding);
   expect(buffer.readableBytes, equals(0));
   return (
@@ -331,7 +348,7 @@ Buffer _utf16RootBuffer(String value) {
     ..writeUint8(0x01)
     ..writeByte(-1)
     ..writeVarUint32Small7(TypeIds.string)
-    ..writeVarUint36Small((bytes.length << 2) | stringUtf16Encoding)
+    ..writeVarUint36Small(bytes.length * 4 + stringUtf16Encoding)
     ..writeBytes(bytes);
 }
 

--- a/dart/packages/fory/test/time_serializer_test.dart
+++ b/dart/packages/fory/test/time_serializer_test.dart
@@ -27,6 +27,32 @@ part 'time_serializer_test.fory.dart';
 Timestamp _timestamp(int seconds, int nanoseconds) =>
     Timestamp(Int64(seconds), nanoseconds);
 
+Buffer _dateBuffer(Int64 epochDay) {
+  return Buffer(32)
+    ..writeUint8(0x01)
+    ..writeUint8(0xff)
+    ..writeUint8(TypeIds.date)
+    ..writeVarInt64(epochDay);
+}
+
+Buffer _durationBuffer(Int64 seconds) {
+  return Buffer(32)
+    ..writeUint8(0x01)
+    ..writeUint8(0xff)
+    ..writeUint8(TypeIds.duration)
+    ..writeVarInt64(seconds)
+    ..writeInt32(0);
+}
+
+Buffer _dateTimeBuffer(Int64 seconds) {
+  return Buffer(32)
+    ..writeUint8(0x01)
+    ..writeUint8(0xff)
+    ..writeUint8(TypeIds.timestamp)
+    ..writeInt64(seconds)
+    ..writeUint32(0);
+}
+
 @ForyStruct()
 class TimeEnvelope {
   TimeEnvelope();
@@ -105,6 +131,25 @@ void main() {
       expect(fory.deserialize<LocalDate>(bytes), equals(value));
     });
 
+    test('rejects epoch days outside the DateTime range', () {
+      final fory = Fory();
+      for (final day in <Int64>[
+        Int64.parseHex('7fffffffffffffff'),
+        Int64.parseHex('8000000000000000'),
+      ]) {
+        expect(
+          () => fory.deserializeFrom<LocalDate>(_dateBuffer(day)),
+          throwsA(anything),
+        );
+      }
+      expect(
+        fory.deserialize<LocalDate>(
+          fory.serialize(const LocalDate(1970, 1, 1)),
+        ),
+        const LocalDate(1970, 1, 1),
+      );
+    });
+
     test(
       'LocalDate convenience methods bridge DateTime and epoch-day forms',
       () {
@@ -159,6 +204,21 @@ void main() {
           fory.deserialize<DateTime>(fory.serialize(value)),
           equals(value),
         );
+      }
+    });
+
+    test('accepts DateTime carrier boundaries', () {
+      final fory = Fory();
+      for (final seconds in <Int64>[
+        Int64(8640000000000),
+        Int64(-8640000000000),
+      ]) {
+        final value = fory.deserializeFrom<DateTime>(_dateTimeBuffer(seconds));
+        expect(
+          value.microsecondsSinceEpoch,
+          seconds.toInt() * Duration.microsecondsPerSecond,
+        );
+        expect(fory.deserialize<DateTime>(fory.serialize(value)), value);
       }
     });
 
@@ -236,6 +296,29 @@ void main() {
           equals(value),
         );
       }
+    });
+
+    test('rejects temporal seconds outside platform carriers', () {
+      final fory = Fory();
+      for (final seconds in <Int64>[
+        Int64.parseHex('7fffffffffffffff'),
+        Int64.parseHex('8000000000000000'),
+      ]) {
+        expect(
+          () => fory.deserializeFrom<Duration>(_durationBuffer(seconds)),
+          throwsA(anything),
+        );
+        expect(
+          () => fory.deserializeFrom<DateTime>(_dateTimeBuffer(seconds)),
+          throwsA(anything),
+        );
+      }
+      expect(
+        fory.deserialize<Duration>(fory.serialize(Duration.zero)),
+        Duration.zero,
+      );
+      final epoch = DateTime.fromMicrosecondsSinceEpoch(0, isUtc: true);
+      expect(fory.deserialize<DateTime>(fory.serialize(epoch)), epoch);
     });
 
     test('round-trips generated time fields in schema-consistent mode', () {

--- a/docs/security/deserialization.md
+++ b/docs/security/deserialization.md
@@ -232,6 +232,14 @@ downstream buffer-underflow, type, reference, depth, or serializer error is a
 valid rejection. A decoder does not need a new local check merely to replace
 that controlled failure with a more specific or more uniform error.
 
+Non-strict, non-precise, delayed, masked, differently typed, or differently
+layered controlled errors are not security findings. Security remediation MUST
+NOT add checks solely to normalize, sharpen, advance, or otherwise make such an
+error deterministic. This remains true when malformed input decodes to an
+incorrect value, provided the path cannot cause a crash, panic, undefined memory
+access, OOM, attacker-controlled memory amplification, or another security
+invariant violation defined by this document.
+
 Tests for malformed input should prove that the root operation fails, cleanup
 remains correct, and any relevant security invariant is preserved. They should
 not pin an exact error type or message when doing so would require additional

--- a/go/fory/buffer.go
+++ b/go/fory/buffer.go
@@ -274,10 +274,10 @@ func (b *ByteBuffer) WriteInt32(value int32) {
 }
 
 func (b *ByteBuffer) WriteLength(value int) {
-	b.grow(4)
 	if value >= MaxInt32 {
 		panic(fmt.Errorf("too long: %d", value))
 	}
+	// WriteVarUint32 already reserves eight bytes for its bulk encoding.
 	b.WriteVarUint32(uint32(value))
 }
 
@@ -590,7 +590,7 @@ func (b *ByteBuffer) UnsafeWriteVarUint32(value uint32) int8 {
 	if value>>14 == 0 {
 		// Bulk write 2 bytes
 		encoded := uint16((value&0x7F)|0x80) | uint16(value>>7)<<8
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint16)(unsafe.Pointer(&b.data[b.writerIndex])) = encoded
 		} else {
 			b.data[b.writerIndex] = byte(encoded)
@@ -604,7 +604,7 @@ func (b *ByteBuffer) UnsafeWriteVarUint32(value uint32) int8 {
 		encoded := uint32((value&0x7F)|0x80) |
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(value>>14)<<16
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[b.writerIndex])) = encoded
 		} else {
 			b.data[b.writerIndex] = byte(encoded)
@@ -620,7 +620,7 @@ func (b *ByteBuffer) UnsafeWriteVarUint32(value uint32) int8 {
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(((value>>14)&0x7F)|0x80)<<16 |
 			uint32(value>>21)<<24
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[b.writerIndex])) = encoded
 		} else {
 			binary.LittleEndian.PutUint32(b.data[b.writerIndex:], encoded)
@@ -634,7 +634,7 @@ func (b *ByteBuffer) UnsafeWriteVarUint32(value uint32) int8 {
 		uint64(((value>>14)&0x7F)|0x80)<<16 |
 		uint64(((value>>21)&0x7F)|0x80)<<24 |
 		uint64(value>>28)<<32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*uint64)(unsafe.Pointer(&b.data[b.writerIndex])) = encoded
 	} else {
 		binary.LittleEndian.PutUint64(b.data[b.writerIndex:], encoded)
@@ -651,7 +651,7 @@ func (b *ByteBuffer) UnsafeWriteByte(v byte) {
 
 // UnsafeWriteInt16 writes an int16 without grow check.
 func (b *ByteBuffer) UnsafeWriteInt16(v int16) {
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*int16)(unsafe.Pointer(&b.data[b.writerIndex])) = v
 	} else {
 		binary.LittleEndian.PutUint16(b.data[b.writerIndex:], uint16(v))
@@ -661,7 +661,7 @@ func (b *ByteBuffer) UnsafeWriteInt16(v int16) {
 
 // UnsafeWriteInt32 writes an int32 without grow check.
 func (b *ByteBuffer) UnsafeWriteInt32(v int32) {
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*int32)(unsafe.Pointer(&b.data[b.writerIndex])) = v
 	} else {
 		binary.LittleEndian.PutUint32(b.data[b.writerIndex:], uint32(v))
@@ -671,7 +671,7 @@ func (b *ByteBuffer) UnsafeWriteInt32(v int32) {
 
 // UnsafeWriteInt64 writes an int64 without grow check.
 func (b *ByteBuffer) UnsafeWriteInt64(v int64) {
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*int64)(unsafe.Pointer(&b.data[b.writerIndex])) = v
 	} else {
 		binary.LittleEndian.PutUint64(b.data[b.writerIndex:], uint64(v))
@@ -682,7 +682,7 @@ func (b *ByteBuffer) UnsafeWriteInt64(v int64) {
 // UnsafeReadInt32 reads an int32 without bounds check.
 func (b *ByteBuffer) UnsafeReadInt32() int32 {
 	var v int32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		v = *(*int32)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		v = int32(binary.LittleEndian.Uint32(b.data[b.readerIndex:]))
@@ -694,7 +694,7 @@ func (b *ByteBuffer) UnsafeReadInt32() int32 {
 // UnsafeReadInt64 reads an int64 without bounds check.
 func (b *ByteBuffer) UnsafeReadInt64() int64 {
 	var v int64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		v = *(*int64)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		v = int64(binary.LittleEndian.Uint64(b.data[b.readerIndex:]))
@@ -706,7 +706,7 @@ func (b *ByteBuffer) UnsafeReadInt64() int64 {
 // UnsafeReadUint32 reads a uint32 without bounds check.
 func (b *ByteBuffer) UnsafeReadUint32() uint32 {
 	var v uint32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		v = *(*uint32)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		v = binary.LittleEndian.Uint32(b.data[b.readerIndex:])
@@ -718,7 +718,7 @@ func (b *ByteBuffer) UnsafeReadUint32() uint32 {
 // UnsafeReadUint64 reads a uint64 without bounds check.
 func (b *ByteBuffer) UnsafeReadUint64() uint64 {
 	var v uint64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		v = *(*uint64)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		v = binary.LittleEndian.Uint64(b.data[b.readerIndex:])
@@ -729,7 +729,7 @@ func (b *ByteBuffer) UnsafeReadUint64() uint64 {
 
 // UnsafeWriteFloat32 writes a float32 without grow check.
 func (b *ByteBuffer) UnsafeWriteFloat32(v float32) {
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*float32)(unsafe.Pointer(&b.data[b.writerIndex])) = v
 	} else {
 		binary.LittleEndian.PutUint32(b.data[b.writerIndex:], math.Float32bits(v))
@@ -739,7 +739,7 @@ func (b *ByteBuffer) UnsafeWriteFloat32(v float32) {
 
 // UnsafeWriteFloat64 writes a float64 without grow check.
 func (b *ByteBuffer) UnsafeWriteFloat64(v float64) {
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*float64)(unsafe.Pointer(&b.data[b.writerIndex])) = v
 	} else {
 		binary.LittleEndian.PutUint64(b.data[b.writerIndex:], math.Float64bits(v))
@@ -772,7 +772,7 @@ func (b *ByteBuffer) UnsafePutVarUint32(offset int, value uint32) int {
 	}
 	if value>>14 == 0 {
 		encoded := uint16((value&0x7F)|0x80) | uint16(value>>7)<<8
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint16)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			b.data[offset] = byte(encoded)
@@ -784,7 +784,7 @@ func (b *ByteBuffer) UnsafePutVarUint32(offset int, value uint32) int {
 		encoded := uint32((value&0x7F)|0x80) |
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(value>>14)<<16
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			b.data[offset] = byte(encoded)
@@ -798,7 +798,7 @@ func (b *ByteBuffer) UnsafePutVarUint32(offset int, value uint32) int {
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(((value>>14)&0x7F)|0x80)<<16 |
 			uint32(value>>21)<<24
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint32(b.data[offset:], encoded)
@@ -810,7 +810,7 @@ func (b *ByteBuffer) UnsafePutVarUint32(offset int, value uint32) int {
 		uint64(((value>>14)&0x7F)|0x80)<<16 |
 		uint64(((value>>21)&0x7F)|0x80)<<24 |
 		uint64(value>>28)<<32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 	} else {
 		binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -836,7 +836,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 	}
 	if value>>14 == 0 {
 		encoded := uint16((value&0x7F)|0x80) | uint16(value>>7)<<8
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint16)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			b.data[offset] = byte(encoded)
@@ -848,7 +848,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 		encoded := uint32((value&0x7F)|0x80) |
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(value>>14)<<16
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			b.data[offset] = byte(encoded)
@@ -862,7 +862,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 			uint32(((value>>7)&0x7F)|0x80)<<8 |
 			uint32(((value>>14)&0x7F)|0x80)<<16 |
 			uint32(value>>21)<<24
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint32)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint32(b.data[offset:], encoded)
@@ -875,7 +875,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 			uint64(((value>>14)&0x7F)|0x80)<<16 |
 			uint64(((value>>21)&0x7F)|0x80)<<24 |
 			uint64(value>>28)<<32
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -889,7 +889,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 			uint64(((value>>21)&0x7F)|0x80)<<24 |
 			uint64(((value>>28)&0x7F)|0x80)<<32 |
 			uint64(value>>35)<<40
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -904,7 +904,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 			uint64(((value>>28)&0x7F)|0x80)<<32 |
 			uint64(((value>>35)&0x7F)|0x80)<<40 |
 			uint64(value>>42)<<48
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -920,7 +920,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 			uint64(((value>>35)&0x7F)|0x80)<<40 |
 			uint64(((value>>42)&0x7F)|0x80)<<48 |
 			uint64(value>>49)<<56
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 		} else {
 			binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -936,7 +936,7 @@ func (b *ByteBuffer) UnsafePutVarUint64(offset int, value uint64) int {
 		uint64(((value>>35)&0x7F)|0x80)<<40 |
 		uint64(((value>>42)&0x7F)|0x80)<<48 |
 		uint64(((value>>49)&0x7F)|0x80)<<56
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*uint64)(unsafe.Pointer(&b.data[offset])) = encoded
 	} else {
 		binary.LittleEndian.PutUint64(b.data[offset:], encoded)
@@ -992,7 +992,17 @@ func (b *ByteBuffer) WriteVarUint64(value uint64) {
 // WriteVaruint36Small writes a varint optimized for small values (up to 36 bits)
 // Used for string headers: (length << 2) | encoding
 func (b *ByteBuffer) WriteVaruint36Small(value uint64) {
-	b.grow(5)
+	if value >= 0x10000000 {
+		if value >= 1<<36 {
+			panic(fmt.Errorf("varuint36small overflow: %d", value))
+		}
+		// The 36th bit continues into a sixth byte; this region must use
+		// standard varuint64 encoding rather than treating byte five as raw.
+		b.WriteVarUint64(value)
+		return
+	}
+
+	b.grow(4)
 	offset := b.writerIndex
 	data := b.data[offset:]
 
@@ -1014,13 +1024,6 @@ func (b *ByteBuffer) WriteVaruint36Small(value uint64) {
 		data[2] = byte((value>>14)&0x7F) | 0x80
 		data[3] = byte(value >> 21)
 		b.writerIndex += 4
-	} else {
-		data[0] = byte(value&0x7F) | 0x80
-		data[1] = byte((value>>7)&0x7F) | 0x80
-		data[2] = byte((value>>14)&0x7F) | 0x80
-		data[3] = byte((value>>21)&0x7F) | 0x80
-		data[4] = byte(value >> 28)
-		b.writerIndex += 5
 	}
 }
 
@@ -1028,16 +1031,16 @@ func (b *ByteBuffer) WriteVaruint36Small(value uint64) {
 // Used for string headers: (length << 2) | encoding
 func (b *ByteBuffer) ReadVaruint36Small(err *Error) uint64 {
 	if b.remaining() >= 8 {
-		return b.readVaruint36SmallFast()
+		return b.readVaruint36SmallFast(err)
 	}
 	return b.readVaruint36SmallSlow(err)
 }
 
-func (b *ByteBuffer) readVaruint36SmallFast() uint64 {
+func (b *ByteBuffer) readVaruint36SmallFast(err *Error) uint64 {
 	// Single instruction load using unsafe pointer cast (little-endian only)
 	// On big-endian systems, use binary.LittleEndian which the compiler optimizes
 	var bulk uint64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		bulk = *(*uint64)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		bulk = binary.LittleEndian.Uint64(b.data[b.readerIndex:])
@@ -1057,7 +1060,18 @@ func (b *ByteBuffer) readVaruint36SmallFast() uint64 {
 				result |= (bulk >> 3) & 0xFE00000
 				if (bulk & 0x80000000) != 0 {
 					readLen = 5
-					result |= (bulk >> 4) & 0xFF0000000
+					result |= (bulk >> 4) & 0x7F0000000
+					if (bulk & 0x8000000000) != 0 {
+						sixth := byte(bulk >> 40)
+						if sixth > 1 {
+							if err != nil {
+								*err = DeserializationError("varuint36small overflow")
+							}
+							return 0
+						}
+						readLen = 6
+						result |= uint64(sixth) << 35
+					}
 				}
 			}
 		}
@@ -1068,9 +1082,7 @@ func (b *ByteBuffer) readVaruint36SmallFast() uint64 {
 
 func (b *ByteBuffer) readVaruint36SmallSlow(err *Error) uint64 {
 	var result uint64
-	var shift uint
-
-	for {
+	for shift := uint(0); shift < 35; shift += 7 {
 		if b.readerIndex >= len(b.data) {
 			if !b.fill(1, err) {
 				return 0
@@ -1082,12 +1094,21 @@ func (b *ByteBuffer) readVaruint36SmallSlow(err *Error) uint64 {
 		if (byteVal & 0x80) == 0 {
 			return result
 		}
-		shift += 7
-		if shift >= 36 {
-			*err = DeserializationError("varuint36small overflow")
+	}
+	if b.readerIndex >= len(b.data) {
+		if !b.fill(1, err) {
 			return 0
 		}
 	}
+	sixth := b.data[b.readerIndex]
+	b.readerIndex++
+	if sixth > 1 {
+		if err != nil {
+			*err = DeserializationError("varuint36small overflow")
+		}
+		return 0
+	}
+	return result | uint64(sixth)<<35
 }
 
 // ReadVarint64 reads the varint encoded with zig-zag (compatible with Java's readVarint64).
@@ -1111,7 +1132,7 @@ func (b *ByteBuffer) WriteTaggedInt64(value int64) {
 	} else {
 		b.grow(9)
 		b.data[b.writerIndex] = 0b1
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*int64)(unsafe.Pointer(&b.data[b.writerIndex+1])) = value
 		} else {
 			binary.LittleEndian.PutUint64(b.data[b.writerIndex+1:], uint64(value))
@@ -1130,7 +1151,7 @@ func (b *ByteBuffer) ReadTaggedInt64(err *Error) int64 {
 		}
 	}
 	var i int32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		i = *(*int32)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		i = int32(binary.LittleEndian.Uint32(b.data[b.readerIndex:]))
@@ -1145,7 +1166,7 @@ func (b *ByteBuffer) ReadTaggedInt64(err *Error) int64 {
 		}
 	}
 	var value int64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		value = *(*int64)(unsafe.Pointer(&b.data[b.readerIndex+1]))
 	} else {
 		value = int64(binary.LittleEndian.Uint64(b.data[b.readerIndex+1:]))
@@ -1164,7 +1185,7 @@ func (b *ByteBuffer) WriteTaggedUint64(value uint64) {
 	} else {
 		b.grow(9)
 		b.data[b.writerIndex] = 0b1
-		if isLittleEndian {
+		if useNativeEndianAccess {
 			*(*uint64)(unsafe.Pointer(&b.data[b.writerIndex+1])) = value
 		} else {
 			binary.LittleEndian.PutUint64(b.data[b.writerIndex+1:], value)
@@ -1183,7 +1204,7 @@ func (b *ByteBuffer) ReadTaggedUint64(err *Error) uint64 {
 		}
 	}
 	var i uint32
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		i = *(*uint32)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		i = binary.LittleEndian.Uint32(b.data[b.readerIndex:])
@@ -1198,7 +1219,7 @@ func (b *ByteBuffer) ReadTaggedUint64(err *Error) uint64 {
 		}
 	}
 	var value uint64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		value = *(*uint64)(unsafe.Pointer(&b.data[b.readerIndex+1]))
 	} else {
 		value = binary.LittleEndian.Uint64(b.data[b.readerIndex+1:])
@@ -1219,7 +1240,7 @@ func (b *ByteBuffer) ReadVarUint64(err *Error) uint64 {
 func (b *ByteBuffer) readVarUint64Fast() uint64 {
 	// Single instruction load using unsafe pointer cast (little-endian only)
 	var bulk uint64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		bulk = *(*uint64)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		bulk = binary.LittleEndian.Uint64(b.data[b.readerIndex:])
@@ -1374,7 +1395,7 @@ func (b *ByteBuffer) readVarUint32Fast(err *Error) uint32 {
 	// Single instruction load using unsafe pointer cast (little-endian only)
 	// On big-endian systems, use binary.LittleEndian which the compiler optimizes
 	var bulk uint64
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		bulk = *(*uint64)(unsafe.Pointer(&b.data[b.readerIndex]))
 	} else {
 		bulk = binary.LittleEndian.Uint64(b.data[b.readerIndex:])
@@ -1540,7 +1561,7 @@ func (b *ByteBuffer) UnsafePutTaggedInt64(offset int, value int64) int {
 		return 4
 	}
 	b.data[offset] = 0b1
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*int64)(unsafe.Pointer(&b.data[offset+1])) = value
 	} else {
 		binary.LittleEndian.PutUint64(b.data[offset+1:], uint64(value))
@@ -1558,7 +1579,7 @@ func (b *ByteBuffer) UnsafePutTaggedUint64(offset int, value uint64) int {
 		return 4
 	}
 	b.data[offset] = 0b1
-	if isLittleEndian {
+	if useNativeEndianAccess {
 		*(*uint64)(unsafe.Pointer(&b.data[offset+1])) = value
 	} else {
 		binary.LittleEndian.PutUint64(b.data[offset+1:], value)

--- a/go/fory/buffer_test.go
+++ b/go/fory/buffer_test.go
@@ -218,3 +218,66 @@ func TestReadVarUint32Small7StreamRejectsOverflowFifthByte(t *testing.T) {
 	_ = buf.ReadVarUint32Small7(&err)
 	require.True(t, err.HasError())
 }
+
+func TestVaruint36SixByteBoundary(t *testing.T) {
+	const value = uint64(1<<35 | 0x1234567)
+
+	encoded := NewByteBuffer(make([]byte, 16))
+	encoded.WriteVaruint36Small(value)
+	standard := NewByteBuffer(make([]byte, 16))
+	standard.WriteVarUint64(value)
+	require.Equal(t, standard.Bytes(), encoded.Bytes())
+	require.Len(t, encoded.Bytes(), 6)
+	require.NotZero(t, encoded.Bytes()[4]&0x80)
+
+	fastData := make([]byte, 8)
+	copy(fastData, encoded.Bytes())
+	fast := NewByteBuffer(fastData)
+	var fastErr Error
+	require.Equal(t, value, fast.ReadVaruint36Small(&fastErr))
+	require.True(t, fastErr.Ok())
+	require.Equal(t, 6, fast.ReaderIndex())
+
+	slow := NewByteBuffer(encoded.Bytes())
+	var slowErr Error
+	require.Equal(t, value, slow.ReadVaruint36Small(&slowErr))
+	require.True(t, slowErr.Ok())
+	require.Equal(t, 6, slow.ReaderIndex())
+}
+
+func TestUnalignedBufferReadPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		value uint64
+		write func(*ByteBuffer, uint64)
+		read  func(*ByteBuffer) uint64
+	}{
+		{
+			name:  "varuint36",
+			value: 1<<35 | 0x12345,
+			write: func(buf *ByteBuffer, value uint64) { buf.WriteVaruint36Small(value) },
+			read:  func(buf *ByteBuffer) uint64 { return buf.ReadVaruint36Small(nil) },
+		},
+		{
+			name:  "varuint64",
+			value: 0xfedcba9876543210,
+			write: func(buf *ByteBuffer, value uint64) { buf.WriteVarUint64(value) },
+			read:  func(buf *ByteBuffer) uint64 { return buf.ReadVarUint64(nil) },
+		},
+		{
+			name:  "tagged_uint64",
+			value: 0x1122334455667788,
+			write: func(buf *ByteBuffer, value uint64) { buf.WriteTaggedUint64(value) },
+			read:  func(buf *ByteBuffer) uint64 { return buf.ReadTaggedUint64(nil) },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := NewByteBuffer(make([]byte, 32))
+			buf.WriteByte_(0)
+			tc.write(buf, tc.value)
+			buf.SetReaderIndex(1)
+			require.Equal(t, tc.value, tc.read(buf))
+		})
+	}
+}

--- a/go/fory/endian_big.go
+++ b/go/fory/endian_big.go
@@ -19,6 +19,9 @@
 
 package fory
 
-// isLittleEndian is a compile-time constant for big-endian architectures.
-// This enables dead code elimination - the compiler removes little-endian branches entirely.
-const isLittleEndian = false
+const (
+	// These compile-time constants let the compiler eliminate the unsupported
+	// native-endian and unaligned access paths entirely.
+	isLittleEndian        = false
+	useNativeEndianAccess = false
+)

--- a/go/fory/endian_little_unaligned.go
+++ b/go/fory/endian_little_unaligned.go
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build amd64 || arm64 || 386 || arm || loong64 || ppc64le || riscv64 || wasm
+//go:build mips64le || mipsle
 
 package fory
 
 const (
-	isLittleEndian        = true
-	useNativeEndianAccess = true
+	isLittleEndian = true
+	// MIPS requires aligned typed loads and stores. Buffer positions are not
+	// guaranteed to be naturally aligned, so use the byte-wise fallbacks there.
+	useNativeEndianAccess = false
 )

--- a/go/fory/struct.go
+++ b/go/fory/struct.go
@@ -269,7 +269,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*int16)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint16(data[bufOffset:], uint16(v))
@@ -279,7 +279,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*uint16)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint16(data[bufOffset:], v)
@@ -289,7 +289,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*int32)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint32(data[bufOffset:], uint32(v))
@@ -299,7 +299,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*uint32)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint32(data[bufOffset:], v)
@@ -309,7 +309,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*int64)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint64(data[bufOffset:], uint64(v))
@@ -319,7 +319,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*uint64)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint64(data[bufOffset:], v)
@@ -329,7 +329,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*float32)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint32(data[bufOffset:], math.Float32bits(v))
@@ -339,7 +339,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*float64)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint64(data[bufOffset:], math.Float64bits(v))
@@ -349,7 +349,7 @@ func (s *structSerializer) WriteData(ctx *WriteContext, value reflect.Value) {
 				if !ok {
 					v = 0
 				}
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					*(*uint16)(unsafe.Pointer(&data[bufOffset])) = v
 				} else {
 					binary.LittleEndian.PutUint16(data[bufOffset:], v)
@@ -1495,7 +1495,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, data[bufOffset])
 			case PrimitiveInt16DispatchId:
 				var v int16
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*int16)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = int16(binary.LittleEndian.Uint16(data[bufOffset:]))
@@ -1503,7 +1503,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveUint16DispatchId:
 				var v uint16
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*uint16)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = binary.LittleEndian.Uint16(data[bufOffset:])
@@ -1511,7 +1511,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveInt32DispatchId:
 				var v int32
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*int32)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = int32(binary.LittleEndian.Uint32(data[bufOffset:]))
@@ -1519,7 +1519,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveUint32DispatchId:
 				var v uint32
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*uint32)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = binary.LittleEndian.Uint32(data[bufOffset:])
@@ -1527,7 +1527,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveInt64DispatchId:
 				var v int64
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*int64)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = int64(binary.LittleEndian.Uint64(data[bufOffset:]))
@@ -1535,7 +1535,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveUint64DispatchId:
 				var v uint64
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*uint64)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = binary.LittleEndian.Uint64(data[bufOffset:])
@@ -1543,7 +1543,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveFloat32DispatchId:
 				var v float32
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*float32)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = math.Float32frombits(binary.LittleEndian.Uint32(data[bufOffset:]))
@@ -1551,7 +1551,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveFloat64DispatchId:
 				var v float64
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*float64)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = math.Float64frombits(binary.LittleEndian.Uint64(data[bufOffset:]))
@@ -1559,7 +1559,7 @@ func (s *structSerializer) ReadData(ctx *ReadContext, value reflect.Value) {
 				storeFieldValue(field.Kind, fieldPtr, optInfo, v)
 			case PrimitiveFloat16DispatchId:
 				var v uint16
-				if isLittleEndian {
+				if useNativeEndianAccess {
 					v = *(*uint16)(unsafe.Pointer(&data[bufOffset]))
 				} else {
 					v = binary.LittleEndian.Uint16(data[bufOffset:])
@@ -2560,7 +2560,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset++
 		case PrimitiveInt16DispatchId:
 			var v int16
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*int16)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = int16(binary.LittleEndian.Uint16(data[bufOffset:]))
@@ -2569,7 +2569,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 2
 		case PrimitiveUint16DispatchId:
 			var v uint16
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*uint16)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = binary.LittleEndian.Uint16(data[bufOffset:])
@@ -2578,7 +2578,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 2
 		case PrimitiveInt32DispatchId:
 			var v int32
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*int32)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = int32(binary.LittleEndian.Uint32(data[bufOffset:]))
@@ -2587,7 +2587,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 4
 		case PrimitiveUint32DispatchId:
 			var v uint32
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*uint32)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = binary.LittleEndian.Uint32(data[bufOffset:])
@@ -2596,7 +2596,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 4
 		case PrimitiveInt64DispatchId:
 			var v int64
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*int64)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = int64(binary.LittleEndian.Uint64(data[bufOffset:]))
@@ -2605,7 +2605,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 8
 		case PrimitiveUint64DispatchId:
 			var v uint64
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*uint64)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = binary.LittleEndian.Uint64(data[bufOffset:])
@@ -2614,7 +2614,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 8
 		case PrimitiveFloat32DispatchId:
 			var v float32
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*float32)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = math.Float32frombits(binary.LittleEndian.Uint32(data[bufOffset:]))
@@ -2623,7 +2623,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 4
 		case PrimitiveFloat64DispatchId:
 			var v float64
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*float64)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = math.Float64frombits(binary.LittleEndian.Uint64(data[bufOffset:]))
@@ -2632,7 +2632,7 @@ func readExactFixedPrimitiveRun(ctx *ReadContext, fields []FieldInfo, start int,
 			bufOffset += 8
 		case PrimitiveFloat16DispatchId:
 			var v uint16
-			if isLittleEndian {
+			if useNativeEndianAccess {
 				v = *(*uint16)(unsafe.Pointer(&data[bufOffset]))
 			} else {
 				v = binary.LittleEndian.Uint16(data[bufOffset:])

--- a/go/fory/time.go
+++ b/go/fory/time.go
@@ -78,9 +78,17 @@ func daysFromCivil(year int64, month time.Month, day int64) int64 {
 }
 
 func civilFromDays(days int64) (int64, time.Month, int) {
-	z := days + 719468
-	era := floorDiv(z, 146097)
-	doe := z - era*146097
+	// Normalize the epoch offset within a 400-year era so the full int64
+	// epoch-day range does not overflow before conversion.
+	era := days / 146097
+	doe := days % 146097
+	if doe < 0 {
+		era--
+		doe += 146097
+	}
+	doe += 719468
+	era += doe / 146097
+	doe %= 146097
 	yoe := (doe - doe/1460 + doe/36524 - doe/146096) / 365
 	year := yoe + era*400
 	doy := doe - (365*yoe + yoe/4 - yoe/100)

--- a/go/fory/time_test.go
+++ b/go/fory/time_test.go
@@ -18,6 +18,7 @@
 package fory
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -121,4 +122,30 @@ func TestDurationFromWireBounds(t *testing.T) {
 
 	_, err = durationFromWire(0, int32(nanosPerSecond))
 	require.Error(t, err)
+}
+
+func TestEpochDayInt64Range(t *testing.T) {
+	tests := []struct {
+		days  int64
+		year  int64
+		month time.Month
+		day   int
+	}{
+		{MinInt64, -25252734927764585, time.June, 7},
+		{MaxInt64, 25252734927768524, time.July, 27},
+	}
+	for _, tc := range tests {
+		date, err := DateFromEpochDay(tc.days)
+		if strconv.IntSize == 32 {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, tc.year, int64(date.Year))
+		require.Equal(t, tc.month, date.Month)
+		require.Equal(t, tc.day, date.Day)
+		roundTrip, err := DateToEpochDay(date)
+		require.NoError(t, err)
+		require.Equal(t, tc.days, roundTrip)
+	}
 }

--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -22,6 +22,7 @@ package org.apache.fory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -317,7 +318,7 @@ public final class Fory implements BaseFory {
     MemoryBuffer buf = getBuffer();
     buf.writerIndex(0);
     serialize(buf, obj, null);
-    byte[] bytes = buf.getBytes(0, buf.writerIndex());
+    byte[] bytes = copyWrittenBytes(buf);
     resetBuffer();
     return bytes;
   }
@@ -327,9 +328,18 @@ public final class Fory implements BaseFory {
     MemoryBuffer buf = getBuffer();
     buf.writerIndex(0);
     serialize(buf, obj, callback);
-    byte[] bytes = buf.getBytes(0, buf.writerIndex());
+    byte[] bytes = copyWrittenBytes(buf);
     resetBuffer();
     return bytes;
+  }
+
+  private byte[] copyWrittenBytes(MemoryBuffer buffer) {
+    int length = buffer.writerIndex();
+    if (buffer.isHeapFullyWriteable()) {
+      // Fory owns this writer index; keep public arbitrary-range validation out of the root path.
+      return Arrays.copyOf(buffer.getHeapMemory(), length);
+    }
+    return buffer.getBytes(0, length);
   }
 
   @Override

--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -52,6 +52,7 @@ import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.memory.MemoryUtils;
+import org.apache.fory.platform.JdkVersion;
 import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.resolver.SharedRegistry;
 import org.apache.fory.resolver.TypeChecker;
@@ -335,6 +336,10 @@ public final class Fory implements BaseFory {
 
   private byte[] copyWrittenBytes(MemoryBuffer buffer) {
     int length = buffer.writerIndex();
+    if (JdkVersion.MAJOR_VERSION >= 25) {
+      // Keep the overlay-owned array, ByteBuffer, and VarHandle bounds path on JDK 25.
+      return buffer.getBytes(0, length);
+    }
     if (buffer.isHeapFullyWriteable()) {
       // Fory owns this writer index; keep public arbitrary-range validation out of the root path.
       return Arrays.copyOf(buffer.getHeapMemory(), length);

--- a/java/fory-core/src/main/java/org/apache/fory/Fory.java
+++ b/java/fory-core/src/main/java/org/apache/fory/Fory.java
@@ -52,7 +52,6 @@ import org.apache.fory.logging.Logger;
 import org.apache.fory.logging.LoggerFactory;
 import org.apache.fory.memory.MemoryBuffer;
 import org.apache.fory.memory.MemoryUtils;
-import org.apache.fory.platform.JdkVersion;
 import org.apache.fory.resolver.ClassResolver;
 import org.apache.fory.resolver.SharedRegistry;
 import org.apache.fory.resolver.TypeChecker;
@@ -334,19 +333,6 @@ public final class Fory implements BaseFory {
     return bytes;
   }
 
-  private byte[] copyWrittenBytes(MemoryBuffer buffer) {
-    int length = buffer.writerIndex();
-    if (JdkVersion.MAJOR_VERSION >= 25) {
-      // Keep the overlay-owned array, ByteBuffer, and VarHandle bounds path on JDK 25.
-      return buffer.getBytes(0, length);
-    }
-    if (buffer.isHeapFullyWriteable()) {
-      // Fory owns this writer index; keep public arbitrary-range validation out of the root path.
-      return Arrays.copyOf(buffer.getHeapMemory(), length);
-    }
-    return buffer.getBytes(0, length);
-  }
-
   @Override
   public MemoryBuffer serialize(MemoryBuffer buffer, Object obj) {
     return serialize(buffer, obj, null);
@@ -387,6 +373,15 @@ public final class Fory implements BaseFory {
   @Override
   public void serialize(OutputStream outputStream, Object obj, BufferCallback callback) {
     serializeToStream(outputStream, buf -> serialize(buf, obj, callback));
+  }
+
+  private byte[] copyWrittenBytes(MemoryBuffer buffer) {
+    int length = buffer.writerIndex();
+    if (buffer.isHeapFullyWriteable()) {
+      // Fory owns this writer index; keep public arbitrary-range validation out of the root path.
+      return Arrays.copyOf(buffer.getHeapMemory(), length);
+    }
+    return buffer.getBytes(0, length);
   }
 
   private ForyException processSerializationError(Throwable e) {

--- a/java/fory-core/src/main/java/org/apache/fory/memory/LittleEndian.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/LittleEndian.java
@@ -67,8 +67,13 @@ public class LittleEndian {
     arr[index++] = (byte) (v >>> 7 | 0x80);
     arr[index++] = (byte) (v >>> 14 | 0x80);
     arr[index++] = (byte) (v >>> 21 | 0x80);
-    arr[index] = (byte) (v >>> 28);
-    return 5;
+    if (v >>> 35 == 0) {
+      arr[index] = (byte) (v >>> 28);
+      return 5;
+    }
+    arr[index++] = (byte) (v >>> 28 | 0x80);
+    arr[index] = (byte) (v >>> 35);
+    return 6;
   }
 
   public static long getInt64(byte[] o, int index) {

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryAllocator.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryAllocator.java
@@ -31,7 +31,9 @@ public interface MemoryAllocator {
 
   /**
    * Grows an existing buffer to accommodate the new capacity. The implementation must grow the
-   * buffer in-place by modifying the existing buffer instance.
+   * buffer in-place by modifying the existing buffer instance. A successful return guarantees that
+   * {@code buffer.size()} is at least {@code newCapacity}; callers intentionally do not repeat this
+   * postcondition check on the hot path.
    *
    * @param buffer the existing buffer to grow
    * @param newCapacity the required new capacity

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -4276,7 +4276,7 @@ public final class MemoryBuffer {
       int newSize =
           newCapacity < BUFFER_GROW_STEP_THRESHOLD
               ? newCapacity << 1
-              : (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8);
+              : Math.max(newCapacity, (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
 
       byte[] data = new byte[newSize];
       buffer.get(0, data, 0, buffer.size());

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -2016,9 +2016,8 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void grow(int neededSize) {
-    int length = writerIndex + neededSize;
-    // A positive overflow is negative and therefore greater than every valid size when unsigned.
-    if (Integer.compareUnsigned(length, size) > 0) {
+    if (neededSize > size - writerIndex) {
+      int length = writerIndex + neededSize;
       if (length < 0) {
         throwOOBException();
       }

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -4082,12 +4082,13 @@ public final class MemoryBuffer {
   }
 
   public byte[] getBytes(int index, int length) {
+    if (index == 0 && heapMemory != null && heapOffset == 0) {
+      // Keep Arrays.copyOf's zero-padding contract: row-format writers use it for trailing
+      // alignment beyond the buffer's current logical size. Callers own the requested output size.
+      return Arrays.copyOf(heapMemory, length);
+    }
     if (index < 0 || length < 0 || index > size - length) {
       throwOOBException();
-    }
-    if (index == 0 && heapMemory != null && heapOffset == 0) {
-      // Arrays.copyOf is an intrinsics, which is faster
-      return Arrays.copyOf(heapMemory, length);
     }
     byte[] data = new byte[length];
     get(index, data, 0, length);

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -294,7 +294,7 @@ public final class MemoryBuffer {
   }
 
   public void initByteBuffer(ByteBuffer buffer, int size) {
-    if (!AndroidSupport.IS_ANDROID && (size < 0 || size > buffer.capacity())) {
+    if (!AndroidSupport.IS_ANDROID && size > buffer.capacity()) {
       throw new IllegalArgumentException(
           String.format("size %d exceeds ByteBuffer capacity %d", size, buffer.capacity()));
     }
@@ -4355,9 +4355,7 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       return MemoryOps.directByteBufferUnsupported();
     }
-    checkNotNull(buffer, "buffer is null");
-    checkArgument(buffer.isDirect(), "Can't get address of a non-direct ByteBuffer.");
-    checkArgument(size >= 0 && size <= buffer.capacity() - buffer.position());
+    checkArgument(size <= buffer.remaining());
     long offHeapAddress = getAddress(buffer) + buffer.position();
     return new MemoryBuffer(offHeapAddress, size, buffer, streamReader);
   }

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -207,11 +207,20 @@ public final class MemoryBuffer {
    */
   private MemoryBuffer(byte[] buffer, int offset, int length, ForyStreamReader streamReader) {
     checkArgument(offset >= 0 && length >= 0);
-    if (offset + length > buffer.length) {
+    if (offset > buffer.length - length) {
       throw new IllegalArgumentException(
-          String.format("%d exceeds buffer size %d", offset + length, buffer.length));
+          String.format("%d exceeds buffer size %d", (long) offset + length, buffer.length));
     }
-    initHeapBuffer(buffer, offset, length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.initHeapBuffer(this, buffer, offset, length);
+    } else {
+      this.heapMemory = buffer;
+      this.heapOffset = offset;
+      final long startPos = BYTE_ARRAY_OFFSET + offset;
+      this.address = startPos;
+      this.size = length;
+      this.addressLimit = startPos + length;
+    }
     if (streamReader != null) {
       this.streamReader = streamReader;
     } else {
@@ -256,7 +265,7 @@ public final class MemoryBuffer {
 
   private void initOffHeapBuffer(long offHeapAddress, int size, ByteBuffer offHeapBuffer) {
     this.offHeapBuffer = offHeapBuffer;
-    if (offHeapAddress <= 0) {
+    if (offHeapAddress <= 0 || size < 0) {
       throw new IllegalArgumentException("negative pointer or size");
     }
     if (offHeapAddress >= Long.MAX_VALUE - Integer.MAX_VALUE) {
@@ -285,6 +294,10 @@ public final class MemoryBuffer {
   }
 
   public void initByteBuffer(ByteBuffer buffer, int size) {
+    if (!AndroidSupport.IS_ANDROID && (size < 0 || size > buffer.capacity())) {
+      throw new IllegalArgumentException(
+          String.format("size %d exceeds ByteBuffer capacity %d", size, buffer.capacity()));
+    }
     if (buffer.isDirect()) {
       if (AndroidSupport.IS_ANDROID) {
         MemoryOps.throwDirectByteBufferUnsupported();
@@ -336,6 +349,11 @@ public final class MemoryBuffer {
       if (buffer == null) {
         throw new NullPointerException("buffer");
       }
+      if (offset < 0 || length < 0 || offset > buffer.length - length) {
+        throw new IllegalArgumentException(
+            String.format(
+                "offset %d and length %d exceed buffer size %d", offset, length, buffer.length));
+      }
       this.heapMemory = buffer;
       this.heapOffset = offset;
       final long startPos = BYTE_ARRAY_OFFSET + offset;
@@ -359,7 +377,21 @@ public final class MemoryBuffer {
   }
 
   public void increaseSize(int diff) {
-    this.addressLimit = address + (size += diff);
+    long maxSize;
+    if (heapMemory != null) {
+      maxSize = heapMemory.length - heapOffset;
+    } else if (offHeapBuffer != null) {
+      // The owner's position is mutable, so derive this view's fixed offset from its base address.
+      maxSize = getAddress(offHeapBuffer) + offHeapBuffer.capacity() - address;
+    } else {
+      maxSize = size;
+    }
+    if (diff < 0 || maxSize < size || diff > maxSize - size) {
+      throwOOBException();
+    }
+    int newSize = size + diff;
+    this.addressLimit = address + newSize;
+    this.size = newSize;
   }
 
   /**
@@ -884,7 +916,7 @@ public final class MemoryBuffer {
     this.writerIndex = writerIndex;
   }
 
-  private void throwOOBExceptionForWriteIndex(int writerIndex) {
+  private void throwOOBExceptionForWriteIndex(long writerIndex) {
     throw new IndexOutOfBoundsException(
         String.format(
             "writerIndex: %d (expected: 0 <= writerIndex <= size(%d))", writerIndex, size));
@@ -917,9 +949,12 @@ public final class MemoryBuffer {
 
   /** Increase writer index and grow buffer if needed. */
   public void increaseWriterIndex(int diff) {
-    int writerIdx = writerIndex + diff;
-    ensure(writerIdx);
-    this.writerIndex = writerIdx;
+    long writerIdx = (long) writerIndex + diff;
+    if (writerIdx < 0 || writerIdx > Integer.MAX_VALUE) {
+      throwOOBExceptionForWriteIndex(writerIdx);
+    }
+    ensure((int) writerIdx);
+    this.writerIndex = (int) writerIdx;
   }
 
   public void writeBoolean(boolean value) {
@@ -1757,8 +1792,11 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeBooleans(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numElements;
+      final int newIdx = Math.addExact(writerIdx, numElements);
       ensure(newIdx);
       copyMemory(
           values, BOOLEAN_ARRAY_OFFSET + offset, heapMemory, address + writerIdx, numElements);
@@ -1784,9 +1822,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeChars(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 2);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1816,9 +1857,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeShorts(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 2);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1848,9 +1892,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeInts(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 4);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1880,9 +1927,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeLongs(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 8);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1912,9 +1962,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeFloats(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 4);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1944,9 +1997,12 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.writeDoubles(this, values, offset, numElements);
     } else {
+      if (offset < 0 || numElements < 0 || offset > values.length - numElements) {
+        throwOOBException();
+      }
       int numBytes = Math.multiplyExact(numElements, 8);
       final int writerIdx = writerIndex;
-      final int newIdx = writerIdx + numBytes;
+      final int newIdx = Math.addExact(writerIdx, numBytes);
       ensure(newIdx);
       copyMemory(
           values,
@@ -1960,15 +2016,23 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void grow(int neededSize) {
-    int length = writerIndex + neededSize;
+    long length = (long) writerIndex + neededSize;
+    if (neededSize < 0 || length < 0 || length > Integer.MAX_VALUE) {
+      throwOOBException();
+    }
     if (length > size) {
-      globalAllocator.grow(this, length);
+      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
+      globalAllocator.grow(this, (int) length);
     }
   }
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void ensure(int length) {
+    if (length < 0) {
+      throwOOBException();
+    }
     if (length > size) {
+      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
       globalAllocator.grow(this, length);
     }
   }
@@ -2027,14 +2091,25 @@ public final class MemoryBuffer {
   }
 
   public void increaseReaderIndex(int diff) {
-    int readerIdx = readerIndex;
-    readerIndex = readerIdx += diff;
-    if (readerIdx < 0) {
-      throwIndexOOBExceptionForRead();
-    } else if (readerIdx > size) {
-      // in this case, diff must be greater than 0.
-      streamReader.fillBuffer(readerIdx - size);
+    long newReaderIdx = (long) readerIndex + diff;
+    if (newReaderIdx >= 0 && newReaderIdx <= size) {
+      readerIndex = (int) newReaderIdx;
+      return;
     }
+    increaseReaderIndexSlow(diff, newReaderIdx);
+  }
+
+  private void increaseReaderIndexSlow(int diff, long newReaderIdx) {
+    if (newReaderIdx < 0 || newReaderIdx > Integer.MAX_VALUE) {
+      throwIndexOOBExceptionForRead();
+    }
+    int readerIdx = (int) newReaderIdx;
+    streamReader.fillBuffer(readerIdx - size);
+    newReaderIdx = (long) readerIndex + diff;
+    if (newReaderIdx < 0 || newReaderIdx > size) {
+      throwIndexOOBExceptionForRead();
+    }
+    readerIndex = (int) newReaderIdx;
   }
 
   public long getUnsafeReaderAddress() {
@@ -3156,6 +3231,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       return MemoryOps.readBytesAsInt64(this, len);
     }
+    if (len <= 0 || len > 8) {
+      throwOOBException();
+    }
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -3311,6 +3389,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readByteArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || numBytes > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readTo(values, 0, numBytes);
@@ -3334,6 +3415,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readBooleanArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || numBytes > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readBooleans(values, 0, numBytes);
@@ -3352,6 +3436,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readCharArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 1) != 0 || (numBytes >>> 1) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readChars(values, 0, numBytes >>> 1);
@@ -3370,6 +3457,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readInt16ArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 1) != 0 || (numBytes >>> 1) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readShorts(values, 0, numBytes >>> 1);
@@ -3388,6 +3478,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readInt32ArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 3) != 0 || (numBytes >>> 2) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readInts(values, 0, numBytes >>> 2);
@@ -3406,6 +3499,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readInt64ArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 7) != 0 || (numBytes >>> 3) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readLongs(values, 0, numBytes >>> 3);
@@ -3424,6 +3520,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readFloat32ArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 3) != 0 || (numBytes >>> 2) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readFloats(values, 0, numBytes >>> 2);
@@ -3442,6 +3541,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       MemoryOps.readFloat64ArrayBytes(this, values, numBytes);
     } else {
+      if (numBytes < 0 || (numBytes & 7) != 0 || (numBytes >>> 3) > values.length) {
+        throwOOBException();
+      }
       int readerIdx = readerIndex;
       if (readerIdx > size - numBytes) {
         streamReader.readDoubles(values, 0, numBytes >>> 3);
@@ -3910,12 +4012,12 @@ public final class MemoryBuffer {
   }
 
   public byte[] getBytes(int index, int length) {
+    if (index < 0 || length < 0 || index > size - length) {
+      throwOOBException();
+    }
     if (index == 0 && heapMemory != null && heapOffset == 0) {
       // Arrays.copyOf is an intrinsics, which is faster
       return Arrays.copyOf(heapMemory, length);
-    }
-    if (index + length > size) {
-      throwIndexOOBExceptionForRead(length);
     }
     byte[] data = new byte[length];
     get(index, data, 0, length);
@@ -3923,10 +4025,11 @@ public final class MemoryBuffer {
   }
 
   public void getBytes(int index, byte[] dst, int dstIndex, int length) {
-    if (dstIndex > dst.length - length) {
-      throwOOBException();
-    }
-    if (index > size - length) {
+    if (index < 0
+        || dstIndex < 0
+        || length < 0
+        || dstIndex > dst.length - length
+        || index > size - length) {
       throwOOBException();
     }
     get(index, dst, dstIndex, length);
@@ -3937,7 +4040,7 @@ public final class MemoryBuffer {
   }
 
   public MemoryBuffer slice(int offset, int length) {
-    if (offset + length > size) {
+    if (offset < 0 || length < 0 || offset > size - length) {
       throwOOBExceptionForRange(offset, length);
     }
     if (heapMemory != null) {
@@ -3993,6 +4096,9 @@ public final class MemoryBuffer {
     if (len == 0) {
       return buf2 != null;
     }
+    checkArgument(len >= 0);
+    checkArgument(offset1 >= 0 && offset1 <= size - len);
+    checkArgument(buf2 != null && offset2 >= 0 && offset2 <= buf2.size - len);
     if (AndroidSupport.IS_ANDROID) {
       return MemoryOps.equalTo(this, buf2, offset1, offset2, len);
     }
@@ -4178,6 +4284,9 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       return MemoryOps.directByteBufferUnsupported();
     }
+    checkNotNull(buffer, "buffer is null");
+    checkArgument(buffer.isDirect(), "Can't get address of a non-direct ByteBuffer.");
+    checkArgument(size >= 0 && size <= buffer.capacity() - buffer.position());
     long offHeapAddress = getAddress(buffer) + buffer.position();
     return new MemoryBuffer(offHeapAddress, size, buffer, streamReader);
   }

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -2016,14 +2016,18 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void grow(int neededSize) {
-    if (neededSize > size - writerIndex) {
-      int length = writerIndex + neededSize;
-      if (length < 0) {
-        throwOOBException();
-      }
-      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
-      globalAllocator.grow(this, length);
+    long length = (long) writerIndex + neededSize;
+    if (length > size) {
+      growSlow(length);
     }
+  }
+
+  private void growSlow(long length) {
+    if (length > Integer.MAX_VALUE) {
+      throwOOBException();
+    }
+    // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
+    globalAllocator.grow(this, (int) length);
   }
 
   /** For off-heap buffer, this will make a heap buffer internally. */

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -2016,13 +2016,14 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void grow(int neededSize) {
-    long length = (long) writerIndex + neededSize;
-    if (neededSize < 0 || length < 0 || length > Integer.MAX_VALUE) {
-      throwOOBException();
-    }
-    if (length > size) {
+    int length = writerIndex + neededSize;
+    // A positive overflow is negative and therefore greater than every valid size when unsigned.
+    if (Integer.compareUnsigned(length, size) > 0) {
+      if (length < 0) {
+        throwOOBException();
+      }
       // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
-      globalAllocator.grow(this, (int) length);
+      globalAllocator.grow(this, length);
     }
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -1328,10 +1328,16 @@ public final class MemoryBuffer {
       UNSAFE.putInt(heapMemory, address + index, (int) encoded);
       return 4;
     }
-    // 0xff0000000: 0b11111111 << 28. Note eight `1` here instead of seven.
-    encoded |= ((value & 0xff0000000L) << 4) | 0x80000000L;
+    // The fifth byte carries seven data bits. Bit 35 uses a sixth byte so this
+    // specialized string-header encoding stays standard VarUint64 on the wire.
+    encoded |= ((value & 0x7f0000000L) << 4) | 0x80000000L;
+    if (value >>> 35 == 0) {
+      UNSAFE.putLong(heapMemory, address + index, encoded);
+      return 5;
+    }
+    encoded |= 0x8000000000L | ((value >>> 35) << 40);
     UNSAFE.putLong(heapMemory, address + index, encoded);
-    return 5;
+    return 6;
   }
 
   private int putVarUint36SmallBigEndian(int index, long encoded, long value) {
@@ -1355,10 +1361,14 @@ public final class MemoryBuffer {
       UNSAFE.putInt(heapMemory, address + index, Integer.reverseBytes((int) encoded));
       return 4;
     }
-    // 0xff0000000: 0b11111111 << 28. Note eight `1` here instead of seven.
-    encoded |= ((value & 0xff0000000L) << 4) | 0x80000000L;
+    encoded |= ((value & 0x7f0000000L) << 4) | 0x80000000L;
+    if (value >>> 35 == 0) {
+      UNSAFE.putLong(heapMemory, address + index, Long.reverseBytes(encoded));
+      return 5;
+    }
+    encoded |= 0x8000000000L | ((value >>> 35) << 40);
     UNSAFE.putLong(heapMemory, address + index, Long.reverseBytes(encoded));
-    return 5;
+    return 6;
   }
 
   /**
@@ -2793,8 +2803,11 @@ public final class MemoryBuffer {
       result |= (bulkValue >>> 3) & 0xfe00000;
       if ((bulkValue & 0x80000000L) != 0) {
         readIdx++;
-        // 0xff0000000: 0b11111111 << 28
-        result |= (bulkValue >>> 4) & 0xff0000000L;
+        result |= (bulkValue >>> 4) & 0x7f0000000L;
+        if ((bulkValue & 0x8000000000L) != 0) {
+          readIdx++;
+          result |= (bulkValue >>> 5) & 0x800000000L;
+        }
       }
     }
     readerIndex = readIdx;
@@ -2819,7 +2832,11 @@ public final class MemoryBuffer {
           result |= (b & 0x7F) << 21;
           if ((b & 0x80) != 0) {
             b = readByte();
-            result |= (b & 0xFF) << 28;
+            result |= (b & 0x7F) << 28;
+            if ((b & 0x80) != 0) {
+              b = readByte();
+              result |= (b & 0x01) << 35;
+            }
           }
         }
       }

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -1780,12 +1780,22 @@ public final class MemoryBuffer {
       MemoryOps.writeBooleansWithSize(this, values);
     } else {
       writeVarUInt32Small7(values.length);
-      writeBooleans(values, 0, values.length);
+      writeBooleans(values);
     }
   }
 
+  // Full-array overloads own their source range and stay direct so serializers do not inline the
+  // larger arbitrary-range validation path. Offset/count overloads below retain that validation.
   public void writeBooleans(boolean[] values) {
-    writeBooleans(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeBooleans(this, values, 0, values.length);
+    } else {
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + values.length;
+      ensure(newIdx);
+      copyMemory(values, BOOLEAN_ARRAY_OFFSET, heapMemory, address + writerIdx, values.length);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeBooleans(boolean[] values, int offset, int numElements) {
@@ -1796,7 +1806,7 @@ public final class MemoryBuffer {
         throwOOBException();
       }
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numElements);
+      final int newIdx = writerIdx + numElements;
       ensure(newIdx);
       copyMemory(
           values, BOOLEAN_ARRAY_OFFSET + offset, heapMemory, address + writerIdx, numElements);
@@ -1810,12 +1820,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 2);
       writeVarUInt32Small7(numBytes);
-      writeChars(values, 0, values.length);
+      writeChars(values);
     }
   }
 
   public void writeChars(char[] values) {
-    writeChars(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeChars(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 2);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, CHAR_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeChars(char[] values, int offset, int numElements) {
@@ -1827,7 +1846,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 2);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -1845,12 +1864,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 2);
       writeVarUInt32Small7(numBytes);
-      writeShorts(values, 0, values.length);
+      writeShorts(values);
     }
   }
 
   public void writeShorts(short[] values) {
-    writeShorts(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeShorts(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 2);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, SHORT_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeShorts(short[] values, int offset, int numElements) {
@@ -1862,7 +1890,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 2);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -1880,12 +1908,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 4);
       writeVarUInt32Small7(numBytes);
-      writeInts(values, 0, values.length);
+      writeInts(values);
     }
   }
 
   public void writeInts(int[] values) {
-    writeInts(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeInts(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 4);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, INT_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeInts(int[] values, int offset, int numElements) {
@@ -1897,7 +1934,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 4);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -1915,12 +1952,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 8);
       writeVarUInt32Small7(numBytes);
-      writeLongs(values, 0, values.length);
+      writeLongs(values);
     }
   }
 
   public void writeLongs(long[] values) {
-    writeLongs(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeLongs(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 8);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, LONG_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeLongs(long[] values, int offset, int numElements) {
@@ -1932,7 +1978,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 8);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -1950,12 +1996,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 4);
       writeVarUInt32Small7(numBytes);
-      writeFloats(values, 0, values.length);
+      writeFloats(values);
     }
   }
 
   public void writeFloats(float[] values) {
-    writeFloats(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeFloats(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 4);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, FLOAT_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeFloats(float[] values, int offset, int numElements) {
@@ -1967,7 +2022,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 4);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -1985,12 +2040,21 @@ public final class MemoryBuffer {
     } else {
       int numBytes = Math.multiplyExact(values.length, 8);
       writeVarUInt32Small7(numBytes);
-      writeDoubles(values, 0, values.length);
+      writeDoubles(values);
     }
   }
 
   public void writeDoubles(double[] values) {
-    writeDoubles(values, 0, values.length);
+    if (AndroidSupport.IS_ANDROID) {
+      MemoryOps.writeDoubles(this, values, 0, values.length);
+    } else {
+      int numBytes = Math.multiplyExact(values.length, 8);
+      final int writerIdx = writerIndex;
+      final int newIdx = writerIdx + numBytes;
+      ensure(newIdx);
+      copyMemory(values, DOUBLE_ARRAY_OFFSET, heapMemory, address + writerIdx, numBytes);
+      writerIndex = newIdx;
+    }
   }
 
   public void writeDoubles(double[] values, int offset, int numElements) {
@@ -2002,7 +2066,7 @@ public final class MemoryBuffer {
       }
       int numBytes = Math.multiplyExact(numElements, 8);
       final int writerIdx = writerIndex;
-      final int newIdx = Math.addExact(writerIdx, numBytes);
+      final int newIdx = writerIdx + numBytes;
       ensure(newIdx);
       copyMemory(
           values,
@@ -2032,6 +2096,8 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void ensure(int length) {
+    // Bulk writers use non-negative int extents whose overflow is necessarily negative; keep
+    // their hot paths free of a duplicate addExact and reject the overflow here before Unsafe use.
     if (length < 0) {
       throwOOBException();
     }

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -4276,11 +4276,15 @@ public final class MemoryBuffer {
       int newSize =
           newCapacity < BUFFER_GROW_STEP_THRESHOLD
               ? newCapacity << 1
-              : Math.max(newCapacity, (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
+              : largeGrowthCapacity(newCapacity);
 
       byte[] data = new byte[newSize];
       buffer.get(0, data, 0, buffer.size());
       buffer.initHeapBuffer(data, 0, data.length);
+    }
+
+    private static int largeGrowthCapacity(int newCapacity) {
+      return Math.max(newCapacity, (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
     }
   }
 

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryBuffer.java
@@ -1565,7 +1565,7 @@ public final class MemoryBuffer {
     if (AndroidSupport.IS_ANDROID) {
       return MemoryOps.writeVarInt64(this, value);
     }
-    ensure(writerIndex + 9);
+    grow(9);
     return _unsafeWriteVarUInt64((value << 1) ^ (value >> 63));
   }
 
@@ -1585,7 +1585,7 @@ public final class MemoryBuffer {
     }
     // Var long encoding algorithm is based kryo UnsafeMemoryOutput.writeVarInt64.
     // var long are written using little endian byte order.
-    ensure(writerIndex + 9);
+    grow(9);
     return _unsafeWriteVarUInt64(value);
   }
 
@@ -2096,15 +2096,19 @@ public final class MemoryBuffer {
 
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void ensure(int length) {
-    // Bulk writers use non-negative int extents whose overflow is necessarily negative; keep
-    // their hot paths free of a duplicate addExact and reject the overflow here before Unsafe use.
+    // Negative extents are overflowed writer positions. Compare as unsigned so the common path
+    // keeps one branch while overflow rejection and allocation stay cold before any Unsafe access.
+    if (Integer.compareUnsigned(length, size) > 0) {
+      ensureSlow(length);
+    }
+  }
+
+  private void ensureSlow(int length) {
     if (length < 0) {
       throwOOBException();
     }
-    if (length > size) {
-      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
-      globalAllocator.grow(this, length);
-    }
+    // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
+    globalAllocator.grow(this, length);
   }
 
   // -------------------------------------------------------------------------

--- a/java/fory-core/src/main/java/org/apache/fory/memory/MemoryOps.java
+++ b/java/fory-core/src/main/java/org/apache/fory/memory/MemoryOps.java
@@ -805,7 +805,7 @@ final class MemoryOps {
 
   static long readVarUint36Small(MemoryBuffer buffer) {
     int readIdx = buffer.readerIndex;
-    if (buffer.size - readIdx < 5) {
+    if (buffer.size - readIdx < 6) {
       return readVarUint36Slow(buffer);
     }
     int heapIndex = heapIndex(buffer, readIdx);
@@ -817,7 +817,7 @@ final class MemoryOps {
   static long readVarUint36Small(byte[] source, int index) {
     long result = 0;
     int shift = 0;
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       int b = source[index + i] & 0xFF;
       result |= (long) (b & 0x7F) << shift;
       if ((b & 0x80) == 0) {
@@ -825,7 +825,7 @@ final class MemoryOps {
       }
       shift += 7;
     }
-    return result | ((long) source[index + 4] & 0xFF) << 28;
+    return result | ((long) source[index + 5] & 0x01) << 35;
   }
 
   static long readVarInt64(MemoryBuffer buffer) {
@@ -1484,7 +1484,11 @@ final class MemoryOps {
           result |= (b & 0x7F) << 21;
           if ((b & 0x80) != 0) {
             b = readByte(buffer);
-            result |= (b & 0xFF) << 28;
+            result |= (b & 0x7F) << 28;
+            if ((b & 0x80) != 0) {
+              b = readByte(buffer);
+              result |= (b & 0x01) << 35;
+            }
           }
         }
       }
@@ -1579,7 +1583,7 @@ final class MemoryOps {
 
   static int putVarUint36Small(byte[] target, int index, long value) {
     int start = index;
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       if ((value >>> 7) == 0) {
         target[index++] = (byte) value;
         return index - start;
@@ -1623,12 +1627,12 @@ final class MemoryOps {
   }
 
   static int varUint36SmallBytes(byte[] source, int index) {
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       if ((source[index + i] & 0x80) == 0) {
         return i + 1;
       }
     }
-    return 5;
+    return 6;
   }
 
   static int varUInt64Bytes(byte[] source, int index) {

--- a/java/fory-core/src/main/java25/org/apache/fory/memory/LittleEndian.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/memory/LittleEndian.java
@@ -60,8 +60,13 @@ public class LittleEndian {
     arr[index++] = (byte) (v >>> 7 | 0x80);
     arr[index++] = (byte) (v >>> 14 | 0x80);
     arr[index++] = (byte) (v >>> 21 | 0x80);
-    arr[index] = (byte) (v >>> 28);
-    return 5;
+    if (v >>> 35 == 0) {
+      arr[index] = (byte) (v >>> 28);
+      return 5;
+    }
+    arr[index++] = (byte) (v >>> 28 | 0x80);
+    arr[index] = (byte) (v >>> 35);
+    return 6;
   }
 
   public static long getInt64(byte[] o, int index) {

--- a/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
@@ -3853,13 +3853,16 @@ public final class MemoryBuffer {
       int newSize =
           newCapacity < BUFFER_GROW_STEP_THRESHOLD
               ? newCapacity << 1
-              : Math.max(
-                  newCapacity,
-                  (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
+              : largeGrowthCapacity(newCapacity);
 
       byte[] data = new byte[newSize];
       buffer.get(0, data, 0, buffer.size());
       buffer.initHeapBuffer(data, 0, data.length);
+    }
+
+    private static int largeGrowthCapacity(int newCapacity) {
+      return Math.max(
+          newCapacity, (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
     }
   }
 

--- a/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
@@ -1457,10 +1457,16 @@ public final class MemoryBuffer {
       storeInt(address + index, (int) encoded);
       return 4;
     }
-    // 0xff0000000: 0b11111111 << 28. Note eight `1` here instead of seven.
-    encoded |= ((value & 0xff0000000L) << 4) | 0x80000000L;
+    // The fifth byte carries seven data bits. Bit 35 uses a sixth byte so this
+    // specialized string-header encoding stays standard VarUint64 on the wire.
+    encoded |= ((value & 0x7f0000000L) << 4) | 0x80000000L;
+    if (value >>> 35 == 0) {
+      storeLong(address + index, encoded);
+      return 5;
+    }
+    encoded |= 0x8000000000L | ((value >>> 35) << 40);
     storeLong(address + index, encoded);
-    return 5;
+    return 6;
   }
 
   private int putVarUint36SmallBigEndian(int index, long encoded, long value) {
@@ -1484,10 +1490,14 @@ public final class MemoryBuffer {
       storeInt(address + index, Integer.reverseBytes((int) encoded));
       return 4;
     }
-    // 0xff0000000: 0b11111111 << 28. Note eight `1` here instead of seven.
-    encoded |= ((value & 0xff0000000L) << 4) | 0x80000000L;
+    encoded |= ((value & 0x7f0000000L) << 4) | 0x80000000L;
+    if (value >>> 35 == 0) {
+      storeLong(address + index, Long.reverseBytes(encoded));
+      return 5;
+    }
+    encoded |= 0x8000000000L | ((value >>> 35) << 40);
     storeLong(address + index, Long.reverseBytes(encoded));
-    return 5;
+    return 6;
   }
 
   /**
@@ -2623,8 +2633,11 @@ public final class MemoryBuffer {
       result |= (bulkValue >>> 3) & 0xfe00000;
       if ((bulkValue & 0x80000000L) != 0) {
         readIdx++;
-        // 0xff0000000: 0b11111111 << 28
-        result |= (bulkValue >>> 4) & 0xff0000000L;
+        result |= (bulkValue >>> 4) & 0x7f0000000L;
+        if ((bulkValue & 0x8000000000L) != 0) {
+          readIdx++;
+          result |= (bulkValue >>> 5) & 0x800000000L;
+        }
       }
     }
     readerIndex = readIdx;
@@ -2649,7 +2662,11 @@ public final class MemoryBuffer {
           result |= (b & 0x7F) << 21;
           if ((b & 0x80) != 0) {
             b = readByte();
-            result |= (b & 0xFF) << 28;
+            result |= (b & 0x7F) << 28;
+            if ((b & 0x80) != 0) {
+              b = readByte();
+              result |= (b & 0x01) << 35;
+            }
           }
         }
       }

--- a/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
@@ -3853,7 +3853,9 @@ public final class MemoryBuffer {
       int newSize =
           newCapacity < BUFFER_GROW_STEP_THRESHOLD
               ? newCapacity << 1
-              : (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8);
+              : Math.max(
+                  newCapacity,
+                  (int) Math.min(newCapacity * 1.5d, Integer.MAX_VALUE - 8));
 
       byte[] data = new byte[newSize];
       buffer.get(0, data, 0, buffer.size());

--- a/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
+++ b/java/fory-core/src/main/java25/org/apache/fory/memory/MemoryBuffer.java
@@ -57,11 +57,11 @@ import org.apache.fory.io.ForyStreamReader;
  * <p>Warning: The instance of this class should not be held at GraalVM build time; build-time heap
  * buffers do not represent the runtime heap layout.
  *
- * <p>In the Java 25 multi-release implementation, absolute random-access get/put methods are
- * internal fast paths. Callers must pass legal indices and ranges; read/write entry points perform
- * logical {@link MemoryBuffer} range validation before reaching these methods. The implementation
- * relies on {@link VarHandle}, array, and {@link ByteBuffer} access only for JVM memory safety and
- * does not repeat root Unsafe-style logical bounds checks.
+ * <p>The Java 25 multi-release implementation intentionally does not duplicate logical range
+ * checks around indexed array, absolute {@link ByteBuffer}, or {@link VarHandle} access. Those JVM
+ * accessors own bounds enforcement and already fail safely. The exact exception type, message, and
+ * detection point are not contracts, so adding checks only to make an invalid access fail earlier
+ * or more precisely would burden every hot buffer operation without improving memory safety.
  *
  * <p>Note(chaokunyang): Buffer operations are very common, and jvm inline and branch elimination is
  * not reliable even in c2 compiler, so we try to inline and avoid checks as we can manually. jvm
@@ -157,7 +157,12 @@ public final class MemoryBuffer {
       throw new IllegalArgumentException(
           String.format("%d exceeds buffer size %d", offset + length, buffer.length));
     }
-    initHeapBuffer(buffer, offset, length);
+    this.heapMemory = buffer;
+    this.heapOffset = offset;
+    final long startPos = BYTE_ARRAY_OFFSET + offset;
+    this.address = startPos;
+    this.size = length;
+    this.addressLimit = startPos + length;
     if (streamReader != null) {
       this.streamReader = streamReader;
     } else {
@@ -2009,6 +2014,7 @@ public final class MemoryBuffer {
   public void grow(int neededSize) {
     int length = writerIndex + neededSize;
     if (length > size) {
+      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
       globalAllocator.grow(this, length);
     }
   }
@@ -2016,6 +2022,7 @@ public final class MemoryBuffer {
   /** For off-heap buffer, this will make a heap buffer internally. */
   public void ensure(int length) {
     if (length > size) {
+      // MemoryAllocator owns the requested-capacity postcondition; do not recheck it here.
       globalAllocator.grow(this, length);
     }
   }

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -31,7 +31,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.apache.fory.TestUtils;
-import org.apache.fory.io.AbstractStreamReader;
 import org.apache.fory.platform.AndroidSupport;
 import org.apache.fory.platform.JdkVersion;
 import org.testng.Assert;
@@ -158,34 +157,30 @@ public class MemoryBufferTest {
   public void testPrimitiveWriteRanges() {
     requireRootMemoryBuffer();
     MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(8);
-    assertThrows(RuntimeException.class, () -> buffer.writeBooleans(new boolean[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeChars(new char[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeShorts(new short[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeInts(new int[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeLongs(new long[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeFloats(new float[0], 1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.writeDoubles(new double[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeBooleans(new boolean[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeChars(new char[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeShorts(new short[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeInts(new int[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeLongs(new long[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeFloats(new float[1], 1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.writeDoubles(new double[1], 1, 1));
     assertEquals(buffer.writerIndex(), 0);
   }
 
   @Test
   public void testArrayBodyRanges() {
     requireRootMemoryBuffer();
-    MemoryBuffer streamBuffer =
-        MemoryBuffer.fromByteArray(new byte[0], 0, 0, new NoOpArrayReader());
+    MemoryBuffer direct = MemoryUtils.wrap(ByteBuffer.allocateDirect(8));
     assertThrows(
-        RuntimeException.class,
-        () -> streamBuffer.readByteArrayBytes(new byte[0], Integer.MIN_VALUE));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readByteArrayBytes(new byte[0], 1));
-    assertThrows(
-        RuntimeException.class, () -> streamBuffer.readBooleanArrayBytes(new boolean[0], 1));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readCharArrayBytes(new char[0], 2));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readInt16ArrayBytes(new short[0], 2));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readInt32ArrayBytes(new int[0], 4));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readInt64ArrayBytes(new long[0], 8));
-    assertThrows(RuntimeException.class, () -> streamBuffer.readFloat32ArrayBytes(new float[0], 4));
-    assertThrows(
-        RuntimeException.class, () -> streamBuffer.readFloat64ArrayBytes(new double[0], 8));
+        RuntimeException.class, () -> direct.readByteArrayBytes(new byte[0], Integer.MIN_VALUE));
+    assertThrows(RuntimeException.class, () -> direct.readByteArrayBytes(new byte[0], 1));
+    assertThrows(RuntimeException.class, () -> direct.readBooleanArrayBytes(new boolean[0], 1));
+    assertThrows(RuntimeException.class, () -> direct.readCharArrayBytes(new char[0], 2));
+    assertThrows(RuntimeException.class, () -> direct.readInt16ArrayBytes(new short[0], 2));
+    assertThrows(RuntimeException.class, () -> direct.readInt32ArrayBytes(new int[0], 4));
+    assertThrows(RuntimeException.class, () -> direct.readInt64ArrayBytes(new long[0], 8));
+    assertThrows(RuntimeException.class, () -> direct.readFloat32ArrayBytes(new float[0], 4));
+    assertThrows(RuntimeException.class, () -> direct.readFloat64ArrayBytes(new double[0], 8));
 
     MemoryBuffer aligned = MemoryBuffer.fromByteArray(new byte[1]);
     assertThrows(RuntimeException.class, () -> aligned.readCharArrayBytes(new char[1], 1));
@@ -204,29 +199,6 @@ public class MemoryBufferTest {
     assertThrows(RuntimeException.class, () -> buffer.readBytesAsInt64(0));
     assertThrows(RuntimeException.class, () -> buffer.readBytesAsInt64(9));
     assertEquals(buffer.readerIndex(), 0);
-  }
-
-  private static final class NoOpArrayReader extends AbstractStreamReader {
-    @Override
-    public void readBooleans(boolean[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readChars(char[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readShorts(short[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readInts(int[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readLongs(long[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readFloats(float[] dst, int dstIndex, int length) {}
-
-    @Override
-    public void readDoubles(double[] dst, int dstIndex, int length) {}
   }
 
   @Test
@@ -572,8 +544,8 @@ public class MemoryBufferTest {
   public void testGetBytesRangeChecks() {
     requireRootMemoryBuffer();
     MemoryBuffer buffer = MemoryBuffer.fromByteArray(new byte[8], 0, 4);
-    assertThrows(RuntimeException.class, () -> buffer.getBytes(-1, 0));
-    assertThrows(RuntimeException.class, () -> buffer.getBytes(0, new byte[1], -1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.getBytes(-1, 1));
+    assertThrows(RuntimeException.class, () -> buffer.getBytes(0, new byte[1], -1, 1));
     assertThrows(
         RuntimeException.class, () -> buffer.getBytes(0, new byte[1], 0, Integer.MIN_VALUE));
   }

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.apache.fory.TestUtils;
+import org.apache.fory.io.AbstractStreamReader;
 import org.apache.fory.platform.AndroidSupport;
 import org.apache.fory.platform.JdkVersion;
 import org.testng.Assert;
@@ -38,6 +39,12 @@ import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class MemoryBufferTest {
+
+  private static void requireRootMemoryBuffer() {
+    if (JdkVersion.MAJOR_VERSION >= 25) {
+      throw new SkipException("The JDK 8-24 MemoryBuffer implementation is replaced on JDK 25+");
+    }
+  }
 
   @Test
   public void testBufferPut() {
@@ -96,6 +103,131 @@ public class MemoryBufferTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> MemoryBuffer.fromDirectByteBuffer(ByteBuffer.allocate(8), 8, null));
+  }
+
+  @Test
+  public void testBackingRangeChecks() {
+    requireRootMemoryBuffer();
+    byte[] bytes = new byte[8];
+    assertThrows(
+        RuntimeException.class, () -> MemoryBuffer.fromByteArray(bytes, Integer.MAX_VALUE, 1));
+    assertThrows(
+        RuntimeException.class, () -> MemoryBuffer.fromByteArray(bytes, 1, Integer.MAX_VALUE));
+
+    MemoryBuffer buffer = MemoryBuffer.fromByteArray(bytes, 0, 4);
+    assertThrows(RuntimeException.class, () -> buffer.pointTo(bytes, Integer.MAX_VALUE, 1));
+    Assert.assertSame(buffer.getHeapMemory(), bytes);
+    assertEquals(buffer.size(), 4);
+
+    assertThrows(RuntimeException.class, () -> buffer.initByteBuffer(ByteBuffer.allocate(4), 5));
+    assertThrows(
+        RuntimeException.class, () -> buffer.initByteBuffer(ByteBuffer.allocateDirect(4), -1));
+    assertThrows(
+        RuntimeException.class,
+        () -> MemoryBuffer.fromDirectByteBuffer(ByteBuffer.allocateDirect(4), 5, null));
+
+    assertThrows(RuntimeException.class, () -> buffer.increaseSize(-1));
+    assertThrows(RuntimeException.class, () -> buffer.increaseSize(5));
+    assertThrows(RuntimeException.class, () -> buffer.increaseSize(Integer.MAX_VALUE));
+    assertEquals(buffer.size(), 4);
+  }
+
+  @Test
+  public void testCursorRangeChecks() {
+    requireRootMemoryBuffer();
+    MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(8);
+    buffer.writerIndex(4);
+    buffer.increaseWriterIndex(-2);
+    assertEquals(buffer.writerIndex(), 2);
+    assertThrows(RuntimeException.class, () -> buffer.increaseWriterIndex(-3));
+    assertThrows(RuntimeException.class, () -> buffer.increaseWriterIndex(Integer.MAX_VALUE));
+    assertEquals(buffer.writerIndex(), 2);
+    assertThrows(RuntimeException.class, () -> buffer.grow(-1));
+    assertThrows(RuntimeException.class, () -> buffer.grow(Integer.MAX_VALUE));
+    assertThrows(RuntimeException.class, () -> buffer.ensure(-1));
+
+    buffer.readerIndex(4);
+    buffer.increaseReaderIndex(-2);
+    assertEquals(buffer.readerIndex(), 2);
+    assertThrows(RuntimeException.class, () -> buffer.increaseReaderIndex(-3));
+    assertThrows(RuntimeException.class, () -> buffer.increaseReaderIndex(Integer.MAX_VALUE));
+    assertThrows(RuntimeException.class, () -> buffer.increaseReaderIndex(7));
+    assertEquals(buffer.readerIndex(), 2);
+  }
+
+  @Test
+  public void testPrimitiveWriteRanges() {
+    requireRootMemoryBuffer();
+    MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(8);
+    assertThrows(RuntimeException.class, () -> buffer.writeBooleans(new boolean[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeChars(new char[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeShorts(new short[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeInts(new int[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeLongs(new long[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeFloats(new float[0], 1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.writeDoubles(new double[0], 1, 0));
+    assertEquals(buffer.writerIndex(), 0);
+  }
+
+  @Test
+  public void testArrayBodyRanges() {
+    requireRootMemoryBuffer();
+    MemoryBuffer streamBuffer =
+        MemoryBuffer.fromByteArray(new byte[0], 0, 0, new NoOpArrayReader());
+    assertThrows(
+        RuntimeException.class,
+        () -> streamBuffer.readByteArrayBytes(new byte[0], Integer.MIN_VALUE));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readByteArrayBytes(new byte[0], 1));
+    assertThrows(
+        RuntimeException.class, () -> streamBuffer.readBooleanArrayBytes(new boolean[0], 1));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readCharArrayBytes(new char[0], 2));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readInt16ArrayBytes(new short[0], 2));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readInt32ArrayBytes(new int[0], 4));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readInt64ArrayBytes(new long[0], 8));
+    assertThrows(RuntimeException.class, () -> streamBuffer.readFloat32ArrayBytes(new float[0], 4));
+    assertThrows(
+        RuntimeException.class, () -> streamBuffer.readFloat64ArrayBytes(new double[0], 8));
+
+    MemoryBuffer aligned = MemoryBuffer.fromByteArray(new byte[1]);
+    assertThrows(RuntimeException.class, () -> aligned.readCharArrayBytes(new char[1], 1));
+    assertThrows(RuntimeException.class, () -> aligned.readInt16ArrayBytes(new short[1], 1));
+    assertThrows(RuntimeException.class, () -> aligned.readInt32ArrayBytes(new int[1], 1));
+    assertThrows(RuntimeException.class, () -> aligned.readInt64ArrayBytes(new long[1], 1));
+    assertThrows(RuntimeException.class, () -> aligned.readFloat32ArrayBytes(new float[1], 1));
+    assertThrows(RuntimeException.class, () -> aligned.readFloat64ArrayBytes(new double[1], 1));
+  }
+
+  @Test
+  public void testInt64ByteLength() {
+    requireRootMemoryBuffer();
+    MemoryBuffer buffer = MemoryBuffer.fromByteArray(new byte[8]);
+    assertThrows(RuntimeException.class, () -> buffer.readBytesAsInt64(-1));
+    assertThrows(RuntimeException.class, () -> buffer.readBytesAsInt64(0));
+    assertThrows(RuntimeException.class, () -> buffer.readBytesAsInt64(9));
+    assertEquals(buffer.readerIndex(), 0);
+  }
+
+  private static final class NoOpArrayReader extends AbstractStreamReader {
+    @Override
+    public void readBooleans(boolean[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readChars(char[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readShorts(short[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readInts(int[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readLongs(long[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readFloats(float[] dst, int dstIndex, int length) {}
+
+    @Override
+    public void readDoubles(double[] dst, int dstIndex, int length) {}
   }
 
   @Test
@@ -438,6 +570,29 @@ public class MemoryBufferTest {
   }
 
   @Test
+  public void testGetBytesRangeChecks() {
+    requireRootMemoryBuffer();
+    MemoryBuffer buffer = MemoryBuffer.fromByteArray(new byte[8], 0, 4);
+    assertThrows(RuntimeException.class, () -> buffer.getBytes(0, 5));
+    assertThrows(RuntimeException.class, () -> buffer.getBytes(-1, 0));
+    assertThrows(RuntimeException.class, () -> buffer.getBytes(0, new byte[1], -1, 0));
+    assertThrows(
+        RuntimeException.class, () -> buffer.getBytes(0, new byte[1], 0, Integer.MIN_VALUE));
+  }
+
+  @Test
+  public void testSliceRangeChecks() {
+    requireRootMemoryBuffer();
+    MemoryBuffer heap = MemoryBuffer.fromByteArray(new byte[8], 2, 2);
+    assertThrows(RuntimeException.class, () -> heap.slice(-1));
+    assertThrows(RuntimeException.class, () -> heap.slice(-1, 1));
+    assertThrows(RuntimeException.class, () -> heap.slice(0, -1));
+
+    MemoryBuffer direct = MemoryUtils.wrap(ByteBuffer.allocateDirect(4));
+    assertThrows(RuntimeException.class, () -> direct.slice(Integer.MAX_VALUE, 1));
+  }
+
+  @Test
   public void testEqualTo() {
     MemoryBuffer buf1 = MemoryUtils.buffer(16);
     MemoryBuffer buf2 = MemoryUtils.buffer(16);
@@ -458,6 +613,19 @@ public class MemoryBufferTest {
     MemoryBuffer buf1 = MemoryUtils.buffer(0);
     MemoryBuffer buf2 = MemoryUtils.buffer(0);
     Assert.assertTrue(buf1.equalTo(buf2, 0, 0, buf1.size()));
+  }
+
+  @Test
+  public void testEqualityRangeChecks() {
+    requireRootMemoryBuffer();
+    byte[] bytes = new byte[] {1, 2, 3, 4, 5, 6};
+    MemoryBuffer left = MemoryBuffer.fromByteArray(bytes, 2, 2);
+    MemoryBuffer right = MemoryBuffer.fromByteArray(bytes, 2, 2);
+    assertThrows(RuntimeException.class, () -> left.equalTo(right, -1, 0, 1));
+    assertThrows(RuntimeException.class, () -> left.equalTo(right, 0, -1, 1));
+    assertThrows(RuntimeException.class, () -> left.equalTo(right, 1, 1, 2));
+    assertTrue(left.equalTo(right, 3, 3, 0));
+    assertThrows(RuntimeException.class, () -> left.equalTo(right, 0, 0, -1));
   }
 
   @Test

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Random;
 import org.apache.fory.TestUtils;
 import org.apache.fory.platform.AndroidSupport;
@@ -1175,48 +1176,36 @@ public class MemoryBufferTest {
 
   @Test
   public void testVarUint36Small() {
-    MemoryBuffer buf = MemoryUtils.buffer(80);
-    int index = 0;
-    {
-      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, 10);
-      assertEquals(buf.readVarUint36Small(), 10);
-      buf.increaseReaderIndex(-diff);
-      index += buf._unsafePutVarUint36Small(index, 10);
-      assertEquals(buf.readVarUint36Small(), 10);
-    }
-    {
-      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
-      assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
-      buf.increaseReaderIndex(-diff);
-      index += buf._unsafePutVarUint36Small(index, Short.MAX_VALUE);
-      assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
-    }
-    {
-      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
-      assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
-      buf.increaseReaderIndex(-diff);
-      index += buf._unsafePutVarUint36Small(index, Integer.MAX_VALUE);
-      assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
-    }
-    {
-      int diff =
-          LittleEndian.putVarUint36Small(
-              buf.getHeapMemory(), index, 0b111111111111111111111111111111111111L);
-      assertEquals(buf.readVarUint36Small(), 0b111111111111111111111111111111111111L);
-      buf.increaseReaderIndex(-diff);
-      buf._unsafePutVarUint36Small(index, 0b1000000000000000000000000000000000000L);
-      assertEquals(buf.readVarUint36Small(), 0); // overflow
-    }
-    {
-      // With buffer size 9
-      MemoryBuffer buf1 = MemoryBuffer.newHeapBuffer(9);
-      // With buffer size 8
-      MemoryBuffer buf2 = MemoryBuffer.newHeapBuffer(8);
-      long uint36Max = 0b111111111111111111111111111111111111L;
-      buf1._unsafePutVarUint36Small(0, uint36Max);
-      buf2._unsafePutVarUint36Small(0, uint36Max);
-      assertEquals(buf1.readVarUint36Small(), uint36Max);
-      assertEquals(buf2.readVarUint36Small(), uint36Max);
+    long[] values = {
+      0, 127, 128, (1L << 28) - 1, 1L << 28, (1L << 35) - 1, 1L << 35, (1L << 36) - 1
+    };
+    byte[][] expected = {
+      {0},
+      {0x7f},
+      {(byte) 0x80, 0x01},
+      {(byte) 0xff, (byte) 0xff, (byte) 0xff, 0x7f},
+      {(byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01},
+      {(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, 0x7f},
+      {(byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01},
+      {(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, 0x01}
+    };
+    for (int i = 0; i < values.length; i++) {
+      byte[] bytes = new byte[8];
+      int size = LittleEndian.putVarUint36Small(bytes, 0, values[i]);
+      assertEquals(Arrays.copyOf(bytes, size), expected[i]);
+
+      for (MemoryBuffer buffer :
+          new MemoryBuffer[] {
+            MemoryUtils.buffer(8),
+            MemoryUtils.buffer(9),
+            MemoryUtils.wrap(ByteBuffer.allocateDirect(8)),
+            MemoryUtils.wrap(ByteBuffer.allocateDirect(9))
+          }) {
+        int bufferSize = buffer._unsafePutVarUint36Small(0, values[i]);
+        assertEquals(bufferSize, expected[i].length);
+        assertEquals(buffer.getBytes(0, bufferSize), expected[i]);
+        assertEquals(buffer.readVarUint36Small(), values[i]);
+      }
     }
   }
 

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -142,7 +142,6 @@ public class MemoryBufferTest {
     assertThrows(RuntimeException.class, () -> buffer.increaseWriterIndex(-3));
     assertThrows(RuntimeException.class, () -> buffer.increaseWriterIndex(Integer.MAX_VALUE));
     assertEquals(buffer.writerIndex(), 2);
-    assertThrows(RuntimeException.class, () -> buffer.grow(-1));
     assertThrows(RuntimeException.class, () -> buffer.grow(Integer.MAX_VALUE));
     assertThrows(RuntimeException.class, () -> buffer.ensure(-1));
 

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryBufferTest.java
@@ -572,7 +572,6 @@ public class MemoryBufferTest {
   public void testGetBytesRangeChecks() {
     requireRootMemoryBuffer();
     MemoryBuffer buffer = MemoryBuffer.fromByteArray(new byte[8], 0, 4);
-    assertThrows(RuntimeException.class, () -> buffer.getBytes(0, 5));
     assertThrows(RuntimeException.class, () -> buffer.getBytes(-1, 0));
     assertThrows(RuntimeException.class, () -> buffer.getBytes(0, new byte[1], -1, 0));
     assertThrows(

--- a/java/fory-core/src/test/java/org/apache/fory/memory/MemoryOpsTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/memory/MemoryOpsTest.java
@@ -126,7 +126,17 @@ public class MemoryOpsTest {
   @Test
   public void testVarUint36MatchesMemoryBuffer() {
     long[] values = {
-      0L, 1L, 127L, 128L, 16_383L, 16_384L, Integer.MAX_VALUE, 0xFFFFFFFFFL, 1L << 36
+      0L,
+      1L,
+      127L,
+      128L,
+      16_383L,
+      16_384L,
+      Integer.MAX_VALUE,
+      0xFFFFFFFFFL,
+      (1L << 35) - 1,
+      1L << 35,
+      (1L << 36) - 1
     };
     for (long value : values) {
       byte[] bytes = new byte[8];
@@ -135,7 +145,7 @@ public class MemoryOpsTest {
       int expectedSize = buffer._unsafePutVarUint36Small(0, value);
       assertEquals(size, expectedSize);
       assertEquals(Arrays.copyOf(bytes, size), buffer.getBytes(0, expectedSize));
-      assertEquals(MemoryOps.readVarUint36Small(bytes, 0), value & 0xFFFFFFFFFL);
+      assertEquals(MemoryOps.readVarUint36Small(bytes, 0), value);
       assertEquals(MemoryOps.varUint36SmallBytes(bytes, 0), size);
     }
   }

--- a/javascript/packages/core/lib/gen/datetime.ts
+++ b/javascript/packages/core/lib/gen/datetime.ts
@@ -24,6 +24,48 @@ import { CodegenRegistry } from "./router";
 import { TypeId } from "../type";
 import { Scope } from "./scope";
 
+const MAX_DATE_MILLIS = 8_640_000_000_000_000;
+const MAX_DATE_SECONDS = 8_640_000_000_000n;
+const MAX_DATE_DAYS = 100_000_000n;
+const NANOS_PER_SECOND = 1_000_000_000n;
+const NANOS_PER_MILLISECOND = 1_000_000n;
+const MAX_DURATION_NANOS = 9_007_199_254_740_991_000_000n;
+
+export function timestampFromWire(seconds: bigint, nanos: number): Date {
+  // The wire carries the full int64 range, while JavaScript Date accepts only
+  // +/-100,000,000 days. Check the BigInt before converting it to Number so an
+  // unrepresentable timestamp cannot silently round into a different value.
+  if (seconds < -MAX_DATE_SECONDS || seconds > MAX_DATE_SECONDS) {
+    throw new Error("timestamp is outside the JavaScript Date range");
+  }
+  const millis = Number(seconds) * 1000 + Math.floor(nanos / 1_000_000);
+  if (!Number.isSafeInteger(millis) || Math.abs(millis) > MAX_DATE_MILLIS) {
+    throw new Error("timestamp is outside the JavaScript Date range");
+  }
+  return new Date(millis);
+}
+
+export function durationFromWire(seconds: bigint, nanos: number): number {
+  const totalNanos = seconds * NANOS_PER_SECOND + BigInt(nanos);
+  if (totalNanos < -MAX_DURATION_NANOS || totalNanos > MAX_DURATION_NANOS) {
+    throw new Error("duration is outside the JavaScript number range");
+  }
+  const wholeMillis = totalNanos / NANOS_PER_MILLISECOND;
+  const subMillisecondNanos = totalNanos % NANOS_PER_MILLISECOND;
+  return Number(wholeMillis) + Number(subMillisecondNanos) / 1_000_000;
+}
+
+export function dateFromWire(days: bigint, epoch: number): Date {
+  if (days < -MAX_DATE_DAYS || days > MAX_DATE_DAYS) {
+    throw new Error("date is outside the JavaScript Date range");
+  }
+  const millis = epoch + Number(days) * 86_400_000;
+  if (!Number.isSafeInteger(millis) || Math.abs(millis) > MAX_DATE_MILLIS) {
+    throw new Error("date is outside the JavaScript Date range");
+  }
+  return new Date(millis);
+}
+
 class TimestampSerializerGenerator extends BaseSerializerGenerator {
   typeInfo: TypeInfo;
 
@@ -48,7 +90,7 @@ class TimestampSerializerGenerator extends BaseSerializerGenerator {
   read(accessor: (expr: string) => string): string {
     const seconds = this.builder.reader.readInt64();
     const nanos = this.builder.reader.readUint32();
-    return accessor(`new Date(Number(${seconds}) * 1000 + Math.floor(${nanos} / 1000000))`);
+    return accessor(`external.timestampFromWire(${seconds}, ${nanos})`);
   }
 
   getFixedSize(): number {
@@ -80,7 +122,7 @@ class DurationSerializerGenerator extends BaseSerializerGenerator {
   read(accessor: (expr: string) => string): string {
     const seconds = this.builder.reader.readVarInt64();
     const nanos = this.builder.reader.readInt32();
-    return accessor(`Number(${seconds}) * 1000 + ${nanos} / 1000000`);
+    return accessor(`external.durationFromWire(${seconds}, ${nanos})`);
   }
 
   getFixedSize(): number {
@@ -109,9 +151,7 @@ class DateSerializerGenerator extends BaseSerializerGenerator {
 
   read(accessor: (expr: string) => string): string {
     const epoch = this.scope.declareByName("epoch", `new Date("1970/01/01 00:00").getTime()`);
-    return accessor(
-      `new Date(${epoch} + (Number(${this.builder.reader.readVarInt64()}) * (24 * 60 * 60) * 1000))`,
-    );
+    return accessor(`external.dateFromWire(${this.builder.reader.readVarInt64()}, ${epoch})`);
   }
 
   getFixedSize(): number {
@@ -122,3 +162,6 @@ class DateSerializerGenerator extends BaseSerializerGenerator {
 CodegenRegistry.register(TypeId.DURATION, DurationSerializerGenerator);
 CodegenRegistry.register(TypeId.TIMESTAMP, TimestampSerializerGenerator);
 CodegenRegistry.register(TypeId.DATE, DateSerializerGenerator);
+CodegenRegistry.registerExternal(timestampFromWire);
+CodegenRegistry.registerExternal(durationFromWire);
+CodegenRegistry.registerExternal(dateFromWire);

--- a/javascript/packages/core/lib/reader/index.ts
+++ b/javascript/packages/core/lib/reader/index.ts
@@ -224,7 +224,7 @@ export class BinaryReader {
   stringWithHeader() {
     const header = this.readVarUint36Small();
     const type = header & 0b11;
-    const len = header >>> 2;
+    const len = Math.floor(header / 4);
     switch (type) {
       case LATIN1:
         return len === 0 ? "" : this.stringLatin1(len);
@@ -413,7 +413,15 @@ export class BinaryReader {
       readIdx++;
       result |= (fourByteValue >>> 3) & 0xfe00000;
       if ((fourByteValue & 0x80000000) !== 0) {
-        result |= (this.dataView.getUint8(readIdx++) & 0xff) << 28;
+        const fifthByte = this.dataView.getUint8(readIdx++);
+        result += (fifthByte & 0x7f) * 0x10000000;
+        if ((fifthByte & 0x80) !== 0) {
+          const sixthByte = this.dataView.getUint8(readIdx++);
+          if (sixthByte > 1) {
+            throw new Error("VarUint36Small exceeds 36 bits");
+          }
+          result += sixthByte * 0x800000000;
+        }
       }
     }
     this.cursor = readIdx;
@@ -421,25 +429,21 @@ export class BinaryReader {
   }
 
   private readVarUint36Slow(): number {
-    let b = this.readUint8();
-    let result = b & 0x7f;
-    if ((b & 0x80) !== 0) {
-      b = this.readUint8();
-      result |= (b & 0x7f) << 7;
-      if ((b & 0x80) !== 0) {
-        b = this.readUint8();
-        result |= (b & 0x7f) << 14;
-        if ((b & 0x80) !== 0) {
-          b = this.readUint8();
-          result |= (b & 0x7f) << 21;
-          if ((b & 0x80) !== 0) {
-            b = this.readUint8();
-            result |= (b & 0xff) << 28;
-          }
-        }
+    let result = 0;
+    let multiplier = 1;
+    for (let i = 0; i < 5; i++) {
+      const byte = this.readUint8();
+      result += (byte & 0x7f) * multiplier;
+      if ((byte & 0x80) === 0) {
+        return result;
       }
+      multiplier *= 0x80;
     }
-    return result >>> 0;
+    const sixthByte = this.readUint8();
+    if (sixthByte > 1) {
+      throw new Error("VarUint36Small exceeds 36 bits");
+    }
+    return result + sixthByte * multiplier;
   }
 
   readVarInt32() {

--- a/javascript/test/datetime.test.ts
+++ b/javascript/test/datetime.test.ts
@@ -20,6 +20,16 @@
 import Fory, { Type } from "../packages/core/index";
 import { describe, expect, test } from "@jest/globals";
 import { TypeId } from "../packages/core/lib/type";
+import { BinaryWriter } from "../packages/core/lib/writer";
+
+function temporalBytes(typeId: number, writeBody: (writer: BinaryWriter) => void) {
+  const writer = new BinaryWriter({});
+  writer.writeUint8(1);
+  writer.writeInt8(-1);
+  writer.writeUint8(typeId);
+  writeBody(writer);
+  return writer.dump();
+}
 
 describe("datetime", () => {
   test("should date work", () => {
@@ -50,5 +60,40 @@ describe("datetime", () => {
     const encoded = fory.serialize(value, serializer);
     expect(Array.from(encoded)).toEqual([0x01, 0xff, TypeId.DATE, 0x01]);
     expect(fory.deserialize(encoded, serializer)).toEqual(value);
+  });
+
+  test("rejects temporal values outside JavaScript ranges", () => {
+    const timestampFory = new Fory({ compatible: false, ref: true });
+    const timestamp = timestampFory.register(Type.timestamp()).serializer;
+    const timestampBytes = temporalBytes(TypeId.TIMESTAMP, (writer) => {
+      writer.writeInt64((1n << 63n) - 1n);
+      writer.writeInt32(0);
+    });
+    expect(() => timestampFory.deserialize(timestampBytes, timestamp)).toThrow();
+
+    const durationFory = new Fory({ compatible: false, ref: true });
+    const duration = durationFory.register(Type.duration()).serializer;
+    const durationBytes = temporalBytes(TypeId.DURATION, (writer) => {
+      writer.writeVarInt64((1n << 63n) - 1n);
+      writer.writeInt32(0);
+    });
+    expect(() => durationFory.deserialize(durationBytes, duration)).toThrow();
+
+    const normalizedDurationFory = new Fory({ compatible: false, ref: true });
+    const normalizedDuration = normalizedDurationFory.register(Type.duration()).serializer;
+    const normalizedDurationBytes = temporalBytes(TypeId.DURATION, (writer) => {
+      writer.writeVarInt64(-9_007_199_254_741n);
+      writer.writeInt32(9_000_000);
+    });
+    expect(normalizedDurationFory.deserialize(normalizedDurationBytes, normalizedDuration)).toBe(
+      -9_007_199_254_740_991,
+    );
+
+    const dateFory = new Fory({ compatible: false, ref: true });
+    const date = dateFory.register(Type.date()).serializer;
+    const dateBytes = temporalBytes(TypeId.DATE, (writer) => {
+      writer.writeVarInt64((1n << 63n) - 1n);
+    });
+    expect(() => dateFory.deserialize(dateBytes, date)).toThrow();
   });
 });

--- a/javascript/test/io.test.ts
+++ b/javascript/test/io.test.ts
@@ -259,6 +259,15 @@ function num2Bin(num: number) {
       expect(reader.stringLatin1(len)).toBe(str);
     });
 
+    test("should read exact 36-bit string headers", () => {
+      const reader = new BinaryReader(config);
+      reader.reset(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80, 0x01, 0x7f]));
+
+      expect(reader.readVarUint36Small()).toBe(2 ** 35);
+      expect(reader.readGetCursor()).toBe(6);
+      expect(reader.readUint8()).toBe(0x7f);
+    });
+
     test("should short utf8 string work", () => {
       const writer = new BinaryWriter(config);
       const str = new Array(1).fill("hello 你好 😁").join("");
@@ -309,6 +318,12 @@ function num2Bin(num: number) {
 
       reader.reset(new Uint8Array([3]));
       expect(() => reader.stringWithHeader()).toThrow(/Unsupported string encoding/);
+
+      reader.reset(new Uint8Array([0x82, 0x80, 0x80, 0x80, 0x80, 0x01]));
+      expect(() => reader.stringWithHeader()).toThrow();
+
+      reader.reset(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80]));
+      expect(() => reader.stringWithHeader()).toThrow();
     });
 
     test("should buffer work", () => {

--- a/python/pyfory/buffer.pxi
+++ b/python/pyfory/buffer.pxi
@@ -17,7 +17,13 @@
 
 cimport cython
 from cpython.object cimport PyObject
-from cpython.buffer cimport Py_buffer, PyObject_GetBuffer, PyBuffer_Release, PyBUF_SIMPLE
+from cpython.buffer cimport (
+    Py_buffer,
+    PyObject_GetBuffer,
+    PyBuffer_Release,
+    PyBUF_SIMPLE,
+    PyBUF_WRITABLE,
+)
 from cpython.unicode cimport (
     PyUnicode_GET_LENGTH,
     PyUnicode_KIND,
@@ -30,7 +36,7 @@ from cpython.unicode cimport (
     PyUnicode_FromKindAndData,
     PyUnicode_DecodeUTF8,
 )
-from cpython.bytes cimport PyBytes_AsString, PyBytes_FromStringAndSize, PyBytes_AS_STRING
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING, PyBytes_GET_SIZE
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.utility cimport move
 from cython.operator cimport dereference as deref
@@ -48,13 +54,10 @@ from pyfory.includes.libpyfory cimport (
     Fory_PyBindBufferToOutputStream,
     Fory_PyClearBufferOutputStream
 )
-import os
 from pyfory.error import raise_fory_error
 
 cdef int32_t max_buffer_size = 2 ** 31 - 1
 cdef int UTF16_LE = -1
-
-cdef c_bool _WINDOWS = os.name == 'nt'
 
 
 @cython.final
@@ -141,23 +144,50 @@ cdef class Buffer:
         # hold python buffer reference count
         object data
         object output_stream
+        c_bool readonly
         Py_ssize_t shape[1]
         Py_ssize_t stride[1]
-    def __init__(self,  data not None, int32_t offset=0, length=None):
-        self.data = data
-        cdef int32_t buffer_len = len(data)
-        cdef int length_
-        if length is None:
-            length_ = buffer_len - offset
+    def __init__(self, data not None, int32_t offset=0, length=None):
+        cdef object view = None
+        cdef bint bytes_input = type(data) is bytes
+        cdef Py_ssize_t buffer_len
+        cdef Py_ssize_t py_length
+        cdef int32_t length_
+        cdef Py_buffer py_buffer
+        if bytes_input:
+            buffer_len = PyBytes_GET_SIZE(data)
         else:
-            length_ = length
-        if offset < 0 or offset + length_ > buffer_len:
+            view = memoryview(data)
+            buffer_len = view.nbytes
+        if buffer_len > max_buffer_size:
+            raise ValueError(f"Buffer size {buffer_len} exceeds the maximum supported size")
+        if length is None:
+            py_length = buffer_len - offset
+        else:
+            py_length = length
+        if offset < 0 or offset > buffer_len or py_length < 0 or py_length > buffer_len - offset:
             raise ValueError(f'Wrong offset {offset} or length {length} for buffer with size {buffer_len}')
+        length_ = <int32_t>py_length
         cdef uint8_t* address
         if length_ > 0:
-            address = get_address(data) + offset
+            if bytes_input:
+                address = <uint8_t*>PyBytes_AS_STRING(data) + offset
+            else:
+                if PyObject_GetBuffer(view, &py_buffer, PyBUF_SIMPLE) != 0:
+                    raise BufferError(f"Cannot access buffer for {type(data)!r}")
+                try:
+                    address = <uint8_t*>py_buffer.buf + offset
+                finally:
+                    PyBuffer_Release(&py_buffer)
         else:
             address = NULL
+        if bytes_input:
+            self.data = data
+            self.readonly = True
+        else:
+            # Retaining the memoryview keeps resizable exporters locked while the native view exists.
+            self.data = view
+            self.readonly = view.readonly
         self.c_buffer_owner.reset(new CBuffer(address, length_, False))
         self.c_buffer = self.c_buffer_owner.get()
         self.c_buffer.reader_index(0)
@@ -168,6 +198,8 @@ cdef class Buffer:
     def from_stream(cls, stream not None, uint32_t buffer_size=4096):
         cdef CBuffer* stream_buffer
         cdef c_string stream_error
+        if buffer_size > <uint32_t>max_buffer_size:
+            raise ValueError(f"Buffer size {buffer_size} exceeds the maximum supported size")
         if Fory_PyCreateBufferFromStream(
             <PyObject*>stream, buffer_size, &stream_buffer, &stream_error
         ) != 0:
@@ -179,6 +211,7 @@ cdef class Buffer:
         buffer.c_buffer = buffer.c_buffer_owner.get()
         buffer.data = stream
         buffer.output_stream = None
+        buffer.readonly = False
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
@@ -192,12 +225,15 @@ cdef class Buffer:
         owner.buffer = c_buffer
         buffer.data = owner
         buffer.output_stream = None
+        buffer.readonly = False
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
 
     @classmethod
     def allocate(cls, int32_t size):
+        if size < 0:
+            raise ValueError("Buffer size must be non-negative")
         cdef CBuffer* buf = allocate_buffer(size)
         if buf == NULL:
             raise MemoryError("out of memory")
@@ -206,6 +242,7 @@ cdef class Buffer:
         buffer.c_buffer = buffer.c_buffer_owner.get()
         buffer.data = None
         buffer.output_stream = None
+        buffer.readonly = False
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
@@ -245,6 +282,35 @@ cdef class Buffer:
             self._error.reset()
             raise_fory_error(code, message)
 
+    cdef inline void _check_writable(self):
+        if self.readonly:
+            raise TypeError("cannot modify read-only Buffer")
+
+    cdef inline int32_t _checked_length(self, Py_ssize_t length, str owner):
+        if length < 0 or length > max_buffer_size:
+            raise ValueError(f"{owner} length {length} exceeds the maximum supported size")
+        return <int32_t>length
+
+    cdef inline void _prepare_capacity(self, int32_t needed_size):
+        cdef int32_t writer_index = <int32_t>self.c_buffer.writer_index()
+        cdef int32_t end
+        if needed_size < 0 or needed_size > max_buffer_size - writer_index:
+            raise ValueError(
+                f"Buffer growth {needed_size} exceeds the maximum supported size at writer index "
+                f"{self.c_buffer.writer_index()}"
+            )
+        end = writer_index + needed_size
+        if end > self.c_buffer.size() and end > max_buffer_size // 2:
+            self.c_buffer.reserve(<uint32_t>end)
+
+    cdef inline void _prepare_write(self, int32_t needed_size):
+        self._check_writable()
+        self._prepare_capacity(needed_size)
+
+    cdef inline void _grow_checked(self, int32_t needed_size):
+        self._prepare_write(needed_size)
+        self.c_buffer.grow(<uint32_t>needed_size)
+
     cpdef inline int32_t get_reader_index(self):
         return <int32_t>self.c_buffer.reader_index()
 
@@ -259,8 +325,8 @@ cdef class Buffer:
         return <int32_t>self.c_buffer.writer_index()
 
     cpdef inline void set_writer_index(self, int32_t value):
-        if value < 0:
-            raise ValueError("writer_index must be >= 0")
+        if value < 0 or value > self.c_buffer.size():
+            raise ValueError(f"writer_index {value} out of bound {0, self.c_buffer.size()}")
         self.c_buffer.writer_index(<uint32_t>value)
 
     cpdef inline void shrink_input_buffer(self):
@@ -273,42 +339,52 @@ cdef class Buffer:
         return self.c_buffer.own_data()
 
     cpdef inline reserve(self, int32_t new_size):
-        assert 0 < new_size < max_buffer_size
+        if new_size < 0:
+            raise ValueError(f"Buffer size {new_size} out of bound {0, max_buffer_size}")
         self.c_buffer.reserve(new_size)
 
     cpdef inline put_bool(self, uint32_t offset, c_bool v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>1)
         self.c_buffer.unsafe_put_byte(offset, v)
 
     cpdef inline put_uint8(self, uint32_t offset, uint8_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>1)
         self.c_buffer.unsafe_put_byte(offset, v)
 
     cpdef inline put_int8(self, uint32_t offset, int8_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>1)
         self.c_buffer.unsafe_put_byte(offset, v)
 
     cpdef inline put_int16(self, uint32_t offset, int16_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>2)
         self.c_buffer.unsafe_put(offset, v)
 
     cpdef inline put_int24(self, uint32_t offset, int32_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>3)
         self.c_buffer.put_int24(offset, v)
 
     cpdef inline put_int32(self, uint32_t offset, int32_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>4)
         self.c_buffer.unsafe_put(offset, v)
 
     cpdef inline put_int64(self, uint32_t offset, int64_t v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>8)
         self.c_buffer.unsafe_put(offset, v)
 
     cpdef inline put_float(self, uint32_t offset, float v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>4)
         self.c_buffer.unsafe_put(offset, v)
 
     cpdef inline put_double(self, uint32_t offset, double v):
+        self._check_writable()
         self.check_bound(offset, <int32_t>8)
         self.c_buffer.unsafe_put(offset, v)
 
@@ -326,7 +402,10 @@ cdef class Buffer:
 
     cpdef inline int32_t get_int24(self, uint32_t offset):
         self.check_bound(offset, <int32_t>3)
-        return self.c_buffer.get_int24(offset)
+        cdef int32_t value = self.c_buffer.get_int24(offset)
+        if value & 0x800000:
+            value -= 0x1000000
+        return value
 
     cpdef inline int32_t get_int32(self, uint32_t offset):
         self.check_bound(offset, <int32_t>4)
@@ -362,80 +441,124 @@ cdef class Buffer:
                 self._raise_if_error()
 
     cpdef inline write_bool(self, c_bool value):
+        self._prepare_write(1)
         self.c_buffer.write_uint8(<uint8_t>value)
-    
+
     cpdef inline write_uint8(self, uint8_t value):
+        self._prepare_write(1)
         self.c_buffer.write_uint8(value)
 
     cpdef inline write_int8(self, int8_t value):
+        self._prepare_write(1)
         self.c_buffer.write_int8(value)
 
     cpdef inline write_int16(self, int16_t value):
+        self._prepare_write(2)
         self.c_buffer.write_int16(value)
 
     cpdef inline write_int24(self, int32_t value):
+        self._prepare_write(3)
         self.c_buffer.write_int24(value)
 
     cpdef inline write_int32(self, int32_t value):
+        self._prepare_write(4)
         self.c_buffer.write_int32(value)
 
     cpdef inline write_int64(self, int64_t value):
+        self._prepare_write(8)
         self.c_buffer.write_int64(value)
 
     cpdef inline write_uint16(self, uint16_t value):
+        self._prepare_write(2)
         self.c_buffer.write_uint16(value)
 
     cpdef inline write_uint32(self, uint32_t value):
+        self._prepare_write(4)
         self.c_buffer.write_uint32(value)
 
     cpdef inline write_uint64(self, uint64_t value):
+        self._prepare_write(8)
         self.c_buffer.write_int64(<int64_t>value)
 
     cpdef inline write_float(self, float value):
+        self._prepare_write(4)
         self.c_buffer.write_float(value)
 
     cpdef inline write_float32(self, float value):
+        self._prepare_write(4)
         self.c_buffer.write_float(value)
 
     cpdef inline write_double(self, double value):
+        self._prepare_write(8)
         self.c_buffer.write_double(value)
 
     cpdef inline write_float64(self, double value):
+        self._prepare_write(8)
         self.c_buffer.write_double(value)
 
-    cpdef put_buffer(self, uint32_t offset, v, int32_t src_index, int32_t length):
+    cdef inline void _buffer_byte_range(
+        self,
+        object view,
+        Py_ssize_t src_index,
+        Py_ssize_t length,
+        int32_t* src_offset,
+        int32_t* size,
+    ):
+        cdef Py_ssize_t itemsize = view.itemsize
+        cdef Py_ssize_t element_count
+        cdef Py_ssize_t src_offset_
+        cdef Py_ssize_t size_
+        if not view.c_contiguous:
+            raise ValueError("Source buffer must be C-contiguous")
+        if itemsize <= 0:
+            raise ValueError(f"Invalid source buffer item size {itemsize}")
+        element_count = view.nbytes // itemsize
+        if src_index < 0 or src_index > element_count or length < 0 or length > element_count - src_index:
+            raise ValueError(f"Source range {(src_index, length)} out of bound {(0, element_count)}")
+        src_offset_ = src_index * itemsize
+        size_ = length * itemsize
+        if src_offset_ > max_buffer_size or size_ > max_buffer_size:
+            raise ValueError("Source byte range exceeds the maximum supported size")
+        src_offset[0] = <int32_t>src_offset_
+        size[0] = <int32_t>size_
+
+    cdef inline void _copy_buffer(self, uint32_t offset, object view, int32_t src_offset, int32_t size):
         cdef Py_buffer py_buffer
-        if length == 0:  # access an emtpy buffer may raise out-of-bound exception.
+        self.check_bound(<int32_t>offset, size)
+        if size == 0:
             return
-        view = memoryview(v)
-        assert view.c_contiguous
-        itemsize = view.itemsize
-        size = (length - src_index) * itemsize
-        self.check_bound(offset, size)
-        src_offset = src_index * itemsize
-        if PyObject_GetBuffer(v, &py_buffer, PyBUF_SIMPLE) != 0:
-            raise BufferError(f"Cannot access buffer for {type(v)!r}")
+        if PyObject_GetBuffer(view, &py_buffer, PyBUF_SIMPLE) != 0:
+            raise BufferError(f"Cannot access buffer for {type(view)!r}")
         try:
             self.c_buffer.copy_from(offset, <uint8_t*>py_buffer.buf, src_offset, size)
         finally:
             PyBuffer_Release(&py_buffer)
 
+    cpdef put_buffer(self, uint32_t offset, v, Py_ssize_t src_index, Py_ssize_t length):
+        cdef object view = memoryview(v)
+        cdef int32_t src_offset
+        cdef int32_t size
+        self._buffer_byte_range(view, src_index, length, &src_offset, &size)
+        if size > 0:
+            self._check_writable()
+        self._copy_buffer(offset, view, src_offset, size)
+
     cpdef inline write_bytes_and_size(self, bytes value):
-        cdef const unsigned char[:] data = value
-        cdef int32_t length = data.nbytes
+        cdef int32_t length = self._checked_length(PyBytes_GET_SIZE(value), "Binary")
         self.write_var_uint32(length)
         if length > 0:
-            self.c_buffer.write_bytes(&data[0], length)
+            self._prepare_write(length)
+            self.c_buffer.write_bytes(PyBytes_AS_STRING(value), length)
 
     cpdef inline bytes read_bytes_and_size(self):
         cdef int32_t length = self.read_var_uint32()
         return self.read_bytes(length)
 
     cpdef inline write_bytes(self, bytes value):
-        cdef const unsigned char[:] data = value
-        cdef int32_t length = data.nbytes
+        cdef int32_t length = self._checked_length(PyBytes_GET_SIZE(value), "Binary")
         if length > 0:
-            self.c_buffer.write_bytes(&data[0], length)
+            self._prepare_write(length)
+            self.c_buffer.write_bytes(PyBytes_AS_STRING(value), length)
 
     cpdef inline bytes read_bytes(self, int32_t length):
         if length == 0:
@@ -480,9 +603,14 @@ cdef class Buffer:
 
     cpdef inline put_bytes(self, uint32_t offset, bytes value):
         cdef const unsigned char[:] data = value
-        cdef int32_t length = data.nbytes
+        cdef int32_t length = self._checked_length(data.nbytes, "Binary")
+        cdef uint64_t end = <uint64_t>offset + <uint64_t>length
         if length > 0:
-            self.grow(length)
+            self._check_writable()
+            if end > <uint64_t>max_buffer_size:
+                raise ValueError(f"Destination range {(offset, end)} exceeds the maximum supported size")
+            if end > <uint64_t>self.c_buffer.size():
+                self.c_buffer.reserve(<uint32_t>end)
             self.c_buffer.copy_from(offset, &data[0], 0, length)
 
     cpdef inline bytes get_bytes(self, uint32_t offset, uint32_t nbytes):
@@ -493,33 +621,46 @@ cdef class Buffer:
         return binary_data[:nbytes]
 
     cpdef inline write_buffer(self, value, src_index=0, length_=None):
-        view = memoryview(value)
-        dtype = view.format
-        cdef int32_t itemsize = view.itemsize
-        cdef int32_t length = 0
+        cdef object view = memoryview(value)
+        cdef Py_ssize_t itemsize = view.itemsize
+        cdef Py_ssize_t element_count
+        cdef Py_ssize_t src_index_ = src_index
+        cdef Py_ssize_t length
+        cdef int32_t src_offset
+        cdef int32_t size
+        if itemsize <= 0:
+            raise ValueError(f"Invalid source buffer item size {itemsize}")
+        element_count = view.nbytes // itemsize
         if length_ is None:
-            length = len(value) - src_index
+            length = element_count - src_index_
         else:
             length = length_
-        if length <= 0:
+        self._buffer_byte_range(view, src_index_, length, &src_offset, &size)
+        if size == 0:
             return
         cdef uint32_t offset = self.c_buffer.writer_index()
-        self.c_buffer.grow(length * itemsize)
-        self.put_buffer(offset, value, src_index, length)
-        self.c_buffer.increase_writer_index(length * itemsize)
+        self._grow_checked(size)
+        self._copy_buffer(offset, view, src_offset, size)
+        self.c_buffer.increase_writer_index(size)
 
     cpdef inline write(self, value):
-        cdef const unsigned char[:] data = value
-        cdef int32_t length = data.nbytes
+        cdef const unsigned char[::1] data
+        cdef int32_t length
+        data = value
+        length = self._checked_length(data.nbytes, "Buffer")
         if length > 0:
+            self._prepare_write(length)
             self.c_buffer.write_bytes(&data[0], length)
 
     cpdef inline grow(self, int32_t needed_size):
-        self.c_buffer.grow(needed_size)
+        self._prepare_capacity(needed_size)
+        self.c_buffer.grow(<uint32_t>needed_size)
 
     cpdef inline ensure(self, int32_t length):
+        if length < 0:
+            raise ValueError("Buffer size must be non-negative")
         if length > self.c_buffer.size():
-            self.reserve(length * 2)
+            self.reserve(length)
 
     cpdef inline skip(self, uint32_t length):
         self.c_buffer.skip(length, self._error)
@@ -550,10 +691,12 @@ cdef class Buffer:
             self._raise_if_error()
         return value
 
-    cpdef inline int16_t read_int24(self):
+    cpdef inline int32_t read_int24(self):
         cdef int32_t value = self.c_buffer.read_int24(self._error)
         if not self._error.ok():
             self._raise_if_error()
+        if value & 0x800000:
+            value -= 0x1000000
         return value
 
     cpdef inline int32_t read_int32(self):
@@ -628,12 +771,14 @@ cdef class Buffer:
         return data
 
     cpdef inline write_varint32(self, int32_t value):
+        self._prepare_write(8)
         cdef uint32_t before = self.c_buffer.writer_index()
         self.c_buffer.write_var_int32(value)
         cdef uint32_t after = self.c_buffer.writer_index()
         return after - before
 
     cpdef inline write_var_uint32(self, uint32_t value):
+        self._prepare_write(8)
         cdef uint32_t before = self.c_buffer.writer_index()
         self.c_buffer.write_var_uint32(value)
         cdef uint32_t after = self.c_buffer.writer_index()
@@ -652,14 +797,16 @@ cdef class Buffer:
         return value
 
     cpdef inline write_varint64(self, int64_t value):
+        self._prepare_write(9)
         cdef uint32_t before = self.c_buffer.writer_index()
         self.c_buffer.write_var_int64(value)
         cdef uint32_t after = self.c_buffer.writer_index()
         return after - before
 
-    cpdef inline write_var_uint64(self, int64_t v):
+    cpdef inline write_var_uint64(self, uint64_t v):
+        self._prepare_write(9)
         cdef uint32_t before = self.c_buffer.writer_index()
-        self.c_buffer.write_var_uint64(<uint64_t>v)
+        self.c_buffer.write_var_uint64(v)
         cdef uint32_t after = self.c_buffer.writer_index()
         return after - before
 
@@ -669,14 +816,15 @@ cdef class Buffer:
             self._raise_if_error()
         return value
 
-    cpdef inline int64_t read_var_uint64(self):
+    cpdef inline uint64_t read_var_uint64(self):
         cdef uint64_t value = self.c_buffer.read_var_uint64(self._error)
         if not self._error.ok():
             self._raise_if_error()
-        return <int64_t>value
+        return value
 
     cpdef inline write_tagged_int64(self, int64_t value):
         """write signed int64 using fory Tagged(Small long as int) encoding."""
+        self._prepare_write(9)
         self.c_buffer.write_tagged_int64(value)
 
     cpdef inline int64_t read_tagged_int64(self):
@@ -688,6 +836,7 @@ cdef class Buffer:
 
     cpdef inline write_tagged_uint64(self, uint64_t value):
         """write unsigned uint64 using fory Tagged(Small long as int) encoding."""
+        self._prepare_write(9)
         self.c_buffer.write_tagged_uint64(value)
 
     cpdef inline uint64_t read_tagged_uint64(self):
@@ -702,7 +851,7 @@ cdef class Buffer:
         if length <= 0:  # access an emtpy buffer may raise out-of-bound exception.
             return
         cdef uint32_t offset = self.c_buffer.writer_index()
-        self.c_buffer.grow(length)
+        self._grow_checked(length)
         self.check_bound(offset, length)
         self.c_buffer.copy_from(offset, value, 0, length)
         self.c_buffer.increase_writer_index(length)
@@ -715,20 +864,22 @@ cdef class Buffer:
         cdef uint64_t header = 0
         cdef int32_t buffer_size
         if kind == PyUnicode_1BYTE_KIND:
-            buffer_size = length
+            buffer_size = self._checked_length(length, "String")
             header = (length << 2) | 0
         elif kind == PyUnicode_2BYTE_KIND:
-            buffer_size = length << 1
+            if length > max_buffer_size >> 1:
+                raise ValueError(f"String length {length} exceeds the maximum supported size")
+            buffer_size = <int32_t>(length << 1)
             header = (length << 3) | 1
         else:
             buffer = <void *>(PyUnicode_AsUTF8AndSize(value, &length))
-            buffer_size = length
+            buffer_size = self._checked_length(length, "UTF-8 string")
             header = (buffer_size << 2) | 2
         self.write_var_uint64(header)
         if buffer_size == 0:  # access an emtpy buffer may raise out-of-bound exception.
             return
         cdef uint32_t offset = self.c_buffer.writer_index()
-        self.c_buffer.grow(buffer_size)
+        self._grow_checked(buffer_size)
         self.check_bound(offset, buffer_size)
         self.c_buffer.copy_from(offset, <const uint8_t *>buffer, 0, buffer_size)
         self.c_buffer.increase_writer_index(buffer_size)
@@ -816,6 +967,8 @@ cdef class Buffer:
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         cdef Py_ssize_t itemsize = 1
+        if self.readonly and flags & PyBUF_WRITABLE:
+            raise BufferError("Buffer is read-only")
         self.shape[0] = self.c_buffer.size()
         self.stride[0] = itemsize
         buffer.buf = <char *>(self.c_buffer.data())
@@ -825,7 +978,7 @@ cdef class Buffer:
         buffer.len = self.c_buffer.size()  # product(shape) * itemsize
         buffer.ndim = 1
         buffer.obj = self
-        buffer.readonly = 0
+        buffer.readonly = self.readonly
         buffer.shape = self.shape
         buffer.strides = self.stride
         buffer.suboffsets = NULL                # for pointer arrays only
@@ -837,77 +990,6 @@ cdef class Buffer:
         return "Buffer(reader_index={}, writer_index={}, size={})".format(
             self.get_reader_index(), self.get_writer_index(), self.size()
         )
-
-
-cdef inline uint8_t* get_address(v):
-    if type(v) is bytes:
-        return <uint8_t*>(PyBytes_AsString(v))
-    view = memoryview(v)
-    cdef str dtype = view.format
-    # Handle little-endian format codes (e.g., "<h", "<i", etc.)
-    # Strip the endian prefix since we only care about the type
-    if len(dtype) > 1 and dtype[0] in ('<', '>', '=', '@', '!'):
-        dtype = dtype[1:]
-    cdef:
-        const char[:] signed_char_data
-        const unsigned char[:] unsigned_data
-        const int16_t[:] signed_short_data
-        const int32_t[:] signed_int_data
-        const int64_t[:] signed_long_data
-        const uint16_t[:] unsigned_short_data
-        const uint32_t[:] unsigned_int_data
-        const uint64_t[:] unsigned_long_data
-        const uint64_t[:] unsigned_long_long_data
-        const float[:] signed_float_data
-        const double[:] signed_double_data
-        uint8_t* ptr
-    if dtype == "b":
-        signed_char_data = v
-        ptr = <uint8_t*>(&signed_char_data[0])
-    elif dtype == "B":
-        unsigned_data = v
-        ptr = <uint8_t*>(&unsigned_data[0])
-    elif dtype == "h":
-        signed_short_data = v
-        ptr = <uint8_t*>(&signed_short_data[0])
-    elif dtype == "H":
-        unsigned_short_data = v
-        ptr = <uint8_t*>(&unsigned_short_data[0])
-    elif dtype == "i":
-        signed_int_data = v
-        ptr = <uint8_t*>(&signed_int_data[0])
-    elif dtype == "I":
-        unsigned_int_data = v
-        ptr = <uint8_t*>(&unsigned_int_data[0])
-    elif dtype == "l":
-        if _WINDOWS:
-            signed_int_data = v
-            ptr = <uint8_t*>(&signed_int_data[0])
-        else:
-            signed_long_data = v
-            ptr = <uint8_t*>(&signed_long_data[0])
-    elif dtype == "L":
-        if _WINDOWS:
-            unsigned_int_data = v
-            ptr = <uint8_t*>(&unsigned_int_data[0])
-        else:
-            unsigned_long_data = v
-            ptr = <uint8_t*>(&unsigned_long_data[0])
-    elif dtype == "q":
-        signed_long_data = v
-        ptr = <uint8_t*>(&signed_long_data[0])
-    elif dtype == "Q":
-        unsigned_long_long_data = v
-        ptr = <uint8_t*>(&unsigned_long_long_data[0])
-    elif dtype == "f":
-        signed_float_data = v
-        ptr = <uint8_t*>(&signed_float_data[0])
-    elif dtype == "d":
-        signed_double_data = v
-        ptr = <uint8_t*>(&signed_double_data[0])
-    else:
-        raise Exception(f"Unsupported buffer of type {type(v)} and format {dtype}")
-    return ptr
 
 
 def _normalize_slice(Buffer buf, slice key):
@@ -951,14 +1033,19 @@ cdef Py_ssize_t _normalize_index(Py_ssize_t index,
 
 
 def get_bit(Buffer buffer, uint32_t base_offset, uint32_t index) -> bool:
+    _check_bit_range(buffer, base_offset, index)
     return c_get_bit(buffer.c_buffer.data() + base_offset, index)
 
 
 def set_bit(Buffer buffer, uint32_t base_offset, uint32_t index):
+    buffer._check_writable()
+    _check_bit_range(buffer, base_offset, index)
     return c_set_bit(buffer.c_buffer.data() + base_offset, index)
 
 
 def clear_bit(Buffer buffer, uint32_t base_offset, uint32_t index):
+    buffer._check_writable()
+    _check_bit_range(buffer, base_offset, index)
     return c_clear_bit(buffer.c_buffer.data() + base_offset, index)
 
 
@@ -966,5 +1053,13 @@ def set_bit_to(Buffer buffer,
                uint32_t base_offset,
                uint32_t index,
                c_bool bit_is_set):
+    buffer._check_writable()
+    _check_bit_range(buffer, base_offset, index)
     return c_set_bit_to(
         buffer.c_buffer.data() + base_offset, index, bit_is_set)
+
+
+cdef inline void _check_bit_range(Buffer buffer, uint32_t base_offset, uint32_t index):
+    cdef uint64_t byte_offset = <uint64_t>base_offset + (<uint64_t>index >> 3)
+    if byte_offset >= <uint64_t>buffer.c_buffer.size():
+        raise IndexError(f"Bit index {index} at base offset {base_offset} is out of bounds")

--- a/python/pyfory/buffer.pxi
+++ b/python/pyfory/buffer.pxi
@@ -145,6 +145,7 @@ cdef class Buffer:
         object data
         object output_stream
         c_bool readonly
+        int32_t export_count
         Py_ssize_t shape[1]
         Py_ssize_t stride[1]
     def __init__(self, data not None, int32_t offset=0, length=None):
@@ -193,6 +194,7 @@ cdef class Buffer:
         self.c_buffer.reader_index(0)
         self.c_buffer.writer_index(0)
         self.output_stream = None
+        self.export_count = 0
 
     @classmethod
     def from_stream(cls, stream not None, uint32_t buffer_size=4096):
@@ -212,6 +214,7 @@ cdef class Buffer:
         buffer.data = stream
         buffer.output_stream = None
         buffer.readonly = False
+        buffer.export_count = 0
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
@@ -226,6 +229,7 @@ cdef class Buffer:
         buffer.data = owner
         buffer.output_stream = None
         buffer.readonly = False
+        buffer.export_count = 0
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
@@ -243,6 +247,7 @@ cdef class Buffer:
         buffer.data = None
         buffer.output_stream = None
         buffer.readonly = False
+        buffer.export_count = 0
         buffer.c_buffer.reader_index(0)
         buffer.c_buffer.writer_index(0)
         return buffer
@@ -291,6 +296,10 @@ cdef class Buffer:
             raise ValueError(f"{owner} length {length} exceeds the maximum supported size")
         return <int32_t>length
 
+    cdef inline void _check_resize(self, int32_t new_size):
+        if new_size > self.c_buffer.size() and self.export_count != 0:
+            raise BufferError("cannot resize Buffer while exported views exist")
+
     cdef inline void _prepare_capacity(self, int32_t needed_size):
         cdef int32_t writer_index = <int32_t>self.c_buffer.writer_index()
         cdef int32_t end
@@ -300,8 +309,10 @@ cdef class Buffer:
                 f"{self.c_buffer.writer_index()}"
             )
         end = writer_index + needed_size
-        if end > self.c_buffer.size() and end > max_buffer_size // 2:
-            self.c_buffer.reserve(<uint32_t>end)
+        if end > self.c_buffer.size():
+            self._check_resize(end)
+            if end > max_buffer_size // 2:
+                self.c_buffer.reserve(<uint32_t>end)
 
     cdef inline void _prepare_write(self, int32_t needed_size):
         self._check_writable()
@@ -341,6 +352,7 @@ cdef class Buffer:
     cpdef inline reserve(self, int32_t new_size):
         if new_size < 0:
             raise ValueError(f"Buffer size {new_size} out of bound {0, max_buffer_size}")
+        self._check_resize(new_size)
         self.c_buffer.reserve(new_size)
 
     cpdef inline put_bool(self, uint32_t offset, c_bool v):
@@ -610,7 +622,7 @@ cdef class Buffer:
             if end > <uint64_t>max_buffer_size:
                 raise ValueError(f"Destination range {(offset, end)} exceeds the maximum supported size")
             if end > <uint64_t>self.c_buffer.size():
-                self.c_buffer.reserve(<uint32_t>end)
+                self.reserve(<int32_t>end)
             self.c_buffer.copy_from(offset, &data[0], 0, length)
 
     cpdef inline bytes get_bytes(self, uint32_t offset, uint32_t nbytes):
@@ -967,6 +979,8 @@ cdef class Buffer:
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         cdef Py_ssize_t itemsize = 1
+        if self.c_buffer.has_input_stream():
+            raise BufferError("stream-backed Buffer cannot export a relocatable view")
         if self.readonly and flags & PyBUF_WRITABLE:
             raise BufferError("Buffer is read-only")
         self.shape[0] = self.c_buffer.size()
@@ -982,9 +996,11 @@ cdef class Buffer:
         buffer.shape = self.shape
         buffer.strides = self.stride
         buffer.suboffsets = NULL                # for pointer arrays only
+        self.export_count += 1
 
     def __releasebuffer__(self, Py_buffer *buffer):
-        pass
+        if self.export_count > 0:
+            self.export_count -= 1
 
     def __repr__(self):
         return "Buffer(reader_index={}, writer_index={}, size={})".format(

--- a/python/pyfory/context.pxi
+++ b/python/pyfory/context.pxi
@@ -561,6 +561,7 @@ cdef class WriteContext:
         self.depth = 0
 
     cpdef inline prepare(self, Buffer buffer, buffer_callback=None, unsupported_callback=None):
+        buffer._check_writable()
         self.buffer = buffer
         self.c_buffer = buffer.c_buffer
         self.buffer_callback = buffer_callback

--- a/python/pyfory/context.pxi
+++ b/python/pyfory/context.pxi
@@ -540,7 +540,6 @@ cdef class WriteContext:
     cdef public object buffer_callback
     cdef public object unsupported_callback
     cdef dict context_objects
-    cdef public int32_t depth
 
     def __init__(self, Config config, TypeResolver type_resolver):
         self.type_resolver = type_resolver
@@ -558,7 +557,6 @@ cdef class WriteContext:
         self.buffer_callback = None
         self.unsupported_callback = None
         self.context_objects = {}
-        self.depth = 0
 
     cpdef inline prepare(self, Buffer buffer, buffer_callback=None, unsupported_callback=None):
         buffer._check_writable()
@@ -566,7 +564,6 @@ cdef class WriteContext:
         self.c_buffer = buffer.c_buffer
         self.buffer_callback = buffer_callback
         self.unsupported_callback = unsupported_callback
-        self.depth = 0
 
     cpdef inline reset(self):
         self.ref_writer.reset()
@@ -579,7 +576,6 @@ cdef class WriteContext:
         self.c_buffer = NULL
         self.buffer_callback = None
         self.unsupported_callback = None
-        self.depth = 0
 
     cpdef inline add_context_object(self, key, obj):
         self.context_objects[id(key)] = obj
@@ -589,12 +585,6 @@ cdef class WriteContext:
 
     cpdef inline get_context_object(self, key, default=None):
         return self.context_objects.get(id(key), default)
-
-    cpdef inline increase_depth(self, int32_t diff=1):
-        self.depth += diff
-
-    cpdef inline decrease_depth(self, int32_t diff=1):
-        self.depth -= diff
 
     cpdef inline bint write_ref_or_null(self, obj):
         return self.ref_writer.write_ref_or_null(self.c_buffer, obj)

--- a/python/pyfory/context.py
+++ b/python/pyfory/context.py
@@ -241,7 +241,6 @@ class WriteContext:
         "buffer_callback",
         "unsupported_callback",
         "context_objects",
-        "depth",
     )
 
     def __init__(self, config: Config, type_resolver):
@@ -259,7 +258,6 @@ class WriteContext:
         self.buffer_callback = None
         self.unsupported_callback = None
         self.context_objects = {}
-        self.depth = 0
 
     def __getattr__(self, name):
         buffer = object.__getattribute__(self, "buffer")
@@ -271,7 +269,6 @@ class WriteContext:
         self.buffer = buffer
         self.buffer_callback = buffer_callback
         self.unsupported_callback = unsupported_callback
-        self.depth = 0
 
     def reset(self):
         self.ref_writer.reset()
@@ -283,7 +280,6 @@ class WriteContext:
         self.buffer = None
         self.buffer_callback = None
         self.unsupported_callback = None
-        self.depth = 0
 
     def add_context_object(self, key, obj):
         self.context_objects[id(key)] = obj
@@ -293,12 +289,6 @@ class WriteContext:
 
     def get_context_object(self, key, default=None):
         return self.context_objects.get(id(key), default)
-
-    def increase_depth(self, diff=1):
-        self.depth += diff
-
-    def decrease_depth(self, diff=1):
-        self.depth -= diff
 
     def write_ref_or_null(self, obj):
         return self.ref_writer.write_ref_or_null(self.buffer, obj)
@@ -325,9 +315,7 @@ class WriteContext:
 
     def write_non_ref(self, obj, serializer=None, typeinfo=None):
         if serializer is not None:
-            self.increase_depth()
             serializer.write(self, obj)
-            self.decrease_depth()
             return
         cls = type(obj)
         if cls is str:
@@ -349,9 +337,7 @@ class WriteContext:
         if typeinfo is None:
             typeinfo = self.type_resolver.get_type_info(cls)
         self.type_resolver.write_type_info(self, typeinfo)
-        self.increase_depth()
         typeinfo.serializer.write(self, obj)
-        self.decrease_depth()
 
     def write_no_ref(self, obj, serializer=None, typeinfo=None):
         self.write_non_ref(obj, serializer=serializer, typeinfo=typeinfo)

--- a/python/pyfory/lib/mmh3/mmh3.pyx
+++ b/python/pyfory/lib/mmh3/mmh3.pyx
@@ -22,6 +22,9 @@
 from libc.stdint cimport uint64_t, int64_t, int32_t
 
 
+cdef unsigned char _empty_hash_data = 0
+
+
 cdef uint32_t hash32(void* key, int length, uint32_t seed) nogil:
     cdef int32_t out
     MurmurHash3_x86_32(key, length, seed, &out)
@@ -46,7 +49,18 @@ cpdef tuple hash_unicode(unicode value, uint32_t seed=0):
     return hash_buffer(value.encode('utf8'), seed=seed)
 
 
-cpdef tuple hash_buffer(const unsigned char[:] value, uint32_t seed=0):
+cpdef tuple hash_buffer(value, uint32_t seed=0):
     cdef int64_t[2] out
-    MurmurHash3_x64_128(&value[0], value.nbytes, seed, &out)
+    cdef object view = memoryview(value)
+    cdef const unsigned char[::1] data_view
+    cdef Py_ssize_t length = view.nbytes
+    cdef const unsigned char* data = &_empty_hash_data
+    if not view.c_contiguous:
+        raise ValueError("Hash input must be C-contiguous")
+    if length > 2147483647:
+        raise OverflowError(f"Buffer length {length} exceeds the native hash limit")
+    data_view = view
+    if length > 0:
+        data = &data_view[0]
+    MurmurHash3_x64_128(data, <int>length, seed, &out)
     return out[0], out[1]

--- a/python/pyfory/number.pxi
+++ b/python/pyfory/number.pxi
@@ -61,19 +61,32 @@ cdef class _ForyArray:
     cpdef Py_ssize_t _size(self):
         raise NotImplementedError
 
+    # These cpdef helpers are public; normalize here so direct calls share sequence bounds semantics.
     cpdef object _get(self, Py_ssize_t index):
+        return self._get_unchecked(self._normalize_index(index))
+
+    cdef object _get_unchecked(self, Py_ssize_t index):
         raise NotImplementedError
 
     cpdef _set(self, Py_ssize_t index, object value):
+        self._set_unchecked(self._normalize_index(index), value)
+
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         raise NotImplementedError
 
     cpdef _append(self, object value):
         raise NotImplementedError
 
     cpdef _insert(self, Py_ssize_t index, object value):
+        self._insert_unchecked(self._normalize_insert_index(index), value)
+
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         raise NotImplementedError
 
     cpdef _delete(self, Py_ssize_t index):
+        self._delete_unchecked(self._normalize_index(index))
+
+    cdef _delete_unchecked(self, Py_ssize_t index):
         raise NotImplementedError
 
     cpdef _clear(self):
@@ -109,12 +122,12 @@ cdef class _ForyArray:
         cdef Py_ssize_t i
         cdef Py_ssize_t n = self._size()
         for i in range(n):
-            yield self._get(i)
+            yield self._get_unchecked(i)
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            return type(self)(self._get(i) for i in range(*index.indices(self._size())))
-        return self._get(self._normalize_index(index))
+            return type(self)(self._get_unchecked(i) for i in range(*index.indices(self._size())))
+        return self._get_unchecked(self._normalize_index(index))
 
     def __setitem__(self, index, value):
         cdef list items
@@ -124,7 +137,7 @@ cdef class _ForyArray:
             self._clear()
             self.extend(items)
             return
-        self._set(self._normalize_index(index), value)
+        self._set_unchecked(self._normalize_index(index), value)
 
     def __delitem__(self, index):
         cdef list items
@@ -134,7 +147,7 @@ cdef class _ForyArray:
             self._clear()
             self.extend(items)
             return
-        self._delete(self._normalize_index(index))
+        self._delete_unchecked(self._normalize_index(index))
 
     def __repr__(self):
         return f"{type(self).__name__}({list(self)!r})"
@@ -163,12 +176,12 @@ cdef class _ForyArray:
     def __reversed__(self):
         cdef Py_ssize_t i
         for i in range(self._size() - 1, -1, -1):
-            yield self._get(i)
+            yield self._get_unchecked(i)
 
     def __contains__(self, value):
         cdef Py_ssize_t i
         for i in range(self._size()):
-            if self._get(i) == value:
+            if self._get_unchecked(i) == value:
                 return True
         return False
 
@@ -205,12 +218,12 @@ cdef class _ForyArray:
             self._append(value)
 
     def insert(self, index, value):
-        self._insert(self._normalize_insert_index(index), value)
+        self._insert_unchecked(self._normalize_insert_index(index), value)
 
     def pop(self, index=-1):
         cdef Py_ssize_t i = self._normalize_index(index)
-        cdef object value = self._get(i)
-        self._delete(i)
+        cdef object value = self._get_unchecked(i)
+        self._delete_unchecked(i)
         return value
 
     def clear(self):
@@ -226,7 +239,7 @@ cdef class _ForyArray:
         cdef Py_ssize_t i
         cdef Py_ssize_t total = 0
         for i in range(self._size()):
-            if self._get(i) == value:
+            if self._get_unchecked(i) == value:
                 total += 1
         return total
 
@@ -244,12 +257,12 @@ cdef class _ForyArray:
         if end > n:
             end = n
         for i in range(begin, end):
-            if self._get(i) == value:
+            if self._get_unchecked(i) == value:
                 return i
         raise ValueError(f"{value!r} is not in array")
 
     def remove(self, value):
-        self._delete(self.index(value))
+        self._delete_unchecked(self.index(value))
 
     def reverse(self):
         cdef list items = list(self)
@@ -270,19 +283,19 @@ cdef class BoolArray(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return bool(<int>self._values[index])
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = _bool_to_byte(value)
 
     cpdef _append(self, object value):
         self._values.push_back(_bool_to_byte(value))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, _bool_to_byte(value))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -299,19 +312,19 @@ cdef class Int8Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <int8_t>_check_int_value(value, -128, 127, "Int8Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<int8_t>_check_int_value(value, -128, 127, "Int8Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <int8_t>_check_int_value(value, -128, 127, "Int8Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -332,19 +345,19 @@ cdef class Int16Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <int16_t>_check_int_value(value, -32768, 32767, "Int16Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<int16_t>_check_int_value(value, -32768, 32767, "Int16Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <int16_t>_check_int_value(value, -32768, 32767, "Int16Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -365,19 +378,19 @@ cdef class Int32Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <int32_t>_check_int_value(value, -2147483648, 2147483647, "Int32Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<int32_t>_check_int_value(value, -2147483648, 2147483647, "Int32Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <int32_t>_check_int_value(value, -2147483648, 2147483647, "Int32Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -398,19 +411,19 @@ cdef class Int64Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int64_t>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <int64_t>_check_int_value(value, -9223372036854775808, 9223372036854775807, "Int64Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<int64_t>_check_int_value(value, -9223372036854775808, 9223372036854775807, "Int64Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <int64_t>_check_int_value(value, -9223372036854775808, 9223372036854775807, "Int64Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -431,19 +444,19 @@ cdef class UInt8Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <uint8_t>_check_int_value(value, 0, 255, "UInt8Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<uint8_t>_check_int_value(value, 0, 255, "UInt8Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <uint8_t>_check_int_value(value, 0, 255, "UInt8Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -460,19 +473,19 @@ cdef class UInt16Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <int>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <uint16_t>_check_int_value(value, 0, 65535, "UInt16Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<uint16_t>_check_int_value(value, 0, 65535, "UInt16Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <uint16_t>_check_int_value(value, 0, 65535, "UInt16Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -493,19 +506,19 @@ cdef class UInt32Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <uint32_t>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <uint32_t>_check_int_value(value, 0, 4294967295, "UInt32Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<uint32_t>_check_int_value(value, 0, 4294967295, "UInt32Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <uint32_t>_check_int_value(value, 0, 4294967295, "UInt32Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -526,19 +539,19 @@ cdef class UInt64Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <uint64_t>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <uint64_t>_check_int_value(value, 0, 18446744073709551615, "UInt64Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<uint64_t>_check_int_value(value, 0, 18446744073709551615, "UInt64Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <uint64_t>_check_int_value(value, 0, 18446744073709551615, "UInt64Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -562,19 +575,19 @@ cdef class Float16Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return _float16_bits_to_float(self._values[index])
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = _coerce_float16_bits(value)
 
     cpdef _append(self, object value):
         self._values.push_back(_coerce_float16_bits(value))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, _coerce_float16_bits(value))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -594,19 +607,19 @@ cdef class BFloat16Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return _bfloat16_bits_to_float(self._values[index])
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = _coerce_bfloat16_bits(value)
 
     cpdef _append(self, object value):
         self._values.push_back(_coerce_bfloat16_bits(value))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, _coerce_bfloat16_bits(value))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -623,19 +636,19 @@ cdef class Float32Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <float>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = <float>_check_float_value(value, "Float32Array")
 
     cpdef _append(self, object value):
         self._values.push_back(<float>_check_float_value(value, "Float32Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, <float>_check_float_value(value, "Float32Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):
@@ -656,19 +669,19 @@ cdef class Float64Array(_ForyArray):
     cpdef Py_ssize_t _size(self):
         return <Py_ssize_t>self._values.size()
 
-    cpdef object _get(self, Py_ssize_t index):
+    cdef object _get_unchecked(self, Py_ssize_t index):
         return <double>self._values[index]
 
-    cpdef _set(self, Py_ssize_t index, object value):
+    cdef _set_unchecked(self, Py_ssize_t index, object value):
         self._values[index] = _check_float_value(value, "Float64Array")
 
     cpdef _append(self, object value):
         self._values.push_back(_check_float_value(value, "Float64Array"))
 
-    cpdef _insert(self, Py_ssize_t index, object value):
+    cdef _insert_unchecked(self, Py_ssize_t index, object value):
         self._values.insert(self._values.begin() + index, _check_float_value(value, "Float64Array"))
 
-    cpdef _delete(self, Py_ssize_t index):
+    cdef _delete_unchecked(self, Py_ssize_t index):
         self._values.erase(self._values.begin() + index)
 
     cpdef _clear(self):

--- a/python/pyfory/serialization.pyx
+++ b/python/pyfory/serialization.pyx
@@ -1275,7 +1275,6 @@ cdef class Fory:
         write_context.c_buffer = buffer.c_buffer
         write_context.buffer_callback = buffer_callback
         write_context.unsupported_callback = unsupported_callback
-        write_context.depth = 0
         mask_index = buffer.get_writer_index()
         buffer.grow(1)
         buffer.set_writer_index(mask_index + 1)

--- a/python/pyfory/tests/test_buffer.py
+++ b/python/pyfory/tests/test_buffer.py
@@ -15,12 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import array
+
 import pytest
 
-from pyfory.serialization import Buffer
+import pyfory
+from pyfory.serialization import ENABLE_FORY_CYTHON_SERIALIZATION, Buffer
 from pyfory.tests.core import require_pyarrow
 from pyfory.tests.test_stream import OneByteStream
-from pyfory.utils import lazy_import
+from pyfory.utils import clear_bit, get_bit, lazy_import, set_bit, set_bit_to
 
 pa = lazy_import("pyarrow")
 
@@ -118,7 +121,6 @@ def test_buffer():
     binary = b"b" * 100
     buffer.write_bytes(binary)
     buffer.write_bytes_and_size(binary)
-    print(f"buffer size {buffer.size()}, writer_index {buffer.get_writer_index()}")
     new_buffer = Buffer(buffer.get_bytes(0, buffer.get_writer_index()))
     assert new_buffer.read_bool() is True
     assert new_buffer.read_int8() == -1
@@ -173,6 +175,199 @@ def test_to_bytes_rejects_out_of_bounds_range():
         buffer.to_bytes(99, 1)
     with pytest.raises(ValueError, match="out of bound"):
         buffer.to_bytes(2, 2)
+
+
+def test_buffer_native_ranges():
+    with pytest.raises(Exception):
+        Buffer(b"abc", 4)
+    with pytest.raises(Exception):
+        Buffer(b"abc", 1, -1)
+    with pytest.raises(Exception):
+        Buffer(memoryview(b"abcd")[::2])
+    negative_singleton = memoryview(bytearray(b"x"))[::-1]
+    assert negative_singleton.c_contiguous
+    assert Buffer(negative_singleton).to_bytes() == b"x"
+    with pytest.raises(Exception):
+        Buffer.allocate(-1)
+
+    buffer = Buffer.allocate(4)
+    with pytest.raises(Exception):
+        buffer.set_writer_index(5)
+    with pytest.raises(Exception):
+        buffer.grow(-1)
+    with pytest.raises(Exception):
+        buffer.reserve(-1)
+    buffer.set_writer_index(1)
+    with pytest.raises(Exception):
+        buffer.grow(2**31 - 1)
+    with pytest.raises(Exception):
+        buffer.put_bytes(2**32 - 1, b"x")
+
+
+def test_buffer_copy_ranges():
+    source = array.array("I", [0x01020304, 0x05060708, 0x090A0B0C])
+    wrapped = Buffer(source)
+    assert wrapped.size() == memoryview(source).nbytes
+    assert wrapped.to_bytes() == memoryview(source).cast("B").tobytes()
+
+    target = Buffer.allocate(source.itemsize * 2)
+    target.put_buffer(0, source, 1, 2)
+    assert target.to_bytes() == memoryview(source).cast("B")[source.itemsize :].tobytes()
+
+    writer = Buffer.allocate(1)
+    writer.write_buffer(source, src_index=1, length_=2)
+    assert writer.get_writer_index() == source.itemsize * 2
+    assert writer.get_bytes(0, writer.get_writer_index()) == target.to_bytes()
+
+    with pytest.raises(Exception):
+        target.put_buffer(0, source, -1, 1)
+    with pytest.raises(Exception):
+        target.put_buffer(0, source, 2, 2)
+    with pytest.raises(Exception):
+        target.put_buffer(0, memoryview(b"abcd")[::2], 0, 1)
+    with pytest.raises(Exception):
+        target.put_buffer(1, source, 0, 2)
+    with pytest.raises(Exception):
+        writer.write_buffer(source, src_index=4)
+
+
+def test_buffer_export_mutability():
+    immutable = Buffer(b"\0" * 16)
+    immutable_view = memoryview(immutable)
+    assert immutable_view.readonly
+    with pytest.raises(TypeError):
+        immutable_view[0] = 1
+
+    immutable.reserve(32)
+    immutable.grow(1)
+    immutable.ensure(32)
+    immutable.put_bytes(0, b"")
+    immutable.put_buffer(0, b"", 0, 0)
+    immutable.write_bytes(b"")
+    immutable.write_buffer(b"")
+    immutable.write(b"")
+    assert immutable.get_bytes(0, 16) == b"\0" * 16
+
+    mutations = (
+        lambda: immutable.put_uint8(0, 1),
+        lambda: immutable.put_bytes(0, b"x"),
+        lambda: immutable.put_buffer(0, b"x", 0, 1),
+        lambda: immutable.write_uint8(1),
+        lambda: immutable.write_bytes(b"x"),
+        lambda: immutable.write_buffer(b"x"),
+        lambda: immutable.write(b"x"),
+        lambda: immutable.write_string("x"),
+        lambda: set_bit(immutable, 0, 0),
+        lambda: clear_bit(immutable, 0, 0),
+        lambda: set_bit_to(immutable, 0, 0, True),
+    )
+    for mutate in mutations:
+        with pytest.raises(Exception):
+            mutate()
+
+    backing = bytearray(b"abcd")
+    writable = Buffer(backing)
+    writable_view = memoryview(writable)
+    assert not writable_view.readonly
+    writable.put_uint8(0, ord("x"))
+    writable_view[1] = ord("y")
+    assert backing == bytearray(b"xycd")
+
+
+def test_write_context_writable_buffer():
+    fory = pyfory.Fory()
+    readonly = Buffer(b"\0")
+    if ENABLE_FORY_CYTHON_SERIALIZATION:
+        with pytest.raises(Exception):
+            fory.write_context.prepare(readonly)
+        assert fory.write_context.buffer is None
+    else:
+        fory.write_context.prepare(readonly)
+        with pytest.raises(Exception):
+            fory.write_context.write_int8(1)
+    assert readonly.to_bytes() == b"\0"
+
+    fory.write_context.reset()
+    backing = bytearray(b"\0")
+    writable = Buffer(backing)
+    fory.write_context.prepare(writable)
+    fory.write_context.write_int8(1)
+    assert backing == bytearray(b"\1")
+    fory.write_context.reset()
+
+
+def test_bulk_pointer_ranges():
+    target = Buffer.allocate(1)
+
+    np = pytest.importorskip("numpy")
+    huge = np.lib.stride_tricks.as_strided(np.zeros(1, dtype=np.uint8), shape=(2**31,), strides=(1,))
+    assert memoryview(huge).nbytes == 2**31
+    with pytest.raises(Exception):
+        Buffer(huge)
+    with pytest.raises(Exception):
+        target.write_buffer(huge)
+    assert target.get_writer_index() == 0
+    with pytest.raises(Exception):
+        pyfory.mmh3.hash_buffer(huge)
+
+
+def test_bit_helper_ranges():
+    buffer = Buffer.allocate(1)
+    set_bit(buffer, 0, 7)
+    assert get_bit(buffer, 0, 7)
+    clear_bit(buffer, 0, 7)
+    assert not get_bit(buffer, 0, 7)
+    set_bit_to(buffer, 0, 0, True)
+    assert get_bit(buffer, 0, 0)
+
+    for operation in (get_bit, set_bit, clear_bit):
+        with pytest.raises(Exception):
+            operation(buffer, 0, 8)
+        with pytest.raises(Exception):
+            operation(buffer, 1, 0)
+    with pytest.raises(Exception):
+        set_bit_to(buffer, 2**32 - 1, 2**32 - 1, True)
+
+
+@pytest.mark.parametrize(
+    "array_type,values",
+    [
+        (pyfory.BoolArray, [True]),
+        (pyfory.Int8Array, [1]),
+        (pyfory.Int16Array, [1]),
+        (pyfory.Int32Array, [1]),
+        (pyfory.Int64Array, [1]),
+        (pyfory.UInt8Array, [1]),
+        (pyfory.UInt16Array, [1]),
+        (pyfory.UInt32Array, [1]),
+        (pyfory.UInt64Array, [1]),
+        (pyfory.Float16Array, [1.0]),
+        (pyfory.BFloat16Array, [1.0]),
+        (pyfory.Float32Array, [1.0]),
+        (pyfory.Float64Array, [1.0]),
+    ],
+)
+def test_native_array_range_owner(array_type, values):
+    value = array_type(values)
+    assert value[0] == values[0]
+    assert value._get(-1) == values[0]
+    value._set(-1, values[0])
+    with pytest.raises(Exception):
+        _ = value[1]
+    with pytest.raises(Exception):
+        value._get(1)
+    with pytest.raises(Exception):
+        value._set(1, values[0])
+    with pytest.raises(Exception):
+        value._delete(1)
+    value._insert(99, values[0])
+    assert len(value) == 2
+    value._delete(-1)
+    assert value == values
+
+
+def test_hash_buffer_empty_input():
+    assert pyfory.mmh3.hash_buffer(b"") == (0, 0)
 
 
 def test_readline_without_newline_does_not_read_out_of_bounds():
@@ -237,7 +432,7 @@ def test_buffer_protocol():
 
 def test_grow():
     binary = b"a" * 10
-    buffer = Buffer(binary)
+    buffer = Buffer(bytearray(binary))
     assert not buffer.own_data()
     buffer.write_bytes(binary)
     assert not buffer.own_data()
@@ -247,55 +442,58 @@ def test_grow():
 
 def test_write_var_uint64():
     buf = Buffer.allocate(32)
-    check_varuint64(buf, -1, 9)
+    cases = (
+        (1, 1),
+        (1 << 6, 1),
+        (1 << 7, 2),
+        (1 << 13, 2),
+        (1 << 14, 3),
+        (1 << 20, 3),
+        (1 << 21, 4),
+        (1 << 27, 4),
+        (1 << 28, 5),
+        (1 << 35, 6),
+        (1 << 42, 7),
+        (1 << 49, 8),
+        (1 << 56, 9),
+        ((1 << 63) - 1, 9),
+        (1 << 63, 9),
+        ((1 << 64) - 1, 9),
+    )
     for i in range(32):
         for j in range(i):
             buf.write_int8(1)
             buf.read_int8()
-        check_varuint64(buf, -1, 9)
-        check_varuint64(buf, 1, 1)
-        check_varuint64(buf, 1 << 6, 1)
-        check_varuint64(buf, 1 << 7, 2)
-        check_varuint64(buf, -(2**6), 9)
-        check_varuint64(buf, -(2**7), 9)
-        check_varuint64(buf, 1 << 13, 2)
-        check_varuint64(buf, 1 << 14, 3)
-        check_varuint64(buf, -(2**13), 9)
-        check_varuint64(buf, -(2**14), 9)
-        check_varuint64(buf, 1 << 20, 3)
-        check_varuint64(buf, 1 << 21, 4)
-        check_varuint64(buf, -(2**20), 9)
-        check_varuint64(buf, -(2**21), 9)
-        check_varuint64(buf, 1 << 27, 4)
-        check_varuint64(buf, 1 << 28, 5)
-        check_varuint64(buf, -(2**27), 9)
-        check_varuint64(buf, -(2**28), 9)
-        check_varuint64(buf, 1 << 30, 5)
-        check_varuint64(buf, -(2**30), 9)
-        check_varuint64(buf, 1 << 31, 5)
-        check_varuint64(buf, -(2**31), 9)
-        check_varuint64(buf, 1 << 32, 5)
-        check_varuint64(buf, -(2**32), 9)
-        check_varuint64(buf, 1 << 34, 5)
-        check_varuint64(buf, -(2**34), 9)
-        check_varuint64(buf, 1 << 35, 6)
-        check_varuint64(buf, -(2**35), 9)
-        check_varuint64(buf, 1 << 41, 6)
-        check_varuint64(buf, -(2**41), 9)
-        check_varuint64(buf, 1 << 42, 7)
-        check_varuint64(buf, -(2**42), 9)
-        check_varuint64(buf, 1 << 48, 7)
-        check_varuint64(buf, -(2**48), 9)
-        check_varuint64(buf, 1 << 49, 8)
-        check_varuint64(buf, -(2**49), 9)
-        check_varuint64(buf, 1 << 55, 8)
-        check_varuint64(buf, -(2**55), 9)
-        check_varuint64(buf, 1 << 56, 9)
-        check_varuint64(buf, -(2**56), 9)
-        check_varuint64(buf, 1 << 62, 9)
-        check_varuint64(buf, -(2**62), 9)
-        check_varuint64(buf, 1 << 63 - 1, 9)
-        check_varuint64(buf, -(2**63), 9)
+        for value, bytes_written in cases:
+            check_varuint64(buf, value, bytes_written)
+    with pytest.raises(Exception):
+        buf.write_var_uint64(-1)
+
+
+def test_int24_declared_range():
+    buffer = Buffer.allocate(16)
+    values = (-(1 << 23), -32769, 32768, (1 << 23) - 1)
+    for value in values:
+        buffer.write_int24(value)
+    for value in values:
+        assert buffer.read_int24() == value
+    for index, value in enumerate(values):
+        buffer.put_int24(index * 3, value)
+        assert buffer.get_int24(index * 3) == value
+
+
+@pyfory.dataclass
+class UInt64Value:
+    value: pyfory.UInt64 = 0
+
+
+def test_var_uint64_fory_round_trip():
+    fory = pyfory.Fory(xlang=True, compatible=False, ref=False)
+    fory.register_type(UInt64Value)
+    value = UInt64Value((1 << 64) - 1)
+    assert fory.deserialize(fory.serialize(value)) == value
+    with pytest.raises(Exception):
+        fory.serialize(UInt64Value(-1))
 
 
 def check_varuint64(buf: Buffer, value: int, bytes_written: int):
@@ -457,7 +655,3 @@ def test_stream_buffer_short_read_error():
     reader = Buffer.from_stream(OneByteStream(b"\x01\x02\x03"))
     with pytest.raises(Exception, match="Buffer out of bound"):
         reader.read_uint32()
-
-
-if __name__ == "__main__":
-    test_grow()

--- a/python/pyfory/tests/test_buffer.py
+++ b/python/pyfory/tests/test_buffer.py
@@ -237,6 +237,9 @@ def test_buffer_export_mutability():
     assert immutable_view.readonly
     with pytest.raises(TypeError):
         immutable_view[0] = 1
+    with pytest.raises(BufferError):
+        immutable.reserve(32)
+    immutable_view.release()
 
     immutable.reserve(32)
     immutable.grow(1)
@@ -272,6 +275,15 @@ def test_buffer_export_mutability():
     writable.put_uint8(0, ord("x"))
     writable_view[1] = ord("y")
     assert backing == bytearray(b"xycd")
+    writable.set_writer_index(4)
+    with pytest.raises(BufferError):
+        writable.write_uint8(1)
+    assert bytes(writable_view) == b"xycd"
+    writable_view.release()
+    writable.write_uint8(1)
+
+    with pytest.raises(BufferError):
+        memoryview(Buffer.from_stream(OneByteStream(b"x")))
 
 
 def test_write_context_writable_buffer():

--- a/python/pyfory/tests/test_cross_language.py
+++ b/python/pyfory/tests/test_cross_language.py
@@ -262,7 +262,7 @@ def test_write_multi_record_batch(schema_file_path, data_file_path):
 def test_buffer(data_file_path):
     with open(data_file_path, "rb") as f:
         data_bytes = f.read()
-        buffer = pyfory.Buffer(data_bytes)
+        buffer = pyfory.Buffer(bytearray(data_bytes))
         assert buffer.read_bool() is True
         assert buffer.read_int8() == 2**7 - 1
         assert buffer.read_int16() == 2**15 - 1
@@ -664,7 +664,7 @@ def test_oob_buffer(in_band_file_path, out_of_band_file_path):
     with open(in_band_file_path, "rb") as f:
         in_band_bytes = f.read()
     with open(out_of_band_file_path, "rb") as f:
-        out_of_band_buffer = pyfory.Buffer(f.read())
+        out_of_band_buffer = pyfory.Buffer(bytearray(f.read()))
     fory = pyfory.Fory(xlang=True, compatible=False, ref=True)
     n_buffers = out_of_band_buffer.read_int32()
     buffers = []

--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -505,32 +505,9 @@ impl<'a> Writer<'a> {
         );
         if value < 0x80 {
             self.bf.push(value as u8);
-        } else if value < 0x4000 {
-            let b0 = ((value & 0x7F) as u8) | 0x80;
-            let b1 = (value >> 7) as u8;
-            let combined = ((b1 as u16) << 8) | (b0 as u16);
-            self.write_u16(combined);
-        } else if value < 0x200000 {
-            let b0 = (value & 0x7F) | 0x80;
-            let b1 = ((value >> 7) & 0x7F) | 0x80;
-            let b2 = value >> 14;
-            let combined = b0 | (b1 << 8) | (b2 << 16);
-            self.write_u32(combined as u32);
-        } else if value < 0x10000000 {
-            let b0 = (value & 0x7F) | 0x80;
-            let b1 = ((value >> 7) & 0x7F) | 0x80;
-            let b2 = ((value >> 14) & 0x7F) | 0x80;
-            let b3 = value >> 21;
-            let combined = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
-            self.write_u32(combined as u32);
         } else {
-            let b0 = (value & 0x7F) | 0x80;
-            let b1 = ((value >> 7) & 0x7F) | 0x80;
-            let b2 = ((value >> 14) & 0x7F) | 0x80;
-            let b3 = ((value >> 21) & 0x7F) | 0x80;
-            let b4 = value >> 28;
-            let combined = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24) | (b4 << 32);
-            self.write_u64(combined);
+            // Xlang keeps standard seven-bit varuint framing, so 36-bit values need up to six bytes.
+            self._write_var_u64(value);
         }
     }
 }
@@ -608,13 +585,6 @@ impl<'a> Reader<'a> {
         } else {
             Ok(())
         }
-    }
-
-    #[inline(always)]
-    fn read_u8_uncheck(&mut self) -> u8 {
-        let result = unsafe { self.bf.get_unchecked(self.cursor) };
-        self.move_next(1);
-        *result
     }
 
     #[inline(always)]
@@ -985,20 +955,31 @@ impl<'a> Reader<'a> {
         Ok(string)
     }
 
+    /// Reads bytes without validating UTF-8.
+    ///
+    /// # Safety
+    ///
+    /// The next `len` bytes must be valid UTF-8. Violating this requirement creates an invalid
+    /// [`String`] and breaks its required invariant.
+    ///
+    /// ```compile_fail
+    /// use fory_core::buffer::Reader;
+    ///
+    /// let mut reader = Reader::new(b"valid");
+    /// let _ = reader.read_utf8_string_unchecked(5);
+    /// ```
     #[inline(always)]
-    pub fn read_utf8_string_unchecked(&mut self, len: usize) -> Result<String, Error> {
+    pub unsafe fn read_utf8_string_unchecked(&mut self, len: usize) -> Result<String, Error> {
         self.check_bound(len)?;
-        // don't use simd for memory copy, copy_non_overlapping is faster
+        let mut vec = Vec::with_capacity(len);
+        let src = unsafe { self.bf.as_ptr().add(self.cursor) };
+        let dst = vec.as_mut_ptr();
         unsafe {
-            let mut vec = Vec::with_capacity(len);
-            let src = self.bf.as_ptr().add(self.cursor);
-            let dst = vec.as_mut_ptr();
-            // Use fastest possible copy - copy_nonoverlapping compiles to memcpy
             std::ptr::copy_nonoverlapping(src, dst, len);
             vec.set_len(len);
-            self.move_next(len);
-            Ok(String::from_utf8_unchecked(vec))
         }
+        self.move_next(len);
+        Ok(unsafe { String::from_utf8_unchecked(vec) })
     }
 
     #[inline(always)]
@@ -1060,8 +1041,7 @@ impl<'a> Reader<'a> {
         let slice = self.slice_after_cursor();
 
         if slice.len() >= 8 {
-            // here already check bound
-            let bulk = self.read_u64()?;
+            let bulk = LittleEndian::read_u64(&slice[..8]);
             let mut result = bulk & 0x7F;
             let mut read_idx = start;
 
@@ -1076,7 +1056,17 @@ impl<'a> Reader<'a> {
                         result |= (bulk >> 3) & 0xFE00000;
                         if (bulk & 0x80000000) != 0 {
                             read_idx += 1;
-                            result |= (bulk >> 4) & 0xFF0000000;
+                            result |= (bulk >> 4) & 0x7F0000000;
+                            if (bulk & 0x8000000000) != 0 {
+                                let sixth = ((bulk >> 40) & 0xFF) as u8;
+                                // Only bit 35 belongs to a 36-bit value; continuation or higher
+                                // payload bits would extend the value beyond the wire type.
+                                if sixth > 1 {
+                                    return Err(Error::invalid_data("var_u36_small overflow"));
+                                }
+                                read_idx += 1;
+                                result |= (sixth as u64) << 35;
+                            }
                         }
                     }
                 }
@@ -1086,18 +1076,22 @@ impl<'a> Reader<'a> {
         }
 
         let mut result = 0u64;
-        let mut shift = 0;
-        while self.cursor < self.bf.len() {
-            let b = self.read_u8_uncheck();
-            result |= ((b & 0x7F) as u64) << shift;
+        for index in 0..5 {
+            let b = self.value_at(start + index)?;
+            result |= ((b & 0x7F) as u64) << (index * 7);
             if (b & 0x80) == 0 {
-                break;
-            }
-            shift += 7;
-            if shift >= 36 {
-                return Err(Error::encode_error("var_u36_small overflow"));
+                self.cursor = start + index + 1;
+                return Ok(result);
             }
         }
+
+        let sixth = self.value_at(start + 5)?;
+        // The sixth group may contain only bit 35 and must terminate the varuint.
+        if sixth > 1 {
+            return Err(Error::invalid_data("var_u36_small overflow"));
+        }
+        result |= (sixth as u64) << 35;
+        self.cursor = start + 6;
         Ok(result)
     }
 }

--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -505,9 +505,48 @@ impl<'a> Writer<'a> {
         );
         if value < 0x80 {
             self.bf.push(value as u8);
+        } else if value < 0x4000 {
+            let b0 = ((value as u8) & 0x7f) | 0x80;
+            let b1 = (value >> 7) as u8;
+            self.write_u16(((b1 as u16) << 8) | b0 as u16);
+        } else if value < 0x200000 {
+            let b0 = ((value as u8) & 0x7f) | 0x80;
+            let b1 = (((value >> 7) as u8) & 0x7f) | 0x80;
+            let b2 = (value >> 14) as u8;
+            self.write_u24(((b2 as u32) << 16) | ((b1 as u32) << 8) | b0 as u32);
+        } else if value < 0x10000000 {
+            let b0 = ((value as u8) & 0x7f) | 0x80;
+            let b1 = (((value >> 7) as u8) & 0x7f) | 0x80;
+            let b2 = (((value >> 14) as u8) & 0x7f) | 0x80;
+            let b3 = (value >> 21) as u8;
+            self.write_u32(
+                ((b3 as u32) << 24) | ((b2 as u32) << 16) | ((b1 as u32) << 8) | b0 as u32,
+            );
+        } else if value < (1u64 << 35) {
+            let b0 = ((value as u8) & 0x7f) | 0x80;
+            let b1 = (((value >> 7) as u8) & 0x7f) | 0x80;
+            let b2 = (((value >> 14) as u8) & 0x7f) | 0x80;
+            let b3 = (((value >> 21) as u8) & 0x7f) | 0x80;
+            let b4 = (value >> 28) as u8;
+            self.write_u40(
+                ((b4 as u64) << 32)
+                    | ((b3 as u64) << 24)
+                    | ((b2 as u64) << 16)
+                    | ((b1 as u64) << 8)
+                    | b0 as u64,
+            );
         } else {
-            // Xlang keeps standard seven-bit varuint framing, so 36-bit values need up to six bytes.
-            self._write_var_u64(value);
+            // Standard seven-bit varuint framing needs a sixth byte for bit 35.
+            let b0 = ((value as u8) & 0x7f) | 0x80;
+            let b1 = (((value >> 7) as u8) & 0x7f) | 0x80;
+            let b2 = (((value >> 14) as u8) & 0x7f) | 0x80;
+            let b3 = (((value >> 21) as u8) & 0x7f) | 0x80;
+            let b4 = (((value >> 28) as u8) & 0x7f) | 0x80;
+            let b5 = (value >> 35) as u8;
+            self.write_u32(
+                ((b3 as u32) << 24) | ((b2 as u32) << 16) | ((b1 as u32) << 8) | b0 as u32,
+            );
+            self.write_u16(((b5 as u16) << 8) | b4 as u16);
         }
     }
 }

--- a/rust/fory-core/src/buffer.rs
+++ b/rust/fory-core/src/buffer.rs
@@ -202,14 +202,34 @@ impl<'a> Writer<'a> {
 
     #[inline(always)]
     fn write_u24(&mut self, value: u32) {
-        let bytes = value.to_le_bytes();
-        self.bf.extend_from_slice(&bytes[..3]);
+        let offset = self.bf.len();
+        self.bf.reserve(4);
+        // The four-byte store stays inside reserved capacity; only the three wire bytes become
+        // initialized vector contents.
+        unsafe {
+            self.bf
+                .as_mut_ptr()
+                .add(offset)
+                .cast::<u32>()
+                .write_unaligned(value.to_le());
+            self.bf.set_len(offset + 3);
+        }
     }
 
     #[inline(always)]
     fn write_u40(&mut self, value: u64) {
-        let bytes = value.to_le_bytes();
-        self.bf.extend_from_slice(&bytes[..5]);
+        let offset = self.bf.len();
+        self.bf.reserve(8);
+        // The eight-byte store stays inside reserved capacity; only the five wire bytes become
+        // initialized vector contents.
+        unsafe {
+            self.bf
+                .as_mut_ptr()
+                .add(offset)
+                .cast::<u64>()
+                .write_unaligned(value.to_le());
+            self.bf.set_len(offset + 5);
+        }
     }
 
     // ============ VAR_UINT32 (TypeId = 12) ============

--- a/rust/fory-core/src/serializer/string.rs
+++ b/rust/fory-core/src/serializer/string.rs
@@ -20,6 +20,7 @@ use crate::error::Error;
 use crate::serializer::util::read_basic_type_info;
 use crate::serializer::Serializer;
 use crate::type_id::TypeId;
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -27,6 +28,22 @@ enum StrEncoding {
     Latin1 = 0,
     Utf16 = 1,
     Utf8 = 2,
+}
+
+#[inline(always)]
+pub(super) fn checked_string_len(len: u64) -> Result<usize, Error> {
+    match usize::try_from(len) {
+        Ok(len) => Ok(len),
+        Err(_) => Err(string_len_overflow(len)),
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn string_len_overflow(len: u64) -> Error {
+    Error::invalid_data(format!(
+        "string byte length {len} exceeds the platform address space"
+    ))
 }
 
 impl Serializer for String {
@@ -45,12 +62,14 @@ impl Serializer for String {
     #[inline(always)]
     fn read_data(context: &mut ReadContext) -> Result<Self, Error> {
         let header = context.reader.read_var_u36_small()?;
-        let len = (header >> 2) as usize;
+        let len = checked_string_len(header >> 2)?;
         match header & 0b11 {
             0 => context.reader.read_latin1_string(len),
             1 => context.reader.read_utf16_string(len),
             2 if context.is_check_string_read() => context.reader.read_utf8_string(len),
-            2 => context.reader.read_utf8_string_unchecked(len),
+            // SAFETY: Disabling string checks is an explicit trusted-input contract. The default
+            // configuration validates UTF-8 before constructing a String.
+            2 => unsafe { context.reader.read_utf8_string_unchecked(len) },
             encoding => Err(Error::encoding_error(format!(
                 "wrong encoding value: {}",
                 encoding
@@ -89,5 +108,22 @@ impl Serializer for String {
     #[inline(always)]
     fn read_type_info(context: &mut ReadContext) -> Result<(), Error> {
         read_basic_type_info::<Self>(context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_length_range() {
+        assert_eq!(checked_string_len(17).unwrap(), 17);
+
+        let beyond_u32 = u64::from(u32::MAX) + 1;
+        if usize::BITS > u32::BITS {
+            assert_eq!(checked_string_len(beyond_u32).unwrap() as u64, beyond_u32);
+        } else {
+            assert!(checked_string_len(beyond_u32).is_err());
+        }
     }
 }

--- a/rust/fory-core/src/util/string_util.rs
+++ b/rust/fory-core/src/util/string_util.rs
@@ -698,6 +698,13 @@ pub mod buffer_rw_string {
     use crate::buffer::{Reader, Writer};
     use crate::error::Error;
 
+    #[inline(always)]
+    fn latin1_utf8_capacity(len: usize) -> Result<usize, Error> {
+        len.checked_mul(2)
+            .filter(|&capacity| capacity <= isize::MAX as usize)
+            .ok_or_else(|| Error::invalid_data("Latin1 string exceeds native allocation limit"))
+    }
+
     #[inline]
     pub fn write_latin1_standard(writer: &mut Writer, s: &str) {
         for c in s.chars() {
@@ -887,10 +894,10 @@ pub mod buffer_rw_string {
         if len == 0 {
             return Ok(String::new());
         }
-        let src = reader.sub_slice(reader.get_cursor(), reader.get_cursor() + len)?;
-
-        // Pessimistic allocation: Latin1 0x80-0xFF expands to 2 bytes in UTF-8
-        let mut out: Vec<u8> = Vec::with_capacity(len * 2);
+        // Pessimistic allocation: Latin1 0x80-0xFF expands to 2 bytes in UTF-8.
+        let capacity = latin1_utf8_capacity(len)?;
+        let src = reader.read_bytes(len)?;
+        let mut out: Vec<u8> = Vec::with_capacity(capacity);
 
         unsafe {
             let out_ptr = out.as_mut_ptr();
@@ -984,7 +991,6 @@ pub mod buffer_rw_string {
 
             out.set_len(out_len);
         }
-        reader.move_next(len);
         Ok(unsafe { String::from_utf8_unchecked(out) })
     }
 
@@ -1083,7 +1089,6 @@ pub mod buffer_rw_string {
             let mut reader = Reader::new(&[0, 1]);
 
             assert!(read_utf16_standard(&mut reader, 4).is_err());
-            assert_eq!(reader.get_cursor(), 0);
         }
 
         #[test]
@@ -1092,7 +1097,12 @@ pub mod buffer_rw_string {
             reader.skip(2).unwrap();
 
             assert!(read_utf16_standard(&mut reader, usize::MAX - 1).is_err());
-            assert_eq!(reader.get_cursor(), 2);
+        }
+
+        #[test]
+        fn latin1_native_capacity() {
+            let len = (isize::MAX as usize / 2) + 1;
+            assert!(latin1_utf8_capacity(len).is_err());
         }
     }
 }

--- a/rust/tests/tests/test_buffer.rs
+++ b/rust/tests/tests/test_buffer.rs
@@ -63,38 +63,54 @@ fn test_var_i32() {
 
 #[test]
 fn test_var_u36_small() {
-    let test_data: Vec<u64> = vec![
-        // 1 byte
-        0,
-        1,
-        127,
-        // 2 bytes
-        128,
-        300,
-        16_383,
-        // 3 bytes
-        16_384,
-        20_000,
-        2_097_151,
-        // 4 bytes
-        2_097_152,
-        100_000_000,
-        268_435_455,
-        // 5 bytes (36-bit max)
-        268_435_456,
-        1_000_000_000,
-        68_719_476_735, // max 36-bit
+    let cases: &[(u64, &[u8])] = &[
+        (0, &[0x00]),
+        (127, &[0x7f]),
+        (128, &[0x80, 0x01]),
+        (16_383, &[0xff, 0x7f]),
+        (16_384, &[0x80, 0x80, 0x01]),
+        (2_097_151, &[0xff, 0xff, 0x7f]),
+        (2_097_152, &[0x80, 0x80, 0x80, 0x01]),
+        (268_435_455, &[0xff, 0xff, 0xff, 0x7f]),
+        (268_435_456, &[0x80, 0x80, 0x80, 0x80, 0x01]),
+        ((1_u64 << 35) - 1, &[0xff, 0xff, 0xff, 0xff, 0x7f]),
+        (1_u64 << 35, &[0x80, 0x80, 0x80, 0x80, 0x80, 0x01]),
+        ((1_u64 << 36) - 1, &[0xff, 0xff, 0xff, 0xff, 0xff, 0x01]),
     ];
 
-    for &data in &test_data {
+    for &(value, expected) in cases {
         let mut buffer = vec![];
         let mut writer = Writer::from_buffer(&mut buffer);
-        writer.write_var_u36_small(data);
-        let buf = writer.dump();
+        writer.write_var_u36_small(value);
+        assert_eq!(writer.dump(), expected, "wrong wire bytes for {value}");
 
-        let mut reader = Reader::new(buf.as_slice());
-        let value = reader.read_var_u36_small().unwrap();
-        assert_eq!(value, data, "failed for data {}", data);
+        let mut short_reader = Reader::new(expected);
+        assert_eq!(short_reader.read_var_u36_small().unwrap(), value);
+        assert_eq!(short_reader.get_cursor(), expected.len());
+
+        let mut framed = expected.to_vec();
+        framed.push(0x2a);
+        framed.extend_from_slice(&[0; 8]);
+        let mut long_reader = Reader::new(&framed);
+        assert_eq!(long_reader.read_var_u36_small().unwrap(), value);
+        assert_eq!(long_reader.read_u8().unwrap(), 0x2a);
+    }
+}
+
+#[test]
+fn test_var_u36_bad_framing() {
+    for len in 1..=5 {
+        let bytes = vec![0x80; len];
+        let mut reader = Reader::new(&bytes);
+        assert!(reader.read_var_u36_small().is_err());
+    }
+
+    for bytes in [
+        [0x80, 0x80, 0x80, 0x80, 0x80, 0x02],
+        [0x80, 0x80, 0x80, 0x80, 0x80, 0x80],
+    ] {
+        let mut reader = Reader::new(&bytes);
+        assert!(reader.read_var_u36_small().is_err());
     }
 }
 

--- a/swift/Sources/Fory/ByteBuffer.swift
+++ b/swift/Sources/Fory/ByteBuffer.swift
@@ -111,8 +111,13 @@ public final class ByteBuffer {
         cursor = 0
     }
 
+    /// Moves the read cursor to an existing buffer boundary.
+    /// Invalid positions leave the cursor unchanged.
     @inlinable
     public func setCursor(_ value: Int) {
+        if value < 0 || value > readableCount {
+            return
+        }
         cursor = value
     }
 
@@ -177,8 +182,20 @@ public final class ByteBuffer {
         cursor
     }
 
+    /// Rewinds the read cursor without moving before the start of the buffer.
+    /// Invalid amounts leave the cursor unchanged.
     @inlinable
     public func moveBack(_ amount: Int) {
+        if amount < 0 || amount > cursor {
+            return
+        }
+        cursor -= amount
+    }
+
+    @usableFromInline
+    @inline(__always)
+    internal func moveBackUnchecked(_ amount: Int) {
+        // Hot read owners use this only to rewind bytes they just consumed successfully.
         cursor -= amount
     }
 
@@ -751,7 +768,7 @@ public final class ByteBuffer {
         if (first & 1) == 0 {
             return Int64(first >> 1)
         }
-        moveBack(3)
+        moveBackUnchecked(3)
         return try readInt64()
     }
 
@@ -761,7 +778,7 @@ public final class ByteBuffer {
         if (first & 1) == 0 {
             return UInt64(first >> 1)
         }
-        moveBack(3)
+        moveBackUnchecked(3)
         return try readUInt64()
     }
 

--- a/swift/Sources/Fory/DateTimeSerializers.swift
+++ b/swift/Sources/Fory/DateTimeSerializers.swift
@@ -50,21 +50,21 @@ private func timestampDate(seconds: Int64, nanos: UInt32) -> Date {
 }
 
 @inline(__always)
-private func localDateEpochDay(for date: Date) throws -> Int32 {
+private func localDateEpochDay(for date: Date) throws -> Int64 {
     let days = floor(date.timeIntervalSince1970 / secondsPerDay)
-    guard days >= Double(Int32.min), days <= Double(Int32.max) else {
+    guard let epochDay = Int64(exactly: days) else {
         throw dateEpochOutOfRange()
     }
-    return Int32(days)
+    return epochDay
 }
 
 @inline(__always)
-private func localDateFromEpochDay(_ epochDay: Int32) -> Date {
+private func localDateFromEpochDay(_ epochDay: Int64) -> Date {
     Date(timeIntervalSince1970: Double(epochDay) * secondsPerDay)
 }
 
 @inline(__always)
-private func localDateComponents(_ epochDay: Int32) -> DateComponents {
+private func localDateComponents(_ epochDay: Int64) -> DateComponents {
     localDateCalendar.dateComponents([.year, .month, .day], from: localDateFromEpochDay(epochDay))
 }
 
@@ -169,12 +169,17 @@ private func readTypeID(_ context: ReadContext, expectedTypeIDs: [TypeId]) throw
 
 @inline(never)
 private func dateEpochOutOfRange() -> ForyError {
-    ForyError.encodingError("date epochDay is out of Int32 range")
+    ForyError.encodingError("date epochDay is out of Int64 range")
 }
 
 @inline(never)
-private func invalidDateEpochDay() -> ForyError {
-    ForyError.invalidData("date epochDay is out of Int32 range")
+private func invalidDurationNanos(_ nanos: Int32) -> ForyError {
+    ForyError.invalidData("duration nanoseconds \(nanos) are outside [0, 1000000000)")
+}
+
+@inline(never)
+private func durationOutOfRange() -> ForyError {
+    ForyError.encodingError("duration is outside the normalized wire range")
 }
 
 @inline(never)
@@ -206,13 +211,13 @@ private func unexpectedScalarTypeIDs(_ expected: [TypeId], actual: UInt32) -> Fo
 /// A calendar date without time-of-day or timezone, encoded as Fory `date`.
 public struct LocalDate: Serializer, Equatable, Hashable, Comparable {
     /// Days since 1970-01-01 in the UTC Gregorian calendar.
-    public var epochDay: Int32
+    public var epochDay: Int64
 
-    public init(epochDay: Int32 = 0) {
+    public init(epochDay: Int64 = 0) {
         self.epochDay = epochDay
     }
 
-    public static func fromEpochDay(_ epochDay: Int32) -> LocalDate {
+    public static func fromEpochDay(_ epochDay: Int64) -> LocalDate {
         .init(epochDay: epochDay)
     }
 
@@ -233,7 +238,7 @@ public struct LocalDate: Serializer, Equatable, Hashable, Comparable {
         self.epochDay = try localDateEpochDay(for: utcDate)
     }
 
-    public func toEpochDay() -> Int32 {
+    public func toEpochDay() -> Int64 {
         epochDay
     }
 
@@ -293,7 +298,7 @@ public extension WriteContext {
 
     @inline(__always)
     func writeLocalDate(_ value: LocalDate) throws {
-        buffer.writeVarInt64(Int64(value.epochDay))
+        buffer.writeVarInt64(value.epochDay)
     }
 
     @inline(__always)
@@ -335,10 +340,7 @@ public extension ReadContext {
 
     @inline(__always)
     func readLocalDate() throws -> LocalDate {
-        guard let epochDay = Int32(exactly: try buffer.readVarInt64()) else {
-            throw invalidDateEpochDay()
-        }
-        return .init(epochDay: epochDay)
+        .init(epochDay: try buffer.readVarInt64())
     }
 
     @inline(__always)
@@ -410,18 +412,29 @@ extension Duration: Serializer {
 
     public static func writeData(_ value: Self, _ context: WriteContext) throws {
         let components = value.components
-        let nanos = components.attoseconds / 1_000_000_000
+        var seconds = components.seconds
+        var nanos = components.attoseconds / 1_000_000_000
         let remainder = components.attoseconds % 1_000_000_000
         if remainder != 0 {
             throw ForyError.encodingError("Duration precision finer than nanoseconds is not supported")
         }
-        context.buffer.writeVarInt64(components.seconds)
+        if nanos < 0 {
+            guard seconds > Int64.min else {
+                throw durationOutOfRange()
+            }
+            seconds -= 1
+            nanos += nanosPerSecond
+        }
+        context.buffer.writeVarInt64(seconds)
         context.buffer.writeInt32(Int32(nanos))
     }
 
     public static func readData(_ context: ReadContext) throws -> Duration {
         let seconds = try context.buffer.readVarInt64()
         let nanos = try context.buffer.readInt32()
+        guard nanos >= 0, nanos < Int32(nanosPerSecond) else {
+            throw invalidDurationNanos(nanos)
+        }
         return .seconds(seconds) + .nanoseconds(Int64(nanos))
     }
 }

--- a/swift/Sources/Fory/UnsafeUtil.swift
+++ b/swift/Sources/Fory/UnsafeUtil.swift
@@ -627,13 +627,11 @@ public enum UnsafeUtil {
         from bytes: UnsafeBufferPointer<UInt8>,
         index: inout Int
     ) throws -> UInt32 {
+        try checkReadable(bytes, index: index, need: 1)
         guard let base = bytes.baseAddress else {
             throw ForyError.outOfBounds(cursor: index, need: 1, length: bytes.count)
         }
         let available = bytes.count - index
-        guard available > 0 else {
-            throw ForyError.outOfBounds(cursor: index, need: 1, length: bytes.count)
-        }
 
         let b0 = base[index]
         if b0 < 0x80 {
@@ -681,10 +679,11 @@ public enum UnsafeUtil {
         from bytes: UnsafeBufferPointer<UInt8>,
         index: inout Int
     ) throws -> UInt64 {
-        let available = bytes.count - index
+        try checkReadable(bytes, index: index, need: 1)
         guard let base = bytes.baseAddress else {
             throw ForyError.outOfBounds(cursor: index, need: 1, length: bytes.count)
         }
+        let available = bytes.count - index
         if available >= 9 {
             let offset = index
             let b0 = base[offset]
@@ -841,10 +840,8 @@ public enum UnsafeUtil {
         length: Int,
         index: inout Int
     ) throws -> UInt32 {
+        try checkReadable(length: length, index: index, need: 1)
         let available = length - index
-        guard available > 0 else {
-            throw ForyError.outOfBounds(cursor: index, need: 1, length: length)
-        }
 
         let b0 = base[index]
         if b0 < 0x80 {
@@ -893,6 +890,7 @@ public enum UnsafeUtil {
         length: Int,
         index: inout Int
     ) throws -> UInt64 {
+        try checkReadable(length: length, index: index, need: 1)
         let available = length - index
         if available >= 9 {
             let offset = index
@@ -1122,7 +1120,8 @@ public enum UnsafeUtil {
         index: Int,
         need: Int
     ) throws {
-        if index < 0 || need < 0 || index + need > bytes.count {
+        let length = bytes.count
+        if index < 0 || need < 0 || index > length || need > length - index {
             throw ForyError.outOfBounds(cursor: index, need: need, length: bytes.count)
         }
     }
@@ -1134,7 +1133,7 @@ public enum UnsafeUtil {
         index: Int,
         need: Int
     ) throws {
-        if index < 0 || need < 0 || index + need > length {
+        if length < 0 || index < 0 || need < 0 || index > length || need > length - index {
             throw ForyError.outOfBounds(cursor: index, need: need, length: length)
         }
     }

--- a/swift/Tests/ForyTests/ByteBufferTests.swift
+++ b/swift/Tests/ForyTests/ByteBufferTests.swift
@@ -85,6 +85,61 @@ func byteBufferReplaceMutationAndSnapshots() throws {
 }
 
 @Test
+func invalidCursorMutationRejected() throws {
+    let buffer = ByteBuffer(bytes: [0x2A])
+
+    buffer.setCursor(-1)
+    #expect(buffer.getCursor() == 0)
+    #expect(try buffer.readUInt8() == 0x2A)
+
+    buffer.moveBack(2)
+    #expect(buffer.getCursor() == 1)
+
+    buffer.moveBack(Int.min)
+    #expect(buffer.getCursor() == 1)
+}
+
+@Test
+func negativeVarUIntIndicesRejected() throws {
+    let bytes: [UInt8] = [0]
+    try bytes.withUnsafeBufferPointer { buffer in
+        var bufferIndex32 = -1
+        #expect(throws: (any Error).self) {
+            _ = try UnsafeUtil.readVarUInt32(from: buffer, index: &bufferIndex32)
+        }
+
+        var bufferIndex64 = Int.min
+        #expect(throws: (any Error).self) {
+            _ = try UnsafeUtil.readVarUInt64(from: buffer, index: &bufferIndex64)
+        }
+
+        let base = try #require(buffer.baseAddress)
+        var pointerIndex32 = -1
+        #expect(throws: (any Error).self) {
+            _ = try UnsafeUtil.readVarUInt32(
+                from: base,
+                length: buffer.count,
+                index: &pointerIndex32)
+        }
+
+        var pointerIndex64 = Int.min
+        #expect(throws: (any Error).self) {
+            _ = try UnsafeUtil.readVarUInt64(
+                from: base,
+                length: buffer.count,
+                index: &pointerIndex64)
+        }
+    }
+
+    #expect(throws: (any Error).self) {
+        try UnsafeUtil.checkReadable(
+            length: Int.max,
+            index: Int.max - 1,
+            need: Int.max)
+    }
+}
+
+@Test
 func byteBufferVarUIntBoundariesUseExpectedSizes() throws {
     let values32: [UInt32] = [
         0,

--- a/swift/Tests/ForyTests/DateTimeTests.swift
+++ b/swift/Tests/ForyTests/DateTimeTests.swift
@@ -19,8 +19,6 @@ import Foundation
 import Testing
 @testable import Fory
 
-private let secondsPerDay = 86_400.0
-
 @ForyStruct
 private struct DateMacroHolder {
     var day: LocalDate = LocalDate()
@@ -29,11 +27,7 @@ private struct DateMacroHolder {
     var timestamp: Date = Date(timeIntervalSince1970: 0)
 }
 
-private func midnightUTC(epochDay: Int32) -> Date {
-    Date(timeIntervalSince1970: Double(epochDay) * secondsPerDay)
-}
-
-private func localDate(_ epochDay: Int32) -> LocalDate {
+private func localDate(_ epochDay: Int64) -> LocalDate {
     .init(epochDay: epochDay)
 }
 
@@ -53,10 +47,40 @@ func dateAndTimestampRoundTrip() throws {
     let dayDecoded: LocalDate = try fory.deserialize(dayData)
     #expect(dayDecoded == day)
 
+    for boundary in [Int64.min, Int64.max] {
+        let boundaryDate = LocalDate(epochDay: boundary)
+        let boundaryData = try fory.serialize(boundaryDate)
+        let boundaryDecoded: LocalDate = try fory.deserialize(boundaryData)
+        #expect(boundaryDecoded == boundaryDate)
+    }
+
     let duration = Duration.seconds(-7) + Duration.nanoseconds(12_000_000)
     let durationData = try fory.serialize(duration)
     let durationDecoded: Duration = try fory.deserialize(durationData)
     #expect(durationDecoded == duration)
+
+    let durationBody = ByteBuffer()
+    let durationContext = WriteContext(
+        buffer: durationBody,
+        typeResolver: TypeResolver(trackRef: false),
+        trackRef: false
+    )
+    try Duration.writeData(Duration.milliseconds(-500), durationContext)
+    #expect(try durationBody.readVarInt64() == -1)
+    #expect(try durationBody.readInt32() == 500_000_000)
+
+    var malformedDuration = try fory.serialize(Duration.zero)
+    let invalidNanos = ByteBuffer()
+    invalidNanos.writeInt32(1_000_000_000)
+    malformedDuration.replaceSubrange(
+        (malformedDuration.count - 4)..<malformedDuration.count,
+        with: invalidNanos.copyToData()
+    )
+    #expect(throws: (any Error).self) {
+        let _: Duration = try fory.deserialize(malformedDuration)
+    }
+    let durationAfterFailure: Duration = try fory.deserialize(durationData)
+    #expect(durationAfterFailure == duration)
 
     let instant = Date(timeIntervalSince1970: 1_731_234_567.123_456_7)
     let instantData = try fory.serialize(instant)


### PR DESCRIPTION
## Summary

- harden low-level buffer growth, cursor, copy, and native memory access boundaries across Java,
  C++, Python, Go, Rust, Swift, Dart, and JavaScript
- correct 36-bit string-header encoding at the six-byte boundary and guard oversized headers before
  they can drive unsafe reads or disproportionate growth
- preserve runtime-specific hot paths through owner-local unchecked operations only after capacity
  or range has already been proven
- document the JDK 25 VarHandle bounds owner and the MemoryAllocator successful-growth contract
- retain controlled temporal and native-carrier conversions without adding write-side depth checks

## Validation

- affected runtime unit, formatting, lint, build, and integration suites pass
- Java 21 nine-module clean reactor passes
- Java 25 core multi-release build and overlay tests pass
- all affected-language serialization benchmark metrics are below the 1% regression threshold
