### PR TITLE
test(java): assert non-ASCII meta encoding failures

### DIFF
--- a/java/fory-core/src/test/java/org/apache/fory/meta/MetaStringTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/meta/MetaStringTest.java
@@ -252,10 +252,10 @@ public class MetaStringTest {
     MetaStringEncoder encoder = new MetaStringEncoder('_', '$');
     String nonAsciiString = "こんにちは"; // Non-ASCII string
 
-    try {
-      encoder.encode(nonAsciiString, MetaString.Encoding.LOWER_SPECIAL);
-    } catch (IllegalArgumentException e) {
-      assertEquals(e.getMessage(), "Non-ASCII characters in meta string are not allowed");
-    }
+    IllegalArgumentException exception =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> encoder.encode(nonAsciiString, MetaString.Encoding.LOWER_SPECIAL));
+    assertEquals(exception.getMessage(), "Non-ASCII characters in meta string are not allowed");
   }
 }


### PR DESCRIPTION
## What changes

Make the non-ASCII meta string encoding test fail when the expected exception is not thrown.

The previous try/catch structure only performed the assertion when an exception was raised, so the test could pass silently if the encoder unexpectedly accepted the input.

## Tests

- `mvn -T2 -pl fory-core -am "-Dtest=org.apache.fory.meta.MetaStringTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `mvn -pl fory-core spotless:check`