### PR TITLE
docs: update release version to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Slack Channel](https://img.shields.io/badge/slack-join-3f0e40?logo=slack&style=for-the-badge)](https://join.slack.com/t/fory-project/shared_invite/zt-36g0qouzm-kcQSvV_dtfbtBKHRwT5gsw)
 [![X](https://img.shields.io/badge/@ApacheFory-follow-blue?logo=x&style=for-the-badge)](https://x.com/ApacheFory)
 [![Maven Version](https://img.shields.io/maven-central/v/org.apache.fory/fory-core?style=for-the-badge)](https://search.maven.org/#search|gav|1|g:"org.apache.fory"%20AND%20a:"fory-core")
-[![Crates.io](https://img.shields.io/badge/crates.io-v1.7.0-blue?logo=rust&style=for-the-badge)](https://crates.io/crates/fory)
+[![Crates.io](https://img.shields.io/badge/crates.io-v1.7.1-blue?logo=rust&style=for-the-badge)](https://crates.io/crates/fory)
 [![PyPI](https://img.shields.io/pypi/v/pyfory.svg?logo=PyPI&style=for-the-badge)](https://pypi.org/project/pyfory/)
 [![npm](https://img.shields.io/npm/v/%40apache-fory%2Fcore?logo=npm&style=for-the-badge)](https://www.npmjs.com/package/@apache-fory/core)
 [![NuGet](https://img.shields.io/nuget/v/Apache.Fory?logo=nuget&style=for-the-badge)](https://www.nuget.org/packages/Apache.Fory)
@@ -150,14 +150,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation "org.apache.fory:fory-core:1.7.0"
+implementation "org.apache.fory:fory-core:1.7.1"
 ```
 
 On JDK25+, opening `java.lang.invoke` to Fory core is also recommended. It avoids the
@@ -179,7 +179,7 @@ Use the Fory core module name when Fory is on the module path:
 sbt:
 
 ```scala
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.1"
 ```
 
 **Kotlin**
@@ -187,7 +187,7 @@ libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.0"
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.7.0")
+implementation("org.apache.fory:fory-kotlin:1.7.1")
 ```
 
 Maven:
@@ -196,7 +196,7 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
@@ -218,7 +218,7 @@ pip install "pyfory[format]"
 
 ```toml
 [dependencies]
-fory = "1.7.0"
+fory = "1.7.1"
 ```
 
 **C++**
@@ -230,7 +230,7 @@ include(FetchContent)
 FetchContent_Declare(
   fory
   GIT_REPOSITORY https://github.com/apache/fory.git
-  GIT_TAG v1.7.0
+  GIT_TAG v1.7.1
   SOURCE_SUBDIR cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -241,8 +241,8 @@ Bazel:
 
 ```bazel
 # MODULE.bazel
-bazel_dep(name = "fory", version = "1.7.0")
-git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
+git_override(module_name = "fory", remote = "https://github.com/apache/fory.git", commit = "v1.7.1")
 
 # BUILD
 deps = ["@fory//cpp/fory/serialization:fory_serialization"]
@@ -275,13 +275,13 @@ npm install @apache-fory/core @apache-fory/hps
 **C#**
 
 ```bash
-dotnet add package Apache.Fory --version 1.7.0
+dotnet add package Apache.Fory --version 1.7.1
 ```
 
 **Dart**
 
 ```bash
-dart pub add fory:^1.7.0
+dart pub add fory:^1.7.1
 dart pub add dev:build_runner
 ```
 
@@ -291,7 +291,7 @@ Add Fory to `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apache/fory.git", exact: "1.7.0")
+  .package(url: "https://github.com/apache/fory.git", exact: "1.7.1")
 ],
 targets: [
   .target(
@@ -841,14 +841,14 @@ Add Fory JSON to your project:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 **Gradle**
 
 ```gradle
-implementation "org.apache.fory:fory-json:1.7.0"
+implementation "org.apache.fory:fory-json:1.7.1"
 ```
 
 Keep all Fory modules in the same application on the same version.

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -32,7 +32,7 @@ From NuGet, reference the single `Apache.Fory` package. It includes the Fory lib
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.7.0" />
+  <PackageReference Include="Apache.Fory" Version="1.7.1" />
 </ItemGroup>
 ```
 

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.8.0-dev
 
-- Start the next Dart workspace development cycle after the 1.7.0 release.
+- Start the next Dart workspace development cycle after the 1.7.1 release.
+
+## 1.7.1
+
+- Align the Dart workspace version with the Apache Fory 1.7.1 release.
 
 ## 1.7.0
 

--- a/dart/packages/fory/CHANGELOG.md
+++ b/dart/packages/fory/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.8.0-dev
 
-- Start the next development cycle after the 1.7.0 release.
+- Start the next development cycle after the 1.7.1 release.
+
+## 1.7.1
+
+- Release Apache Fory Dart 1.7.1.
 
 ## 1.7.0
 

--- a/dart/packages/fory/README.md
+++ b/dart/packages/fory/README.md
@@ -25,7 +25,7 @@ Add `fory` to your package dependencies.
 
 ```yaml
 dependencies:
-  fory: ^1.7.0
+  fory: ^1.7.1
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/docs/compiler/build-integration.md
+++ b/docs/compiler/build-integration.md
@@ -211,7 +211,7 @@ Add the Fory dependency to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.7.0
+  fory: ^1.7.1
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/docs/compiler/cli.md
+++ b/docs/compiler/cli.md
@@ -689,5 +689,5 @@ fory = "x.y.z"
 
 ```yaml
 dependencies:
-  fory: ^1.7.0
+  fory: ^1.7.1
 ```

--- a/docs/grpc/csharp.md
+++ b/docs/grpc/csharp.md
@@ -39,7 +39,7 @@ Server project:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.7.0" />
+  <PackageReference Include="Apache.Fory" Version="1.7.1" />
   <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
 </ItemGroup>
 ```
@@ -48,7 +48,7 @@ Client project:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.7.0" />
+  <PackageReference Include="Apache.Fory" Version="1.7.1" />
   <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
   <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
 </ItemGroup>

--- a/docs/grpc/dart.md
+++ b/docs/grpc/dart.md
@@ -38,7 +38,7 @@ application that compiles or runs generated service companions:
 
 ```yaml
 dependencies:
-  fory: ^1.7.0
+  fory: ^1.7.1
   grpc: ^4.0.0
 
 dev_dependencies:

--- a/docs/grpc/rust.md
+++ b/docs/grpc/rust.md
@@ -37,7 +37,7 @@ to build streaming responses or request streams.
 
 ```toml
 [dependencies]
-fory = "1.7.0"
+fory = "1.7.1"
 bytes = "1"
 tonic = { version = "0.14", features = ["transport"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/docs/json/getting-started.md
+++ b/docs/json/getting-started.md
@@ -43,7 +43,7 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
@@ -57,7 +57,7 @@ repositories {
   mavenCentral()
 }
 
-implementation("org.apache.fory:fory-json:1.7.0")
+implementation("org.apache.fory:fory-json:1.7.1")
 ```
 
 ### Kotlin
@@ -66,7 +66,7 @@ Kotlin/JVM applications add the optional Kotlin JSON runtime and use its single 
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-  implementation("org.apache.fory:fory-json-kotlin:1.7.0")
+  implementation("org.apache.fory:fory-json-kotlin:1.7.1")
 }
 ```
 

--- a/docs/json/kotlin.md
+++ b/docs/json/kotlin.md
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-  implementation("org.apache.fory:fory-json-kotlin:1.7.0")
+  implementation("org.apache.fory:fory-json-kotlin:1.7.1")
 }
 ```
 
@@ -54,7 +54,7 @@ plugins {
 }
 
 dependencies {
-  ksp("org.apache.fory:fory-json-kotlin-ksp:1.7.0")
+  ksp("org.apache.fory:fory-json-kotlin-ksp:1.7.1")
 }
 ```
 

--- a/docs/json/scala.md
+++ b/docs/json/scala.md
@@ -25,7 +25,7 @@ module works on the ordinary JVM and GraalVM Native Image. Android is not suppor
 ## Setup
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-json-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-json-scala" % "1.7.1"
 ```
 
 `ForyJsonScala.builder()` installs the Scala module and returns the standard Fory JSON builder:

--- a/docs/object-serialization/cpp/index.md
+++ b/docs/object-serialization/cpp/index.md
@@ -62,7 +62,7 @@ include(FetchContent)
 FetchContent_Declare(
     fory
     GIT_REPOSITORY https://github.com/apache/fory.git
-    GIT_TAG        v1.7.0
+    GIT_TAG        v1.7.1
     SOURCE_SUBDIR  cpp
 )
 FetchContent_MakeAvailable(fory)
@@ -92,11 +92,11 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.1.1")
 
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
-    commit = "v1.7.0",  # Or use a specific commit hash for reproducibility
+    commit = "v1.7.1",  # Or use a specific commit hash for reproducibility
 )
 ```
 
@@ -128,7 +128,7 @@ bazel run //:my_app
 For local development, you can use `local_path_override` instead:
 
 ```bazel
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 local_path_override(
     module_name = "fory",
     path = "/path/to/fory",

--- a/docs/object-serialization/csharp/index.md
+++ b/docs/object-serialization/csharp/index.md
@@ -46,7 +46,7 @@ Reference the single `Apache.Fory` package. It includes the Fory library and the
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Apache.Fory" Version="1.7.0" />
+  <PackageReference Include="Apache.Fory" Version="1.7.1" />
 </ItemGroup>
 ```
 

--- a/docs/object-serialization/dart/index.md
+++ b/docs/object-serialization/dart/index.md
@@ -47,7 +47,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: ^1.7.0
+  fory: ^1.7.1
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/docs/object-serialization/java/index.md
+++ b/docs/object-serialization/java/index.md
@@ -63,7 +63,7 @@ or later.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ or later.
 
 ```kotlin
 // Binary object serialization
-implementation("org.apache.fory:fory-core:1.7.0")
+implementation("org.apache.fory:fory-core:1.7.1")
 ```
 
 #### JDK 25 and Later

--- a/docs/object-serialization/kotlin/index.md
+++ b/docs/object-serialization/kotlin/index.md
@@ -53,14 +53,14 @@ See [Java Features](../java/index.md#features) for complete feature list.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-kotlin</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("org.apache.fory:fory-kotlin:1.7.0")
+implementation("org.apache.fory:fory-kotlin:1.7.1")
 ```
 
 ### JDK25+

--- a/docs/object-serialization/rust/basic-serialization.md
+++ b/docs/object-serialization/rust/basic-serialization.md
@@ -147,7 +147,7 @@ let later = timestamp.checked_add_duration(duration)?;
 
 ```toml
 [dependencies]
-fory = { version = "1.7.0", features = ["chrono"] }
+fory = { version = "1.7.1", features = ["chrono"] }
 ```
 
 ### Custom Types

--- a/docs/object-serialization/rust/index.md
+++ b/docs/object-serialization/rust/index.md
@@ -37,9 +37,9 @@ The Rust implementation provides versatile and high-performance serialization wi
 
 | Crate                                                                       | Description                                           | Version                                       |
 | --------------------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------- |
-| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, public Fory types, and derive macros | [1.7.0](https://crates.io/crates/fory)        |
-| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level core crate for advanced integrations      | [1.7.0](https://crates.io/crates/fory-core)   |
-| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Procedural macro crate for direct derive-macro use    | [1.7.0](https://crates.io/crates/fory-derive) |
+| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, public Fory types, and derive macros | [1.7.1](https://crates.io/crates/fory)        |
+| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level core crate for advanced integrations      | [1.7.1](https://crates.io/crates/fory-core)   |
+| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Procedural macro crate for direct derive-macro use    | [1.7.1](https://crates.io/crates/fory-derive) |
 
 Most applications should depend on `fory` only. It re-exports the derive
 macros and the public Fory types needed by generated code. Use `fory-core`
@@ -52,7 +52,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.7.0"
+fory = "1.7.1"
 ```
 
 ### Basic Example

--- a/docs/object-serialization/scala/index.md
+++ b/docs/object-serialization/scala/index.md
@@ -49,7 +49,7 @@ See [Java Features](../java/index.md#features) for complete feature list.
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.1"
 ```
 
 ### JDK25+

--- a/docs/row-format/java.md
+++ b/docs/row-format/java.md
@@ -43,14 +43,14 @@ For Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 For Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-format:1.7.0")
+implementation("org.apache.fory:fory-format:1.7.1")
 ```
 
 ## Basic Usage

--- a/docs/start/cpp.md
+++ b/docs/start/cpp.md
@@ -45,7 +45,7 @@ include(FetchContent)
 FetchContent_Declare(
   fory
   GIT_REPOSITORY https://github.com/apache/fory.git
-  GIT_TAG v1.7.0
+  GIT_TAG v1.7.1
   SOURCE_SUBDIR cpp
 )
 FetchContent_MakeAvailable(fory)

--- a/docs/start/csharp.md
+++ b/docs/start/csharp.md
@@ -36,7 +36,7 @@ Create a console project and add the released package:
 ```bash
 dotnet new console -n ForyExample
 cd ForyExample
-dotnet add package Apache.Fory --version 1.7.0
+dotnet add package Apache.Fory --version 1.7.1
 ```
 
 Replace `Program.cs` with:

--- a/docs/start/dart.md
+++ b/docs/start/dart.md
@@ -36,7 +36,7 @@ Add Fory and the generator to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fory: 1.7.0
+  fory: 1.7.1
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/docs/start/go.md
+++ b/docs/start/go.md
@@ -38,7 +38,7 @@ Create a module and install the released Fory module:
 mkdir fory-example
 cd fory-example
 go mod init example.com/fory-example
-go get github.com/apache/fory/go/fory@v1.7.0
+go get github.com/apache/fory/go/fory@v1.7.1
 ```
 
 If a Go proxy has not picked up a new submodule tag yet, retry later or use

--- a/docs/start/java.md
+++ b/docs/start/java.md
@@ -44,14 +44,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-core:1.7.0")
+implementation("org.apache.fory:fory-core:1.7.1")
 ```
 
 Run this complete xlang round trip:
@@ -97,7 +97,7 @@ Fory JSON maps Java objects to standard JSON text and UTF-8 bytes. Add
 `fory-json` instead of `fory-core` when the application only needs JSON:
 
 ```kotlin
-implementation("org.apache.fory:fory-json:1.7.0")
+implementation("org.apache.fory:fory-json:1.7.1")
 ```
 
 Add the import to `ForyExample.java`:

--- a/docs/start/javascript.md
+++ b/docs/start/javascript.md
@@ -36,7 +36,7 @@ npm --version
 Install the core package:
 
 ```bash
-npm install @apache-fory/core@1.7.0
+npm install @apache-fory/core@1.7.1
 ```
 
 Define a schema and run an xlang round trip:
@@ -72,7 +72,7 @@ JavaScript uses xlang mode. Continue with
 For the optional Node.js string fast path, install the matching package version:
 
 ```bash
-npm install @apache-fory/core@1.7.0 @apache-fory/hps@1.7.0
+npm install @apache-fory/core@1.7.1 @apache-fory/hps@1.7.1
 ```
 
 ## Other Capabilities

--- a/docs/start/kotlin.md
+++ b/docs/start/kotlin.md
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  implementation("org.apache.fory:fory-kotlin:1.7.0")
+  implementation("org.apache.fory:fory-kotlin:1.7.1")
 }
 ```
 
@@ -88,7 +88,7 @@ module when interoperating with ordinary JSON APIs, browsers, logs, or other JSO
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-  implementation("org.apache.fory:fory-json-kotlin:1.7.0")
+  implementation("org.apache.fory:fory-json-kotlin:1.7.1")
 }
 ```
 

--- a/docs/start/python.md
+++ b/docs/start/python.md
@@ -35,7 +35,7 @@ python -m pip --version
 Install the released package:
 
 ```bash
-python -m pip install pyfory==1.7.0
+python -m pip install pyfory==1.7.1
 ```
 
 Run an xlang round trip:

--- a/docs/start/rust.md
+++ b/docs/start/rust.md
@@ -36,7 +36,7 @@ Add the public crate:
 
 ```toml title="Cargo.toml"
 [dependencies]
-fory = "1.7.0"
+fory = "1.7.1"
 ```
 
 ```rust

--- a/docs/start/scala.md
+++ b/docs/start/scala.md
@@ -37,7 +37,7 @@ Add the Fory Scala library to `build.sbt`:
 
 ```sbt
 ThisBuild / scalaVersion := "3.3.1"
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.1"
 ```
 
 Create `src/main/scala/ScalaExample.scala`:

--- a/docs/start/swift.md
+++ b/docs/start/swift.md
@@ -42,7 +42,7 @@ Add the released package and depend on its `Fory` library in the generated `Pack
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/apache/fory.git", exact: "1.7.0")
+    .package(url: "https://github.com/apache/fory.git", exact: "1.7.1")
 ],
 targets: [
     .executableTarget(

--- a/examples/cpp/hello_row/MODULE.bazel.example
+++ b/examples/cpp/hello_row/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.7.0")
+# bazel_dep(name = "fory", version = "1.7.1")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_row/README.md
+++ b/examples/cpp/hello_row/README.md
@@ -77,7 +77,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/examples/cpp/hello_world/MODULE.bazel.example
+++ b/examples/cpp/hello_world/MODULE.bazel.example
@@ -28,7 +28,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Fory dependency
 # Option 1: Use git_override to fetch from GitHub (recommended for external projects)
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",
@@ -36,7 +36,7 @@ git_override(
 )
 
 # Option 2: Use local_path_override for local development
-# bazel_dep(name = "fory", version = "1.7.0")
+# bazel_dep(name = "fory", version = "1.7.1")
 # local_path_override(
 #     module_name = "fory",
 #     path = "/path/to/fory",

--- a/examples/cpp/hello_world/README.md
+++ b/examples/cpp/hello_world/README.md
@@ -70,7 +70,7 @@ For your own project using Fory as a dependency:
 
 ```bazel
 # In your MODULE.bazel
-bazel_dep(name = "fory", version = "1.7.0")
+bazel_dep(name = "fory", version = "1.7.1")
 git_override(
     module_name = "fory",
     remote = "https://github.com/apache/fory.git",

--- a/java/README.md
+++ b/java/README.md
@@ -95,28 +95,28 @@ aligned. `fory-json` includes `fory-core` transitively.
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-core</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 
 <!-- Row format -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-format</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 
 <!-- JSON serialization -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 
 <!-- Optional: Serializers for Protobuf data -->
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-extensions</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
@@ -125,13 +125,13 @@ aligned. `fory-json` includes `fory-core` transitively.
 ```gradle
 dependencies {
     // Binary object serialization
-    implementation 'org.apache.fory:fory-core:1.7.0'
+    implementation 'org.apache.fory:fory-core:1.7.1'
     // Row format
-    implementation 'org.apache.fory:fory-format:1.7.0'
+    implementation 'org.apache.fory:fory-format:1.7.1'
     // JSON serialization
-    implementation 'org.apache.fory:fory-json:1.7.0'
+    implementation 'org.apache.fory:fory-json:1.7.1'
     // Optional: Protobuf serializers and metadata compression
-    implementation 'org.apache.fory:fory-extensions:1.7.0'
+    implementation 'org.apache.fory:fory-extensions:1.7.1'
 }
 ```
 

--- a/java/fory-json/README.md
+++ b/java/fory-json/README.md
@@ -42,14 +42,14 @@ Maven:
 <dependency>
   <groupId>org.apache.fory</groupId>
   <artifactId>fory-json</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.apache.fory:fory-json:1.7.0")
+implementation("org.apache.fory:fory-json:1.7.1")
 ```
 
 On JDK 25 and later, opening `java.lang.invoke` to Fory core is also recommended. It avoids

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # Apache Fory™ Rust
 
-[![Crates.io](https://img.shields.io/badge/crates.io-v1.7.0-blue?logo=rust)](https://crates.io/crates/fory)
+[![Crates.io](https://img.shields.io/badge/crates.io-v1.7.1-blue?logo=rust)](https://crates.io/crates/fory)
 [![Documentation](https://docs.rs/fory/badge.svg)](https://docs.rs/fory)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/apache/fory/blob/main/LICENSE)
 
@@ -23,9 +23,9 @@ The Rust implementation provides versatile and high-performance serialization wi
 
 | Crate                                                                       | Description                                               | Version                                       |
 | --------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
-| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.7.0](https://crates.io/crates/fory)        |
-| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.7.0](https://crates.io/crates/fory-core)   |
-| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.7.0](https://crates.io/crates/fory-derive) |
+| [`fory`](https://github.com/apache/fory/blob/main/rust/fory)                | User-facing API, runtime types, and derive macros         | [1.7.1](https://crates.io/crates/fory)        |
+| [`fory-core`](https://github.com/apache/fory/blob/main/rust/fory-core/)     | Lower-level runtime crate for advanced integrations       | [1.7.1](https://crates.io/crates/fory-core)   |
+| [`fory-derive`](https://github.com/apache/fory/blob/main/rust/fory-derive/) | Lower-level procedural macro crate for direct runtime use | [1.7.1](https://crates.io/crates/fory-derive) |
 
 Most applications should depend on `fory` only. It re-exports the derive
 macros and the public runtime types needed by generated code. Use `fory-core`
@@ -38,7 +38,7 @@ Add Apache Fory™ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fory = "1.7.0"
+fory = "1.7.1"
 ```
 
 ### Basic Example

--- a/scala/fory-json-scala/README.md
+++ b/scala/fory-json-scala/README.md
@@ -7,7 +7,7 @@ Native Image.
 Add the Scala artifact that matches the application Scala version:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-json-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-json-scala" % "1.7.1"
 ```
 
 Create and reuse one Scala-aware Fory JSON instance:

--- a/scala/fory-scala/README.md
+++ b/scala/fory-scala/README.md
@@ -163,7 +163,7 @@ val fory = ForyScala.builder().withXlang(false)
 Add the dependency with sbt:
 
 ```sbt
-libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.0"
+libraryDependencies += "org.apache.fory" %% "fory-scala" % "1.7.1"
 ```
 
 ## Additional Notes

--- a/swift/README.md
+++ b/swift/README.md
@@ -34,7 +34,7 @@ The Swift implementation provides high-performance object graph serialization wi
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apache/fory.git", from: "1.7.0")
+    .package(url: "https://github.com/apache/fory.git", from: "1.7.1")
 ],
 targets: [
     .target(


### PR DESCRIPTION
## Summary

- update released dependency and installation examples from 1.7.0 to 1.7.1
- update Rust badges and package tables
- add Dart 1.7.1 changelog entries while keeping development metadata on 1.8.0-dev

## Validation

- formatted all changed Markdown files with Prettier
- verified user-facing docs contain no stale 1.7.0 or development-version references
- verified active development metadata is unchanged
- ran `git diff --check`
- local tests and builds were not run; GitHub Actions owns test validation