### PR TITLE
feat(c++): add field validation options for cpp generator

### DIFF
--- a/compiler/fory_compiler/frontend/fdl/parser.py
+++ b/compiler/fory_compiler/frontend/fdl/parser.py
@@ -19,6 +19,7 @@
 
 import warnings
 from typing import List, Set, Optional, Tuple
+from fory_compiler.ir.validator import ValidationRule
 
 from fory_compiler.ir.ast import (
     Schema,
@@ -77,7 +78,7 @@ KNOWN_FIELD_OPTIONS: Set[str] = {
     "thread_safe_pointer",
     "weak_ref",
     "java_array",
-}
+} | {rule.value for rule in ValidationRule}
 
 KNOWN_REF_OPTIONS: Set[str] = {
     "weak",

--- a/compiler/fory_compiler/generators/cpp.py
+++ b/compiler/fory_compiler/generators/cpp.py
@@ -39,6 +39,7 @@ from fory_compiler.ir.ast import (
     Schema,
 )
 from fory_compiler.ir.types import PrimitiveKind
+from fory_compiler.ir.validator import ValidationRule
 
 
 class CppGenerator(CppServiceGeneratorMixin, BaseGenerator):
@@ -829,6 +830,15 @@ class CppGenerator(CppServiceGeneratorMixin, BaseGenerator):
     def _namespace_for_type(self, type_def: object) -> str:
         location = getattr(type_def, "location", None)
         file_path = getattr(location, "file", None) if location else None
+        if not file_path:
+            return self.get_namespace()
+        try:
+            if self.schema.source_file and str(Path(file_path).resolve()) == str(
+                Path(self.schema.source_file).resolve()
+            ):
+                return self.get_namespace()
+        except Exception:
+            pass
         schema = self._load_schema(file_path)
         if schema is None:
             return ""
@@ -901,6 +911,449 @@ class CppGenerator(CppServiceGeneratorMixin, BaseGenerator):
         lines.append(f"{indent}}}")
         return lines
 
+    def generate_validator(self) -> List[str]:
+        lines: List[str] = []
+        lines.append("namespace Validator {")
+        for type_def in self.schema.messages + self.schema.unions:
+            lines.extend(self.generate_validator_forward_declarations(type_def, 0, []))
+        for message in self.schema.messages:
+            lines.extend(self.generate_message_validation(message, 0, []))
+        for union in self.schema.unions:
+            lines.extend(self.generate_union_validation(union, 0, []))
+        lines.append("} // namespace Validator")
+        return lines
+
+    def generate_validator_forward_declarations(
+        self,
+        type_def: typing.Union["Message", "Union"],
+        indent: int,
+        stack: List[Message],
+    ) -> List[str]:
+        if (
+            not stack
+            and type_def.source_package
+            and type_def.source_package != self.schema.package
+        ):
+            return []
+
+        lines: List[str] = []
+        lines.append(self.indent(f"namespace {type_def.name} {{", indent))
+
+        if isinstance(type_def, Message):
+            stack.append(type_def)
+            for nested in type_def.nested_messages:
+                lines.extend(
+                    self.generate_validator_forward_declarations(
+                        nested, indent + 1, stack
+                    )
+                )
+            for nested in type_def.nested_unions:
+                lines.extend(
+                    self.generate_validator_forward_declarations(
+                        nested, indent + 1, stack
+                    )
+                )
+            stack.pop()
+
+        lines.append(
+            self.indent(
+                f"inline bool validate(const ::{self.get_namespaced_type_name(type_def.name, stack)}& obj);",
+                indent + 1,
+            )
+        )
+        lines.append(self.indent(f"}} // namespace {type_def.name}", indent))
+        return lines
+
+    def _validation_access(
+        self, message: Message, field: Field, stack: List[Message]
+    ) -> Tuple[Optional[str], str]:
+        """Return (guard, value) for accessing a field's value inside the validator."""
+        fname = self.get_field_identifier(message, field)
+        is_msg = self.is_message_type(field.field_type, stack)
+        weak_ref = self.get_field_weak_ref(field)
+
+        if is_msg and weak_ref:
+            return (f"if (auto p = obj.{fname}().upgrade())", "*p")
+        if is_msg and field.ref:
+            return (f"if (obj.{fname}())", f"*obj.{fname}()")
+        if is_msg or field.optional:
+            return (f"if (obj.has_{fname}())", f"obj.{fname}()")
+        return (None, f"obj.{fname}()")
+
+    def generate_message_validation(
+        self, message: Message, indent: int, stack: List[Message]
+    ) -> List[str]:
+        if (
+            not stack
+            and message.source_package
+            and message.source_package != self.schema.package
+        ):
+            return []
+
+        email_pattern = R"(^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$)"
+        lines: List[str] = []
+        lines.append(self.indent(f"namespace {message.name} {{", indent))
+
+        stack.append(message)
+        for nested in message.nested_messages:
+            lines.extend(self.generate_message_validation(nested, indent + 1, stack))
+        for nested in message.nested_unions:
+            lines.extend(self.generate_union_validation(nested, indent + 1, stack))
+        stack.pop()
+
+        lines.append(
+            self.indent(
+                f"inline bool validate(const ::{self.get_namespaced_type_name(message.name, stack)}& obj) {{",
+                indent + 1,
+            )
+        )
+        lines.append(self.indent("bool ok = true;", indent + 2))
+
+        for field in message.fields:
+            field_name = self.get_field_identifier(message, field)
+            guard, value = self._validation_access(message, field, stack + [message])
+            resolved = (
+                self.resolve_named_type(field.field_type.name, stack + [message])
+                if isinstance(field.field_type, NamedType)
+                else None
+            )
+            if isinstance(resolved, Message) or isinstance(resolved, Union):
+                qualified_name = self._validator_path_for(resolved)
+                if guard:
+                    lines.append(
+                        self.indent(
+                            f"{guard} {{ ok &= {qualified_name}::validate({value}); }}",
+                            indent + 2,
+                        )
+                    )
+                else:
+                    lines.append(
+                        self.indent(
+                            f"ok &= {qualified_name}::validate({value});", indent + 2
+                        )
+                    )
+            option_lines: List[str] = []
+            for key, rule_val in field.options.items():
+                try:
+                    rule = ValidationRule(key)
+                except ValueError:
+                    continue
+                if rule == ValidationRule.GTE:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} >= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.LTE:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} <= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.GT:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} > {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.LT:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} < {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.EQL:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} == {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.NEQ:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value} != {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.MIN_LEN:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() >= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.MAX_LEN:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() <= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.PATTERN:
+                    option_lines.append(
+                        self.indent(
+                            f'static const std::regex re_{field_name}(R"({rule_val})");',
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= (std::regex_match({value}, re_{field_name}));",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.EMAIL and rule_val:
+                    option_lines.append(
+                        self.indent(
+                            f'static const std::regex re_{field_name}(R"({email_pattern})");',
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= (std::regex_match({value}, re_{field_name}));",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.UUID and rule_val:
+                    i3 = indent + 3 if guard else indent + 2
+                    option_lines.append(
+                        self.indent(f"ok &= ({value}.size() == 36);", i3)
+                    )
+                    option_lines.append(
+                        self.indent(f"if ({value}.size() == 36) {{", i3)
+                    )
+                    option_lines.append(
+                        self.indent("for (size_t i = 0; i < 36; i++) {", i3 + 1)
+                    )
+                    option_lines.append(
+                        self.indent(
+                            "if (i == 8 || i == 13 || i == 18 || i == 23) {", i3 + 2
+                        )
+                    )
+                    option_lines.append(
+                        self.indent(f"ok &= ({value}[i] == '-');", i3 + 3)
+                    )
+                    option_lines.append(self.indent("} else {", i3 + 2))
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= (std::isxdigit(static_cast<unsigned char>({value}[i])));",
+                            i3 + 3,
+                        )
+                    )
+                    option_lines.append(self.indent("}", i3 + 2))
+                    option_lines.append(self.indent("}", i3 + 1))
+                    option_lines.append(self.indent("}", i3))
+                elif rule == ValidationRule.MIN_ITEMS:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() >= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+                elif rule == ValidationRule.MAX_ITEMS:
+                    option_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() <= {rule_val});",
+                            indent + 3 if guard else indent + 2,
+                        )
+                    )
+
+            if option_lines:
+                if guard:
+                    lines.append(self.indent(f"{guard} {{", indent + 2))
+                    lines.extend(option_lines)
+                    lines.append(self.indent("}", indent + 2))
+                else:
+                    lines.extend(option_lines)
+
+        lines.append(self.indent("return ok;", indent + 2))
+        lines.append(self.indent("}", indent + 1))
+        lines.append(self.indent(f"}} // namespace {message.name}", indent))
+        return lines
+
+    def generate_union_validation(
+        self, union: Union, indent: int, stack: List[Message]
+    ) -> List[str]:
+        if (
+            not stack
+            and union.source_package
+            and union.source_package != self.schema.package
+        ):
+            return []
+
+        email_pattern = R"(^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$)"
+        lines: List[str] = []
+        lines.append(self.indent(f"namespace {union.name} {{", indent))
+        lines.append(
+            self.indent(
+                f"inline bool validate(const ::{self.get_namespaced_type_name(union.name, stack)}& obj) {{",
+                indent + 1,
+            )
+        )
+        lines.append(self.indent("bool ok = true;", indent + 2))
+
+        for field in union.fields:
+            field_name = self.get_union_case_identifier(union, field)
+            value = f"obj.{field_name}()"
+            guard = f"if (obj.is_{field_name}())"
+
+            case_lines: List[str] = []
+            resolved = (
+                self.resolve_named_type(field.field_type.name, stack)
+                if isinstance(field.field_type, NamedType)
+                else None
+            )
+            if isinstance(resolved, Message) or isinstance(resolved, Union):
+                qualified_name = self._validator_path_for(resolved)
+                if guard:
+                    case_lines.append(
+                        self.indent(
+                            f"{guard} {{ ok &= {qualified_name}::validate({value}); }}",
+                            indent + 2,
+                        )
+                    )
+                else:
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= {qualified_name}::validate({value});", indent + 2
+                        )
+                    )
+
+            for key, rule_val in field.options.items():
+                try:
+                    rule = ValidationRule(key)
+                except ValueError:
+                    continue
+                if rule == ValidationRule.GTE:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} >= {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.LTE:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} <= {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.GT:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} > {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.LT:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} < {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.EQL:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} == {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.NEQ:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value} != {rule_val});", indent + 3)
+                    )
+                elif rule == ValidationRule.MIN_LEN:
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() >= {rule_val});", indent + 3
+                        )
+                    )
+                elif rule == ValidationRule.MAX_LEN:
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() <= {rule_val});", indent + 3
+                        )
+                    )
+                elif rule == ValidationRule.PATTERN:
+                    case_lines.append(
+                        self.indent(
+                            f'static const std::regex re_{field_name}(R"({rule_val})");',
+                            indent + 3,
+                        )
+                    )
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= (std::regex_match({value}, re_{field_name}));",
+                            indent + 3,
+                        )
+                    )
+                elif rule == ValidationRule.EMAIL and rule_val:
+                    case_lines.append(
+                        self.indent(
+                            f'static const std::regex re_{field_name}(R"({email_pattern})");',
+                            indent + 3,
+                        )
+                    )
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= (std::regex_match({value}, re_{field_name}));",
+                            indent + 3,
+                        )
+                    )
+                elif rule == ValidationRule.UUID and rule_val:
+                    case_lines.append(
+                        self.indent(f"ok &= ({value}.size() == 36);", indent + 3)
+                    )
+                    case_lines.append(
+                        self.indent(f"if ({value}.size() == 36) {{", indent + 3)
+                    )
+                    case_lines.append(
+                        self.indent("for (size_t i = 0; i < 36; i++) {", indent + 4)
+                    )
+                    case_lines.append(
+                        self.indent(
+                            "if (i == 8 || i == 13 || i == 18 || i == 23) {",
+                            indent + 5,
+                        )
+                    )
+                    case_lines.append(
+                        self.indent(f"ok &= ({value}[i] == '-');", indent + 6)
+                    )
+                    case_lines.append(self.indent("} else {", indent + 5))
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= (std::isxdigit(static_cast<unsigned char>({value}[i])));",
+                            indent + 6,
+                        )
+                    )
+                    case_lines.append(self.indent("}", indent + 5))
+                    case_lines.append(self.indent("}", indent + 4))
+                    case_lines.append(self.indent("}", indent + 3))
+                elif rule == ValidationRule.MIN_ITEMS:
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() >= {rule_val});", indent + 3
+                        )
+                    )
+                elif rule == ValidationRule.MAX_ITEMS:
+                    case_lines.append(
+                        self.indent(
+                            f"ok &= ({value}.size() <= {rule_val});", indent + 3
+                        )
+                    )
+
+            if case_lines:
+                lines.append(self.indent(f"{guard} {{", indent + 2))
+                lines.extend(case_lines)
+                lines.append(self.indent("}", indent + 2))
+
+        lines.append(self.indent("return ok;", indent + 2))
+        lines.append(self.indent("}", indent + 1))
+        lines.append(self.indent(f"}} // namespace {union.name}", indent))
+        return lines
+
+    def _validator_path_for(self, type_def: object) -> str:
+        ns = self._namespace_for_type(type_def)
+        parents = self._parent_stack_for_type(type_def)
+        parts = [self.get_type_identifier(p) for p in parents]
+        parts.append(self.get_type_identifier(type_def))
+        qualified = "::".join(parts)
+        if ns:
+            return f"::{ns}::Validator::{qualified}"
+        return f"::Validator::{qualified}"
+
     def generate_header(self) -> GeneratedFile:
         """Generate a C++ header file with all types."""
         lines = []
@@ -918,9 +1371,11 @@ class CppGenerator(CppServiceGeneratorMixin, BaseGenerator):
         includes.add("<unordered_map>")
         includes.add("<vector>")
         includes.add("<utility>")
+        includes.add("<regex>")
+        includes.add("<cctype>")
+        includes.add("<cstddef>")
         includes.add('"fory/serialization/fory.h"')
         if self.schema_has_unions():
-            includes.add("<cstddef>")
             includes.add("<utility>")
             includes.add("<variant>")
             includes.add("<memory>")
@@ -1013,6 +1468,7 @@ class CppGenerator(CppServiceGeneratorMixin, BaseGenerator):
         lines.extend(self.generate_registration())
         lines.append("")
 
+        lines.extend(self.generate_validator())
         if namespace:
             lines.append(f"}} // namespace {namespace}")
             lines.append("")

--- a/compiler/fory_compiler/ir/validator.py
+++ b/compiler/fory_compiler/ir/validator.py
@@ -19,6 +19,8 @@
 
 from dataclasses import dataclass
 from typing import List, Optional, Union as TypingUnion
+from enum import Enum as PyEnum
+import re
 
 from fory_compiler.ir.ast import (
     Schema,
@@ -51,6 +53,22 @@ OPTIONAL_ANY_MESSAGE = "optional or nullable any is not supported; use any inste
 MAX_FIELD_TAG_ID = (1 << 29) - 1
 
 
+class ValidationRule(PyEnum):
+    GTE = "gte"
+    LTE = "lte"
+    GT = "gt"
+    LT = "lt"
+    EQL = "eql"
+    NEQ = "neq"
+    MIN_LEN = "min_len"
+    MAX_LEN = "max_len"
+    PATTERN = "pattern"
+    UUID = "uuid"
+    EMAIL = "email"
+    MIN_ITEMS = "min_items"
+    MAX_ITEMS = "max_items"
+
+
 @dataclass
 class ValidationIssue:
     """Validation issue with optional source location."""
@@ -67,6 +85,21 @@ class ValidationIssue:
 
 class SchemaValidator:
     """Validates a Fory IR schema."""
+
+    NUMERIC_PRIMITIVES = {
+        PrimitiveKind.INT8,
+        PrimitiveKind.INT16,
+        PrimitiveKind.INT32,
+        PrimitiveKind.INT64,
+        PrimitiveKind.UINT8,
+        PrimitiveKind.UINT16,
+        PrimitiveKind.UINT32,
+        PrimitiveKind.UINT64,
+        PrimitiveKind.FLOAT16,
+        PrimitiveKind.BFLOAT16,
+        PrimitiveKind.FLOAT32,
+        PrimitiveKind.FLOAT64,
+    }
 
     def __init__(self, schema: Schema, allow_nested_collections: bool = False):
         self.schema = schema
@@ -88,6 +121,7 @@ class SchemaValidator:
             self._check_collection_nesting()
         self._check_ref_rules()
         self._check_weak_refs()
+        self._check_validation_options()
         return not self.errors
 
     def _error(self, message: str, location: Optional[SourceLocation]) -> None:
@@ -308,6 +342,152 @@ class SchemaValidator:
 
         for message in self.schema.messages:
             validate_message(message)
+
+    def _check_validation_options(self) -> None:
+        def walk_nested_messages(message: Message, parent_name: str) -> None:
+            for nested in message.nested_messages:
+                full = f"{parent_name}.{nested.name}"
+                for field in nested.fields:
+                    self._check_field_options(field, full)
+                walk_nested_messages(nested, full)
+
+            for nested in message.nested_unions:
+                full = f"{parent_name}.{nested.name}"
+                for field in nested.fields:
+                    self._check_field_options(field, full)
+
+        for message in self.schema.messages:
+            for field in message.fields:
+                self._check_field_options(field, message.name)
+            walk_nested_messages(message, message.name)
+
+        for union in self.schema.unions:
+            for field in union.fields:
+                self._check_field_options(field, union.name)
+
+    def _check_field_options(self, field: Field, full_name: str) -> None:
+        """Validate that the option is appropriate for the field's type."""
+        ft = field.field_type
+        re_rules_present = []
+        for key in field.options:
+            try:
+                r = ValidationRule(key)
+            except ValueError:
+                continue
+            if r in (ValidationRule.PATTERN, ValidationRule.EMAIL, ValidationRule.UUID):
+                re_rules_present.append(r.value)
+
+        if len(re_rules_present) > 1:
+            self._error(
+                f"Field '{full_name}.{field.name}' cannot combine "
+                f"{', '.join(re_rules_present)}. Pick one of pattern, email, uuid",
+                field.location,
+            )
+
+        for key, val in field.options.items():
+            try:
+                rule = ValidationRule(key)
+            except ValueError:
+                continue
+
+            if rule in (
+                ValidationRule.GTE,
+                ValidationRule.LTE,
+                ValidationRule.GT,
+                ValidationRule.LT,
+                ValidationRule.EQL,
+                ValidationRule.NEQ,
+            ):
+                if (
+                    not isinstance(ft, PrimitiveType)
+                    or ft.kind not in self.NUMERIC_PRIMITIVES
+                ):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a numeric primitive type, "
+                        f"but got {type(ft).__name__}",
+                        field.location,
+                    )
+
+            elif rule in (
+                ValidationRule.MIN_LEN,
+                ValidationRule.MAX_LEN,
+                ValidationRule.PATTERN,
+                ValidationRule.UUID,
+                ValidationRule.EMAIL,
+            ):
+                if not isinstance(ft, PrimitiveType) or ft.kind != PrimitiveKind.STRING:
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a string type, "
+                        f"but got {type(ft).__name__}",
+                        field.location,
+                    )
+
+            elif rule in (ValidationRule.MIN_ITEMS, ValidationRule.MAX_ITEMS):
+                if not isinstance(ft, (ListType, ArrayType, MapType)):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a collection type (list/array/map), "
+                        f"but got {type(ft).__name__}",
+                        field.location,
+                    )
+
+            if rule in (
+                ValidationRule.GTE,
+                ValidationRule.LTE,
+                ValidationRule.GT,
+                ValidationRule.LT,
+                ValidationRule.EQL,
+                ValidationRule.NEQ,
+            ):
+                if not isinstance(val, (int, float)) or isinstance(val, bool):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a numeric primitive value, "
+                        f"but got {val}",
+                        field.location,
+                    )
+
+            elif rule in (
+                ValidationRule.MIN_LEN,
+                ValidationRule.MAX_LEN,
+                ValidationRule.MIN_ITEMS,
+                ValidationRule.MAX_ITEMS,
+            ):
+                if not isinstance(val, int) or isinstance(val, bool):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a numeric primitive value, "
+                        f"but got {val}",
+                        field.location,
+                    )
+
+                elif val < 0:
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a positive numeric primitive value, "
+                        f"but got {val}",
+                        field.location,
+                    )
+
+            elif rule in (ValidationRule.EMAIL, ValidationRule.UUID):
+                if not isinstance(val, bool):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a boolean value, "
+                        f"but got {val}",
+                        field.location,
+                    )
+
+            elif rule == ValidationRule.PATTERN:
+                if not isinstance(val, str):
+                    self._error(
+                        f"Field '{full_name}.{field.name}' option '{key}' requires a string value, "
+                        f"but got {val}",
+                        field.location,
+                    )
+                else:
+                    try:
+                        re.compile(val)
+                    except re.error as e:
+                        self._error(
+                            f"Field '{full_name}.{field.name}' option 'pattern' has invalid regex: {e}",
+                            field.location,
+                        )
 
     def _apply_field_defaults(self) -> None:
         def apply_message_fields(

--- a/compiler/fory_compiler/tests/test_generated_code.py
+++ b/compiler/fory_compiler/tests/test_generated_code.py
@@ -1577,6 +1577,76 @@ def test_cpp_temporal_map_keys_use_fory_owned_wrappers():
     assert "std::map<" not in cpp_output
 
 
+def test_cpp_validation_options():
+    fdl = dedent(
+        """
+        package test;
+
+        message Address {
+            string street = 1 [min_len = 1, max_len = 100];
+            int32 zipcode = 2 [gte = 10000, lte = 99999];
+        }
+
+        message Account {
+            int64 account_id = 1 [gte = 1000, lte = 2000];
+            string username = 2 [min_len = 4, max_len = 16, pattern = "^[a-zA-Z0-9]+$"];
+            string email = 3 [email = true];
+            string uuid = 4 [uuid = true];
+            list<string> tags = 5 [min_items = 1, max_items = 5];
+            int32 status = 6 [eql = 1, neq = 3];
+            Address address = 7;
+        }
+
+        union Shape {
+            string name = 1 [max_len = 32];
+            int32 sides = 2 [gte = 3, lte = 100];
+        }
+        """
+    )
+    schema = parse_fdl(fdl)
+    cpp_output = render_files(generate_files(schema, CppGenerator))
+
+    assert "namespace Validator {" in cpp_output
+    assert "namespace Account {" in cpp_output
+    assert "namespace Address {" in cpp_output
+    assert "namespace Shape {" in cpp_output
+
+    assert "bool validate(const ::test::Account& obj)" in cpp_output
+    assert "bool validate(const ::test::Address& obj)" in cpp_output
+    assert "bool validate(const ::test::Shape& obj)" in cpp_output
+
+    assert "ok &= (obj.account_id() >= 1000);" in cpp_output
+    assert "ok &= (obj.account_id() <= 2000);" in cpp_output
+    assert "ok &= (obj.status() == 1);" in cpp_output
+    assert "ok &= (obj.status() != 3);" in cpp_output
+
+    assert "ok &= (obj.username().size() >= 4);" in cpp_output
+    assert "ok &= (obj.username().size() <= 16);" in cpp_output
+
+    assert 'static const std::regex re_username(R"(^[a-zA-Z0-9]+$)");' in cpp_output
+    assert "std::regex_match(obj.username(), re_username)" in cpp_output
+    assert (
+        r'static const std::regex re_email(R"((^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$))");'
+        in cpp_output
+    )
+
+    assert "std::regex_match(obj.email(), re_email)" in cpp_output
+    assert "ok &= (obj.uuid().size() == 36);" in cpp_output
+    assert "for (size_t i = 0; i < 36; i++)" in cpp_output
+    assert "ok &= (obj.tags().size() >= 1);" in cpp_output
+    assert "ok &= (obj.tags().size() <= 5);" in cpp_output
+    assert (
+        "if (obj.has_address()) { ok &= ::test::Validator::Address::validate(obj.address()); }"
+        in cpp_output
+    )
+
+    assert "if (obj.is_name()) {" in cpp_output
+    assert "ok &= (obj.name().size() <= 32);" in cpp_output
+    assert "if (obj.is_sides()) {" in cpp_output
+    assert "ok &= (obj.sides() >= 3);" in cpp_output
+    assert "ok &= (obj.sides() <= 100);" in cpp_output
+
+
 def test_java_enum_generation_uses_fory_enum_ids():
     schema = parse_fdl(
         dedent(

--- a/compiler/fory_compiler/tests/test_validation_options.py
+++ b/compiler/fory_compiler/tests/test_validation_options.py
@@ -1,0 +1,201 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for validation rule options in the FDL schema validator."""
+
+from textwrap import dedent
+from typing import List
+
+from fory_compiler.frontend.fdl.lexer import Lexer
+from fory_compiler.frontend.fdl.parser import Parser
+from fory_compiler.ir.validator import SchemaValidator, ValidationIssue
+
+
+def _parse(source: str):
+    lexer = Lexer(dedent(source))
+    parser = Parser(lexer.tokenize())
+    return parser.parse()
+
+
+def _validate(source: str) -> List[ValidationIssue]:
+    schema = _parse(source)
+    validator = SchemaValidator(schema)
+    validator.validate()
+    return validator.errors
+
+
+def _assert_rejected(source: str, fragment: str) -> None:
+    errors = _validate(source)
+    assert errors, f"expected validation errors for:\n{source}"
+    messages = [e.message for e in errors]
+    assert any(fragment in m for m in messages), (
+        f"expected {fragment!r} in errors: {messages}"
+    )
+
+
+def test_gte_on_non_numeric_field_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [gte = 1]; }
+        """,
+        "requires a numeric primitive type",
+    )
+
+
+def test_min_len_on_non_string_field_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { int32 x = 1 [min_len = 1]; }
+        """,
+        "requires a string type",
+    )
+
+
+def test_email_on_non_string_field_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { int32 x = 1 [email = true]; }
+        """,
+        "requires a string type",
+    )
+
+
+def test_min_items_on_non_collection_field_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { int32 x = 1 [min_items = 1]; }
+        """,
+        "requires a collection type",
+    )
+
+
+def test_gte_with_bool_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { int32 x = 1 [gte = true]; }
+        """,
+        "requires a numeric primitive value",
+    )
+
+
+def test_min_len_with_string_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [min_len = "four"]; }
+        """,
+        "requires a numeric primitive value",
+    )
+
+
+def test_min_len_with_negative_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [min_len = -1]; }
+        """,
+        "requires a positive numeric primitive value",
+    )
+
+
+def test_max_items_with_negative_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { list<int32> xs = 1 [max_items = -1]; }
+        """,
+        "requires a positive numeric primitive value",
+    )
+
+
+def test_email_with_non_bool_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [email = "yes"]; }
+        """,
+        "requires a boolean value",
+    )
+
+
+def test_uuid_with_non_bool_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [uuid = 1]; }
+        """,
+        "requires a boolean value",
+    )
+
+
+def test_pattern_with_non_string_value_rejected():
+    _assert_rejected(
+        """
+        package test;
+        message M { string s = 1 [pattern = 42]; }
+        """,
+        "requires a string value",
+    )
+
+
+def test_validation_options_checked_in_nested_message():
+    _assert_rejected(
+        """
+        package test;
+        message Outer {
+            message Inner {
+                string s = 1 [min_len = "x"];
+            }
+            Inner inner = 1;
+        }
+        """,
+        "requires a numeric primitive value",
+    )
+
+
+def test_validation_options_checked_in_union():
+    _assert_rejected(
+        """
+        package test;
+        union U {
+            int32 x = 1 [gte = true];
+        }
+        """,
+        "requires a numeric primitive value",
+    )
+
+
+def test_valid_validation_options_accepted():
+    errors = _validate(
+        """
+        package test;
+        message M {
+            int32 x = 1 [gte = 0, lte = 100];
+            string s = 2 [min_len = 1, max_len = 10];
+            string e = 3 [email = true];
+            string u = 4 [uuid = true];
+            string p = 5 [pattern = "^[a-z]+$"];
+            list<int32> xs = 6 [min_items = 1, max_items = 5];
+        }
+        """
+    )
+    assert errors == [], f"unexpected errors: {[e.message for e in errors]}"

--- a/docs/compiler/schema-idl.md
+++ b/docs/compiler/schema-idl.md
@@ -1152,6 +1152,50 @@ Use `ref(thread_safe=false)` in Fory IDL (or
 `[(fory).thread_safe_pointer = false]` in protobuf) to generate `Rc` instead of
 `Arc` in Rust.
 
+### Validation Options
+
+Fields can declare validation rules as field options. The compiler checks
+the option's type compatibility at schema compile time and generates
+validator functions in supported target languages.
+
+| Option      | Applies to               | Meaning                               |
+| ----------- | ------------------------ | ------------------------------------- |
+| `gte`       | numeric primitives       | value must be `>=` the given number   |
+| `lte`       | numeric primitives       | value must be `<=` the given number   |
+| `gt`        | numeric primitives       | value must be `>` the given number    |
+| `lt`        | numeric primitives       | value must be `<` the given number    |
+| `eql`       | numeric primitives       | value must equal the given number     |
+| `neq`       | numeric primitives       | value must not equal the given number |
+| `min_len`   | `string`                 | length must be `>=` the given count   |
+| `max_len`   | `string`                 | length must be `<=` the given count   |
+| `pattern`   | `string`                 | value must match the given regex      |
+| `uuid`      | `string`                 | value must be a 36-char UUID          |
+| `email`     | `string`                 | value must be a valid email address   |
+| `min_items` | `list` / `array` / `map` | collection size must be `>=` N        |
+| `max_items` | `list` / `array` / `map` | collection size must be `<=` N        |
+
+**Rules:**
+
+- Numeric options accept integer or float values.
+- Length and item-count options accept non-negative integers.
+- `pattern` must be a valid regular expression.
+- `email` and `uuid` are boolean flags: `[email = true]`, `[uuid = true]`.
+- `pattern`, `email`, and `uuid` are mutually exclusive on the same field.
+- Validation options may only be used on fields of a compatible type
+  (for example, `gte` on a non-numeric field is a compile error).
+
+**Example:**
+
+```protobuf
+message Account {
+    int64 account_id = 1 [gte = 1000, lte = 2000000000];
+    string username = 2 [min_len = 4, max_len = 16, pattern = "^[a-zA-Z0-9_]+$"];
+    string email = 3 [email = true];
+    string uuid = 4 [uuid = true];
+    list<string> tags = 5 [min_items = 1, max_items = 5];
+}
+```
+
 ## Field Numbers
 
 Each field must have a unique tag ID in the protocol range:


### PR DESCRIPTION
## Why?

FDL currently lacks a way to express validation constraints directly in the schema. Users must manually write validation logic in their application code, leading to duplication and boilerplate.

## What does this PR do?

Parser: Adds recognition of validation options (`gte`, `lte`, `gt`, `lt`, `eql`, `neq`, `min_len`, `max_len`, `pattern`, `uuid`, `email`, `min_items`, `max_items`) as valid field options (silencing the "Unknown option" warning).

Semantic Validator: Adds `_check_validation_options()` and `_check_field_options()` to ensure validation options are used on appropriate field types:

- Numeric options (`gte`, `lte`, `gt`, `lt`, `eql`, `neq`): only on numeric primitive types
- String options (`min_len`, `max_len`, `pattern`, `uuid`, `email`): only on string fields
- Collection options (`min_items`, `max_items`): only on list/array/map fields

C++ Generator: Adds a `generate_validator()` method that emits a `namespace Validator { ... }` block containing per-message validation functions. For each field option, the generator emits the corresponding C++ check:

- `gte`: `obj.field() >= value`
- `min_len`: `obj.field().size() >= value`
- `pattern`: `std::regex_match(obj.field(), std::regex(R"(...)"))`
- ...

Unit Test: Adds `test_cpp_validation_options()` in `test_generated_code.py` verifying that the generated C++ contains the expected checks.

## Related issues
- #3904

## AI Contribution Checklist

- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.

## Does this PR introduce any user-facing change?

Yes, new validation options in FDL fields:
```fdl
int64 id = 1 [gte = 1, lte = 1000000];
string username = 2 [min_len = 3, max_len = 20, pattern = "^[a-zA-Z0-9_]+$"];
string email = 3 [email = true];
string uuid = 4 [uuid = true];
list<string> tags = 5 [min_items = 1, max_items = 5];
```

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?