### PR TITLE
fix(java): restore contexts for nested Externalizable callbacks

### DIFF
--- a/java/fory-core/src/main/java/org/apache/fory/io/MemoryBufferObjectInput.java
+++ b/java/fory-core/src/main/java/org/apache/fory/io/MemoryBufferObjectInput.java
@@ -49,9 +49,12 @@ public class MemoryBufferObjectInput extends InputStream implements ObjectInput 
     this.buffer = buffer;
   }
 
-  public void setReadContext(ReadContext readContext) {
+  /** Binds the read context and returns the previous context, or null if unbound. */
+  public ReadContext setReadContext(ReadContext readContext) {
+    ReadContext previous = this.readContext;
     this.readContext = readContext;
     this.buffer = readContext.getBuffer();
+    return previous;
   }
 
   public void clearReadContext() {

--- a/java/fory-core/src/main/java/org/apache/fory/io/MemoryBufferObjectOutput.java
+++ b/java/fory-core/src/main/java/org/apache/fory/io/MemoryBufferObjectOutput.java
@@ -45,9 +45,12 @@ public class MemoryBufferObjectOutput extends OutputStream implements ObjectOutp
     }
   }
 
-  public void setWriteContext(WriteContext writeContext) {
+  /** Binds the write context and returns the previous context, or null if unbound. */
+  public WriteContext setWriteContext(WriteContext writeContext) {
+    WriteContext previous = this.writeContext;
     this.writeContext = writeContext;
     this.buffer = writeContext.getBuffer();
+    return previous;
   }
 
   public void clearWriteContext() {

--- a/java/fory-core/src/main/java/org/apache/fory/serializer/ExternalizableSerializer.java
+++ b/java/fory-core/src/main/java/org/apache/fory/serializer/ExternalizableSerializer.java
@@ -45,13 +45,18 @@ public class ExternalizableSerializer<T extends Externalizable>
     if (config.isXlang()) {
       throw new UnsupportedOperationException("Externalizable can only be used in java");
     }
-    objectOutput.setWriteContext(writeContext);
+    WriteContext previous = objectOutput.setWriteContext(writeContext);
     try {
       value.writeExternal(objectOutput);
     } catch (IOException e) {
       ExceptionUtils.throwException(e);
     } finally {
-      objectOutput.clearWriteContext();
+      // Nested callbacks reuse this adapter; only the outermost call may clear it.
+      if (previous == null) {
+        objectOutput.clearWriteContext();
+      } else {
+        objectOutput.setWriteContext(previous);
+      }
     }
   }
 
@@ -59,13 +64,18 @@ public class ExternalizableSerializer<T extends Externalizable>
   public T read(ReadContext readContext) {
     T t = objectInstantiator.newInstance();
     readContext.reference(t);
-    objectInput.setReadContext(readContext);
+    ReadContext previous = objectInput.setReadContext(readContext);
     try {
       t.readExternal(objectInput);
     } catch (IOException | ClassNotFoundException e) {
       ExceptionUtils.throwException(e);
     } finally {
-      objectInput.clearReadContext();
+      // Restore the enclosing readExternal callback before it resumes reading.
+      if (previous == null) {
+        objectInput.clearReadContext();
+      } else {
+        objectInput.setReadContext(previous);
+      }
     }
     return t;
   }

--- a/java/fory-core/src/test/java/org/apache/fory/serializer/ExternalizableSerializerTest.java
+++ b/java/fory-core/src/test/java/org/apache/fory/serializer/ExternalizableSerializerTest.java
@@ -20,10 +20,19 @@
 package org.apache.fory.serializer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
 
 import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import lombok.EqualsAndHashCode;
 import org.apache.fory.Fory;
 import org.apache.fory.ForyTestBase;
+import org.apache.fory.exception.ForyException;
+import org.apache.fory.reflect.ReflectionUtils;
 import org.apache.fory.serializer.test.Factory;
 import org.testng.annotations.Test;
 
@@ -47,5 +56,98 @@ public class ExternalizableSerializerTest extends ForyTestBase {
   public void testInaccessibleExternalizable(Fory fory) {
     Externalizable e = Factory.newInstance(1, 1, "bytes".getBytes());
     copyCheck(fory, e);
+  }
+
+  @Test(dataProvider = "twoBoolOptions")
+  public void testNestedExternalizable(boolean refTracking, boolean primitiveTail) {
+    Fory fory = newFory(refTracking);
+    Container child = new Container(1, 1, 2, 3);
+    Container value = primitiveTail ? new Container(2, child) : new Container(2, child, child, 4);
+    Container result = (Container) fory.deserialize(fory.serialize(value));
+    assertEquals(result, value);
+    if (refTracking && !primitiveTail) {
+      assertSame(result.items[0], result.items[1]);
+    }
+    assertAdaptersCleared(fory);
+
+    Container deeper = new Container(3, value, new Container(4, value));
+    assertEquals(fory.deserialize(fory.serialize(deeper)), deeper);
+    assertAdaptersCleared(fory);
+  }
+
+  @Test(dataProvider = "oneBoolOption")
+  public void testExternalizableFailure(boolean refTracking) {
+    Fory fory = newFory(refTracking);
+    Container invalid = new Container(2, new Container(-1, 1));
+    assertThrows(ForyException.class, () -> fory.serialize(invalid));
+    assertAdaptersCleared(fory);
+
+    Container valid = new Container(2, new Container(1, 1), 2);
+    byte[] bytes = fory.serialize(valid);
+    assertEquals(fory.deserialize(bytes), valid);
+    assertAdaptersCleared(fory);
+
+    Container unreadable = new Container(2, new Container(-2, 1));
+    byte[] unreadableBytes = fory.serialize(unreadable);
+    assertThrows(ForyException.class, () -> fory.deserialize(unreadableBytes));
+    assertAdaptersCleared(fory);
+    assertEquals(fory.deserialize(bytes), valid);
+    assertAdaptersCleared(fory);
+  }
+
+  private Fory newFory(boolean refTracking) {
+    Fory fory =
+        Fory.builder().withXlang(false).withCompatible(false).withRefTracking(refTracking).build();
+    fory.register(Container.class);
+    return fory;
+  }
+
+  private void assertAdaptersCleared(Fory fory) {
+    Serializer<?> serializer = fory.getTypeResolver().getSerializer(Container.class);
+    Object output = ReflectionUtils.getObjectFieldValue(serializer, "objectOutput");
+    Object input = ReflectionUtils.getObjectFieldValue(serializer, "objectInput");
+    assertNull(ReflectionUtils.getObjectFieldValue(output, "writeContext"));
+    assertNull(ReflectionUtils.getObjectFieldValue(output, "buffer"));
+    assertNull(ReflectionUtils.getObjectFieldValue(input, "readContext"));
+    assertNull(ReflectionUtils.getObjectFieldValue(input, "buffer"));
+  }
+
+  @EqualsAndHashCode
+  public static class Container implements Externalizable {
+    private int marker;
+    private Object[] items;
+
+    public Container() {}
+
+    Container(int marker, Object... items) {
+      this.marker = marker;
+      this.items = items;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+      out.writeInt(items.length);
+      for (Object item : items) {
+        out.writeObject(item);
+      }
+      out.writeInt(marker);
+      out.writeUTF("end");
+      if (marker == -1) {
+        throw new IOException("writeExternal failed");
+      }
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+      items = new Object[in.readInt()];
+      for (int i = 0; i < items.length; i++) {
+        items[i] = in.readObject();
+      }
+      marker = in.readInt();
+      assertEquals(in.readUTF(), "end");
+      if (marker == -2) {
+        throw new IOException("readExternal failed");
+      }
+    }
   }
 }


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues

Closes #4035

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

