### PR TITLE
fix(android): align Kotlin JSON inclusion assertions

### DIFF
--- a/integration_tests/android_tests/src/main/kotlin/org/apache/fory/android/AndroidKotlinJsonScenarios.kt
+++ b/integration_tests/android_tests/src/main/kotlin/org/apache/fory/android/AndroidKotlinJsonScenarios.kt
@@ -89,8 +89,9 @@ internal object AndroidKotlinJsonScenarios {
         val accountType = jsonTypeRef<AndroidKotlinAccount>()
         val value = AndroidKotlinAccount(26, "android", null)
         // Omitting null restores the constructor default; explicit null inclusion preserves null.
+        // Assert inclusion independently of the reflected property order.
         val text = json.toJson(value, accountType)
-        check(text == "{\"id\":26,\"name\":\"android\"}")
+        check(!text.contains("\"label\":")) { text }
         check(json.toJsonBytes(value, accountType).decodeToString() == text)
         val defaulted = AndroidKotlinAccount(26, "android")
         check(json.fromJson(text, accountType) == defaulted)
@@ -99,7 +100,7 @@ internal object AndroidKotlinJsonScenarios {
         val jsonWithNulls =
             ForyJsonKotlin.builder().writeNullFields(true).withAsyncCompilation(false).build()
         val textWithNulls = jsonWithNulls.toJson(value, accountType)
-        check(textWithNulls == "{\"id\":26,\"name\":\"android\",\"label\":null}")
+        check(textWithNulls.contains("\"label\":null")) { textWithNulls }
         check(jsonWithNulls.toJsonBytes(value, accountType).decodeToString() == textWithNulls)
         check(jsonWithNulls.fromJson(textWithNulls, accountType) == value)
         check(jsonWithNulls.fromJson(textWithNulls.toByteArray(), accountType) == value)

--- a/integration_tests/android_tests/src/main/kotlin/org/apache/fory/android/AndroidKotlinJsonScenarios.kt
+++ b/integration_tests/android_tests/src/main/kotlin/org/apache/fory/android/AndroidKotlinJsonScenarios.kt
@@ -88,7 +88,21 @@ internal object AndroidKotlinJsonScenarios {
                 .build()
         val accountType = jsonTypeRef<AndroidKotlinAccount>()
         val value = AndroidKotlinAccount(26, "android", null)
-        check(json.fromJson(json.toJson(value, accountType), accountType) == value)
+        // Omitting null restores the constructor default; explicit null inclusion preserves null.
+        val text = json.toJson(value, accountType)
+        check(text == "{\"id\":26,\"name\":\"android\"}")
+        check(json.toJsonBytes(value, accountType).decodeToString() == text)
+        val defaulted = AndroidKotlinAccount(26, "android")
+        check(json.fromJson(text, accountType) == defaulted)
+        check(json.fromJson(text.toByteArray(), accountType) == defaulted)
+
+        val jsonWithNulls =
+            ForyJsonKotlin.builder().writeNullFields(true).withAsyncCompilation(false).build()
+        val textWithNulls = jsonWithNulls.toJson(value, accountType)
+        check(textWithNulls == "{\"id\":26,\"name\":\"android\",\"label\":null}")
+        check(jsonWithNulls.toJsonBytes(value, accountType).decodeToString() == textWithNulls)
+        check(jsonWithNulls.fromJson(textWithNulls, accountType) == value)
+        check(jsonWithNulls.fromJson(textWithNulls.toByteArray(), accountType) == value)
         check(
             json.fromJson("{\"id\":27,\"name\":\"default\"}", accountType) ==
                 AndroidKotlinAccount(27, "default")


### PR DESCRIPTION
After #4040, the Android metadata scenario still expected `label = null` to survive a round trip with default inclusion. The writer now correctly omits that property, and the reader restores its `"android-default"` constructor default, causing both Android API 26 and API 36 CI to fail.

Update the scenario to assert omission and default restoration, then explicitly enable `writeNullFields(true)` and verify the null-preserving round trip. Cover both String and UTF-8 output/input while retaining the existing metadata, default-mask, singleton, and shared-corpus checks.

Validation is delegated to CI as requested; the local test run was stopped before completion.

Fixes the [Android CI failure](https://github.com/apache/fory/actions/runs/34702925778/job/103577771632).
