### PR TITLE
fix(javascript): use correct typemeta special chars

### DIFF
--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -33,8 +33,9 @@ const fieldEncoder = new MetaStringEncoder("$", "_");
 const fieldDecoder = new MetaStringDecoder("$", "_");
 const pkgEncoder = new MetaStringEncoder(".", "_");
 const pkgDecoder = new MetaStringDecoder(".", "_");
-const typeNameEncoder = new MetaStringEncoder("$", ".");
-const typeNameDecoder = new MetaStringDecoder("$", ".");
+// Spec special-char set for type names is ("$", "_").
+const typeNameEncoder = new MetaStringEncoder("$", "_");
+const typeNameDecoder = new MetaStringDecoder("$", "_");
 
 const COMPRESS_META_FLAG = 1n << 8n;
 const RESERVED_META_FLAGS = 0b111n << 9n;

--- a/javascript/packages/core/lib/meta/TypeMeta.ts
+++ b/javascript/packages/core/lib/meta/TypeMeta.ts
@@ -33,7 +33,6 @@ const fieldEncoder = new MetaStringEncoder("$", "_");
 const fieldDecoder = new MetaStringDecoder("$", "_");
 const pkgEncoder = new MetaStringEncoder(".", "_");
 const pkgDecoder = new MetaStringDecoder(".", "_");
-// Spec special-char set for type names is ("$", "_").
 const typeNameEncoder = new MetaStringEncoder("$", "_");
 const typeNameDecoder = new MetaStringDecoder("$", "_");
 

--- a/javascript/test/typemeta.test.ts
+++ b/javascript/test/typemeta.test.ts
@@ -2952,6 +2952,32 @@ describe("typemeta", () => {
 
     expect(result).toBeInstanceOf(EmptyWrapper);
   });
+
+  // Bytes a spec-conformant peer (for example Java) emits for a named struct
+  // with namespace "example", typeName "Type_1", and one fixed int32 field
+  // "v". The type name uses LOWER_UPPER_DIGIT_SPECIAL, where char value 63 is
+  // "_" per the spec's type-name special-char set ("$", "_").
+  const specTypeNameMetaBytes = new Uint8Array([
+    16, 64, 45, 74, 58, 106, 49, 48, 161, 21, 18, 224, 99, 214, 64, 22, 90, 193, 226, 127, 168, 64,
+    4, 84,
+  ]);
+
+  test("decodes spec char value 63 in type names as underscore", () => {
+    const reader = new BinaryReader({});
+    reader.reset(specTypeNameMetaBytes);
+    const decoded = TypeMeta.fromBytes(reader);
+    expect(decoded.getTypeName()).toBe("Type_1");
+  });
+
+  test("encodes underscore type names with the spec charset", () => {
+    const meta = TypeMeta.fromTypeInfo(
+      Type.struct(
+        { namespace: "example", typeName: "Type_1" },
+        { v: Type.int32({ encoding: "fixed" }) },
+      ),
+    );
+    expect(Array.from(meta.toBytes())).toEqual(Array.from(specTypeNameMetaBytes));
+  });
 });
 
 function typeMetaBodyOffset(bytes: Uint8Array) {


### PR DESCRIPTION


## Why?
Spec special-char set for type names is ("$", "_"); see "Special Character Sets by Context" in `docs/specification/xlang_serialization_spec.md`.



## What does this PR do?



## Related issues



## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

