### PR TITLE
fix(json): honor Kotlin property inclusion

### DIFF
--- a/.agents/languages/kotlin.md
+++ b/.agents/languages/kotlin.md
@@ -4,6 +4,10 @@ Load this file when changing `kotlin/` or compiler code that generates Kotlin so
 
 ## Rules
 
+- Fory JSON Kotlin property inclusion follows the configured global or property-level rule,
+  independently of constructor defaults and deferred initializers. Do not override or reject
+  `NON_NULL` or `NON_EMPTY` to guarantee round trips. Missing-property defaults and nullability
+  remain reader-owned; serialization must not evaluate default expressions.
 - Run Kotlin Maven commands from within `kotlin/`.
 - Kotlin serializers build on the Java implementation. If Java changed and the updated Java artifacts are not installed yet, run `cd ../java && mvn -T16 install -DskipTests` first.
 - KSP `@ForyStruct` serializers that use a primary constructor map constructor parameters to

--- a/docs/json/annotations.md
+++ b/docs/json/annotations.md
@@ -178,8 +178,10 @@ present Optional containing an empty list remain included. Root values, collecti
 entries, and Any entries are not filtered by property inclusion. Raw JSON String properties are
 checked as strings without parsing their text.
 
-Language-specific reconstruction rules still apply; see
-[Kotlin inclusion](kotlin.md#immutable-classes-and-compiler-defaults).
+Kotlin properties follow the configured inclusion even when omission changes the value restored by
+a default or causes a missing-property read failure; see
+[Kotlin inclusion](kotlin.md#immutable-classes-and-compiler-defaults). Scala retains its
+[required-constructor-property rules](scala.md#case-classes-and-annotations).
 
 Inclusion affects writing only. A non-default inclusion is invalid for a creator-only property with
 no write source. Repeating the same declaration is allowed; conflicting explicit names, indexes, or

--- a/docs/json/kotlin.md
+++ b/docs/json/kotlin.md
@@ -146,20 +146,37 @@ after construction, followed by validators; input member order does not choose a
 order. Kotlin class instances are always constructed normally, so primary-constructor initialization and
 validation are not bypassed.
 
-Fory must be able to read its own output under the same configuration. Consequently, nullable
-constructor parameters and nullable deferred properties are emitted explicitly when null, even
-when the builder's general Java default is to omit null fields. An explicit
-`JsonProperty.Include.NON_NULL` on such a property is rejected if omission could fail or invoke a
-different compiler default.
+Kotlin properties follow the configured [property inclusion](annotations.md#jsonproperty),
+including constructor parameters and body properties. The default `NON_NULL` omits null values;
+`NON_EMPTY` also omits empty strings, arrays, collections, and maps, and absent JDK Optional values.
+A property's `@JsonProperty(include = ...)` overrides the builder default. Use `ALWAYS` or
+`writeNullFields(true)` to retain null values.
 
-The same rule applies to `NON_EMPTY`. A global
-`defaultPropertyInclusion(JsonProperty.Include.NON_EMPTY)` preserves empty Kotlin constructor and
-deferred properties, including those declared with `emptyList()` defaults. Fory does not compare
-values with compiler defaults or evaluate initializers to decide whether to omit them. An explicit
-`NON_EMPTY` annotation is rejected on a reconstructible property whose logical type can be empty,
-or whose nullable value would otherwise be omitted. Non-null value classes remain present even
-when their underlying string or collection is empty. Use a custom codec for a containing model
-that needs a different omission and reconstruction contract.
+```kotlin
+import org.apache.fory.json.annotation.JsonProperty.Include
+import org.apache.fory.json.kotlin.ForyJsonKotlin
+
+data class Response(
+    val id: Int,
+    val name: String? = null,
+    val items: List<String>? = null,
+)
+
+val json = ForyJsonKotlin.builder().defaultPropertyInclusion(Include.NON_EMPTY).build()
+val text = json.toJson(Response(1, items = emptyList())) // {"id":1}
+```
+
+Inclusion affects writing only. Reading the example's output uses the declared `items` default
+of null, so the original empty list is not preserved. A missing constructor parameter uses its
+declared default, or fails if it has no default; a missing body property keeps its initializer.
+Explicit null remains distinct from a missing field and is rejected for a non-nullable property.
+Choose an inclusion rule that retains values when exact round trips are required.
+
+Fory does not compare values with Kotlin defaults or evaluate initializers during serialization.
+An empty list is omitted by `NON_EMPTY` regardless of whether its default is null, `emptyList()`, or
+a non-empty list. Empty underlying string or collection carriers do not make non-null value-class
+properties empty. An explicit `NON_EMPTY` is unsupported when an unboxed value class itself
+implements `CharSequence`, `Collection`, or `Map`; use a containing custom codec for that shape.
 
 ## Nullability
 

--- a/java/fory-json/src/main/java/org/apache/fory/json/ForyJsonBuilder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/ForyJsonBuilder.java
@@ -87,7 +87,9 @@ public final class ForyJsonBuilder {
    * <p>The default is {@code NON_NULL}. {@code NON_EMPTY} additionally omits empty CharSequence
    * values, arrays, collections, maps, and absent JDK Optional values. Root values and container
    * entries are not filtered. Inclusion examines the logical property value before a custom value
-   * codec runs. Language models retain properties needed for reconstruction.
+   * codec runs. Kotlin properties follow this policy even when omission changes the value restored
+   * by a constructor default or causes a missing-property read failure. Other language models may
+   * retain properties needed for reconstruction.
    *
    * @throws IllegalArgumentException if inclusion is {@code DEFAULT}, which requires a parent
    *     default

--- a/java/fory-json/src/main/java/org/apache/fory/json/codec/ObjectCodecBuilder.java
+++ b/java/fory-json/src/main/java/org/apache/fory/json/codec/ObjectCodecBuilder.java
@@ -462,6 +462,29 @@ final class ObjectCodecBuilder {
       FieldBuilder builder,
       JsonCreatorInfo creatorInfo,
       JsonObjectModel objectModel) {
+    if (objectModel != null && field.requiresUnboxedBinding()) {
+      if (builder.explicitInclude == Include.NON_EMPTY && field.mayBeEmpty()) {
+        // A lowered carrier cannot prove the logical CharSequence/collection emptiness. Keep this
+        // unsupported shape separate from ordinary Kotlin property inclusion and default values.
+        throw new ForyJsonException(
+            "JSON property " + field.name() + " cannot check an unboxed logical empty value");
+      }
+      // The logical codec is bound only after the recursive parent shell is published. Its exact
+      // transparent-null action and physical carrier are normalized in JsonFieldInfo.resolveTypes.
+      return;
+    }
+    if (objectModel != null && field.hasOccurrenceNullability()) {
+      // Kotlin inclusion controls writing independently of constructor defaults. An omitted value
+      // may restore a different default or fail a required read; never override the chosen policy.
+      if (!field.occurrenceNullable()
+          && builder.hasWriteSource()
+          && !field.occurrenceWrapsNull()
+          && field.writeRawType() != null
+          && !field.writeRawType().isPrimitive()) {
+        field.requireNonNullWrite();
+      }
+      return;
+    }
     int argumentIndex = builder.creatorArgumentIndex;
     boolean requiredArgument =
         objectModel != null
@@ -469,41 +492,9 @@ final class ObjectCodecBuilder {
             && argumentIndex >= 0
             && !creatorInfo.hasDefault(argumentIndex)
             && builder.hasWriteSource();
-    if (objectModel != null
-        && (field.hasOccurrenceNullability() || requiredArgument)
-        && builder.explicitInclude == Include.NON_EMPTY
-        && field.mayBeEmpty()) {
-      // Validate the logical type even when a value class is lowered to a different JVM carrier.
+    if (requiredArgument && builder.explicitInclude == Include.NON_EMPTY && field.mayBeEmpty()) {
       throw new ForyJsonException(
           "Reconstructible JSON property " + field.name() + " cannot omit an empty value");
-    }
-    if (objectModel != null && field.requiresUnboxedBinding()) {
-      // The logical codec is bound only after the recursive parent shell is published. Its exact
-      // transparent-null action and physical carrier are normalized in JsonFieldInfo.resolveTypes.
-      return;
-    }
-    if (objectModel != null && field.hasOccurrenceNullability()) {
-      // Compiler defaults and deferred initializers may differ from an empty value. Preserve the
-      // occurrence instead of evaluating application defaults during serialization.
-      if (field.omitEmpty()) {
-        field.includeEmptyWrite();
-      }
-      if (field.occurrenceNullable()) {
-        if (builder.explicitInclude == Include.NON_NULL
-            || builder.explicitInclude == Include.NON_EMPTY) {
-          throw new ForyJsonException(
-              "Nullable reconstructible JSON property "
-                  + field.name()
-                  + " cannot omit an explicit null value");
-        }
-        field.includeNullWrite();
-      } else if (builder.hasWriteSource()
-          && !field.occurrenceWrapsNull()
-          && field.writeRawType() != null
-          && !field.writeRawType().isPrimitive()) {
-        field.requireNonNullWrite();
-      }
-      return;
     }
     if (requiredArgument && !field.writeNull() && !field.writeRawType().isPrimitive()) {
       // Language models without occurrence nullability still need every non-defaulted argument.

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/ForyJsonKotlinTest.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/ForyJsonKotlinTest.kt
@@ -92,8 +92,9 @@ class ForyJsonKotlinTest {
       Account(9, "explicit", null),
       fory.fromJson("{\"id\":9,\"name\":\"explicit\",\"label\":null}", jsonTypeRef<Account>())
     )
-    assertTrue(
-      fory.toJson(Account(9, "default"), jsonTypeRef<Account>()).contains("\"label\":null")
+    assertEquals(
+      """{"id":9,"name":"default"}""",
+      fory.toJson(Account(9, "default"), jsonTypeRef<Account>())
     )
   }
 

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinBuiltInCodecsTest.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinBuiltInCodecsTest.kt
@@ -88,6 +88,7 @@ class KotlinBuiltInCodecsTest {
 
   @Test
   fun products() {
+    val fory = ForyJsonKotlin.builder().writeNullFields(true).withAsyncCompilation(false).build()
     val pairType = jsonTypeRef<Pair<Int?, String>>()
     val pair = Pair(null, "right")
     assertEquals("{\"first\":null,\"second\":\"right\"}", fory.toJson(pair, pairType))
@@ -275,7 +276,7 @@ class KotlinBuiltInCodecsTest {
       "{\"ubyte\":255,\"ushort\":65535,\"uint\":4294967295," +
         "\"ulong\":18446744073709551615,\"nullable\":null,\"tag\":\"ascii\"}"
     val utf16Json = latin1Json.replace("ascii", "\u4e2d")
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       assertEquals(latin1Json, json.toJson(latin1, type))
       assertEquals(latin1, json.fromJson(latin1Json, type))
       assertEquals(utf16, json.fromJson(utf16Json, type))
@@ -469,7 +470,7 @@ class KotlinBuiltInCodecsTest {
       "{\"zero\":\"PT0S\",\"negative\":\"-PT0.000000001S\",\"nullable\":null,\"tag\":\"ascii\"}"
     val utf16Json =
       "{\"zero\":\"PT0S\",\"negative\":\"-PT0.000000001S\",\"nullable\":null,\"tag\":\"\u4e2d\"}"
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       assertEquals(latin1Json, json.toJson(latin1Holder, holderType))
       assertEquals(latin1Holder, json.fromJson(latin1Json, holderType))
       assertEquals(utf16Holder, json.fromJson(utf16Json, holderType))
@@ -545,6 +546,7 @@ class KotlinBuiltInCodecsTest {
 
   @Test
   fun timedValue() {
+    val fory = ForyJsonKotlin.builder().writeNullFields(true).withAsyncCompilation(false).build()
     val type = jsonTypeRef<TimedValue<String>>()
     val value = TimedValue("done", 2.seconds + 17.nanoseconds)
     assertEquals(value, fory.fromJson(fory.toJson(value, type), type))
@@ -570,6 +572,7 @@ class KotlinBuiltInCodecsTest {
 
   @Test
   fun nullOnly() {
+    val fory = ForyJsonKotlin.builder().writeNullFields(true).withAsyncCompilation(false).build()
     val value = NullOnly(null)
     assertEquals(
       value,

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinGenericRuntimeTest.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinGenericRuntimeTest.kt
@@ -66,7 +66,7 @@ class KotlinGenericRuntimeTest {
   @Test
   fun exactRecursiveBinding() {
     val value = GenericNode("root", GenericNode("leaf", null))
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       val type = jsonTypeRef<GenericNode<String>>()
       assertEquals(value, json.fromJson(json.toJson(value, type), type))
       assertEquals(value, json.fromJson(json.toJsonBytes(value, type), type))
@@ -83,7 +83,7 @@ class KotlinGenericRuntimeTest {
   @Test
   fun exactMutualCycle() {
     val value = MutualLeft("left", MutualRight("right", MutualLeft("tail", null)))
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       val type = jsonTypeRef<MutualLeft<String>>()
       assertEquals(value, json.fromJson(json.toJson(value, type), type))
       assertEquals(value, json.fromJson(json.toJsonBytes(value, type), type))

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinNullabilityRuntimeTest.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinNullabilityRuntimeTest.kt
@@ -73,7 +73,7 @@ class KotlinNullabilityRuntimeTest {
     override fun hashCode(): Int = 31 * id + (value?.hashCode() ?: 0)
   }
 
-  data class InvalidOmission(
+  data class NullOmission(
     @get:JsonProperty(include = JsonProperty.Include.NON_NULL) val value: String?,
   )
 
@@ -86,12 +86,12 @@ class KotlinNullabilityRuntimeTest {
     var deferred: String = "initializer"
   }
 
-  data class InvalidEmptyOmission(
+  data class EmptyOmission(
     @get:JsonProperty(include = JsonProperty.Include.NON_EMPTY)
     val value: List<String> = emptyList(),
   )
 
-  class InvalidDeferredOmission {
+  class DeferredOmission {
     @get:JsonProperty(include = JsonProperty.Include.NON_EMPTY) var value: String = "initializer"
   }
 
@@ -111,8 +111,62 @@ class KotlinNullabilityRuntimeTest {
     @get:JsonProperty(include = JsonProperty.Include.NON_EMPTY) val value: T,
   )
 
+  data class InclusionModel(
+    var id: Int? = null,
+    var name: String? = null,
+    var list: List<String>? = null,
+  )
+
+  data class PropertyInclusion(
+    val id: Int,
+    @get:JsonProperty(include = JsonProperty.Include.NON_NULL) val name: String? = null,
+    @JsonProperty(include = JsonProperty.Include.NON_EMPTY) val list: List<String>? = null,
+    @get:JsonProperty(include = JsonProperty.Include.ALWAYS) val retained: List<String>? = null,
+  )
+
   @Test
-  fun reconstructibleEmptyOmission() {
+  fun propertyInclusion() {
+    for (mode in KotlinJsonTestMode.entries) {
+      for (inclusion in JsonProperty.Include.values()) {
+        val json =
+          newKotlinJson(mode) {
+            if (inclusion != JsonProperty.Include.DEFAULT) defaultPropertyInclusion(inclusion)
+          }
+        val value = InclusionModel(1, list = emptyList())
+        val expected =
+          when (inclusion) {
+            JsonProperty.Include.ALWAYS -> """{"id":1,"name":null,"list":[]}"""
+            JsonProperty.Include.NON_EMPTY -> """{"id":1}"""
+            else -> """{"id":1,"list":[]}"""
+          }
+        val annotated = PropertyInclusion(1, list = emptyList())
+        repeat(if (mode == KotlinJsonTestMode.ASYNCHRONOUS) 2 else 1) {
+          assertEquals(expected, json.toJson(value))
+          assertEquals(expected, json.toJsonBytes(value).decodeToString())
+          val type = jsonTypeRef<InclusionModel>()
+          val decoded = json.fromJson(expected, type)
+          assertEquals(decoded, json.fromJson(expected.toByteArray(), type))
+          assertEquals(
+            if (inclusion == JsonProperty.Include.NON_EMPTY) null else emptyList(),
+            decoded.list
+          )
+          assertEquals("""{"id":1,"retained":null}""", json.toJson(annotated))
+          assertEquals("""{"id":1,"retained":null}""", json.toJsonBytes(annotated).decodeToString())
+          val retained = annotated.copy(retained = emptyList())
+          assertEquals("""{"id":1,"retained":[]}""", json.toJson(retained))
+          assertEquals("""{"id":1,"retained":[]}""", json.toJsonBytes(retained).decodeToString())
+          val nonEmpty = annotated.copy(name = "kept", list = listOf("x"))
+          val nonEmptyText = """{"id":1,"name":"kept","list":["x"],"retained":null}"""
+          assertEquals(nonEmptyText, json.toJson(nonEmpty))
+          assertEquals(nonEmptyText, json.toJsonBytes(nonEmpty).decodeToString())
+          if (mode == KotlinJsonTestMode.ASYNCHRONOUS) awaitAsyncCodegen(json)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun emptyInclusion() {
     for (codegen in listOf(false, true)) {
       val json =
         ForyJsonKotlin.builder()
@@ -123,12 +177,18 @@ class KotlinNullabilityRuntimeTest {
       val value = EmptyValues(emptyList(), emptyList(), null, Optional.empty())
       value.deferred = ""
       val type = jsonTypeRef<EmptyValues>()
-      val text = """{"required":[],"defaults":[],"nullable":null,"optional":null,"deferred":""}"""
-      assertEquals(text, json.toJson(value, type))
-      assertEquals(text, json.toJsonBytes(value, type).decodeToString())
-      for (decoded in listOf(json.fromJson(text, type), json.fromJson(text.toByteArray(), type))) {
-        assertEquals(value, decoded)
-        assertEquals("", decoded.deferred)
+      assertEquals("{}", json.toJson(value, type))
+      assertEquals("{}", json.toJsonBytes(value, type).decodeToString())
+      assertFailsWith<ForyJsonException> { json.fromJson("{}", type) }
+      assertFailsWith<ForyJsonException> { json.fromJson("{}".toByteArray(), type) }
+      val present = """{"required":[]}"""
+      for (decoded in
+        listOf(json.fromJson(present, type), json.fromJson(present.toByteArray(), type))) {
+        assertEquals(emptyList(), decoded.required)
+        assertEquals(listOf("default"), decoded.defaults)
+        assertEquals("default", decoded.nullable)
+        assertEquals(Optional.of("default"), decoded.optional)
+        assertEquals("initializer", decoded.deferred)
       }
       val wrapped = ValueClassOmission(EmptyText(""))
       val wrappedType = jsonTypeRef<ValueClassOmission>()
@@ -138,15 +198,25 @@ class KotlinNullabilityRuntimeTest {
       val genericType = jsonTypeRef<GenericOmission<EmptyText>>()
       assertEquals("""{"value":""}""", json.toJson(generic, genericType))
       assertEquals(generic, json.fromJson(json.toJsonBytes(generic, genericType), genericType))
-      assertFailsWith<ForyJsonException> { json.toJson(InvalidEmptyOmission()) }
-      assertFailsWith<ForyJsonException> { json.toJsonBytes(InvalidDeferredOmission()) }
+      val empty = EmptyOmission()
+      val emptyType = jsonTypeRef<EmptyOmission>()
+      assertEquals("{}", json.toJson(empty, emptyType))
+      assertEquals("{}", json.toJsonBytes(empty, emptyType).decodeToString())
+      assertEquals(empty, json.fromJson("{}", emptyType))
+      val deferred = DeferredOmission().apply { this.value = "" }
+      assertEquals("{}", json.toJson(deferred))
+      assertEquals("{}", json.toJsonBytes(deferred).decodeToString())
+      assertEquals("initializer", json.fromJson("{}", jsonTypeRef<DeferredOmission>()).value)
       assertFailsWith<ForyJsonException> { json.toJson(SequenceOmission(TextSequence(""))) }
-      assertFailsWith<ForyJsonException> {
-        json.toJsonBytes(
-          GenericOmission(TextSequence("")),
-          jsonTypeRef<GenericOmission<TextSequence>>()
-        )
-      }
+      assertEquals(
+        "{}",
+        json
+          .toJsonBytes(
+            GenericOmission(TextSequence("")),
+            jsonTypeRef<GenericOmission<TextSequence>>()
+          )
+          .decodeToString()
+      )
     }
   }
 
@@ -168,7 +238,7 @@ class KotlinNullabilityRuntimeTest {
 
   @Test
   fun constructorPresenceAndNull() {
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       val type = jsonTypeRef<ConstructorNulls>()
       val defaultsJson = """{"required":"漢","nullable":null,"count":1,"nullableCount":null}"""
       val defaults =
@@ -338,27 +408,35 @@ class KotlinNullabilityRuntimeTest {
   }
 
   @Test
-  fun reconstructibleNullOmission() {
+  fun nullInclusion() {
     KotlinJsonTestMode.entries.forEach { mode ->
-      val json = newNullOmittingJson(mode)
+      val json = newKotlinJson(mode) { writeNullFields(false) }
       val type = jsonTypeRef<OmissionModel>()
       val value = OmissionModel(id = 1, requiredNull = null)
       val text = json.toJson(value, type)
-      assertTrue(text.contains("\"defaultNull\":null"), text)
-      assertTrue(text.contains("\"requiredNull\":null"), text)
-      assertEquals(value, json.fromJson(text, type))
-      assertEquals(value, json.fromJson(json.toJsonBytes(value, type), type))
+      assertEquals("""{"id":1}""", text)
+      assertEquals(text, json.toJsonBytes(value, type).decodeToString())
+      assertFailsWith<ForyJsonException> { json.fromJson(text, type) }
+      assertFailsWith<ForyJsonException> { json.fromJson(text.toByteArray(), type) }
 
       val deferredType = jsonTypeRef<DeferredNullableModel>()
       val deferred = DeferredNullableModel(2).also { it.value = null }
       val deferredText = json.toJson(deferred, deferredType)
-      assertTrue(deferredText.contains("\"value\":null"), deferredText)
-      assertEquals(deferred, json.fromJson(deferredText, deferredType))
-    }
+      assertEquals("""{"id":2}""", deferredText)
+      assertEquals(deferredText, json.toJsonBytes(deferred, deferredType).decodeToString())
+      assertEquals("initializer", json.fromJson(deferredText, deferredType).value)
+      assertEquals("initializer", json.fromJson(deferredText.toByteArray(), deferredType).value)
 
-    val json = newKotlinJson(KotlinJsonTestMode.INTERPRETED)
-    assertFailsWith<ForyJsonException> {
-      json.toJson(InvalidOmission(null), jsonTypeRef<InvalidOmission>())
+      val always = newKotlinJson(mode) { writeNullFields(true) }
+      assertEquals(value, always.fromJson(always.toJson(value, type), type))
+      assertEquals(value, always.fromJson(always.toJsonBytes(value, type), type))
+      assertEquals(deferred, always.fromJson(always.toJson(deferred, deferredType), deferredType))
+      assertEquals(
+        deferred,
+        always.fromJson(always.toJsonBytes(deferred, deferredType), deferredType)
+      )
+      assertEquals("{}", always.toJson(NullOmission(null)))
+      assertEquals("{}", always.toJsonBytes(NullOmission(null)).decodeToString())
     }
   }
 
@@ -435,16 +513,5 @@ class KotlinNullabilityRuntimeTest {
   ) {
     assertEquals(expected.length(), actual.length())
     repeat(expected.length()) { assertEquals(expected.get(it), actual.get(it)) }
-  }
-
-  private fun newNullOmittingJson(mode: KotlinJsonTestMode): ForyJson {
-    val builder = ForyJsonKotlin.builder().writeNullFields(false)
-    return when (mode) {
-      KotlinJsonTestMode.INTERPRETED -> builder.withCodegen(false).build()
-      KotlinJsonTestMode.SYNCHRONOUS ->
-        builder.withCodegen(true).withAsyncCompilation(false).build()
-      KotlinJsonTestMode.ASYNCHRONOUS ->
-        builder.withCodegen(true).withAsyncCompilation(true).build()
-    }
   }
 }

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinRuntimeTestSupport.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinRuntimeTestSupport.kt
@@ -41,9 +41,12 @@ internal enum class KotlinJsonTestMode {
   ASYNCHRONOUS,
 }
 
-internal fun forEachJsonMode(action: (ForyJson) -> Unit) {
+internal fun forEachJsonMode(
+  configure: ForyJsonBuilder.() -> Unit = {},
+  action: (ForyJson) -> Unit,
+) {
   KotlinJsonTestMode.entries.forEach { mode ->
-    val json = newKotlinJson(mode)
+    val json = newKotlinJson(mode, configure)
     action(json)
     if (mode == KotlinJsonTestMode.ASYNCHRONOUS && awaitAsyncCodegen(json)) action(json)
   }

--- a/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinValueClassCodecTest.kt
+++ b/kotlin/fory-json-kotlin/src/test/kotlin/org/apache/fory/json/kotlin/KotlinValueClassCodecTest.kt
@@ -211,7 +211,7 @@ class KotlinValueClassCodecTest {
   fun selfRecursiveOccurrence() {
     val type = jsonTypeRef<SelfValueHolder>()
     val value = SelfValueHolder(RecursiveValueId(1), SelfValueHolder(RecursiveValueId(2), null))
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       assertEquals(value, json.fromJson(json.toJson(value, type), type))
       assertEquals(value, json.fromJson(json.toJsonBytes(value, type), type))
     }
@@ -228,7 +228,7 @@ class KotlinValueClassCodecTest {
           MutualValueLeftHolder(RecursiveValueId(3), null),
         ),
       )
-    forEachJsonMode { json ->
+    forEachJsonMode({ writeNullFields(true) }) { json ->
       assertEquals(value, json.fromJson(json.toJson(value, type), type))
       assertEquals(value, json.fromJson(json.toJsonBytes(value, type), type))
     }


### PR DESCRIPTION


## Why?



## What does this PR do?



## Related issues

Closes #4039 

## AI Contribution Checklist



- [ ] Substantial AI assistance was used in this PR: `yes` / `no`
- [ ] If `yes`, I included a completed [AI Contribution Checklist](https://github.com/apache/fory/blob/main/AI_POLICY.md#9-contributor-checklist-for-ai-assisted-prs) in this PR description and the required `AI Usage Disclosure`.
- [ ] If `yes`, my PR description includes the required `ai_review` summary and screenshot evidence or equivalent persisted links of the final clean AI review results from both fresh reviewers described in `AI_POLICY.md`, the Fory-guided reviewer and the independent general reviewer, on the current PR diff or current HEAD after the latest code changes.



## Does this PR introduce any user-facing change?



- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

